### PR TITLE
RavenDB-26550 Restrict bot triggers to OWNER and MEMBER only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,7 @@ jobs:
     if: |
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '@hugin-review') &&
-      (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')
+      (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER')
 
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 20

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,13 +14,13 @@ jobs:
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@hugin-bot') &&
-        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@hugin-bot') &&
-        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@hugin-bot') &&
-        (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER' || github.event.review.author_association == 'COLLABORATOR')) ||
+        (github.event.review.author_association == 'OWNER' || github.event.review.author_association == 'MEMBER')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@hugin-bot') || contains(github.event.issue.title, '@hugin-bot')) &&
-        (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'COLLABORATOR'))
+        (github.event.issue.author_association == 'OWNER' || github.event.issue.author_association == 'MEMBER'))
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26550

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
