### PR TITLE
RavenDB-26517 - Reduce test 'CanResumeConversation' token usage, Fix BadRequest after sending trimmed conversation

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -583,7 +583,11 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             return;
 
         // Never remove the system prompt at index 0
-        truncateCount = Math.Min(truncateCount, messages.Count - 1);
+        if (truncateCount >= messages.Count - 1)
+        {
+            messages.RemoveRange(1, messages.Count - 1);
+            return;
+        }
 
         var removedCount = 0;
         var toolCallIds = new HashSet<string>();
@@ -600,9 +604,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             var message = messages[i];
 
             // Message may already be removed because it was deleted as part of tool cleanup
-            if (messages.Remove(message) == false)
-                continue;
-
+            messages.RemoveAt(i);
             removedCount++;
             i--;
 
@@ -651,7 +653,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                 if (toolCallIds.Contains(toolCallId))
                 {
                     toolCallIds.Remove(toolCallId);
-                    messages.Remove(message);
+                    messages.RemoveAt(j);
                     j--;
 
                     if (toolCallIds.Count == 0)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -541,7 +541,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                 if (truncateCount > 0)
                 {
                     var chatBefore = reduction.History == null ? null : _document.ToHistoryBlittable(context, _configuration, historyExpiration);
-                    _document.Messages.RemoveRange(1, truncateCount);
+                    TrimMessages(_document.Messages, truncateCount);
                     return chatBefore;
                 }
             }
@@ -562,6 +562,89 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         }
 
         return null; // if reduction wasn't executed -> no history to persist (return null)
+    }
+
+    /// <summary>
+    /// Truncates up to <paramref name="n"/> messages from the beginning of the conversation,
+    /// while always preserving the system prompt at index 0.
+    ///
+    /// If an assistant message containing <c>tool_calls</c> is removed, all matching
+    /// <c>role = "tool"</c> result messages are also removed to keep the conversation valid.
+    ///
+    /// This cleanup is required because OpenAI chat APIs reject orphaned tool messages:
+    /// a <c>role = "tool"</c> message must always have a corresponding preceding assistant
+    /// message containing the matching <c>tool_calls</c> entry.
+    ///
+    /// Returns the total number of removed messages, including removed tool result messages.
+    /// </summary>
+    private static void TrimMessages(
+        List<BlittableJsonReaderObject> messages,
+        int n)
+    {
+        if (messages == null || messages.Count == 0 || n <= 0 || n >= messages.Count-1)
+            return;
+
+        // Skip system prompt
+        var slice = messages.Skip(1).Take(n).ToList();
+
+        var truncatedCount = 0;
+        var toolCallIds = new HashSet<string>();
+
+        foreach (var message in slice)
+        {
+            if (truncatedCount >= n)
+                break;
+
+            // Message may already be removed because it was deleted as part of tool cleanup
+            if (messages.Remove(message) == false)
+                continue;
+
+            truncatedCount++;
+
+            // Check if assistant message contains tool_calls
+            if (message.TryGet("tool_calls", out BlittableJsonReaderArray toolCalls) == false ||
+                toolCalls == null ||
+                toolCalls.Length == 0)
+                continue;
+
+            foreach (BlittableJsonReaderObject toolCall in toolCalls)
+            {
+                if (toolCall.TryGet("id", out string id) &&
+                    string.IsNullOrWhiteSpace(id) == false)
+                {
+                    toolCallIds.Add(id);
+                }
+            }
+
+            if (toolCallIds.Count == 0)
+                continue;
+
+            // Walk forward and remove matching tool results
+            for (int i = 1; i < messages.Count; i++)
+            {
+                if (toolCallIds.Count == 0)
+                    break;
+
+                var candidate = messages[i];
+
+                if (candidate.TryGet("role", out string role) == false ||
+                    role != "tool")
+                    continue;
+
+                if (candidate.TryGet("tool_call_id", out string toolCallId) == false)
+                    continue;
+
+                if (toolCallIds.Remove(toolCallId) == false)
+                    continue;
+
+                messages.RemoveAt(i);
+                i--;
+
+                truncatedCount++;
+            }
+
+            toolCallIds.Clear();
+        }
     }
 
     private async Task SummarizeAsync(JsonOperationContext context, ChatCompletionClient client, AiAgentConfiguration configuration, ConversationDocument oldChat, CancellationToken token)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -565,7 +565,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
     }
 
     /// <summary>
-    /// Removes up to <paramref name="n"/> messages from the beginning of the conversation in place,
+    /// Removes up to <paramref name="truncateCount"/> messages from the beginning of the conversation in place,
     /// while always preserving the system prompt at index 0.
     ///
     /// If an assistant message containing <c>tool_calls</c> is removed, all matching
@@ -577,74 +577,87 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
     /// </summary>
     private static void TrimMessages(
         List<BlittableJsonReaderObject> messages,
-        int n)
+        int truncateCount)
     {
-        if (messages == null || messages.Count <= 1 || n <= 0)
+        if (messages == null || messages.Count <= 1 || truncateCount <= 0)
             return;
 
         // Never remove the system prompt at index 0
-        n = Math.Min(n, messages.Count - 1);
+        truncateCount = Math.Min(truncateCount, messages.Count - 1);
 
-        // Skip system prompt
-        var slice = messages.Skip(1).Take(n).ToList();
-
-        var truncatedCount = 0;
+        var removedCount = 0;
         var toolCallIds = new HashSet<string>();
 
-        foreach (var message in slice)
+        int i;
+        // Bound by messages.Count (re-evaluated each iteration) so the access below is always safe
+        // as the list shrinks. The break condition stops us once we've scheduled enough removals;
+        // we don't bound by n+1 because that's the *original* target and the list is shrinking.
+        for (i = 1; i < messages.Count; i++)
         {
-            if (truncatedCount >= n)
+            if (removedCount + toolCallIds.Count >= truncateCount)
                 break;
+
+            var message = messages[i];
 
             // Message may already be removed because it was deleted as part of tool cleanup
             if (messages.Remove(message) == false)
                 continue;
 
-            truncatedCount++;
+            removedCount++;
+            i--;
 
-            // Check if assistant message contains tool_calls
-            if (message.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray toolCalls) == false ||
-                toolCalls == null ||
-                toolCalls.Length == 0)
+            if (message.TryGet(ChatCompletionClient.Constants.ResponseFields.Role, out string role) == false)
                 continue;
 
-            foreach (BlittableJsonReaderObject toolCall in toolCalls)
+            if (role == ChatCompletionClient.Constants.RequestFields.RoleAssistantValue)
             {
-                if (toolCall.TryGet(ChatCompletionClient.Constants.ResponseFields.Id, out string id) &&
-                    string.IsNullOrWhiteSpace(id) == false)
+                // Check if assistant message contains tool_calls
+                if (message.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray toolCalls) &&
+                    toolCalls != null)
                 {
-                    toolCallIds.Add(id);
+                    foreach (BlittableJsonReaderObject toolCall in toolCalls)
+                    {
+                        if (toolCall.TryGet(ChatCompletionClient.Constants.ResponseFields.Id, out string id) &&
+                            string.IsNullOrWhiteSpace(id) == false)
+                        {
+                            toolCallIds.Add(id);
+                        }
+                    }
+                }
+
+                continue;
+            }
+            if (role == ChatCompletionClient.Constants.RequestFields.RoleToolValue)
+            {
+                if (message.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCallId, out string toolCallId) == false)
+                    continue;
+
+                toolCallIds.Remove(toolCallId);
+            }
+        }
+
+        if (toolCallIds.Count > 0)
+        {
+            // Bound by messages.Count (current size after the first pass) — not n+1, which
+            // is the original target and would over-shoot the now-shrunken list.
+            for (int j = i; j < messages.Count; j++)
+            {
+                var message = messages[j];
+                if (message.TryGet(ChatCompletionClient.Constants.ResponseFields.Role, out string role) == false ||
+                    role != ChatCompletionClient.Constants.RequestFields.RoleToolValue ||
+                    message.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCallId, out string toolCallId) == false)
+                    continue;
+
+                if (toolCallIds.Contains(toolCallId))
+                {
+                    toolCallIds.Remove(toolCallId);
+                    messages.Remove(message);
+                    j--;
+
+                    if (toolCallIds.Count == 0)
+                        break;
                 }
             }
-
-            if (toolCallIds.Count == 0)
-                continue;
-
-            // Walk forward and remove matching tool results
-            for (int i = 1; i < messages.Count; i++)
-            {
-                if (toolCallIds.Count == 0)
-                    break;
-
-                var candidate = messages[i];
-
-                if (candidate.TryGet(ChatCompletionClient.Constants.ResponseFields.Role, out string role) == false ||
-                    role != ChatCompletionClient.Constants.RequestFields.RoleToolValue)
-                    continue;
-
-                if (candidate.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCallId, out string toolCallId) == false)
-                    continue;
-
-                if (toolCallIds.Remove(toolCallId) == false)
-                    continue;
-
-                messages.RemoveAt(i);
-                i--;
-
-                truncatedCount++;
-            }
-
-            toolCallIds.Clear();
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -565,7 +565,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
     }
 
     /// <summary>
-    /// Truncates up to <paramref name="n"/> messages from the beginning of the conversation,
+    /// Removes up to <paramref name="n"/> messages from the beginning of the conversation in place,
     /// while always preserving the system prompt at index 0.
     ///
     /// If an assistant message containing <c>tool_calls</c> is removed, all matching
@@ -574,15 +574,16 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
     /// This cleanup is required because OpenAI chat APIs reject orphaned tool messages:
     /// a <c>role = "tool"</c> message must always have a corresponding preceding assistant
     /// message containing the matching <c>tool_calls</c> entry.
-    ///
-    /// Returns the total number of removed messages, including removed tool result messages.
     /// </summary>
     private static void TrimMessages(
         List<BlittableJsonReaderObject> messages,
         int n)
     {
-        if (messages == null || messages.Count == 0 || n <= 0 || n >= messages.Count-1)
+        if (messages == null || messages.Count <= 1 || n <= 0)
             return;
+
+        // Never remove the system prompt at index 0
+        n = Math.Min(n, messages.Count - 1);
 
         // Skip system prompt
         var slice = messages.Skip(1).Take(n).ToList();
@@ -602,14 +603,14 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             truncatedCount++;
 
             // Check if assistant message contains tool_calls
-            if (message.TryGet("tool_calls", out BlittableJsonReaderArray toolCalls) == false ||
+            if (message.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray toolCalls) == false ||
                 toolCalls == null ||
                 toolCalls.Length == 0)
                 continue;
 
             foreach (BlittableJsonReaderObject toolCall in toolCalls)
             {
-                if (toolCall.TryGet("id", out string id) &&
+                if (toolCall.TryGet(ChatCompletionClient.Constants.ResponseFields.Id, out string id) &&
                     string.IsNullOrWhiteSpace(id) == false)
                 {
                     toolCallIds.Add(id);
@@ -627,11 +628,11 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
                 var candidate = messages[i];
 
-                if (candidate.TryGet("role", out string role) == false ||
-                    role != "tool")
+                if (candidate.TryGet(ChatCompletionClient.Constants.ResponseFields.Role, out string role) == false ||
+                    role != ChatCompletionClient.Constants.RequestFields.RoleToolValue)
                     continue;
 
-                if (candidate.TryGet("tool_call_id", out string toolCallId) == false)
+                if (candidate.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCallId, out string toolCallId) == false)
                     continue;
 
                 if (toolCallIds.Remove(toolCallId) == false)

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -50,6 +50,14 @@ public class RavenDB_24407 : RavenTestBase
         public JToken Content { get; set; }
     }
 
+    private class Drink
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public int Price { get; set; }
+        public string[] Tags { get; set; }
+    }
+
     [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, false])]
