### PR TITLE
RavenDB-26584 Fix AI/S3/Azure tests failing instead of skipping when credentials are missing

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiRemoteAttachments.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiRemoteAttachments.cs
@@ -31,7 +31,7 @@ public class GenAiRemoteAttachments(ITestOutputHelper output) : RemoteAttachment
 
     private record Comment(string Id, string Author, string Content, string AuthorDescription, string ProfileImage);
 
-    [RavenTheory(RavenTestCategory.Ai | RavenTestCategory.Attachments)]
+    [RavenTheory(RavenTestCategory.Ai | RavenTestCategory.Attachments, AzureRequired = true)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ShouldBeAbleToUseRemoteAttachments(Options options, GenAiConfiguration config)
     {
@@ -134,7 +134,7 @@ public class GenAiRemoteAttachments(ITestOutputHelper output) : RemoteAttachment
         }
     }
     
-    [RavenTheory(RavenTestCategory.Ai | RavenTestCategory.Attachments)]
+    [RavenTheory(RavenTestCategory.Ai | RavenTestCategory.Attachments, AzureRequired = true)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ShouldUseCachedResultGenAiResultWhenAttachmentsBecomeRemote(Options options, GenAiConfiguration config)
     {

--- a/test/SlowTests/Server/Documents/Attachments/Issues/RavenDB-11532.cs
+++ b/test/SlowTests/Server/Documents/Attachments/Issues/RavenDB-11532.cs
@@ -19,7 +19,7 @@ namespace SlowTests.Server.Documents.Attachments.Issues
         {
         }
 
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.Attachments, S3Required = true)]
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.Attachments, AwsRequired = true)]
         public async Task Can_Copy_Remote_Attachment_In_Patch()
         {
             using var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/Attachments/Issues/RavenDB-11532.cs
+++ b/test/SlowTests/Server/Documents/Attachments/Issues/RavenDB-11532.cs
@@ -19,7 +19,7 @@ namespace SlowTests.Server.Documents.Attachments.Issues
         {
         }
 
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.Attachments)]
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.Attachments, S3Required = true)]
         public async Task Can_Copy_Remote_Attachment_In_Patch()
         {
             using var store = GetDocumentStore();

--- a/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
+++ b/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
@@ -83,7 +83,7 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
 
     private bool HasSkipReason(IAiConnectorForTesting<TConfig> aiConnectorForTesting)
     {
-        if (string.IsNullOrEmpty(Skip))
+        if (string.IsNullOrEmpty(Skip) == false)
             return true;
 
         if (RavenTestHelper.SkipAiIntegrationTests)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26584

### Additional description

Two issues caused tests to fail instead of skip when external credentials are missing:

1. **Inverted condition in `HasSkipReason()`** (~55 AI/GenAi tests): In `RavenAiIntegrationAttribute.cs`, `string.IsNullOrEmpty(Skip)` returns true when Skip is null (the normal case), causing the method to return immediately without ever checking `MissingRequiredEnvVariables`, `SkipAiIntegrationTests`, or `IsRunningOnCI`. Fixed by inverting to `string.IsNullOrEmpty(Skip) == false`.

2. **Missing skip attributes** (3 tests):
   - `AttachmentsPatchSlowTests.Can_Copy_Remote_Attachment_In_Patch` used `[RavenFact]` instead of `[AmazonS3RetryFact]`
   - `GenAiRemoteAttachments` tests were missing `AzureRequired = true` on their `[RavenTheory]` attribute

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed