### PR TITLE
RavenDB-26563 Replace index query lock convoy with ReaderDrainLock

### DIFF
--- a/bench/Micro.Benchmark/Benchmarks/ReaderDrainLockBench.cs
+++ b/bench/Micro.Benchmark/Benchmarks/ReaderDrainLockBench.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Validators;
+using Nito.AsyncEx;
+using Sparrow.Server;
+
+namespace Micro.Benchmark.Benchmarks
+{
+    /// <summary>
+    /// Compares the production reader-acquire path against ReaderDrainLock.
+    /// The "Token" variants mirror the Index.cs idiom: allocate a per-call
+    /// CancellationTokenSource(timeout) and pass its token to the lock.
+    /// The "Try" variant uses the non-blocking entry on the new primitive
+    /// (no CTS allocation) - this is what the swap will move to where a
+    /// synchronous "fail-if-busy" semantic suffices.
+    /// </summary>
+    [MemoryDiagnoser]
+    [Config(typeof(ReaderDrainLockBench.Config))]
+    public class ReaderDrainLockBench
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddJob(new Job
+                {
+                    Environment =
+                    {
+                        Platform = Platform.X64,
+                        Jit = Jit.RyuJit,
+                    }
+                });
+
+                AddExporter(GetExporters().ToArray());
+                AddValidator(BaselineValidator.FailOnError);
+                AddValidator(JitOptimizationsValidator.FailOnError);
+                AddAnalyser(EnvironmentAnalyser.Default);
+            }
+        }
+
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(3);
+
+        private AsyncReaderWriterLock _nito;
+        private ReaderDrainLock _new;
+
+        [Params(1, 4, 16)]
+        public int Threads;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _nito = new AsyncReaderWriterLock();
+            _new = new ReaderDrainLock();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _new?.Dispose();
+        }
+
+        [Benchmark(Baseline = true)]
+        public void Nito_ReaderLock_WithToken()
+        {
+            if (Threads == 1)
+            {
+                NitoOnce();
+                return;
+            }
+
+            Parallel.For(0, Threads, _ => NitoOnce());
+        }
+
+        private void NitoOnce()
+        {
+            using CancellationTokenSource cts = new CancellationTokenSource(Timeout);
+            using IDisposable _ = _nito.ReaderLock(cts.Token);
+        }
+
+        [Benchmark]
+        public void New_EnterRead_WithToken()
+        {
+            if (Threads == 1)
+            {
+                NewOnceToken();
+                return;
+            }
+
+            Parallel.For(0, Threads, _ => NewOnceToken());
+        }
+
+        private void NewOnceToken()
+        {
+            using CancellationTokenSource cts = new CancellationTokenSource(Timeout);
+            using ReaderDrainLock.ReadHandle _ = _new.EnterRead(cts.Token);
+        }
+
+        [Benchmark]
+        public void New_TryEnterRead()
+        {
+            if (Threads == 1)
+            {
+                NewOnceTry();
+                return;
+            }
+
+            Parallel.For(0, Threads, _ => NewOnceTry());
+        }
+
+        private void NewOnceTry()
+        {
+            if (_new.TryEnterRead(out ReaderDrainLock.ReadHandle h))
+                h.Dispose();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -13,7 +13,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Corax.Utils;
 using Microsoft.AspNetCore.Http;
-using Nito.AsyncEx;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.DataArchival;
 using Raven.Client.Documents.Indexes;
@@ -247,7 +246,7 @@ namespace Raven.Server.Documents.Indexes
         private Lazy<Size?> _transactionSizeLimit;
         private bool _scratchSpaceLimitExceeded;
 
-        private readonly AsyncReaderWriterLock _currentlyRunningQueriesLock = new AsyncReaderWriterLock();
+        private readonly ReaderDrainLock _currentlyRunningQueriesLock = new ReaderDrainLock();
         private readonly AsyncLocal<bool> _isRunningQueriesWriteLockTaken = new AsyncLocal<bool>();
         private readonly MultipleUseFlag _priorityChanged = new MultipleUseFlag();
         private readonly MultipleUseFlag _hadRealIndexingWorkToDo = new MultipleUseFlag();
@@ -360,6 +359,8 @@ namespace Raven.Server.Documents.Indexes
             {
                 using (DrainRunningQueries())
                     DisposeIndex();
+
+                _currentlyRunningQueriesLock.Dispose();
             });
         }
 
