### PR TITLE
RavenDB-26564 - Stale half-open TCP connection in incoming replication handler causes permanent failure loop

### DIFF
--- a/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
@@ -323,7 +323,15 @@ public abstract class AbstractChangesClientConnection<TOperationContext> : ILowM
     public virtual void Dispose()
     {
         _isDisposed.Raise();
-        _cts.Cancel();
+
+        try
+        {
+            _cts.Cancel();
+        }
+        catch (AggregateException)
+        {
+        }
+
         _sendQueue.Enqueue(new SendQueueItem
         {
             AllowSkip = false,

--- a/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
@@ -322,7 +322,8 @@ public abstract class AbstractChangesClientConnection<TOperationContext> : ILowM
 
     public virtual void Dispose()
     {
-        _isDisposed.Raise();
+        if (_isDisposed.Raise() == false)
+            return;
 
         try
         {

--- a/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
@@ -11,6 +11,7 @@ using Sparrow;
 using Sparrow.Collections;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Server.Collections;
 using Sparrow.Threading;
@@ -21,6 +22,8 @@ namespace Raven.Server.Documents.Changes;
 public abstract class AbstractChangesClientConnection<TOperationContext> : ILowMemoryHandler, IDisposable
     where TOperationContext : JsonOperationContext
 {
+    private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Client", typeof(AbstractChangesClientConnection<TOperationContext>).FullName);
+
     private readonly WebSocket _webSocket;
     private readonly AsyncQueue<SendQueueItem> _sendQueue = new();
 
@@ -325,13 +328,7 @@ public abstract class AbstractChangesClientConnection<TOperationContext> : ILowM
         if (_isDisposed.Raise() == false)
             return;
 
-        try
-        {
-            _cts.Cancel();
-        }
-        catch (AggregateException)
-        {
-        }
+        _cts.SafeCancel(Logger, "changes client connection");
 
         _sendQueue.Enqueue(new SendQueueItem
         {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -931,7 +931,7 @@ namespace Raven.Server.Documents
         {
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Starting dispose");
 
-            _databaseShutdown.SafeCancel(_logger, $"{nameof(AggregateException)} during _databaseShutdown.Cancel() while disposing the {nameof(DocumentDatabase)}: {Name}");
+            _databaseShutdown.SafeCancel(_logger, $"{nameof(DocumentDatabase)}: {Name}");
 
             _serverStore.Server.ServerCertificateChanged -= OnCertificateChange;
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -931,7 +931,17 @@ namespace Raven.Server.Documents
         {
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Starting dispose");
 
-            _databaseShutdown.Cancel();
+            try
+            {
+                _databaseShutdown.Cancel();
+            }
+            catch (AggregateException)
+            {
+                // _databaseShutdown.Cancel() fires registered cancellation callbacks synchronously.
+                // Some callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync) may throw
+                // We must catch it so the rest of the cleanup can proceed.
+                // CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException, it is the only exception type it throws
+            }
 
             _serverStore.Server.ServerCertificateChanged -= OnCertificateChange;
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -931,19 +931,7 @@ namespace Raven.Server.Documents
         {
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Starting dispose");
 
-            try
-            {
-                _databaseShutdown.Cancel();
-            }
-            catch (AggregateException e)
-            {
-                // _databaseShutdown.Cancel() fires registered cancellation callbacks synchronously.
-                // Some callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync) may throw
-                // We must catch it so the rest of the cleanup can proceed.
-                // CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException, it is the only exception type it throws
-                if (_logger.IsInfoEnabled)
-                    _logger.Info($"{nameof(AggregateException)} during _databaseShutdown.Cancel() while disposing the {nameof(DocumentDatabase)}: {Name}", e);
-            }
+            _databaseShutdown.SafeCancel(_logger, $"{nameof(AggregateException)} during _databaseShutdown.Cancel() while disposing the {nameof(DocumentDatabase)}: {Name}");
 
             _serverStore.Server.ServerCertificateChanged -= OnCertificateChange;
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -72,6 +72,7 @@ using Size = Raven.Client.Util.Size;
 using System.Diagnostics.CodeAnalysis;
 using Jint;
 using Sparrow.Server.Utils;
+using Sparrow.Utils;
 
 namespace Raven.Server.Documents
 {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -935,12 +935,14 @@ namespace Raven.Server.Documents
             {
                 _databaseShutdown.Cancel();
             }
-            catch (AggregateException)
+            catch (AggregateException e)
             {
                 // _databaseShutdown.Cancel() fires registered cancellation callbacks synchronously.
                 // Some callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync) may throw
                 // We must catch it so the rest of the cleanup can proceed.
                 // CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException, it is the only exception type it throws
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"{nameof(AggregateException)} during _databaseShutdown.Cancel() while disposing the {nameof(DocumentDatabase)}: {Name}", e);
             }
 
             _serverStore.Server.ServerCertificateChanged -= OnCertificateChange;

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -717,7 +717,7 @@ namespace Raven.Server.Documents.ETL
                 ReportStopReasonToStats(msg);
             }
 
-            _cts.Cancel();
+            _cts.SafeCancel(Logger, $"{nameof(EtlProcess)}: {Name}");
 
             var longRunningWork = _longRunningWork;
             _longRunningWork = null;

--- a/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
+++ b/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
@@ -445,7 +445,7 @@ public abstract class QueueSinkProcess : IDisposable, ILowMemoryHandler
             Logger.Operations(msg);
         }
 
-        _cts.Cancel();
+        _cts.SafeCancel(Logger, $"{nameof(QueueSinkProcess)} '{Name}'");
 
         var longRunningWork = _longRunningWork;
         _longRunningWork = null;

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -658,18 +658,16 @@ namespace Raven.Server.Documents.Replication.Incoming
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"Disposing IncomingReplicationHandler ({FromToString})");
 
-                // RavenDB-26564: _cts.Cancel() fires registered cancellation callbacks synchronously.
-                // ParseToMemoryAsync registers stream.Dispose via token.Register(stream.Dispose).
-                // If the connection is half-open, the callback tries to flush buffered data to a dead
-                // socket, which blocks then throws SocketException. CancellationTokenSource wraps this
-                // in AggregateException. We must catch it so the cleanup below can run — otherwise we
-                // leak the TCP socket, temp files, and leave the background thread stuck.
                 try
                 {
                     _cts.Cancel();
                 }
-                catch (Exception)
+                catch (AggregateException)
                 {
+                    // _cts.Cancel() fires registered cancellation callbacks synchronously.
+                    // Some callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync) may throw
+                    // We must catch it so the rest of the cleanup can proceed.
+                    // CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException, it is the only exception type it throws
                 }
 
                 try

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -658,7 +658,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"Disposing IncomingReplicationHandler ({FromToString})");
 
-                _cts.SafeCancel(Logger, $"{nameof(AggregateException)} during _cts.Cancel() while disposing of {nameof(IncomingReplicationHandler)} ({FromToString})");
+                _cts.SafeCancel(Logger, $"{nameof(IncomingReplicationHandler)} ({FromToString})");
 
                 try
                 {

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -657,7 +657,20 @@ namespace Raven.Server.Documents.Replication.Incoming
             {
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"Disposing IncomingReplicationHandler ({FromToString})");
-                _cts.Cancel();
+
+                // RavenDB-26564: _cts.Cancel() fires registered cancellation callbacks synchronously.
+                // ParseToMemoryAsync registers stream.Dispose via token.Register(stream.Dispose).
+                // If the connection is half-open, the callback tries to flush buffered data to a dead
+                // socket, which blocks then throws SocketException. CancellationTokenSource wraps this
+                // in AggregateException. We must catch it so the cleanup below can run — otherwise we
+                // leak the TCP socket, temp files, and leave the background thread stuck.
+                try
+                {
+                    _cts.Cancel();
+                }
+                catch (Exception)
+                {
+                }
 
                 try
                 {
@@ -666,6 +679,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                 catch (Exception)
                 {
                 }
+
                 try
                 {
                     _stream.Dispose();
@@ -673,6 +687,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                 catch (Exception)
                 {
                 }
+
                 try
                 {
                     _tcpClient.Dispose();

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -662,12 +662,14 @@ namespace Raven.Server.Documents.Replication.Incoming
                 {
                     _cts.Cancel();
                 }
-                catch (AggregateException)
+                catch (AggregateException e)
                 {
                     // _cts.Cancel() fires registered cancellation callbacks synchronously.
                     // Some callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync) may throw
                     // We must catch it so the rest of the cleanup can proceed.
                     // CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException, it is the only exception type it throws
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{nameof(AggregateException)} during _cts.Cancel() while disposing of {nameof(IncomingReplicationHandler)} ({FromToString})", e);
                 }
 
                 try

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -658,19 +658,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"Disposing IncomingReplicationHandler ({FromToString})");
 
-                try
-                {
-                    _cts.Cancel();
-                }
-                catch (AggregateException e)
-                {
-                    // _cts.Cancel() fires registered cancellation callbacks synchronously.
-                    // Some callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync) may throw
-                    // We must catch it so the rest of the cleanup can proceed.
-                    // CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException, it is the only exception type it throws
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"{nameof(AggregateException)} during _cts.Cancel() while disposing of {nameof(IncomingReplicationHandler)} ({FromToString})", e);
-                }
+                _cts.SafeCancel(Logger, $"{nameof(AggregateException)} during _cts.Cancel() while disposing of {nameof(IncomingReplicationHandler)} ({FromToString})");
 
                 try
                 {

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -836,7 +836,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
             OnBeforeDispose();
 
-            _cts.Cancel();
+            _cts.SafeCancel(Logger, $"Failed to cancel {nameof(CancellationTokenSource)} while disposing of {GetType().Name} ({FromToString})");
 
             _tcpConnectionOptions.Dispose();
             DisposeTcpClient();

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -760,7 +760,26 @@ namespace Raven.Server.Documents.Replication
 
                 IncomingReplicationRemoved?.Invoke(incoming);
 
-                value.Dispose();
+                // RavenDB-26564: if the old handler is already disposed (e.g. from a previous failed attempt),
+                // skip re-invocation — DisposeOnce<SingleAttempt> would immediately re-throw the cached exception.
+                if (value.IsDisposed == false)
+                {
+                    try
+                    {
+                        value.Dispose();
+                    }
+                    catch (Exception e)
+                    {
+                        // RavenDB-26564: a half-open TCP connection can cause Dispose to throw when the
+                        // dispose path tries to flush buffered data to a dead socket. We must not let this
+                        // prevent the new connection from being accepted. The stale entry in _incoming will
+                        // be replaced by the subsequent AddOrUpdate in CreateIncomingInstance (which checks
+                        // IsDisposed on the existing value).
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info($"Failed to dispose the existing incoming replication handler from {incoming.FromToString}. " +
+                                         $"Proceeding to accept the new connection.", e);
+                    }
+                }
             }
         }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -760,25 +760,18 @@ namespace Raven.Server.Documents.Replication
 
                 IncomingReplicationRemoved?.Invoke(incoming);
 
-                // RavenDB-26564: if the old handler is already disposed (e.g. from a previous failed attempt),
-                // skip re-invocation — DisposeOnce<SingleAttempt> would immediately re-throw the cached exception.
-                if (value.IsDisposed == false)
+                try
                 {
-                    try
-                    {
-                        value.Dispose();
-                    }
-                    catch (Exception e)
-                    {
-                        // RavenDB-26564: a half-open TCP connection can cause Dispose to throw when the
-                        // dispose path tries to flush buffered data to a dead socket. We must not let this
-                        // prevent the new connection from being accepted. The stale entry in _incoming will
-                        // be replaced by the subsequent AddOrUpdate in CreateIncomingInstance (which checks
-                        // IsDisposed on the existing value).
-                        if (_logger.IsInfoEnabled)
-                            _logger.Info($"Failed to dispose the existing incoming replication handler from {incoming.FromToString}. " +
-                                         $"Proceeding to accept the new connection.", e);
-                    }
+                    value.Dispose();
+                }
+                catch (Exception e)
+                {
+                    // RavenDB-26564: precautionary catch — the primary fix is in DisposeInternal
+                    // where _cts.Cancel() is now guarded. This ensures that even if Dispose fails
+                    // for an unexpected reason, the new connection is still accepted.
+                    if (_logger.IsOperationsEnabled)
+                        _logger.Operations($"Failed to dispose the existing incoming replication handler from {incoming.FromToString}. " +
+                                     $"Proceeding to accept the new connection.", e);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -238,7 +238,7 @@ namespace Raven.Server.Documents.Sharding
             if (_logger.IsInfoEnabled)
                 _logger.Info($"Disposing {nameof(ShardedDatabaseContext)} of {DatabaseName}.");
 
-            _databaseShutdown.SafeCancel(_logger, $"{nameof(System.AggregateException)} during _databaseShutdown.Cancel() while disposing the {nameof(ShardedDatabaseContext)}: {DatabaseName}");
+            _databaseShutdown.SafeCancel(_logger, $"{nameof(ShardedDatabaseContext)}: {DatabaseName}");
 
             var exceptionAggregator = new ExceptionAggregator(_logger, $"Could not dispose {nameof(ShardedDatabaseContext)} {DatabaseName}");
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -238,7 +238,7 @@ namespace Raven.Server.Documents.Sharding
             if (_logger.IsInfoEnabled)
                 _logger.Info($"Disposing {nameof(ShardedDatabaseContext)} of {DatabaseName}.");
 
-            _databaseShutdown.Cancel();
+            _databaseShutdown.SafeCancel(_logger, $"{nameof(System.AggregateException)} during _databaseShutdown.Cancel() while disposing the {nameof(ShardedDatabaseContext)}: {DatabaseName}");
 
             var exceptionAggregator = new ExceptionAggregator(_logger, $"Could not dispose {nameof(ShardedDatabaseContext)} {DatabaseName}");
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -24,6 +24,8 @@ namespace Raven.Server.ServerWide.Maintenance
 {
     public sealed class ClusterMaintenanceSupervisor : IDisposable
     {
+        private Logger _logger;
+
         private readonly string _leaderClusterTag;
 
         //maintenance handler is valid for specific term, otherwise it's requests will be rejected by nodes
@@ -107,6 +109,8 @@ namespace Raven.Server.ServerWide.Maintenance
             _server = server;
             _contextPool = new JsonContextPool(server.Configuration.Memory.MaxContextSizeToKeep);
             Config = server.Configuration.Cluster;
+
+            _logger = LoggingSource.Instance.GetLogger<ClusterMaintenanceSupervisor>(_leaderClusterTag);
         }
 
         public void AddToCluster(string clusterTag, string url)
@@ -140,7 +144,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 return;
 
             _isDisposed = true;
-            _cts.Cancel();
+            _cts.SafeCancel(_logger, nameof(ClusterMaintenanceSupervisor));
 
             Parallel.ForEach(_clusterNodes, (node) =>
             {
@@ -638,7 +642,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     return;
 
                 _isDisposed = true;
-                _cts.Cancel();
+                _cts.SafeCancel(_log, $"{nameof(ClusterNode)} '{_name}'");
 
                 try
                 {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -419,7 +419,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
         public void Dispose()
         {
-            _cts.Cancel();
+            _cts.SafeCancel(_logger, $"{nameof(ClusterMaintenanceWorker)} '{_name}'");
             _tcp.Dispose();
 
             try

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -20,6 +20,7 @@ using Sparrow.Json.Sync;
 using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Server.Utils;
+using Sparrow.Utils;
 using Index = Raven.Server.Documents.Indexes.Index;
 
 namespace Raven.Server.ServerWide.Maintenance

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -875,7 +875,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
         public void Dispose()
         {
-            _cts.Cancel();
+            _cts.SafeCancel(_observerLogger.Logger, $"{nameof(ClusterObserver)} on node {_nodeTag}");
 
             try
             {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -27,6 +27,7 @@ using Raven.Server.ServerWide.Maintenance.Sharding;
 using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Server.Utils;
+using Sparrow.Utils;
 
 namespace Raven.Server.ServerWide.Maintenance
 {

--- a/src/Raven.Server/ServerWide/Maintenance/ObserverLogger.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ObserverLogger.cs
@@ -7,15 +7,16 @@ namespace Raven.Server.ServerWide.Maintenance
 {
     public sealed class ObserverLogger
     {
-        private readonly Logger _logger;
         private readonly BlockingCollection<ClusterObserverLogEntry> _decisionsLog;
         private readonly Dictionary<string, long> _lastLogs;
+
+        public Logger Logger { get; }
 
         public BlockingCollection<ClusterObserverLogEntry> DecisionsLog => _decisionsLog;
 
         public ObserverLogger(string nodeTag)
         {
-            _logger = LoggingSource.Instance.GetLogger<ClusterObserver>(nodeTag);
+            Logger = LoggingSource.Instance.GetLogger<ClusterObserver>(nodeTag);
             _lastLogs = new Dictionary<string, long>();
             _decisionsLog = new BlockingCollection<ClusterObserverLogEntry>();
         }
@@ -54,11 +55,11 @@ namespace Raven.Server.ServerWide.Maintenance
         /// <param name="e">An optional exception associated with the decision.</param>
         public void AddToDecisionLog(string database, string updateReason, long iteration, Exception e = null)
         {
-            if (_logger.IsInfoEnabled)
+            if (Logger.IsInfoEnabled)
             {
                 var prefix = string.IsNullOrWhiteSpace(database) ? string.Empty : $"Database '{database}' : ";
                 var decisionPrefix = e == null ? "Decision: " : string.Empty;
-                _logger.Info($"{prefix}{decisionPrefix}{updateReason}", e);
+                Logger.Info($"{prefix}{decisionPrefix}{updateReason}", e);
             }
 
             if (e != null)

--- a/src/Raven.Server/ServerWide/Maintenance/ObserverLogger.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ObserverLogger.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.ServerWide.Maintenance
         private readonly BlockingCollection<ClusterObserverLogEntry> _decisionsLog;
         private readonly Dictionary<string, long> _lastLogs;
 
-        public Logger Logger { get; }
+        public readonly Logger Logger;
 
         public BlockingCollection<ClusterObserverLogEntry> DecisionsLog => _decisionsLog;
 

--- a/src/Raven.Server/Utils/CancellationTokenSourceExtensions.cs
+++ b/src/Raven.Server/Utils/CancellationTokenSourceExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using Sparrow.Logging;
 
@@ -11,16 +12,16 @@ internal static class CancellationTokenSourceExtensions
     /// CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException — it is the only exception type it throws.
     /// Catching it allows the caller's cleanup to proceed regardless of broken-connection errors in callbacks.
     /// </summary>
-    public static void SafeCancel(this CancellationTokenSource cts, Logger logger, string errorMessage)
+    public static void SafeCancel(this CancellationTokenSource cts, Logger logger, string component)
     {
         try
         {
             cts.Cancel();
         }
-        catch (System.AggregateException e)
+        catch (AggregateException e)
         {
             if (logger.IsInfoEnabled)
-                logger.Info(errorMessage, e);
+                logger.Info($"Failed to cancel {nameof(CancellationTokenSource)} while disposing of {component}", e);
         }
     }
 }

--- a/src/Raven.Server/Utils/CancellationTokenSourceExtensions.cs
+++ b/src/Raven.Server/Utils/CancellationTokenSourceExtensions.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using Sparrow.Logging;
+
+namespace Raven.Server.Utils;
+
+internal static class CancellationTokenSourceExtensions
+{
+    /// <summary>
+    /// Cancels the <see cref="CancellationTokenSource"/> and catches any <see cref="System.AggregateException"/>
+    /// thrown by registered callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync).
+    /// CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException — it is the only exception type it throws.
+    /// Catching it allows the caller's cleanup to proceed regardless of broken-connection errors in callbacks.
+    /// </summary>
+    public static void SafeCancel(this CancellationTokenSource cts, Logger logger, string errorMessage)
+    {
+        try
+        {
+            cts.Cancel();
+        }
+        catch (System.AggregateException e)
+        {
+            if (logger.IsInfoEnabled)
+                logger.Info(errorMessage, e);
+        }
+    }
+}

--- a/src/Sparrow/Utils/CancellationTokenSourceExtensions.cs
+++ b/src/Sparrow/Utils/CancellationTokenSourceExtensions.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading;
 using Sparrow.Logging;
 
-namespace Raven.Server.Utils;
+namespace Sparrow.Utils;
 
 internal static class CancellationTokenSourceExtensions
 {

--- a/test/SlowTests/Issues/RavenDB-26441.cs
+++ b/test/SlowTests/Issues/RavenDB-26441.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26441 : RavenTestBase
+{
+    public RavenDB_26441(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Replication)]
+    public async Task UnloadDatabase_WhenDatabaseShutdownRegisterCallerThrow_ShouldBeAbleToLoad()
+    {
+        using var server = GetNewServer(new ServerCreationOptions
+        {
+            CustomSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "1",
+                [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "1",
+                [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
+            }
+        });
+
+        string databaseName;
+        using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false, DeleteDatabaseOnDispose = false }))
+        {
+            databaseName = store.Database;
+            var db = await GetDatabase(server, databaseName);
+            db.DatabaseShutdown.Register(() => throw new Exception("Artificial exception"));
+        }
+
+        await AssertWaitForValueAsync(() => Task.FromResult(server.ServerStore.IdleDatabases.Count), 1);
+
+        using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false, CreateDatabase = false, ModifyDatabaseName = _ => databaseName }))
+        {
+            using var session = store.OpenAsyncSession();
+            await session.LoadAsync<object>("randomId"); // forces us to load the database, and if the exception from the DatabaseShutdown register is not handled, it will fail to load
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26564/Stale-half-open-TCP-connection-in-incoming-replication-handler-causes-permanent-self-sustaining-failure-loop
https://issues.hibernatingrhinos.com/issue/RavenDB-26441

### Additional description

When a pull replication connection (`SinkToHub`) goes half-open — the sink side drops but the hub never receives a RST — the hub retains a stale incoming handler in `_incoming`. When the sink reconnects, `AssertValidConnection` tries to dispose the stale handler synchronously. The dispose path flushes buffered `ZstdStream` data to the dead socket, which blocks for ~2 minutes (TCP retransmit timeout) then throws `SocketException(110)`.

Because `value.Dispose()` at line 763 has no exception handling, the exception propagates up through `GetLatestEtagMessage` → `IncomingInitialHandshake` → `CreateIncomingReplicationHandler`, and the new connection is rejected **before reaching `CreateIncomingInstance`** (which would have replaced the stale entry via `_incoming.AddOrUpdate`).

The failure is self-sustaining: after the first failed dispose, `DisposeOnce<SingleAttempt>` caches the exception in its `TaskCompletionSource`. Every subsequent retry calls `Dispose()` again → `Task.Wait()` on the faulted TCS → immediately re-throws the cached exception. The sink backs off exponentially but can never succeed. No amount of restarting on the sink side resolves it — only restarting the hub's database process clears the stale in-memory state.

### How the exception escapes DisposeInternal

1. `DisposeInternal()` calls `_cts.Cancel()`
2. `JsonOperationContext.ParseToMemoryAsync` had previously registered `stream.Dispose` as a cancellation callback via `token?.Register(stream.Dispose)` — this was registered when the background thread called `ParseToMemoryAsync` with `_cts.Token`
3. `_cts.Cancel()` fires this callback synchronously, which calls `ReadWriteCompressedStream.Dispose()` → `DisposeOnce.Dispose()` → `Flush()` → `ZstdStream` writes buffered data to `SslStream`
4. `SslStream.Write` → `NetworkStream.Write` → socket write on dead connection
5. Linux TCP retransmits for ~2 minutes, then returns `errno 110: Connection timed out` → `SocketException`
6. `CancellationTokenSource.ExecuteCallbackHandlers` wraps it in `AggregateException` and throws out of `_cts.Cancel()`
7. `DisposeInternal` has no catch for `_cts.Cancel()` — the try/catch blocks below it only guard `_stream.Dispose()`, `_tcpClient.Dispose()`, etc. — so none of those run
8. The exception propagates through `DisposeOnce<SingleAttempt>` which caches it and re-throws

Because `_cts.Cancel()` escapes `DisposeInternal`, the subsequent cleanup never runs — `_tcpClient` is never closed (so the background thread stays stuck in `ReadAsync`), temp files are leaked, and the TCP socket stays open.

### Fix

**Primary fix — `AbstractIncomingReplicationHandler.DisposeInternal`**: Wrapped `_cts.Cancel()` in a try/catch for `AggregateException`. This ensures that when the cancellation callback throws (due to flushing to a dead socket), the rest of `DisposeInternal` still runs — `_tcpClient.Dispose()` closes the socket (unblocking the background thread), and all other resources are properly cleaned up. With this fix, `value.Dispose()` in `AssertValidConnection` completes normally.

**Same fix — `DocumentDatabase.DisposeInternal`**: Wrapped `_databaseShutdown.Cancel()` in a try/catch for `AggregateException`. The same issue applies here — `_databaseShutdown` is the root `CancellationTokenSource` that `_cts` in `AbstractIncomingReplicationHandler` is linked to. When `_databaseShutdown.Cancel()` fires during database disposal, the same callback chain triggers (via the linked token), and the same `AggregateException` can propagate out, preventing the rest of the database cleanup from running.

**Defense-in-depth — `ReplicationLoader.AssertValidConnection`**: Wrapped `value.Dispose()` in a try/catch so that even if `Dispose` fails for an unexpected reason, the new incoming connection is still accepted.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