@@ -58,46 +66,127 @@ public class RavenDB_24407 : RavenTestBase
     public async Task CanResumeConversationWithSummarization(Options options, GenAiConfiguration config, bool summarization, bool withHistory)
     {
         using var store = GetDocumentStore(options);
-        await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/1",
+                Name = "coca cola",
+                Price = 10,
+                Tags = ["sweet", "cold", "carbonated"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/2",
+                Name = "sprite",
+                Price = 10,
+                Tags = ["sweet", "sour", "cold", "carbonated"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/3",
+                Name = "fanta orange",
+                Price = 11,
+                Tags = ["sweet", "fruity", "cold", "carbonated"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/4",
+                Name = "sparkling water",
+                Price = 8,
+                Tags = ["bitter", "cold", "carbonated"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/5",
+                Name = "beer",
+                Price = 18,
+                Tags = ["bitter", "alcoholic", "cold"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/6",
+                Name = "lager beer",
+                Price = 20,
+                Tags = ["bitter", "alcoholic", "cold", "light"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/7",
+                Name = "red wine",
+                Price = 95,
+                Tags = ["bitter", "sour", "very alcoholic"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/8",
+                Name = "whiskey",
+                Price = 140,
+                Tags = ["bitter", "very alcoholic", "strong"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/9",
+                Name = "vodka",
+                Price = 120,
+                Tags = ["very alcoholic", "strong"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/10",
+                Name = "mojito",
+                Price = 55,
+                Tags = ["sweet", "sour", "alcoholic", "mint"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/11",
+                Name = "lemonade",
+                Price = 14,
+                Tags = ["sweet", "sour", "cold"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/12",
+                Name = "iced tea",
+                Price = 13,
+                Tags = ["sweet", "cold", "tea"]
+            });
+
+            await session.SaveChangesAsync();
+        }
 
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
-        const string systemPrompt = @"
-You are an AI shopping assistant for an online store.
+        const string systemPrompt = """
+                                    You are a shopping assistant.
 
-You MUST use the available tools to answer user questions whenever the information can be retrieved from them.
-
-Rules:
-- ALWAYS use the ""RecentOrder"" tool when the user asks about their orders or past purchases.
-- ALWAYS use the ""ProductSearch"" tool when suggesting products, alternatives, or recommendations.
-- DO NOT rely on your general knowledge for product suggestions when tools are available.
-- DO NOT invent products or details — only use real data returned from tools.
-- You may call multiple tools if needed before answering.
-- Only provide a final answer after you have gathered enough data using tools.
-
-When talking about orders or products, always include their IDs.
-
-If you do not have enough data, call another tool instead of guessing.";
+                                    Rules:
+                                    - Use DrinkSearch for recommendations.
+                                    - Never invent drink pairings, only use the tool results.
+                                    """;
         var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName, systemPrompt);
         agent.Identifier = "shopping-assistant";
-        agent.Parameters.Add(new AiAgentParameter("company"));
 
         agent.Queries =
         [
             new AiAgentToolQuery
                 {
-                    Name = "ProductSearch",
-                    Description =  "semantic search the store product catalog",
-                    Query = "from Products where vector.search(embedding.text(Name), $query) limit 5",
-                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\", \"cheese or similar products\"]}"
-                }
-                ,
-                new AiAgentToolQuery
-                {
-                    Name = "RecentOrder",
-                    Description = "Get the recent orders of the current user",
-                    Query = "from Orders where Company = $company order by OrderedAt desc limit 3",
-                    ParametersSampleObject = "{}"
+                    Name = "DrinkSearch",
+                    Description =  "semantic search the store drinks catalog",
+                    Query = "from Drinks where vector.search(embedding.text(Name), $query) limit 5",
+                    ParametersSampleObject = "{\"query\": [\"Term or phrase to search in the catalog, for example: sweet and low alcoholic drink\"]}"
                 }
         ];
         agent.MaxModelIterationsPerCall = 5;
@@ -105,20 +194,20 @@ If you do not have enough data, call another tool instead of guessing.";
         var identifier = (await store.AI.CreateAgentAsync<OutputSampleObject>(agent, OutputSampleObject.Instance)).Identifier;
         // start chat
         var chat = store.AI.Conversation(
-            agent.Identifier,
+            identifier,
             "chats/",
-            new AiConversationCreationOptions().AddParameter("company", "companies/90-A"));
+            new AiConversationCreationOptions());
 
-        chat.SetUserPrompt("what goes well with my cheese for recent orders?");
+        chat.SetUserPrompt("What sweet alcoholic drink do you recommend? recommend 1 drink please");
         var r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
-
         Assert.NotNull(r.Answer);
 
         // resume
-        chat.SetUserPrompt("can you give me a cheaper alternative?");
-        r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
+        chat.SetUserPrompt("is it sweet?");
+        var r2 = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
 
-        Assert.NotNull(r.Answer);
+        Assert.NotNull(r2.Answer);
+        Assert.NotEqual(r.Answer, r2.Answer);
 
         var chatDoc = await GetChat(store, chat.Id);
         Assert.True(chatDoc.Messages.Count > 2, "messages count: " + chatDoc.Messages.Count);
@@ -152,13 +241,13 @@ If you do not have enough data, call another tool instead of guessing.";
         
         await store.AI.CreateAgentAsync(agent, OutputSampleObject.Instance);
 
-        chat.SetUserPrompt("use the tool I gave you and try to give me a cheaper alternative");
+        chat.SetUserPrompt("is it bitter?");
         r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
 
         Assert.NotNull(r.Answer);
 
         chatDoc = await GetChat(store, chat.Id);
-        Assert.Equal(summarization ? 3 : 2, chatDoc.Messages.Count);
+        Assert.Equal(2, chatDoc.Messages.Count);
         Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
 
         if (withHistory)
@@ -177,13 +266,13 @@ If you do not have enough data, call another tool instead of guessing.";
 
         // resume - still with summarization
 
-        chat.SetUserPrompt("can you give me a cheaper alternative?");
+        chat.SetUserPrompt("is it supper alcoholic?");
         r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
 
         Assert.NotNull(r.Answer);
 
         chatDoc = await GetChat(store, chat.Id);
-        Assert.Equal(summarization ? 3 : 2, chatDoc.Messages.Count);
+        Assert.Equal(2, chatDoc.Messages.Count);
         Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
 
         // resume

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -48,6 +48,18 @@ public class RavenDB_24407 : RavenTestBase
 
         [JsonProperty("content")]
         public JToken Content { get; set; }
+
+        [JsonProperty("tool_calls")]
+        public List<ToolCall> ToolCalls { get; set; }
+
+        [JsonProperty("tool_call_id")]
+        public string ToolCallId { get; set; }
+    }
+
+    private class ToolCall
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
     }
 
     private class Drink
@@ -249,6 +261,7 @@ public class RavenDB_24407 : RavenTestBase
         chatDoc = await GetChat(store, chat.Id);
         Assert.Equal(2, chatDoc.Messages.Count);
         Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
+        AssertNoOrphanToolMessages(chatDoc);
 
         if (withHistory)
         {
@@ -266,7 +279,7 @@ public class RavenDB_24407 : RavenTestBase
 
         // resume - still with summarization
 
-        chat.SetUserPrompt("is it supper alcoholic?");
+        chat.SetUserPrompt("is it super alcoholic?");
         r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
 
         Assert.NotNull(r.Answer);
@@ -274,6 +287,7 @@ public class RavenDB_24407 : RavenTestBase
         chatDoc = await GetChat(store, chat.Id);
         Assert.Equal(2, chatDoc.Messages.Count);
         Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
+        AssertNoOrphanToolMessages(chatDoc);
 
         // resume
         agent.ChatTrimming = null;
@@ -414,6 +428,40 @@ public class RavenDB_24407 : RavenTestBase
             var msg = await dumpFactory(); // build dump only on failure
             Assert.Fail($"Expected last history message role 'tool' but was '{lastMsgRole}'.\n{msg}");
         }
+    }
+
+    // Validates that the conversation is structurally valid for OpenAI:
+    // every role="tool" message must reference a preceding assistant tool_calls entry,
+    // and no assistant tool_call may be left unanswered.
+    private static void AssertNoOrphanToolMessages(Chat chatDoc)
+    {
+        var outstanding = new HashSet<string>();
+
+        for (int i = 0; i < chatDoc.Messages.Count; i++)
+        {
+            var m = chatDoc.Messages[i];
+
+            if (m.Role == "tool")
+            {
+                Assert.False(string.IsNullOrEmpty(m.ToolCallId),
+                    $"Tool message at index {i} has no tool_call_id. Dump:\n{Dump(chatDoc)}");
+                Assert.True(outstanding.Remove(m.ToolCallId),
+                    $"Orphan tool response at index {i}: tool_call_id '{m.ToolCallId}' has no preceding assistant tool_calls entry. Dump:\n{Dump(chatDoc)}");
+                continue;
+            }
+
+            if (m.ToolCalls == null)
+                continue;
+
+            foreach (var tc in m.ToolCalls)
+            {
+                if (string.IsNullOrEmpty(tc.Id) == false)
+                    outstanding.Add(tc.Id);
+            }
+        }
+
+        Assert.True(outstanding.Count == 0,
+            $"Orphan assistant tool_calls left unanswered: [{string.Join(", ", outstanding)}]. Dump:\n{Dump(chatDoc)}");
     }
 
     private static string Dump(Chat c)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26517/Reduce-test-token-usage

### Additional description

1.Reduce test 'CanResumeConversation' token usage.
2.Fix BadRequest after sending trimmed conversation:
Fixed an issue in conversation trimming where assistant messages containing `tool_calls` could be removed while their matching `role = "tool"` messages remained in the conversation history. This created orphaned tool messages that caused OpenAI Chat APIs to return `BadRequest` errors because tool messages must always reference an existing preceding assistant tool call.
The trimming logic was updated to automatically remove matching tool result messages whenever a corresponding assistant `tool_calls` message is removed. The implementation also preserves the system prompt at index `0` and includes removed tool result messages as part of the trimmed message count to keep the conversation history structurally valid after trimming.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