@@ -812,7 +813,7 @@ namespace Raven.Server.Documents.Indexes
             try
             {
                 using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
-                    currentlyRunningQueriesWriteLock = _currentlyRunningQueriesLock.WriterLock(cts.Token);
+                    currentlyRunningQueriesWriteLock = _currentlyRunningQueriesLock.EnterWrite(cts.Token);
 
                 _isRunningQueriesWriteLockTaken.Value = true;
             }
@@ -5451,18 +5452,8 @@ namespace Raven.Server.Documents.Indexes
 
             private static readonly TimeSpan ExtendedLockTimeout = TimeSpan.FromSeconds(30);
 
-            private static readonly CancellationToken CancelledToken;
-
-            static IndexQueryDoneRunning()
-            {
-                var cts = new CancellationTokenSource();
-                cts.Cancel();
-
-                CancelledToken = cts.Token;
-            }
-
             private readonly Index _parent;
-            private IDisposable _lock;
+            private bool _heldLock;
 
             public IndexQueryDoneRunning(Index parent)
             {
@@ -5475,13 +5466,14 @@ namespace Raven.Server.Documents.Indexes
                     ? ExtendedLockTimeout
                     : DefaultLockTimeout;
 
-                if (_lock != null)
+                if (_heldLock)
                     ThrowLockAlreadyTaken();
 
                 try
                 {
                     using (var cts = new CancellationTokenSource(timeout))
-                        _lock = _parent._currentlyRunningQueriesLock.ReaderLock(cts.Token);
+                        _parent._currentlyRunningQueriesLock.AcquireRead(cts.Token);
+                    _heldLock = true;
                 }
                 catch (OperationCanceledException)
                 {
@@ -5489,19 +5481,33 @@ namespace Raven.Server.Documents.Indexes
                 }
             }
 
-            public async ValueTask HoldLockAsync()
+            public ValueTask HoldLockAsync()
             {
+                if (_heldLock)
+                    ThrowLockAlreadyTaken();
+
+                // The common case must stay allocation-free and complete synchronously.
+                // Only fall back to the async slow path when a writer is pending.
+                if (_parent._currentlyRunningQueriesLock.TryAcquireRead())
+                {
+                    _heldLock = true;
+                    return ValueTask.CompletedTask;
+                }
+
                 var timeout = _parent._isReplacing
                     ? ExtendedLockTimeout
                     : DefaultLockTimeout;
 
-                if (_lock != null)
-                    ThrowLockAlreadyTaken();
+                return HoldLockSlowAsync(timeout);
+            }
 
+            private async ValueTask HoldLockSlowAsync(TimeSpan timeout)
+            {
                 try
                 {
                     using (var cts = new CancellationTokenSource(timeout))
-                        _lock = await _parent._currentlyRunningQueriesLock.ReaderLockAsync(cts.Token);
+                        await _parent._currentlyRunningQueriesLock.AcquireReadAsync(cts.Token).ConfigureAwait(false);
+                    _heldLock = true;
                 }
                 catch (OperationCanceledException)
                 {
@@ -5511,18 +5517,13 @@ namespace Raven.Server.Documents.Indexes
 
             public bool TryHoldLock()
             {
-                if (_lock != null)
+                if (_heldLock)
                     ThrowLockAlreadyTaken();
 
-                try
-                {
-                    _lock = _parent._currentlyRunningQueriesLock.ReaderLock(CancelledToken);
-                }
-                catch (OperationCanceledException)
-                {
+                if (_parent._currentlyRunningQueriesLock.TryAcquireRead() == false)
                     return false;
-                }
 
+                _heldLock = true;
                 return true;
             }
 
@@ -5542,14 +5543,26 @@ namespace Raven.Server.Documents.Indexes
 
             public void ReleaseLock()
             {
-                _lock?.Dispose();
-                _lock = null;
+                if (_heldLock == false)
+                    return;
+                _parent._currentlyRunningQueriesLock.ReleaseRead();
+                _heldLock = false;
             }
 
             public void Dispose()
             {
                 ReleaseLock();
+#if DEBUG
+                GC.SuppressFinalize(this);
+#endif
             }
+
+#if DEBUG
+            ~IndexQueryDoneRunning()
+            {
+                Debug.Assert(_heldLock == false, $"IndexQueryDoneRunning for '{_parent?.Name}' finalized without ReleaseLock - read leaked");
+            }
+#endif
         }
 
         internal sealed class ExitWriteLock : IDisposable

--- a/src/Sparrow.Server/ReaderDrainLock.cs
+++ b/src/Sparrow.Server/ReaderDrainLock.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Sparrow.Server
 {
@@ -57,6 +58,13 @@ namespace Sparrow.Server
         // path; a writer resets it on entry and sets it on exit.
         private readonly ManualResetEventSlim _writerCleared = new ManualResetEventSlim(initialState: true, spinCount: 0);
 
+        // Async readers use a separate completion source so the synchronous
+        // path can keep ManualResetEventSlim and avoid async machinery. The
+        // completed instance means the uncontended async path does not allocate
+        // or schedule continuations; writers swap in a non-completed source
+        // only while the writer-pending bit is published.
+        private TaskCompletionSource<bool> _asyncWriterCleared = CreateCompletedTaskCompletionSource();
+
         // Serializes writers. Held from EnterWrite to WriteHandle.Dispose.
         private readonly object _writerGate = new object();
 
@@ -85,6 +93,21 @@ namespace Sparrow.Server
                 _writerCleared.Wait(token);
         }
 
+        private async ValueTask AcquireAsync(CancellationToken token)
+        {
+            while (TryAcquire() == false)
+            {
+                // We only get here after the same one-atomic-op reader fast
+                // path rejected us because a writer is pending. Await the
+                // async signal instead of blocking a request thread, then retry
+                // the normal acquire path because another writer may have won.
+                await Volatile.Read(ref _asyncWriterCleared).Task.WaitAsync(token).ConfigureAwait(false);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool HasWriterPendingForTesting() => (Volatile.Read(ref _state) & WriterPendingBit) != 0;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryEnterRead(out ReadHandle handle)
         {
@@ -105,6 +128,16 @@ namespace Sparrow.Server
 
         // Holder-pattern API. Pair Acquire/TryAcquire with exactly one Release.
         public void AcquireRead(CancellationToken token) => Acquire(token);
+
+        public ValueTask AcquireReadAsync(CancellationToken token)
+        {
+            // Preserve the query hot path: if there is no writer pending this
+            // is the same TryAcquire fast path and returns a completed ValueTask.
+            if (TryAcquire())
+                return ValueTask.CompletedTask;
+
+            return AcquireAsync(token);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryAcquireRead() => TryAcquire();
@@ -145,6 +178,7 @@ namespace Sparrow.Server
                 Monitor.Enter(_writerGate, ref gateHeld);
 
                 _drained.Reset();
+                ResetAsyncWriterCleared();
                 _writerCleared.Reset();
 
                 // Publish writer-pending and atomically observe the reader
@@ -173,6 +207,7 @@ namespace Sparrow.Server
                     // Roll back the writer-pending flag so readers can resume.
                     Interlocked.And(ref _state, ~WriterPendingBit);
                     _writerCleared.Set();
+                    SetAsyncWriterCleared();
                     _drained.Set();
                 }
                 if (gateHeld)
@@ -185,8 +220,33 @@ namespace Sparrow.Server
         {
             Interlocked.And(ref _state, ~WriterPendingBit);
             _writerCleared.Set();
+            SetAsyncWriterCleared();
             _drained.Set();
             Monitor.Exit(_writerGate);
+        }
+
+        private static TaskCompletionSource<bool> CreateTaskCompletionSource() =>
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private static TaskCompletionSource<bool> CreateCompletedTaskCompletionSource()
+        {
+            var tcs = CreateTaskCompletionSource();
+            tcs.SetResult(true);
+            return tcs;
+        }
+
+        private void ResetAsyncWriterCleared()
+        {
+            var tcs = Volatile.Read(ref _asyncWriterCleared);
+            if (tcs.Task.IsCompleted == false)
+                return;
+
+            Interlocked.CompareExchange(ref _asyncWriterCleared, CreateTaskCompletionSource(), tcs);
+        }
+
+        private void SetAsyncWriterCleared()
+        {
+            Volatile.Read(ref _asyncWriterCleared).TrySetResult(true);
         }
 
         public void Dispose()
@@ -196,6 +256,7 @@ namespace Sparrow.Server
             _disposed = true;
             _drained.Dispose();
             _writerCleared.Dispose();
+            Volatile.Read(ref _asyncWriterCleared).TrySetCanceled();
         }
 
         // ref struct: cannot be stored in a field, captured, awaited, or boxed.
@@ -204,7 +265,10 @@ namespace Sparrow.Server
         {
             private ReaderDrainLock _parent;
 
-            internal ReadHandle(ReaderDrainLock parent) { _parent = parent; }
+            internal ReadHandle(ReaderDrainLock parent)
+            {
+                _parent = parent;
+            }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void Dispose()
@@ -221,7 +285,10 @@ namespace Sparrow.Server
         {
             private ReaderDrainLock _parent;
 
-            internal WriteHandle(ReaderDrainLock parent) { _parent = parent; }
+            internal WriteHandle(ReaderDrainLock parent)
+            {
+                _parent = parent;
+            }
 
             public void Dispose()
             {

--- a/src/Sparrow.Server/ReaderDrainLock.cs
+++ b/src/Sparrow.Server/ReaderDrainLock.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Sparrow.Server
+{
+    /// <summary>
+    /// Many-reader / rare-writer lock specialized for the "drain readers
+    /// before maintenance" contract. Optimized for an uncontended reader
+    /// hot path: one atomic op per acquire, zero allocations.
+    ///
+    /// Contract:
+    ///   - Readers are non-exclusive among themselves.
+    ///   - A pending or active writer blocks new readers (no writer starvation).
+    ///   - Writers are serialized; a writer waits until readers drain to zero.
+    ///   - No reentrancy; callers track that externally if they need it.
+    ///
+    /// State (single 64-bit word, atomic):
+    ///   bit 0          WriterPending - blocks new readers.
+    ///   bits 1..62     active reader count, stored shifted (each reader is +/- 2).
+    ///   bit 63 (sign)  reachable only on overflow/underflow - a bug, fail loudly.
+    ///
+    /// Reader fast path is unconditional Interlocked.Add followed by
+    /// inspect-and-undo if WriterPending is set in the post-add state. This
+    /// bounds the hot path at one atomic op even under contention; a CAS-retry
+    /// loop would devolve into a cache-line storm at high reader counts.
+    /// The counter can briefly bump above zero during an aborted acquire, but
+    /// the aborting reader decrements before doing protected work, so the
+    /// writer's exclusivity is intact. The writer's drain decision is anchored
+    /// on the count snapshot Interlocked.Or observes when publishing the flag.
+    ///
+    /// Usage:
+    ///   Stack RAII:    using var h = lock.EnterRead(token);
+    ///   Holder class:  AcquireRead/TryAcquireRead + ReleaseRead, paired
+    ///                  with a bool _heldLock and a Debug finalizer.
+    /// Forgotten release leaks the read - next writer hangs to timeout.
+    /// TODO: Roslyn analyzer to require `using` on every ReadHandle local.
+    /// </summary>
+    public sealed class ReaderDrainLock : IDisposable
+    {
+        // Encoding rationale: by stepping readers in +/- 2 and parking the
+        // writer flag in bit 0, no reader arithmetic can ever flip the flag
+        // (carries propagate upward, never down through bit 0). The sign bit
+        // doubles as overflow/underflow detection: any reach into it is a
+        // bug, caught by a single `s < 0` check on every reader op.
+        private const long WriterPendingBit = 1L;
+        private const long ReaderUnit = 2L;
+
+        private long _state;
+
+        // Set when no readers are active or no writer is pending. The writer
+        // waits on this; readers signal it on the 1->0 transition while a
+        // writer is pending.
+        private readonly ManualResetEventSlim _drained = new ManualResetEventSlim(initialState: true, spinCount: 0);
+
+        // Set when no writer is pending. Readers wait on this in the slow
+        // path; a writer resets it on entry and sets it on exit.
+        private readonly ManualResetEventSlim _writerCleared = new ManualResetEventSlim(initialState: true, spinCount: 0);
+
+        // Serializes writers. Held from EnterWrite to WriteHandle.Dispose.
+        private readonly object _writerGate = new object();
+
+        private bool _disposed;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryAcquire()
+        {
+            long s = Interlocked.Add(ref _state, ReaderUnit);
+            if (s < 0)
+                ThrowReaderOverflow();
+            if ((s & WriterPendingBit) == 0)
+                return true;
+
+            // Writer beat us. Undo and, if our undo emptied the count
+            // while a writer is still pending, wake the writer.
+            s = Interlocked.Add(ref _state, -ReaderUnit);
+            if (s == WriterPendingBit)
+                _drained.Set();
+            return false;
+        }
+
+        private void Acquire(CancellationToken token)
+        {
+            while (TryAcquire() == false)
+                _writerCleared.Wait(token);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryEnterRead(out ReadHandle handle)
+        {
+            if (TryAcquire())
+            {
+                handle = new ReadHandle(this);
+                return true;
+            }
+            handle = default;
+            return false;
+        }
+
+        public ReadHandle EnterRead(CancellationToken token)
+        {
+            Acquire(token);
+            return new ReadHandle(this);
+        }
+
+        // Holder-pattern API. Pair Acquire/TryAcquire with exactly one Release.
+        public void AcquireRead(CancellationToken token) => Acquire(token);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryAcquireRead() => TryAcquire();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleaseRead()
+        {
+            // Each reader pairs Add(+ReaderUnit) with Add(-ReaderUnit). A
+            // negative result is the unambiguous signature of either
+            // underflow (release without acquire) or count overflow; both
+            // are bugs, fail loudly at the site.
+            long s = Interlocked.Add(ref _state, -ReaderUnit);
+            if (s < 0)
+                ThrowReleaseUnderflow();
+            if (s == WriterPendingBit)
+                _drained.Set();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowReleaseUnderflow() =>
+            throw new InvalidOperationException("ReaderDrainLock.ReleaseRead called with no matching acquire (reader count underflow).");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowReaderOverflow() =>
+            throw new InvalidOperationException("ReaderDrainLock reader count overflowed.");
+
+        public IDisposable EnterWrite(CancellationToken token)
+        {
+            // Serialize writers. Held until WriteHandle.Dispose, or until we
+            // throw on timeout/cancel.
+            bool gateHeld = false;
+            bool publishedFlag = false;
+            try
+            {
+                // Acquire inside the try with the ref-bool overload so an
+                // async exception between Monitor.Enter returning and the
+                // try-block entry cannot leak the gate.
+                Monitor.Enter(_writerGate, ref gateHeld);
+
+                _drained.Reset();
+                _writerCleared.Reset();
+
+                // Publish writer-pending and atomically observe the reader
+                // count at the moment the flag becomes visible. Any reader
+                // that races us sees WriterPending in its post-Add result and
+                // undoes before doing protected work.
+                long s = Interlocked.Or(ref _state, WriterPendingBit);
+                publishedFlag = true;
+
+                // Any non-flag bit set means readers are still active.
+                if ((s & ~WriterPendingBit) != 0)
+                {
+                    // Note: count may transiently bump above zero here from
+                    // racing readers in inspect-and-undo. Those readers see
+                    // WriterPending and roll back before doing protected work,
+                    // so exclusivity is preserved without waiting for the
+                    // count to settle.
+                    _drained.Wait(token);
+                }
+                return new WriteHandle(this);
+            }
+            catch
+            {
+                if (publishedFlag)
+                {
+                    // Roll back the writer-pending flag so readers can resume.
+                    Interlocked.And(ref _state, ~WriterPendingBit);
+                    _writerCleared.Set();
+                    _drained.Set();
+                }
+                if (gateHeld)
+                    Monitor.Exit(_writerGate);
+                throw;
+            }
+        }
+
+        internal void ExitWrite()
+        {
+            Interlocked.And(ref _state, ~WriterPendingBit);
+            _writerCleared.Set();
+            _drained.Set();
+            Monitor.Exit(_writerGate);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            _drained.Dispose();
+            _writerCleared.Dispose();
+        }
+
+        // ref struct: cannot be stored in a field, captured, awaited, or boxed.
+        // Always declare with `using`. Double-Dispose is a no-op.
+        public ref struct ReadHandle
+        {
+            private ReaderDrainLock _parent;
+
+            internal ReadHandle(ReaderDrainLock parent) { _parent = parent; }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Dispose()
+            {
+                ReaderDrainLock parent = _parent;
+                if (parent == null)
+                    return;
+                _parent = null;
+                parent.ReleaseRead();
+            }
+        }
+
+        private sealed class WriteHandle : IDisposable
+        {
+            private ReaderDrainLock _parent;
+
+            internal WriteHandle(ReaderDrainLock parent) { _parent = parent; }
+
+            public void Dispose()
+            {
+                ReaderDrainLock parent = _parent;
+                if (parent == null)
+                    return;
+                _parent = null;
+                parent.ExitWrite();
+            }
+        }
+    }
+}

--- a/test/FastTests/Sparrow/ReaderDrainLockTests.cs
+++ b/test/FastTests/Sparrow/ReaderDrainLockTests.cs
@@ -93,6 +93,11 @@ namespace FastTests.Sparrow
                 writerEntered.Set();
             });
 
+            // Wait until the writer has actually published the pending bit;
+            // otherwise a delayed Task schedule could make this test pass without
+            // proving that the writer is blocked by the active reader.
+            Assert.True(SpinWait.SpinUntil(l.HasWriterPendingForTesting, TimeSpan.FromSeconds(1)));
+
             // Writer should not enter while reader holds.
             Assert.False(writerEntered.Wait(TimeSpan.FromMilliseconds(150)));
 
@@ -151,14 +156,7 @@ namespace FastTests.Sparrow
             });
 
             writerPublishedPending.Wait();
-            // Spin briefly so EnterWrite has flipped the bit.
-            SpinWait.SpinUntil(() =>
-            {
-                if (l.TryEnterRead(out ReaderDrainLock.ReadHandle probe) == false)
-                    return true;
-                probe.Dispose();
-                return false;
-            }, TimeSpan.FromSeconds(1));
+            Assert.True(SpinWait.SpinUntil(l.HasWriterPendingForTesting, TimeSpan.FromSeconds(1)));
 
             using CancellationTokenSource readerToken = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
             Assert.Throws<OperationCanceledException>(() => l.EnterRead(readerToken.Token));
@@ -223,7 +221,7 @@ namespace FastTests.Sparrow
                 }
             });
 
-            Task.WaitAll(tasks);
+            Assert.True(Task.WaitAll(tasks, TimeSpan.FromSeconds(10)));
             Assert.Equal(0, violations);
         }
     }

--- a/test/FastTests/Sparrow/ReaderDrainLockTests.cs
+++ b/test/FastTests/Sparrow/ReaderDrainLockTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Sparrow
+{
+    public class ReaderDrainLockTests : NoDisposalNeeded
+    {
+        public ReaderDrainLockTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void TryEnterRead_GrantsWhenIdle()
+        {
+            using ReaderDrainLock l = new ReaderDrainLock();
+
+            Assert.True(l.TryEnterRead(out ReaderDrainLock.ReadHandle h));
+            h.Dispose();
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void TryEnterRead_ManyReadersConcurrently()
+        {
+            using ReaderDrainLock l = new ReaderDrainLock();
+
+            ReaderDrainLock.ReadHandle h1, h2, h3;
+            Assert.True(l.TryEnterRead(out h1));
+            Assert.True(l.TryEnterRead(out h2));
+            Assert.True(l.TryEnterRead(out h3));
+
+            h1.Dispose();
+            h2.Dispose();
+            h3.Dispose();
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void TryEnterRead_FailsWhileWriterPending()
+        {
+            using ReaderDrainLock l = new ReaderDrainLock();
+
+            // Hold a reader so the writer must wait.
+            Assert.True(l.TryEnterRead(out ReaderDrainLock.ReadHandle reader));
+
+            ManualResetEventSlim writerPending = new ManualResetEventSlim();
+            Task writerTask = Task.Run(() =>
+            {
+                using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                // Set the flag *before* entering the wait by doing a tiny pre-step:
+                // EnterWrite publishes the pending bit before waiting on drain.
+                writerPending.Set();
+                using IDisposable _ = l.EnterWrite(cts.Token);
+            });
+
+            // Give the writer a moment to publish the pending bit.
+            writerPending.Wait();
+            SpinWait.SpinUntil(() =>
+            {
+                if (l.TryEnterRead(out ReaderDrainLock.ReadHandle h) == false)
+                    return true;
+                h.Dispose();
+                return false;
+            }, TimeSpan.FromSeconds(1));
+
+            // While the writer is pending, new readers must be blocked.
+            Assert.False(l.TryEnterRead(out ReaderDrainLock.ReadHandle blocked));
+
+            reader.Dispose();
+            writerTask.Wait(TimeSpan.FromSeconds(5));
+            Assert.True(writerTask.IsCompletedSuccessfully);
+
+            // Once the writer is gone, readers proceed.
+            Assert.True(l.TryEnterRead(out ReaderDrainLock.ReadHandle after));
+            after.Dispose();
+        }
+
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void EnterWrite_WaitsForActiveReaderThenAcquires()
+        {
+            using ReaderDrainLock l = new ReaderDrainLock();
+
+            Assert.True(l.TryEnterRead(out ReaderDrainLock.ReadHandle reader));
+
+            ManualResetEventSlim writerEntered = new ManualResetEventSlim();
+            Task writerTask = Task.Run(() =>
+            {
+                using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                using IDisposable _ = l.EnterWrite(cts.Token);
+                writerEntered.Set();
+            });
+
+            // Writer should not enter while reader holds.
+            Assert.False(writerEntered.Wait(TimeSpan.FromMilliseconds(150)));
+
+            reader.Dispose();
+            Assert.True(writerEntered.Wait(TimeSpan.FromSeconds(5)));
+            writerTask.Wait(TimeSpan.FromSeconds(5));
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void EnterWrite_NoActiveReaders_AcquiresImmediately()
+        {
+            using ReaderDrainLock l = new ReaderDrainLock();
+            using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            using IDisposable w = l.EnterWrite(cts.Token);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void EnterWrite_TimeoutRollsBackPendingBit()
+        {
+            using ReaderDrainLock l = new ReaderDrainLock();
+
+            Assert.True(l.TryEnterRead(out ReaderDrainLock.ReadHandle reader));
+
+            using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100)))
+            {
+                Assert.Throws<OperationCanceledException>(() => l.EnterWrite(cts.Token));
+            }
+
+            reader.Dispose();
+
+            // After rollback, readers can proceed and a fresh writer can enter.
+            Assert.True(l.TryEnterRead(out ReaderDrainLock.ReadHandle after));
+            after.Dispose();
+
+            using CancellationTokenSource cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using IDisposable w = l.EnterWrite(cts2.Token);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void EnterRead_HonorsCancellation()
+        {
+            using ReaderDrainLock l = new ReaderDrainLock();
+            using CancellationTokenSource writerToken = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            Assert.True(l.TryEnterRead(out ReaderDrainLock.ReadHandle longReader));
+
+            // Background writer that publishes the pending bit and then blocks
+            // on the drain. While it is blocked, a fresh reader call must
+            // wait, and we cancel that wait.
+            ManualResetEventSlim writerPublishedPending = new ManualResetEventSlim();
+            Task writerTask = Task.Run(() =>
+            {
+                writerPublishedPending.Set();
+                using IDisposable _ = l.EnterWrite(writerToken.Token);
+            });
+
+            writerPublishedPending.Wait();
+            // Spin briefly so EnterWrite has flipped the bit.
+            SpinWait.SpinUntil(() =>
+            {
+                if (l.TryEnterRead(out ReaderDrainLock.ReadHandle probe) == false)
+                    return true;
+                probe.Dispose();
+                return false;
+            }, TimeSpan.FromSeconds(1));
+
+            using CancellationTokenSource readerToken = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+            Assert.Throws<OperationCanceledException>(() => l.EnterRead(readerToken.Token));
+
+            longReader.Dispose();
+            writerTask.Wait(TimeSpan.FromSeconds(5));
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void Readers_AndWriters_NeverOverlap()
+        {
+            using ReaderDrainLock l = new ReaderDrainLock();
+
+            int activeReaders = 0;
+            int activeWriters = 0;
+            int violations = 0;
+
+            using CancellationTokenSource stop = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+            int readerThreads = Math.Max(2, Environment.ProcessorCount);
+            Task[] tasks = new Task[readerThreads + 1];
+
+            for (int i = 0; i < readerThreads; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    while (!stop.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+                            using ReaderDrainLock.ReadHandle h = l.EnterRead(cts.Token);
+                            Interlocked.Increment(ref activeReaders);
+                            if (Volatile.Read(ref activeWriters) != 0)
+                                Interlocked.Increment(ref violations);
+                            Interlocked.Decrement(ref activeReaders);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                        }
+                    }
+                });
+            }
+
+            tasks[readerThreads] = Task.Run(() =>
+            {
+                while (!stop.IsCancellationRequested)
+                {
+                    try
+                    {
+                        using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+                        using IDisposable w = l.EnterWrite(cts.Token);
+                        Interlocked.Increment(ref activeWriters);
+                        if (Volatile.Read(ref activeReaders) != 0)
+                            Interlocked.Increment(ref violations);
+                        Thread.SpinWait(50);
+                        Interlocked.Decrement(ref activeWriters);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                }
+            });
+
+            Task.WaitAll(tasks);
+            Assert.Equal(0, violations);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26563

### Additional description

`Index._currentlyRunningQueriesLock` was a `Nito.AsyncEx.AsyncReaderWriterLock`. Every query passes through `IndexQueryDoneRunning.HoldLock`/`TryHoldLock`/`HoldLockAsync`, so the lock sits on the query hot path. `AsyncReaderWriterLock` protects its wait queue and state machine with a CLR `Monitor`; under reader load every acquire/release serializes through that bookkeeping Monitor, producing a lock convoy where reader throughput collapses to Monitor wakeup cadence rather than the work done under the read. The FIFO fairness provided by that queue is not useful here: writers are rare drain-before-maintenance operations, readers are non-exclusive among themselves, and new readers only need to be stopped once a writer is pending.

This PR introduces `Sparrow.Server.ReaderDrainLock`, a many-reader / rare-writer primitive whose uncontended reader fast path is lock-free (one `Interlocked.Add`, zero allocations for the holder path, no internal Monitor) and swaps it in at the index query lock. Writer-cannot-starve is preserved: a pending writer blocks new readers; writers are serialized and wait for the reader count to drain, bounded by a CancellationToken. Synchronous readers keep using `ManualResetEventSlim` when contended. Async readers use the same fast path and return a completed `ValueTask` when uncontended, but fall back to a real async wait when a writer is pending, avoiding request-thread blocking during drain windows. `IndexQueryDoneRunning` keeps its public surface and uses the holder-pattern API (`AcquireRead`/`ReleaseRead`) since the read straddles stack frames; a Debug-only finalizer asserts the holder was disposed, catching leaks that previously surfaced as the misleading "probably undergoing maintenance" timeout.

Micro-benchmark vs. `AsyncReaderWriterLock`, single-thread uncontended:
```
Nito ReaderLock(token):     954 ns / 464 B
New  EnterRead(token):      305 ns / 144 B   (3.1x faster, 0.31x alloc)
New  TryEnterRead:           44 ns /   0 B   (21.7x faster, zero alloc)
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
