### PR TITLE
RavenDB : 26012 - Enable Debug for conversation

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -602,6 +602,8 @@ namespace Raven.Client
                 public const string AiAgentConversationCollection = "@conversations";
 
                 public const string AiAgentConversationHistoryCollection = "@conversations-history";
+
+                public const string AiAgentConversationDebugCollection = "@conversations-debug";
             }
 
             internal sealed class Ai

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -21,7 +21,7 @@ internal class AiConversation : IAiConversationOperations
     private readonly AiOperations _aiOperations;
     private readonly string _agentId;
     private readonly AiConversationCreationOptions _options;
-    private readonly bool? _enableFullDebug;
+    private readonly bool? _debug;
 
     private string _conversationId;
     private List<AiAgentActionRequest> _actionRequests;
@@ -53,10 +53,10 @@ internal class AiConversation : IAiConversationOperations
         _changeVector = changeVector;
     }
 
-    internal AiConversation(AiOperations aiOperations, string agentId, string conversationId, AiConversationCreationOptions options, string changeVector, bool? enableFullDebug)
+    internal AiConversation(AiOperations aiOperations, string agentId, string conversationId, AiConversationCreationOptions options, string changeVector, bool? debug)
         : this(aiOperations, agentId, conversationId, options, changeVector)
     {
-        _enableFullDebug = enableFullDebug;
+        _debug = debug;
     }
 
     public void AddAttachment(string name, Stream stream, string contentType)
@@ -306,7 +306,7 @@ internal class AiConversation : IAiConversationOperations
                 Status = AiConversationResult.Done
             };
         }
-        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _promptParts, [.. _actionResponses.Values], _artificialActions, _options, _changeVector, _attachmentsCommands, streamPropertyPath, streamedChunksCallback, _enableFullDebug);
+        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _promptParts, [.. _actionResponses.Values], _artificialActions, _options, _changeVector, _attachmentsCommands, streamPropertyPath, streamedChunksCallback, _debug);
 
         try
         {

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -21,6 +21,7 @@ internal class AiConversation : IAiConversationOperations
     private readonly AiOperations _aiOperations;
     private readonly string _agentId;
     private readonly AiConversationCreationOptions _options;
+    private readonly bool? _enableFullDebug;
 
     private string _conversationId;
     private List<AiAgentActionRequest> _actionRequests;
@@ -39,7 +40,7 @@ internal class AiConversation : IAiConversationOperations
     private readonly Dictionary<string, HandleActionDelegate> _invocations = new();
     private readonly HashSet<string> _dispatchedToolIds = new();
 
-    public AiConversation(AiOperations aiOperations, string agentId, string conversationId, AiConversationCreationOptions options, string changeVector)
+    public AiConversation(AiOperations aiOperations, string agentId, string conversationId, AiConversationCreationOptions options, string changeVector, bool? enableFullDebug = null)
     {
         ValidationMethods.AssertNotNullOrEmpty(aiOperations, nameof(aiOperations));
         ValidationMethods.AssertNotNullOrEmpty(agentId, nameof(agentId));
@@ -50,6 +51,7 @@ internal class AiConversation : IAiConversationOperations
         _conversationId = conversationId;
         _options = options;
         _changeVector = changeVector;
+        _enableFullDebug = enableFullDebug;
     }
     
     public void AddAttachment(string name, Stream stream, string contentType)
@@ -299,7 +301,7 @@ internal class AiConversation : IAiConversationOperations
                 Status = AiConversationResult.Done
             };
         }
-        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _promptParts, [.. _actionResponses.Values], _artificialActions, _options, _changeVector, _attachmentsCommands, streamPropertyPath, streamedChunksCallback);
+        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _promptParts, [.. _actionResponses.Values], _artificialActions, _options, _changeVector, _attachmentsCommands, streamPropertyPath, streamedChunksCallback, _enableFullDebug);
 
         try
         {

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -40,7 +40,7 @@ internal class AiConversation : IAiConversationOperations
     private readonly Dictionary<string, HandleActionDelegate> _invocations = new();
     private readonly HashSet<string> _dispatchedToolIds = new();
 
-    public AiConversation(AiOperations aiOperations, string agentId, string conversationId, AiConversationCreationOptions options, string changeVector, bool? enableFullDebug = null)
+    public AiConversation(AiOperations aiOperations, string agentId, string conversationId, AiConversationCreationOptions options, string changeVector)
     {
         ValidationMethods.AssertNotNullOrEmpty(aiOperations, nameof(aiOperations));
         ValidationMethods.AssertNotNullOrEmpty(agentId, nameof(agentId));
@@ -51,9 +51,14 @@ internal class AiConversation : IAiConversationOperations
         _conversationId = conversationId;
         _options = options;
         _changeVector = changeVector;
+    }
+
+    internal AiConversation(AiOperations aiOperations, string agentId, string conversationId, AiConversationCreationOptions options, string changeVector, bool? enableFullDebug)
+        : this(aiOperations, agentId, conversationId, options, changeVector)
+    {
         _enableFullDebug = enableFullDebug;
     }
-    
+
     public void AddAttachment(string name, Stream stream, string contentType)
     {
         if (stream == null)

--- a/src/Raven.Client/Documents/AI/AiOperations.cs
+++ b/src/Raven.Client/Documents/AI/AiOperations.cs
@@ -148,6 +148,6 @@ public class AiOperations
     public IAiConversationOperations Conversation(string agentId, string conversationId, AiConversationCreationOptions creationOptions, string changeVector = null) => 
         new AiConversation(this, agentId, conversationId, creationOptions, changeVector);
 
-    internal IAiConversationOperations Conversation(string agentId, string conversationId, AiConversationCreationOptions creationOptions, bool? enableFullDebug, string changeVector = null) =>
-        new AiConversation(this, agentId, conversationId, creationOptions, changeVector, enableFullDebug);
+    internal IAiConversationOperations Conversation(string agentId, string conversationId, AiConversationCreationOptions creationOptions, bool? debug, string changeVector = null) =>
+        new AiConversation(this, agentId, conversationId, creationOptions, changeVector, debug);
 }

--- a/src/Raven.Client/Documents/AI/AiOperations.cs
+++ b/src/Raven.Client/Documents/AI/AiOperations.cs
@@ -145,6 +145,14 @@ public class AiOperations
     /// <param name="conversationId">The unique identifier for the conversation.</param>
     /// <param name="creationOptions">Options for creating the conversation.</param>
     /// <param name="changeVector">An optional change vector for concurrency control.</param>
-    public IAiConversationOperations Conversation(string agentId, string conversationId, AiConversationCreationOptions creationOptions, string changeVector = null) => 
-        new AiConversation(this, agentId, conversationId, creationOptions, changeVector);
+    /// <param name="enableFullDebug">
+    /// Persistently overrides the per-conversation debug-tracing flag. true forces tracing on,
+    /// false forces it off, null (default) uses the value stored on the conversation document.
+    /// The value is written back to the conversation document and takes effect on all subsequent turns
+    /// until overridden again. When enabled, the full provider request/response for every model call
+    /// is persisted in the @conversations-debug collection.
+    /// Note: trace documents contain sensitive content such as prompts, tool arguments, and attachment payloads.
+    /// </param>
+    public IAiConversationOperations Conversation(string agentId, string conversationId, AiConversationCreationOptions creationOptions, string changeVector = null, bool? enableFullDebug = null) =>
+        new AiConversation(this, agentId, conversationId, creationOptions, changeVector, enableFullDebug);
 }

--- a/src/Raven.Client/Documents/AI/AiOperations.cs
+++ b/src/Raven.Client/Documents/AI/AiOperations.cs
@@ -145,14 +145,9 @@ public class AiOperations
     /// <param name="conversationId">The unique identifier for the conversation.</param>
     /// <param name="creationOptions">Options for creating the conversation.</param>
     /// <param name="changeVector">An optional change vector for concurrency control.</param>
-    /// <param name="enableFullDebug">
-    /// Persistently overrides the per-conversation debug-tracing flag. true forces tracing on,
-    /// false forces it off, null (default) uses the value stored on the conversation document.
-    /// The value is written back to the conversation document and takes effect on all subsequent turns
-    /// until overridden again. When enabled, the full provider request/response for every model call
-    /// is persisted in the @conversations-debug collection.
-    /// Note: trace documents contain sensitive content such as prompts, tool arguments, and attachment payloads.
-    /// </param>
-    public IAiConversationOperations Conversation(string agentId, string conversationId, AiConversationCreationOptions creationOptions, string changeVector = null, bool? enableFullDebug = null) =>
+    public IAiConversationOperations Conversation(string agentId, string conversationId, AiConversationCreationOptions creationOptions, string changeVector = null) => 
+        new AiConversation(this, agentId, conversationId, creationOptions, changeVector);
+
+    internal IAiConversationOperations Conversation(string agentId, string conversationId, AiConversationCreationOptions creationOptions, bool? enableFullDebug, string changeVector = null) =>
         new AiConversation(this, agentId, conversationId, creationOptions, changeVector, enableFullDebug);
 }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -146,11 +146,25 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         string changeVector,
         List<ICommandData> attachmentsCommands,
         string streamPropertyPath,
-        Func<string, Task> streamedChunksCallback,
-        bool? enableFullDebug = null)
+        Func<string, Task> streamedChunksCallback)
         : this(agentId, conversationId, promptParts, actionResponses, artificialActions, options, changeVector, streamPropertyPath, streamedChunksCallback)
     {
         _attachmentsCommands = attachmentsCommands;
+    }
+
+    internal RunConversationOperation(string agentId,
+        string conversationId,
+        IEnumerable<ContentPart> promptParts,
+        List<AiAgentActionResponse> actionResponses,
+        List<AiAgentArtificialActionResponse> artificialActions,
+        AiConversationCreationOptions options,
+        string changeVector,
+        List<ICommandData> attachmentsCommands,
+        string streamPropertyPath,
+        Func<string, Task> streamedChunksCallback,
+        bool? enableFullDebug)
+        : this(agentId, conversationId, promptParts, actionResponses, artificialActions, options, changeVector, attachmentsCommands, streamPropertyPath, streamedChunksCallback)
+    {
         _enableFullDebug = enableFullDebug;
     }
 

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -251,7 +251,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
                 url += $"&streaming=true&streamPropertyPath={Uri.EscapeDataString(_parent._streamPropertyPath)}";
 
             if (_parent._enableFullDebug.HasValue)
-                url += $"&enableFullDebug={(_parent._enableFullDebug.Value ? "true" : "false")}";
+                url += $"&enableFullDebug={_parent._enableFullDebug.Value}";
 
             var body = new ConversionRequestBody
             {

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -33,6 +33,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     private readonly string _streamPropertyPath;
     private readonly Func<string, Task> _streamedChunksCallback;
     private readonly List<ICommandData> _attachmentsCommands;
+    private readonly bool? _enableFullDebug;
 
     /// <summary>
     /// Initializes a new conversation step for the specified agent and conversation.
@@ -145,10 +146,12 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         string changeVector,
         List<ICommandData> attachmentsCommands,
         string streamPropertyPath,
-        Func<string, Task> streamedChunksCallback)
+        Func<string, Task> streamedChunksCallback,
+        bool? enableFullDebug = null)
         : this(agentId, conversationId, promptParts, actionResponses, artificialActions, options, changeVector, streamPropertyPath, streamedChunksCallback)
     {
         _attachmentsCommands = attachmentsCommands;
+        _enableFullDebug = enableFullDebug;
     }
 
     [Obsolete("Use the constructor that accepts a List or an Array instead. This is for backward compatibility.", error: false)]
@@ -232,6 +235,9 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
 
             if (_parent._streamPropertyPath is not null)
                 url += $"&streaming=true&streamPropertyPath={Uri.EscapeDataString(_parent._streamPropertyPath)}";
+
+            if (_parent._enableFullDebug.HasValue)
+                url += $"&enableFullDebug={(_parent._enableFullDebug.Value ? "true" : "false")}";
 
             var body = new ConversionRequestBody
             {

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -33,7 +33,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     private readonly string _streamPropertyPath;
     private readonly Func<string, Task> _streamedChunksCallback;
     private readonly List<ICommandData> _attachmentsCommands;
-    private readonly bool? _enableFullDebug;
+    private readonly bool? _debug;
 
     /// <summary>
     /// Initializes a new conversation step for the specified agent and conversation.
@@ -162,10 +162,10 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         List<ICommandData> attachmentsCommands,
         string streamPropertyPath,
         Func<string, Task> streamedChunksCallback,
-        bool? enableFullDebug)
+        bool? debug)
         : this(agentId, conversationId, promptParts, actionResponses, artificialActions, options, changeVector, attachmentsCommands, streamPropertyPath, streamedChunksCallback)
     {
-        _enableFullDebug = enableFullDebug;
+        _debug = debug;
     }
 
     [Obsolete("Use the constructor that accepts a List or an Array instead. This is for backward compatibility.", error: false)]
@@ -250,8 +250,8 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             if (_parent._streamPropertyPath is not null)
                 url += $"&streaming=true&streamPropertyPath={Uri.EscapeDataString(_parent._streamPropertyPath)}";
 
-            if (_parent._enableFullDebug.HasValue)
-                url += $"&enableFullDebug={_parent._enableFullDebug.Value}";
+            if (_parent._debug.HasValue)
+                url += $"&debug={_parent._debug.Value}";
 
             var body = new ConversionRequestBody
             {

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -213,11 +213,7 @@ public class ChatCompletionClient : IDisposable
                 break;
             }
 
-            if (trace != null)
-            {
-                trace.StreamEvents ??= [];
-                trace.StreamEvents.Add(sseEvent.Data.Clone(streamingContext));
-            }
+            trace?.CaptureSseEvent(streamingContext, sseEvent.Data);
 
             if (sseEvent.Data.TryGet(Constants.ResponseFields.Usage, out BlittableJsonReaderObject streamedUsage) && streamedUsage is not null)
             {
@@ -331,8 +327,7 @@ public class ChatCompletionClient : IDisposable
         using var response = await SendRequestAsync(request, token);
         var responseContent = await GetResponseContentAsync(context, response, token);
 
-        if (trace != null)
-            trace.Response = responseContent.CloneOnTheSameContext();
+        trace?.CaptureResponse(responseContent);
 
         var responseParser = new AiResponseParser(this, response, responseContent);
         responseParser.EnsureSuccessfulResponse();
@@ -441,33 +436,33 @@ public class ChatCompletionClient : IDisposable
         if (_settings.Model is null)
             throw new ArgumentNullException(nameof(_settings.Model));
 
-        // When tracing is on, TeeStream tees the write to a capture buffer; caller owns both streams.
         HttpContent content = new BlittableJsonContent(async stream =>
         {
-            var capture = trace != null ? RecyclableMemoryStreamFactory.GetRecyclableStream() : null;
+            if (trace == null)
+            {
+                await WritePayloadAsync(stream).ConfigureAwait(false);
+                return;
+            }
+
+            var capture = RecyclableMemoryStreamFactory.GetRecyclableStream();
+            await using var target = new TeeStream(stream, capture);
             try
             {
-                Stream target = capture != null ? new TeeStream(stream, capture) : stream;
-
-                await using (var writer = new AsyncBlittableJsonTextWriter(ctx, target))
-                {
-                    if (_forTestingPurposes?.ModifyPayload != null)
-                        _forTestingPurposes.ModifyPayload.Invoke(writer);
-                    else
-                        WriteCompletionRequestPayload(writer, ctx, messages.Where(IsValidMessage),
-                            attachments, tools, useTools, streaming, schema, promptCacheKey);
-                }
-
-                if (capture != null)
-                {
-                    capture.Position = 0;
-                    trace.Request = ctx.Sync.ReadForMemory(capture, "ai-agent/request");
-                }
+                await WritePayloadAsync(target).ConfigureAwait(false);
             }
             finally
             {
-                if (capture != null)
-                    await capture.DisposeAsync().ConfigureAwait(false);
+                trace.CaptureRequestBody(capture);
+            }
+
+            async Task WritePayloadAsync(Stream s)
+            {
+                await using var writer = new AsyncBlittableJsonTextWriter(ctx, s);
+                if (_forTestingPurposes?.ModifyPayload != null)
+                    _forTestingPurposes.ModifyPayload.Invoke(writer);
+                else
+                    WriteCompletionRequestPayload(writer, ctx, messages.Where(IsValidMessage),
+                        attachments, tools, useTools, streaming, schema, promptCacheKey);
             }
         }, ConventionsToUse);
 

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -161,7 +161,7 @@ public class ChatCompletionClient : IDisposable
     public async Task<AiResponse> StreamingCompleteAsync(JsonOperationContext streamingContext, IMemoryContextPool contextPool,
         string streamPropertyPath, HttpRequestMessage request,
         Func<Memory<byte>, Task> streamedPropertyCallback,
-        AiUsage usage, CancellationToken token)
+        AiUsage usage, AiDebugTrace trace, CancellationToken token)
     {
         AddDefaultHeaders(request);
         using var streamedPropertyBuffer = new JsonOperationContextBuffer<byte>(streamingContext);
@@ -211,6 +211,12 @@ public class ChatCompletionClient : IDisposable
             {
                 toolCallState.AddAndReset();
                 break;
+            }
+
+            if (trace != null)
+            {
+                trace.StreamEvents ??= [];
+                trace.StreamEvents.Add(sseEvent.Data.Clone(streamingContext));
             }
 
             if (sseEvent.Data.TryGet(Constants.ResponseFields.Usage, out BlittableJsonReaderObject streamedUsage) && streamedUsage is not null)
@@ -315,15 +321,18 @@ public class ChatCompletionClient : IDisposable
         }, "system/msg");
 
         var request = CreateCompletionRequest(context, [prompt, user], attachments: null, tools: null, useTools: false, streaming: false, schema);
-        var r = await CompleteAsync(context, request, new AiUsage(), token);
+        var r = await CompleteAsync(context, request, new AiUsage(), trace: null, token);
         return (r.Result.ToString(), r.Message.ToString());
     }
 
-    public async Task<AiResponse> CompleteAsync(JsonOperationContext context, HttpRequestMessage request, AiUsage usage, CancellationToken token)
+    public async Task<AiResponse> CompleteAsync(JsonOperationContext context, HttpRequestMessage request, AiUsage usage, AiDebugTrace trace, CancellationToken token)
     {
         AddDefaultHeaders(request);
         using var response = await SendRequestAsync(request, token);
         var responseContent = await GetResponseContentAsync(context, response, token);
+
+        if (trace != null)
+            trace.Response = responseContent.CloneOnTheSameContext();
 
         var responseParser = new AiResponseParser(this, response, responseContent);
         responseParser.EnsureSuccessfulResponse();
@@ -426,25 +435,39 @@ public class ChatCompletionClient : IDisposable
         bool useTools,
         bool streaming,
         string schema,
-        string promptCacheKey = null)
-     {
-
+        string promptCacheKey = null,
+        AiDebugTrace trace = null)
+    {
         if (_settings.Model is null)
             throw new ArgumentNullException(nameof(_settings.Model));
 
-        var content = new BlittableJsonContent(async stream =>
+        // When tracing is on, TeeStream tees the write to a capture buffer; caller owns both streams.
+        HttpContent content = new BlittableJsonContent(async stream =>
         {
-            await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
+            var capture = trace != null ? RecyclableMemoryStreamFactory.GetRecyclableStream() : null;
+            try
             {
-                if (_forTestingPurposes?.ModifyPayload != null)
+                Stream target = capture != null ? new TeeStream(stream, capture) : stream;
+
+                await using (var writer = new AsyncBlittableJsonTextWriter(ctx, target))
                 {
-                    _forTestingPurposes?.ModifyPayload.Invoke(writer);
-                    return;
+                    if (_forTestingPurposes?.ModifyPayload != null)
+                        _forTestingPurposes.ModifyPayload.Invoke(writer);
+                    else
+                        WriteCompletionRequestPayload(writer, ctx, messages.Where(IsValidMessage),
+                            attachments, tools, useTools, streaming, schema, promptCacheKey);
                 }
 
-                WriteCompletionRequestPayload(writer, ctx,
-                    messages.Where(IsValidMessage) // IEnumerable of valid messages
-                    , attachments, tools, useTools, streaming, schema, promptCacheKey);
+                if (capture != null)
+                {
+                    capture.Position = 0;
+                    trace.Request = ctx.Sync.ReadForMemory(capture, "ai-agent/request");
+                }
+            }
+            finally
+            {
+                if (capture != null)
+                    await capture.DisposeAsync().ConfigureAwait(false);
             }
         }, ConventionsToUse);
 

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -436,6 +436,8 @@ public class ChatCompletionClient : IDisposable
         if (_settings.Model is null)
             throw new ArgumentNullException(nameof(_settings.Model));
 
+        trace?.CaptureAttachments(attachments);
+
         HttpContent content = new BlittableJsonContent(async stream =>
         {
             if (trace == null)
@@ -444,15 +446,14 @@ public class ChatCompletionClient : IDisposable
                 return;
             }
 
-            var capture = RecyclableMemoryStreamFactory.GetRecyclableStream();
-            await using var target = new TeeStream(stream, capture);
+            await using var target = new TeeStream(stream);
             try
             {
                 await WritePayloadAsync(target).ConfigureAwait(false);
             }
             finally
             {
-                trace.CaptureRequestBody(capture);
+                trace.CaptureRequestBody(target.Result());
             }
 
             async Task WritePayloadAsync(Stream s)

--- a/src/Raven.Server/Documents/AI/TeeStream.cs
+++ b/src/Raven.Server/Documents/AI/TeeStream.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Raven.Server.Documents.AI;
+
+/// <summary>
+/// A write-only <see cref="Stream"/> wrapper that forwards every write to two underlying streams
+/// simultaneously — named after the Unix <c>tee</c> command.
+/// The caller owns both inner streams; <see cref="Dispose"/> is intentionally a no-op.
+/// </summary>
+internal sealed class TeeStream : Stream
+{
+    private readonly Stream _primary;
+    private readonly Stream _secondary;
+
+    public TeeStream(Stream primary, Stream secondary)
+    {
+        _primary = primary ?? throw new ArgumentNullException(nameof(primary));
+        _secondary = secondary ?? throw new ArgumentNullException(nameof(secondary));
+    }
+
+    public override bool CanWrite => true;
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        _primary.Write(buffer, offset, count);
+        _secondary.Write(buffer, offset, count);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        _primary.Write(buffer);
+        _secondary.Write(buffer);
+    }
+
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        await _primary.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        await _secondary.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        await _primary.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+        await _secondary.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override void Flush()
+    {
+        _primary.Flush();
+        _secondary.Flush();
+    }
+
+    public override async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        await _primary.FlushAsync(cancellationToken).ConfigureAwait(false);
+        await _secondary.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing) { }
+}

--- a/src/Raven.Server/Documents/AI/TeeStream.cs
+++ b/src/Raven.Server/Documents/AI/TeeStream.cs
@@ -5,20 +5,16 @@ using System.Threading.Tasks;
 
 namespace Raven.Server.Documents.AI;
 
-/// <summary>
-/// A write-only <see cref="Stream"/> wrapper that forwards every write to two underlying streams
-/// simultaneously — named after the Unix <c>tee</c> command.
-/// The caller owns both inner streams; <see cref="Dispose"/> is intentionally a no-op.
-/// </summary>
 internal sealed class TeeStream : Stream
 {
     private readonly Stream _primary;
-    private readonly Stream _secondary;
+    private readonly Stream _ownedSecondary;
+    private bool _disposed;
 
-    public TeeStream(Stream primary, Stream secondary)
+    public TeeStream(Stream primary, Stream ownedSecondary)
     {
         _primary = primary ?? throw new ArgumentNullException(nameof(primary));
-        _secondary = secondary ?? throw new ArgumentNullException(nameof(secondary));
+        _ownedSecondary = ownedSecondary ?? throw new ArgumentNullException(nameof(ownedSecondary));
     }
 
     public override bool CanWrite => true;
@@ -34,42 +30,77 @@ internal sealed class TeeStream : Stream
     public override void Write(byte[] buffer, int offset, int count)
     {
         _primary.Write(buffer, offset, count);
-        _secondary.Write(buffer, offset, count);
+        _ownedSecondary.Write(buffer, offset, count);
     }
 
     public override void Write(ReadOnlySpan<byte> buffer)
     {
         _primary.Write(buffer);
-        _secondary.Write(buffer);
+        _ownedSecondary.Write(buffer);
     }
 
     public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
-        await _primary.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
-        await _secondary.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        await _primary.WriteAsync(buffer, offset, count, cancellationToken);
+        await _ownedSecondary.WriteAsync(buffer, offset, count, cancellationToken);
     }
 
     public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
     {
-        await _primary.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
-        await _secondary.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+        await _primary.WriteAsync(buffer, cancellationToken);
+        await _ownedSecondary.WriteAsync(buffer, cancellationToken);
     }
 
     public override void Flush()
     {
         _primary.Flush();
-        _secondary.Flush();
+        _ownedSecondary.Flush();
     }
 
     public override async Task FlushAsync(CancellationToken cancellationToken)
     {
-        await _primary.FlushAsync(cancellationToken).ConfigureAwait(false);
-        await _secondary.FlushAsync(cancellationToken).ConfigureAwait(false);
+        await _primary.FlushAsync(cancellationToken);
+        await _ownedSecondary.FlushAsync(cancellationToken);
     }
 
     public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
     public override void SetLength(long value) => throw new NotSupportedException();
 
-    protected override void Dispose(bool disposing) { }
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+
+        try
+        {
+            if (disposing)
+            {
+                // Primary stream is NOT owned — do not dispose.
+                _ownedSecondary.Dispose();
+            }
+        }
+        finally
+        {
+            _disposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        try
+        {
+            // Primary stream is NOT owned — do not dispose.
+            await _ownedSecondary.DisposeAsync();
+        }
+        finally
+        {
+            _disposed = true;
+            await base.DisposeAsync();
+        }
+    }
 }

--- a/src/Raven.Server/Documents/AI/TeeStream.cs
+++ b/src/Raven.Server/Documents/AI/TeeStream.cs
@@ -1,20 +1,32 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IO;
+using Sparrow;
 
 namespace Raven.Server.Documents.AI;
 
 internal sealed class TeeStream : Stream
 {
     private readonly Stream _primary;
-    private readonly Stream _ownedSecondary;
+    private readonly RecyclableMemoryStream _ownedSecondary;
     private bool _disposed;
-
-    public TeeStream(Stream primary, Stream ownedSecondary)
+    public TeeStream(Stream primary)
     {
         _primary = primary ?? throw new ArgumentNullException(nameof(primary));
-        _ownedSecondary = ownedSecondary ?? throw new ArgumentNullException(nameof(ownedSecondary));
+        _ownedSecondary = RecyclableMemoryStreamFactory.GetRecyclableStream();
+    }
+
+    /// <summary>
+    /// Returns the bytes written through the tee so far, decoded as UTF-8.
+    /// May be partial / non-JSON if serialization failed mid-write.
+    /// </summary>
+    public string Result()
+    {
+        _ownedSecondary.TryGetBuffer(out var seg);
+        return Encoding.UTF8.GetString(seg);
     }
 
     public override bool CanWrite => true;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -32,6 +32,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             var agentId = RequestHandler.GetStringQueryString("agentId");
             var streaming = RequestHandler.GetBoolValueQueryString("streaming", required: false) ?? false;
             var changeVector = RequestHandler.GetChangeVectorStringQueryString("changeVector", required: false);
+            var enableFullDebugOverride = RequestHandler.GetBoolValueQueryString("enableFullDebug", required: false);
 
             AiAgentConfiguration configuration = GetAiAgentConfiguration(agentId);
 
@@ -45,13 +46,13 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 Authentication = RequestHandler.HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection
             };
 
-            await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, token);
+            await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, token, enableFullDebugOverride);
         }
 
         protected async Task ExecuteInternalAsync(ConversationHandler handler, DocumentsOperationContext context, AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector,
-            bool streaming, OperationCancelToken token)
+            bool streaming, OperationCancelToken token, bool? enableFullDebugOverride = null)
         {
-            handler.Initialize(configuration, conversationId, body, changeVector, RequestHandler.GetRaftRequestIdFromQuery());
+            handler.Initialize(configuration, conversationId, body, changeVector, RequestHandler.GetRaftRequestIdFromQuery(), enableFullDebugOverride);
             AiInternalConversationResult r;
 
             if (streaming)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             var agentId = RequestHandler.GetStringQueryString("agentId");
             var streaming = RequestHandler.GetBoolValueQueryString("streaming", required: false) ?? false;
             var changeVector = RequestHandler.GetChangeVectorStringQueryString("changeVector", required: false);
-            var enableFullDebugOverride = RequestHandler.GetBoolValueQueryString("enableFullDebug", required: false);
+            var debugOverride = RequestHandler.GetBoolValueQueryString("debug", required: false);
 
             AiAgentConfiguration configuration = GetAiAgentConfiguration(agentId);
 
@@ -46,13 +46,13 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 Authentication = RequestHandler.HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection
             };
 
-            await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, enableFullDebugOverride, token);
+            await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, debugOverride, token);
         }
 
         protected async Task ExecuteInternalAsync(ConversationHandler handler, DocumentsOperationContext context, AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector,
-            bool streaming, bool? enableFullDebugOverride, OperationCancelToken token)
+            bool streaming, bool? debugOverride, OperationCancelToken token)
         {
-            handler.Initialize(configuration, conversationId, body, changeVector, RequestHandler.GetRaftRequestIdFromQuery(), enableFullDebugOverride);
+            handler.Initialize(configuration, conversationId, body, changeVector, RequestHandler.GetRaftRequestIdFromQuery(), debugOverride);
             AiInternalConversationResult r;
 
             if (streaming)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -46,11 +46,11 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 Authentication = RequestHandler.HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection
             };
 
-            await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, token, enableFullDebugOverride);
+            await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, enableFullDebugOverride, token);
         }
 
         protected async Task ExecuteInternalAsync(ConversationHandler handler, DocumentsOperationContext context, AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector,
-            bool streaming, OperationCancelToken token, bool? enableFullDebugOverride = null)
+            bool streaming, bool? enableFullDebugOverride, OperationCancelToken token)
         {
             handler.Initialize(configuration, conversationId, body, changeVector, RequestHandler.GetRaftRequestIdFromQuery(), enableFullDebugOverride);
             AiInternalConversationResult r;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -48,7 +48,7 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         if (ServerStore.LicenseManager.LicenseStatus.HasAiAgent == false)
             throw new LicenseLimitException(LimitType.AiAgent, "Your license doesn't support using the AI Agent feature.");
 
-        await ExecuteInternalAsync(handler, context, request.Configuration, conversationId, body, changeVector: null, streaming: streaming, enableFullDebugOverride: null, token: token);
+        await ExecuteInternalAsync(handler, context, request.Configuration, conversationId, body, changeVector: null, streaming: streaming, debugOverride: null, token: token);
     }
 
     public class TestConversationHandler(ServerStore server, DocumentDatabase database, AiAgentTestRequest request) : ConversationHandler(server, database)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -48,7 +48,7 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         if (ServerStore.LicenseManager.LicenseStatus.HasAiAgent == false)
             throw new LicenseLimitException(LimitType.AiAgent, "Your license doesn't support using the AI Agent feature.");
 
-        await ExecuteInternalAsync(handler, context, request.Configuration, conversationId, body, changeVector: null, streaming: streaming, token: token);
+        await ExecuteInternalAsync(handler, context, request.Configuration, conversationId, body, changeVector: null, streaming: streaming, enableFullDebugOverride: null, token: token);
     }
 
     public class TestConversationHandler(ServerStore server, DocumentDatabase database, AiAgentTestRequest request) : ConversationHandler(server, database)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiDebugTrace.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiDebugTrace.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using Raven.Client;
+using Raven.Server.Documents.ETL.Providers.AI;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -14,17 +13,29 @@ public sealed class AiDebugTrace
 
     public string RequestBody;
 
+    // Names of the attachments sent on this LLM call. Captured separately because
+    // the names are not reliably present in the outgoing request JSON on the first
+    // call (the "[Attachments: ...]" marker message is only added after the first turn).
+    public List<string> AttachmentNames;
+
     public BlittableJsonReaderObject Response;
     public List<BlittableJsonReaderObject> StreamEvents;
 
-    public void CaptureRequestBody(Stream captureStream)
+    public void CaptureRequestBody(string request)
     {
-        if (captureStream == null)
+        RequestBody = request;
+    }
+
+    public void CaptureAttachments(IEnumerable<AiAttachment> attachments)
+    {
+        if (attachments == null)
             return;
 
-        captureStream.Position = 0;
-        using var reader = new StreamReader(captureStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, leaveOpen: true);
-        RequestBody = reader.ReadToEnd();
+        foreach (var a in attachments)
+        {
+            AttachmentNames ??= [];
+            AttachmentNames.Add(a.Name);
+        }
     }
 
     public void CaptureResponse(BlittableJsonReaderObject responseContent)
@@ -57,6 +68,7 @@ public sealed class AiDebugTrace
                 [nameof(ConversationDocument.Agent)] = document.Agent
             },
             ["MessagesCount"] = document.Messages?.Count ?? 0,
+            [nameof(AttachmentNames)] = AttachmentNames == null ? null : new DynamicJsonArray(AttachmentNames),
             [nameof(RequestBody)] = RequestBody,
             [nameof(Response)] = Response,
             [nameof(StreamEvents)] = StreamEvents == null ? null : new DynamicJsonArray(StreamEvents)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiDebugTrace.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiDebugTrace.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using Raven.Client;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents;
+
+public sealed class AiDebugTrace
+{
+    internal const string TraceSegment = "request-trace";
+
+    // Fallback TTL applied when the parent conversation has no expiration, so trace
+    // documents never accumulate indefinitely on servers without conversation expiry.
+    internal static readonly TimeSpan DefaultMaxExpiration = TimeSpan.FromDays(7);
+
+    public BlittableJsonReaderObject Request;
+    public BlittableJsonReaderObject Response;
+    public List<BlittableJsonReaderObject> StreamEvents;
+
+    public BlittableJsonReaderObject ToBlittable(JsonOperationContext context, ConversationDocument document, TimeSpan? expiration)
+    {
+        var effectiveExpiration = expiration ?? DefaultMaxExpiration;
+
+        var metadata = new DynamicJsonValue
+        {
+            [Constants.Documents.Metadata.Collection] = Constants.Documents.Collections.AiAgentConversationDebugCollection,
+            [Constants.Documents.Metadata.Expires] = DateTime.UtcNow.Add(effectiveExpiration)
+        };
+
+        var json = new DynamicJsonValue
+        {
+            [Constants.Documents.Metadata.Key] = metadata,
+            [nameof(ConversationDocument)] = new DynamicJsonValue
+            {
+                [nameof(ConversationDocument.Id)] = document.Id,
+                [nameof(ConversationDocument.Agent)] = document.Agent
+            },
+            ["MessagesCount"] = document.Messages?.Count ?? 0,
+            [nameof(Request)] = Request,
+            [nameof(Response)] = Response,
+            [nameof(StreamEvents)] = StreamEvents == null ? null : new DynamicJsonArray(StreamEvents)
+        };
+
+        return context.ReadObject(json, "ai-agent/debug-trace");
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiDebugTrace.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiDebugTrace.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using Raven.Client;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -10,23 +12,41 @@ public sealed class AiDebugTrace
 {
     internal const string TraceSegment = "request-trace";
 
-    // Fallback TTL applied when the parent conversation has no expiration, so trace
-    // documents never accumulate indefinitely on servers without conversation expiry.
-    internal static readonly TimeSpan DefaultMaxExpiration = TimeSpan.FromDays(7);
+    public string RequestBody;
 
-    public BlittableJsonReaderObject Request;
     public BlittableJsonReaderObject Response;
     public List<BlittableJsonReaderObject> StreamEvents;
 
+    public void CaptureRequestBody(Stream captureStream)
+    {
+        if (captureStream == null)
+            return;
+
+        captureStream.Position = 0;
+        using var reader = new StreamReader(captureStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, leaveOpen: true);
+        RequestBody = reader.ReadToEnd();
+    }
+
+    public void CaptureResponse(BlittableJsonReaderObject responseContent)
+    {
+        Response = responseContent.CloneOnTheSameContext();
+    }
+
+    public void CaptureSseEvent(JsonOperationContext context, BlittableJsonReaderObject sseEventData)
+    {
+        StreamEvents ??= [];
+        StreamEvents.Add(sseEventData.Clone(context));
+    }
+
     public BlittableJsonReaderObject ToBlittable(JsonOperationContext context, ConversationDocument document, TimeSpan? expiration)
     {
-        var effectiveExpiration = expiration ?? DefaultMaxExpiration;
-
         var metadata = new DynamicJsonValue
         {
-            [Constants.Documents.Metadata.Collection] = Constants.Documents.Collections.AiAgentConversationDebugCollection,
-            [Constants.Documents.Metadata.Expires] = DateTime.UtcNow.Add(effectiveExpiration)
+            [Constants.Documents.Metadata.Collection] = Constants.Documents.Collections.AiAgentConversationDebugCollection
         };
+
+        if (expiration.HasValue)
+            metadata[Constants.Documents.Metadata.Expires] = DateTime.UtcNow.Add(expiration.Value);
 
         var json = new DynamicJsonValue
         {
@@ -37,7 +57,7 @@ public sealed class AiDebugTrace
                 [nameof(ConversationDocument.Agent)] = document.Agent
             },
             ["MessagesCount"] = document.Messages?.Count ?? 0,
-            [nameof(Request)] = Request,
+            [nameof(RequestBody)] = RequestBody,
             [nameof(Response)] = Response,
             [nameof(StreamEvents)] = StreamEvents == null ? null : new DynamicJsonArray(StreamEvents)
         };

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiDebugTraceCollector.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiDebugTraceCollector.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents;
+
+internal sealed class AiDebugTraceCollector
+{
+    private readonly List<AiDebugTrace> _traces;
+
+    public bool Enabled => _traces != null;
+
+    public AiDebugTraceCollector(bool enabled)
+    {
+        if (enabled)
+            _traces = new List<AiDebugTrace>();
+    }
+
+    public AiDebugTrace CreateTrace()
+    {
+        if (_traces == null)
+            return null;
+
+        var t = new AiDebugTrace();
+        _traces.Add(t);
+        return t;
+    }
+
+    public async Task PersistAsync(ConversationDocument document, DocumentDatabase database)
+    {
+        if (_traces == null || _traces.Count == 0)
+            return;
+
+        try
+        {
+            await database.TxMerger.Enqueue(new PutConversationDebugCommand(_traces, document, database));
+        }
+        catch (Exception e)
+        {
+            // Swallow only the secondary debug-trace persistence failure so the original
+            // provider/model exception (if any) is preserved and propagated to the caller.
+            var logger = database.Loggers.GetLogger<AiDebugTraceCollector>();
+            if (logger.IsDebugEnabled)
+                logger.Debug($"Failed to persist {_traces.Count} debug trace(s) for conversation '{document.Id}'.", e);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiDebugTraceCollector.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiDebugTraceCollector.cs
@@ -1,19 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Sparrow.Server.Logging;
 
 namespace Raven.Server.Documents.Handlers.AI.Agents;
 
 internal sealed class AiDebugTraceCollector
 {
     private readonly List<AiDebugTrace> _traces;
+    private readonly DocumentDatabase _database;
+    private readonly RavenLogger _logger;
 
     public bool Enabled => _traces != null;
 
-    public AiDebugTraceCollector(bool enabled)
+    public AiDebugTraceCollector(bool enabled, DocumentDatabase database)
     {
-        if (enabled)
-            _traces = new List<AiDebugTrace>();
+        if (enabled == false)
+            return;
+
+        _traces = new List<AiDebugTrace>();
+        _database = database;
+        _logger = database.Loggers.GetLogger<AiDebugTraceCollector>();
     }
 
     public AiDebugTrace CreateTrace()
@@ -26,22 +33,21 @@ internal sealed class AiDebugTraceCollector
         return t;
     }
 
-    public async Task PersistAsync(ConversationDocument document, DocumentDatabase database)
+    public async Task PersistAsync(ConversationDocument document)
     {
         if (_traces == null || _traces.Count == 0)
             return;
 
         try
         {
-            await database.TxMerger.Enqueue(new PutConversationDebugCommand(_traces, document, database));
+            await _database.TxMerger.Enqueue(new PutConversationDebugCommand(_traces, document, _database));
         }
         catch (Exception e)
         {
             // Swallow only the secondary debug-trace persistence failure so the original
             // provider/model exception (if any) is preserved and propagated to the caller.
-            var logger = database.Loggers.GetLogger<AiDebugTraceCollector>();
-            if (logger.IsDebugEnabled)
-                logger.Debug($"Failed to persist {_traces.Count} debug trace(s) for conversation '{document.Id}'.", e);
+            if (_logger.IsDebugEnabled)
+                _logger.Debug($"Failed to persist {_traces.Count} debug trace(s) for conversation '{document.Id}'.", e);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -38,6 +38,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
 
     public int RemainingToolIterations;
 
+    public bool EnableFullDebug;
+
     public HashSet<string> SubConversationIds = new (StringComparer.OrdinalIgnoreCase);
 
     public void Initialize(JsonOperationContext context, AiAgentConfiguration configuration, bool resetRemainingToolIterations, int maxModelIterationsPerCall)
@@ -223,7 +225,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
 
     public DynamicJsonValue ToJson()
     {
-        return new DynamicJsonValue
+        var json = new DynamicJsonValue
         {
             [nameof(Agent)] = Agent,
             [nameof(Parameters)] = Parameters,
@@ -238,6 +240,11 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             [nameof(RemainingToolIterations)] = RemainingToolIterations,
             [nameof(SubConversationIds)] = new DynamicJsonArray(SubConversationIds)
         };
+
+        if (EnableFullDebug)
+            json[nameof(EnableFullDebug)] = true;
+
+        return json;
     }
 
     public const string DateProperty = "date";
@@ -277,6 +284,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         if (document.TryGet(nameof(RemainingToolIterations), out int remainingToolIterations) == false)
             remainingToolIterations = maxModelIterationsPerCall;
 
+        document.TryGet(nameof(EnableFullDebug), out bool enableFullDebug);
+
         var openTools = new Dictionary<string, AiAgentActionRequest>();
         foreach (var callId in openToolCalls.GetPropertyNames())
         {
@@ -294,7 +303,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             LastMessageAt = lastMessageAt,
             CreatedAt = createAt,
             Expires = expires,
-            RemainingToolIterations = remainingToolIterations
+            RemainingToolIterations = remainingToolIterations,
+            EnableFullDebug = enableFullDebug
         };
 
         if (document.TryGet(nameof(CurrentUsage), out BlittableJsonReaderObject currentUsageBlittable))

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -38,7 +38,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
 
     public int RemainingToolIterations;
 
-    public bool EnableFullDebug;
+    public bool Debug;
 
     public HashSet<string> SubConversationIds = new (StringComparer.OrdinalIgnoreCase);
 
@@ -241,8 +241,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             [nameof(SubConversationIds)] = new DynamicJsonArray(SubConversationIds)
         };
 
-        if (EnableFullDebug)
-            json[nameof(EnableFullDebug)] = true;
+        if (Debug)
+            json[nameof(Debug)] = true;
 
         return json;
     }
@@ -284,7 +284,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         if (document.TryGet(nameof(RemainingToolIterations), out int remainingToolIterations) == false)
             remainingToolIterations = maxModelIterationsPerCall;
 
-        document.TryGet(nameof(EnableFullDebug), out bool enableFullDebug);
+        document.TryGet(nameof(Debug), out bool debug);
 
         var openTools = new Dictionary<string, AiAgentActionRequest>();
         foreach (var callId in openToolCalls.GetPropertyNames())
@@ -304,7 +304,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             CreatedAt = createAt,
             Expires = expires,
             RemainingToolIterations = remainingToolIterations,
-            EnableFullDebug = enableFullDebug
+            Debug = debug
         };
 
         if (document.TryGet(nameof(CurrentUsage), out BlittableJsonReaderObject currentUsageBlittable))

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
@@ -118,10 +118,16 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
         protected virtual DynamicJsonValue CreateAgentRequest(string agent, string conversationId, string prompt, IEnumerable<object> actionResponses, DynamicJsonValue creationOptions)
         {
-            var queryString = new StringBuilder("?")
+            var queryStringBuilder = new StringBuilder("?")
                 .Append("&conversationId=").Append(Uri.EscapeDataString(conversationId))
-                .Append("&agentId=").Append(Uri.EscapeDataString(agent))
-                .ToString();
+                .Append("&agentId=").Append(Uri.EscapeDataString(agent));
+
+            // Parent-debug ON -> force sub-agent debug ON. Parent OFF/null -> leave the
+            // sub-agent's own stored value untouched (no query string appended).
+            if (_document.EnableFullDebug)
+                queryStringBuilder.Append("&enableFullDebug=true");
+
+            var queryString = queryStringBuilder.ToString();
 
             return new DynamicJsonValue
             {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
@@ -123,8 +123,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 .Append("&agentId=").Append(Uri.EscapeDataString(agent));
 
             // Always propagate the parent's current debug state to the sub-agent so the child
-            // doesn't keep `EnableFullDebug=true` sticky once the parent flips it off.
-            queryStringBuilder.Append($"&enableFullDebug={_document.EnableFullDebug}");
+            // doesn't keep `Debug=true` sticky once the parent flips it off.
+            queryStringBuilder.Append($"&debug={_document.Debug}");
 
             var queryString = queryStringBuilder.ToString();
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
@@ -122,10 +122,9 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 .Append("&conversationId=").Append(Uri.EscapeDataString(conversationId))
                 .Append("&agentId=").Append(Uri.EscapeDataString(agent));
 
-            // Parent-debug ON -> force sub-agent debug ON. Parent OFF/null -> leave the
-            // sub-agent's own stored value untouched (no query string appended).
-            if (_document.EnableFullDebug)
-                queryStringBuilder.Append("&enableFullDebug=true");
+            // Always propagate the parent's current debug state to the sub-agent so the child
+            // doesn't keep `EnableFullDebug=true` sticky once the parent flips it off.
+            queryStringBuilder.Append($"&enableFullDebug={_document.EnableFullDebug}");
 
             var queryString = queryStringBuilder.ToString();
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -777,10 +777,9 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
     protected virtual async Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)
     {
         var changeVectorLsv = context.GetLazyString(_document.ChangeVector);
-
         var cmd = new PutConversationCommand(_document, historyDocs, changeVectorLsv, _configuration, database)
         {
-            Attachments = _request.AttachmentCommands,
+            Attachments = _request.AttachmentCommands
         };
         await database.TxMerger.Enqueue(cmd);
         _document.ChangeVector = cmd.PutResult.ChangeVector;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -50,18 +50,18 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
     private AiAgentConfiguration _configuration;
     private string _changeVector;
     private string _raftId;
-    private bool? _enableFullDebugOverride;
+    private bool? _debugOverride;
     protected int _maxModelIterationsPerCall;
     internal List<string> _persistedAttachmentsNames;
     public required RavenServer.AuthenticateConnection Authentication;
-    public void Initialize(AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector, string raftId = null, bool? enableFullDebugOverride = null)
+    public void Initialize(AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector, string raftId = null, bool? debugOverride = null)
     {
         _conversationId = conversationId;
         _request = body;
         _configuration = configuration;
         _changeVector = changeVector;
         _raftId = raftId;
-        _enableFullDebugOverride = enableFullDebugOverride;
+        _debugOverride = debugOverride;
         _maxModelIterationsPerCall = GetMaxModelIterationsPerCall(body, configuration);
     }
 
@@ -131,8 +131,8 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             }
         }
 
-        if (_enableFullDebugOverride.HasValue)
-            _document.EnableFullDebug = _enableFullDebugOverride.Value;
+        if (_debugOverride.HasValue)
+            _document.Debug = _debugOverride.Value;
 
         if (_request.AttachmentCommands?.ParsedCommands is { Count: >0})
         {
@@ -395,7 +395,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
         var pendingAlertsDetails = new List<ExceededTokenThresholdDetails>();
         bool isFirstIteration = true;
-        var debugTraces = new AiDebugTraceCollector(_document.EnableFullDebug);
+        var debugTraces = new AiDebugTraceCollector(_document.Debug, database);
 
         try
         {
@@ -475,7 +475,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         }
         finally
         {
-            await debugTraces.PersistAsync(_document, database);
+            await debugTraces.PersistAsync(_document);
         }
 
         foreach (ExceededTokenThresholdDetails pendingAlertDetails in pendingAlertsDetails)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -395,7 +395,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
         var pendingAlertsDetails = new List<ExceededTokenThresholdDetails>();
         bool isFirstIteration = true;
-        List<AiDebugTrace> debugTraces = _document.EnableFullDebug ? [] : null;
+        var debugTraces = new AiDebugTraceCollector(_document.EnableFullDebug);
 
         try
         {
@@ -405,12 +405,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
                 database.ForTestingPurposes?.BeforeAiAgentTalk?.Invoke(talker.Document);
 
-                AiDebugTrace trace = null;
-                if (debugTraces != null)
-                {
-                    trace = new AiDebugTrace();
-                    debugTraces.Add(trace);
-                }
+                var trace = debugTraces.CreateTrace();
 
                 using var request = talker.CreateCompletionRequest(attachments, trace);
                 r = await talker.RunAsync(database.DocumentsStorage.ContextPool, request, trace, token);
@@ -480,8 +475,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         }
         finally
         {
-            if (debugTraces is { Count: > 0 })
-                await TryPersistDebugTracesAsync(debugTraces);
+            await debugTraces.PersistAsync(_document, database);
         }
 
         foreach (ExceededTokenThresholdDetails pendingAlertDetails in pendingAlertsDetails)
@@ -497,23 +491,6 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             Usage = talker.AiUsage,
             ToolsIterations = toolsIterations,
         };
-    }
-
-    private async Task TryPersistDebugTracesAsync(List<AiDebugTrace> debugTraces)
-    {
-        try
-        {
-            var cmd = new PutConversationDebugCommand(debugTraces, _document, database);
-            await database.TxMerger.Enqueue(cmd);
-        }
-        catch (Exception e)
-        {
-            // Swallow only the secondary debug-trace persistence failure so the original
-            // provider/model exception (if any) is preserved and propagated to the caller.
-            var logger = database.Loggers.GetLogger<ConversationHandler>();
-            if (logger.IsDebugEnabled)
-                logger.Debug($"Failed to persist {debugTraces.Count} debug trace(s) for conversation '{_document.Id}' after a failed turn.", e);
-        }
     }
 
     private void AddMessageWithAttachmentsName(JsonOperationContext context, bool isFirstIteration)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -50,16 +50,18 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
     private AiAgentConfiguration _configuration;
     private string _changeVector;
     private string _raftId;
+    private bool? _enableFullDebugOverride;
     protected int _maxModelIterationsPerCall;
     internal List<string> _persistedAttachmentsNames;
     public required RavenServer.AuthenticateConnection Authentication;
-    public void Initialize(AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector, string raftId = null)
+    public void Initialize(AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector, string raftId = null, bool? enableFullDebugOverride = null)
     {
         _conversationId = conversationId;
         _request = body;
         _configuration = configuration;
         _changeVector = changeVector;
         _raftId = raftId;
+        _enableFullDebugOverride = enableFullDebugOverride;
         _maxModelIterationsPerCall = GetMaxModelIterationsPerCall(body, configuration);
     }
 
@@ -128,6 +130,9 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                 _document.ChangeVector = conversation.ChangeVector;
             }
         }
+
+        if (_enableFullDebugOverride.HasValue)
+            _document.EnableFullDebug = _enableFullDebugOverride.Value;
 
         if (_request.AttachmentCommands?.ParsedCommands is { Count: >0})
         {
@@ -390,78 +395,94 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
         var pendingAlertsDetails = new List<ExceededTokenThresholdDetails>();
         bool isFirstIteration = true;
-        while (shouldContinueConversation)
+        List<AiDebugTrace> debugTraces = _document.EnableFullDebug ? [] : null;
+
+        try
         {
-            var attachments = _request.Attachments ?? new List<AiAttachment>();
-
-            database.ForTestingPurposes?.BeforeAiAgentTalk?.Invoke(talker.Document);
-
-            using var request = talker.CreateCompletionRequest(attachments);
-            
-            r = await talker.RunAsync(database.DocumentsStorage.ContextPool, request, token);
-
-            var currentTurnUsage = AiUsage.GetUsageDifference(talker.AiUsage, _document.CurrentUsage);
-            //we want that message only on when we upload an attachment and not when the internal tool is called.
-            if (isFirstIteration && _request.AttachmentCommands?.ParsedCommands.Count > 0)
+            while (shouldContinueConversation)
             {
-                AddMessageWithAttachmentsName(context, isFirstIteration);
-            }
-            isFirstIteration = false;
+                var attachments = _request.Attachments ?? new List<AiAttachment>();
 
-            _document.AddMessage(context, r.Message, currentTurnUsage);
-            _document.UpdateUsage(talker.AiUsage);
-            OnUpdateUsage?.Invoke(database.Name, currentTurnUsage);
+                database.ForTestingPurposes?.BeforeAiAgentTalk?.Invoke(talker.Document);
 
-            if (currentTurnUsage.PromptTokens > database.Configuration.Ai.ToolsTokenUsageThreshold)
-            {
-                if (_document.TryGetDetailsOfRecentToolCall(_configuration, out var toolCalls))
+                AiDebugTrace trace = null;
+                if (debugTraces != null)
                 {
-                    pendingAlertsDetails.Add(ExceededTokenThresholdDetails.Add(
-                            database.NotificationCenter,
-                            _configuration.Name,
-                            _conversationId,
-                            currentTurnUsage.PromptTokens,
-                            database.Configuration.Ai.ToolsTokenUsageThreshold,
-                            toolCalls
-                        )
-                    );
+                    trace = new AiDebugTrace();
+                    debugTraces.Add(trace);
                 }
-            }
 
-            toolsIterations++;
-            if (r.Type is AiResponseType.Result)
-            {
-                _document.RemainingToolIterations = _maxModelIterationsPerCall;
-                shouldContinueConversation = false;
-            }
-            else
-            {
-                var iterations = await HandleQueryAndAgentCallsAsync(context, r.ToolCalls);
-                toolsIterations += iterations;
-                if (TryGetUserTools(context, r.ToolCalls))
+                using var request = talker.CreateCompletionRequest(attachments, trace);
+                r = await talker.RunAsync(database.DocumentsStorage.ContextPool, request, trace, token);
+
+                var currentTurnUsage = AiUsage.GetUsageDifference(talker.AiUsage, _document.CurrentUsage);
+                //we want that message only on when we upload an attachment and not when the internal tool is called.
+                if (isFirstIteration && _request.AttachmentCommands?.ParsedCommands.Count > 0)
                 {
+                    AddMessageWithAttachmentsName(context, isFirstIteration);
+                }
+                isFirstIteration = false;
+
+                _document.AddMessage(context, r.Message, currentTurnUsage);
+                _document.UpdateUsage(talker.AiUsage);
+                OnUpdateUsage?.Invoke(database.Name, currentTurnUsage);
+
+                if (currentTurnUsage.PromptTokens > database.Configuration.Ai.ToolsTokenUsageThreshold)
+                {
+                    if (_document.TryGetDetailsOfRecentToolCall(_configuration, out var toolCalls))
+                    {
+                        pendingAlertsDetails.Add(ExceededTokenThresholdDetails.Add(
+                                database.NotificationCenter,
+                                _configuration.Name,
+                                _conversationId,
+                                currentTurnUsage.PromptTokens,
+                                database.Configuration.Ai.ToolsTokenUsageThreshold,
+                                toolCalls
+                            )
+                        );
+                    }
+                }
+
+                toolsIterations++;
+                if (r.Type is AiResponseType.Result)
+                {
+                    _document.RemainingToolIterations = _maxModelIterationsPerCall;
                     shouldContinueConversation = false;
                 }
                 else
                 {
-                    //should close the tool calls that were handled internally
-                    HandleInternalSystemActions(context, _document.OpenActionCalls.Values.ToList());
+                    var iterations = await HandleQueryAndAgentCallsAsync(context, r.ToolCalls);
+                    toolsIterations += iterations;
+                    if (TryGetUserTools(context, r.ToolCalls))
+                    {
+                        shouldContinueConversation = false;
+                    }
+                    else
+                    {
+                        //should close the tool calls that were handled internally
+                        HandleInternalSystemActions(context, _document.OpenActionCalls.Values.ToList());
+                    }
+                }
+
+                _document.CurrentUsage = talker.AiUsage;
+
+                // check if we should summarize or truncate the chat history
+                var reductionResult = await TryReduceChatSizeAsync(context, talker.Client, talker.AiUsage, token);
+                if (reductionResult != null)
+                {
+                    historyDocs ??= [];
+                    historyDocs.Add(reductionResult);
                 }
             }
 
-            _document.CurrentUsage = talker.AiUsage;
-
-            // check if we should summarize or truncate the chat history
-            var reductionResult = await TryReduceChatSizeAsync(context, talker.Client, talker.AiUsage, token);
-            if (reductionResult != null)
-            {
-                historyDocs ??= [];
-                historyDocs.Add(reductionResult);
-            }
+            _elapsed = sw.Elapsed;
+            _conversationId = await TryPersistAsync(context, historyDocs);
         }
-
-        _elapsed = sw.Elapsed;
-        _conversationId = await TryPersistAsync(context, historyDocs);
+        finally
+        {
+            if (debugTraces is { Count: > 0 })
+                await TryPersistDebugTracesAsync(debugTraces);
+        }
 
         foreach (ExceededTokenThresholdDetails pendingAlertDetails in pendingAlertsDetails)
         {
@@ -476,6 +497,23 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             Usage = talker.AiUsage,
             ToolsIterations = toolsIterations,
         };
+    }
+
+    private async Task TryPersistDebugTracesAsync(List<AiDebugTrace> debugTraces)
+    {
+        try
+        {
+            var cmd = new PutConversationDebugCommand(debugTraces, _document, database);
+            await database.TxMerger.Enqueue(cmd);
+        }
+        catch (Exception e)
+        {
+            // Swallow only the secondary debug-trace persistence failure so the original
+            // provider/model exception (if any) is preserved and propagated to the caller.
+            var logger = database.Loggers.GetLogger<ConversationHandler>();
+            if (logger.IsDebugEnabled)
+                logger.Debug($"Failed to persist {debugTraces.Count} debug trace(s) for conversation '{_document.Id}' after a failed turn.", e);
+        }
     }
 
     private void AddMessageWithAttachmentsName(JsonOperationContext context, bool isFirstIteration)
@@ -591,7 +629,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         var usage = new AiUsage();
         var tools = client.GenerateTools(context, configuration, this);
         using var request = client.CreateCompletionRequest(context, messages, attachments: null, tools, useTools: false, streaming: false, schema: SummarizationOutputSchema);
-        var result = await client.CompleteAsync(context, request, usage, token);
+        var result = await client.CompleteAsync(context, request, usage, trace: null, token);
 
         if (result.Result.TryGet(nameof(SummarizationSampleObject.Answer), out string messagesSummary) == false)
             throw new UnexpectedResponseException($"Unable to get a summary from response of agent '{oldChat.Agent}'.") { RequestId = null };
@@ -762,9 +800,10 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
     protected virtual async Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)
     {
         var changeVectorLsv = context.GetLazyString(_document.ChangeVector);
+
         var cmd = new PutConversationCommand(_document, historyDocs, changeVectorLsv, _configuration, database)
         {
-            Attachments = _request.AttachmentCommands
+            Attachments = _request.AttachmentCommands,
         };
         await database.TxMerger.Enqueue(cmd);
         _document.ChangeVector = cmd.PutResult.ChangeVector;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationDebugCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationDebugCommand.cs
@@ -21,14 +21,11 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         protected override long ExecuteCmd(DocumentsOperationContext context)
         {
             var sep = _database.IdentityPartsSeparator;
+            var idPrefix = $"{_conversation.Id}{sep}{AiDebugTrace.TraceSegment}{sep}";
             foreach (var trace in _traces)
             {
-                var id = _database.DocumentsStorage.DocumentPut.BuildDocumentId(
-                    $"{_conversation.Id}{sep}{AiDebugTrace.TraceSegment}{sep}",
-                    _database.DocumentsStorage.GenerateNextEtag(), out _);
-
                 var doc = trace.ToBlittable(context, _conversation, _conversation.Expires);
-                _database.DocumentsStorage.Put(context, id, expectedChangeVector: null, doc,
+                _database.DocumentsStorage.Put(context, idPrefix, expectedChangeVector: null, doc,
                     nonPersistentFlags: NonPersistentDocumentFlags.SkipSchemaValidation);
             }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationDebugCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationDebugCommand.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents
+{
+    internal sealed class PutConversationDebugCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
+    {
+        private readonly List<AiDebugTrace> _traces;
+        private readonly ConversationDocument _conversation;
+        private readonly DocumentDatabase _database;
+
+        public PutConversationDebugCommand(List<AiDebugTrace> traces, ConversationDocument conversation, DocumentDatabase database)
+        {
+            _traces = traces;
+            _conversation = conversation;
+            _database = database;
+        }
+
+        protected override long ExecuteCmd(DocumentsOperationContext context)
+        {
+            var sep = _database.IdentityPartsSeparator;
+            foreach (var trace in _traces)
+            {
+                var id = _database.DocumentsStorage.DocumentPut.BuildDocumentId(
+                    $"{_conversation.Id}{sep}{AiDebugTrace.TraceSegment}{sep}",
+                    _database.DocumentsStorage.GenerateNextEtag(), out _);
+
+                var doc = trace.ToBlittable(context, _conversation, _conversation.Expires);
+                _database.DocumentsStorage.Put(context, id, expectedChangeVector: null, doc,
+                    nonPersistentFlags: NonPersistentDocumentFlags.SkipSchemaValidation);
+            }
+
+            return 1;
+        }
+
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+        {
+            return new PutConversationDebugCommandDto(_traces, _conversation, _database);
+        }
+
+        public class PutConversationDebugCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, PutConversationDebugCommand>
+        {
+            private readonly List<AiDebugTrace> _traces;
+            private readonly ConversationDocument _conversation;
+            private readonly DocumentDatabase _database;
+
+            public PutConversationDebugCommandDto(List<AiDebugTrace> traces, ConversationDocument conversation, DocumentDatabase database)
+            {
+                _traces = traces;
+                _conversation = conversation;
+                _database = database;
+            }
+
+            public PutConversationDebugCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+            {
+                return new PutConversationDebugCommand(_traces, _conversation, _database);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
@@ -23,19 +23,18 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
     public void Init()
     {
         document.EnsureInitialized();
-
         _schema = ChatCompletionClient.GetSchemaForRequest(configuration.OutputSchema, configuration.SampleObject);
         Client = handler.CreateClient();
         _tools = Client.GenerateTools(context, configuration, handler);
     }
 
-    public HttpRequestMessage CreateCompletionRequest(List<AiAttachment> attachments)
+    public HttpRequestMessage CreateCompletionRequest(List<AiAttachment> attachments, AiDebugTrace trace)
     {
         AiUsage = new();
-        return Client.CreateCompletionRequest(context, document.Messages, attachments, _tools, useTools: document.RemainingToolIterations-- > 0, streaming != null, _schema, promptCacheKey: document.Id);
+        return Client.CreateCompletionRequest(context, document.Messages, attachments, _tools, useTools: document.RemainingToolIterations-- > 0, streaming != null, _schema, promptCacheKey: document.Id, trace: trace);
     }
 
-    public async Task<AiResponse> RunAsync(IMemoryContextPool contextPool, HttpRequestMessage request, CancellationToken token)
+    public async Task<AiResponse> RunAsync(IMemoryContextPool contextPool, HttpRequestMessage request, AiDebugTrace trace, CancellationToken token)
     {
         if (streaming is null)
         {
@@ -43,6 +42,7 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
                 context,
                 request,
                 AiUsage,
+                trace,
                 token
             );
         }
@@ -54,6 +54,7 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
             request,
             streaming,
             AiUsage,
+            trace,
             token
         );
     }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
@@ -23,6 +23,7 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
     public void Init()
     {
         document.EnsureInitialized();
+
         _schema = ChatCompletionClient.GetSchemaForRequest(configuration.OutputSchema, configuration.SampleObject);
         Client = handler.CreateClient();
         _tools = Client.GenerateTools(context, configuration, handler);

--- a/src/Raven.Server/Utils/TeeStream.cs
+++ b/src/Raven.Server/Utils/TeeStream.cs
@@ -6,13 +6,14 @@ using System.Threading.Tasks;
 using Microsoft.IO;
 using Sparrow;
 
-namespace Raven.Server.Documents.AI;
+namespace Raven.Server.Utils;
 
 internal sealed class TeeStream : Stream
 {
     private readonly Stream _primary;
     private readonly RecyclableMemoryStream _ownedSecondary;
     private bool _disposed;
+
     public TeeStream(Stream primary)
     {
         _primary = primary ?? throw new ArgumentNullException(nameof(primary));
@@ -22,10 +23,13 @@ internal sealed class TeeStream : Stream
     /// <summary>
     /// Returns the bytes written through the tee so far, decoded as UTF-8.
     /// May be partial / non-JSON if serialization failed mid-write.
+    /// Returns null if the underlying buffer cannot be retrieved.
     /// </summary>
     public string Result()
     {
-        _ownedSecondary.TryGetBuffer(out var seg);
+        if (_ownedSecondary.TryGetBuffer(out var seg) == false)
+            return null;
+
         return Encoding.UTF8.GetString(seg);
     }
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentDebugTracing.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentDebugTracing.cs
@@ -234,7 +234,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task EnableFullDebug_WithAttachment_PersistsRequestWithAttachmentPayload(Options options, GenAiConfiguration config)
+    public async Task EnableFullDebug_WithAttachment_PersistsAttachmentNames(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -257,8 +257,12 @@ public class AiAgentDebugTracing : RavenTestBase
         var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
         Assert.True(tracesList.Count == 1);
 
-        // The request payload must be present — it carries the base64-encoded image inline.
-        Assert.NotNull(tracesList.First().RequestBody);
+        var first = tracesList.First();
+        Assert.NotNull(first.RequestBody);
+
+        // Attachment names are persisted as a separate field on the trace doc.
+        Assert.NotNull(first.AttachmentNames);
+        Assert.Contains("heart.png", first.AttachmentNames);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
@@ -493,54 +497,108 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task EnableFullDebug_PropagatesToSubAgent(Options options, GenAiConfiguration config)
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { null })]
+    public async Task EnableFullDebug_PropagatesToSubAgent(Options options, GenAiConfiguration config, bool? enableFullDebug)
     {
-        using var store = GetDocumentStore(options);
-        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        using var store = await CreateStoreWithSubAgentArithmetic(options, config);
 
-        var subAgent = new AiAgentConfiguration("debug-sub-agent", config.ConnectionStringName,
-            "You answer arithmetic questions. Return a short numeric answer.")
+        const string conversationId = "chats/propagation-test";
+
+        // Null case: we need the parent doc to already have EnableFullDebug=true persisted so the
+        // null override actually has something to preserve. Drive a non-arithmetic warm-up turn
+        // that won't invoke the sub-agent, then the real turn below uses the null override.
+        if (enableFullDebug == null)
         {
-            SampleObject = "{\"Answer\":\"42\"}"
-        };
-        var subAgentResult = await store.AI.CreateAgentAsync(subAgent, OutputSchema.Instance);
+            var warmup = store.AI.Conversation(_parentAgentIdentifier, conversationId,
+                creationOptions: null, enableFullDebug: true);
+            warmup.SetUserPrompt("Just say hi. Do not call any tools.");
+            await warmup.RunAsync<OutputSchema>(CancellationToken.None);
 
-        var parentAgent = new AiAgentConfiguration("debug-parent-agent", config.ConnectionStringName,
-            "Delegate any arithmetic question to the math sub-agent and return its answer.")
-        {
-            SampleObject = "{\"Answer\":\"answer here\"}",
-            SubAgents =
-            [
-                new AiAgentToolSubAgent
-                {
-                    Identifier = subAgentResult.Identifier,
-                    Description = "Use to answer arithmetic questions."
-                }
-            ]
-        };
-        var parentResult = await store.AI.CreateAgentAsync(parentAgent, OutputSchema.Instance);
+            // Reliability gate: if a future system-prompt change causes the parent to eagerly invoke
+            // the sub-agent on a greeting, this assertion fires with a clear message — and the
+            // real turn below would no longer be the first arithmetic prompt in the conversation.
+            using var s = store.OpenAsyncSession();
+            var warmupDoc = await s.LoadAsync<ConversationDocShape>(conversationId);
+            Assert.NotNull(warmupDoc);
+            Assert.True(warmupDoc.EnableFullDebug, "warm-up should persist EnableFullDebug=true");
+            Assert.Empty(warmupDoc.SubConversationIds);
+        }
 
-        var chat = store.AI.Conversation(parentResult.Identifier, "chats/",
-            creationOptions: null, enableFullDebug: true);
+        var chat = store.AI.Conversation(_parentAgentIdentifier, conversationId,
+            creationOptions: null, changeVector: null, enableFullDebug: enableFullDebug);
         chat.SetUserPrompt("What is 2+2?");
         var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
         Assert.Equal(AiConversationResult.Done, r.Status);
 
-        // Traces should exist for the parent conversation AND for at least one sub-agent conversation.
-        var stats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
-        Assert.True(stats.Collections.TryGetValue(Constants.Documents.Collections.AiAgentConversationDebugCollection, out long count));
-        Assert.True(count >= 2, $"Expected at least 2 trace documents (parent + sub-agent), got {count}");
+        var snap = await LoadDebugSnapshot(store, conversationId);
+        Assert.NotNull(snap.SubId);
+
+        // true OR null-after-true-warmup -> tracing on; false -> tracing off.
+        var expectTracing = enableFullDebug != false;
+        Assert.Equal(expectTracing, snap.ParentPersisted);
+        Assert.Equal(expectTracing, snap.SubPersisted);
+
+        if (expectTracing)
+        {
+            // Lower bounds derived from the protocol, not LLM behavior:
+            //   * sub-agent: 1 LLM call (no further tools defined on it).
+            //   * parent: 2 LLM calls per arithmetic turn — one to receive the tool dispatch, one to
+            //     finalize the answer after the sub-agent returned. The null case adds 1 more from
+            //     the warm-up turn ("just say hi" -> single LLM call, no tool dispatch).
+            // A real LLM may occasionally do an extra reflection / re-dispatch round, so we use
+            // lower bounds rather than equality.
+            var minParentTraces = enableFullDebug == null ? 3 : 2;
+            Assert.True(snap.ParentTraces >= minParentTraces,
+                $"expected >= {minParentTraces} parent trace docs, got {snap.ParentTraces}");
+            Assert.True(snap.SubAgentTraces >= 1,
+                $"expected >= 1 sub-agent trace doc, got {snap.SubAgentTraces}");
+        }
+        else
+        {
+            Assert.Equal(0, snap.ParentTraces);
+            Assert.Equal(0, snap.SubAgentTraces);
+
+            // No trace collection should exist at all when neither parent nor sub-agent tracing is on.
+            var stats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
+            Assert.False(stats.Collections.ContainsKey(Constants.Documents.Collections.AiAgentConversationDebugCollection));
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task EnableFullDebug_MultipleAttachments_PersistsAllNamesInOrder(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("debug-test-agent", config.ConnectionStringName,
+            "You are a helpful assistant. Describe images concisely.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}"
+        };
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/",
+            creationOptions: null, enableFullDebug: true);
+
+        chat.AddAttachment("heart.png", new MemoryStream(Convert.FromBase64String(AiTestData.HeartPngBase64)), "image/png");
+        chat.AddAttachment("star.png", new MemoryStream(Convert.FromBase64String(AiTestData.StarPngBase64)), "image/png");
+        chat.SetUserPrompt("Describe both images briefly.");
+        var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
+        Assert.Equal(AiConversationResult.Done, r.Status);
 
         using var session = store.OpenAsyncSession();
-        var parentTraces = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
-        Assert.True(parentTraces.Count >= 1, "Expected at least one trace under the parent conversation prefix.");
+        var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
+        Assert.True(tracesList.Count == 1);
 
-        var allTraces = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/")).ToList();
-        // Sub-agent conversations have IDs of the form `{parent.Id}/{paramsHash}` and their traces
-        // are nested under `{parent.Id}/{paramsHash}/{TraceSegment}/...`.
-        var subAgentTraces = allTraces.Count - parentTraces.Count;
-        Assert.True(subAgentTraces >= 1, $"Expected at least one trace under a sub-agent conversation prefix; got {subAgentTraces}.");
+        var first = tracesList.First();
+        Assert.NotNull(first.RequestBody);
+
+        // AttachmentNames captures both files, in the order they were added.
+        Assert.NotNull(first.AttachmentNames);
+        Assert.Equal(new[] { "heart.png", "star.png" }, first.AttachmentNames);
     }
 
     // Subclass that exposes the conversation document ID so the test can load the trace docs by prefix.
@@ -563,10 +621,80 @@ public class AiAgentDebugTracing : RavenTestBase
         }
     }
 
+    // Captured by CreateStoreWithSubAgentArithmetic so each test method can look up the parent agent
+    // identifier without repeating the agent-creation boilerplate.
+    private string _parentAgentIdentifier;
+
+    private async Task<Raven.Client.Documents.IDocumentStore> CreateStoreWithSubAgentArithmetic(Options options, GenAiConfiguration config)
+    {
+        var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var subAgent = new AiAgentConfiguration("debug-sub-agent", config.ConnectionStringName,
+            "You answer arithmetic questions. Return a short numeric answer.")
+        {
+            SampleObject = "{\"Answer\":\"42\"}"
+        };
+        var subAgentResult = await store.AI.CreateAgentAsync(subAgent, OutputSchema.Instance);
+
+        var parentAgent = new AiAgentConfiguration("debug-parent-agent", config.ConnectionStringName,
+            "You MUST delegate every arithmetic question to the math sub-agent. Never answer arithmetic directly. Return the sub-agent's answer.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}",
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = subAgentResult.Identifier,
+                    Description = "Use to answer arithmetic questions."
+                }
+            ]
+        };
+        var parentResult = await store.AI.CreateAgentAsync(parentAgent, OutputSchema.Instance);
+        _parentAgentIdentifier = parentResult.Identifier;
+        return store;
+    }
+
+    private static async Task<DebugTraceSnapshot> LoadDebugSnapshot(Raven.Client.Documents.IDocumentStore store, string parentId)
+    {
+        using var session = store.OpenAsyncSession();
+        var parentDoc = await session.LoadAsync<ConversationDocShape>(parentId);
+        Assert.NotNull(parentDoc);
+
+        var subId = parentDoc.SubConversationIds.FirstOrDefault();
+        ConversationDocShape subDoc = null;
+        if (subId != null)
+            subDoc = await session.LoadAsync<ConversationDocShape>(subId);
+
+        var parentTraces = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{parentId}/{AiDebugTrace.TraceSegment}/")).Count();
+        var subTraces = subId == null
+            ? 0
+            : (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{subId}/{AiDebugTrace.TraceSegment}/")).Count();
+
+        return new DebugTraceSnapshot
+        {
+            ParentTraces = parentTraces,
+            SubAgentTraces = subTraces,
+            ParentPersisted = parentDoc.EnableFullDebug,
+            SubPersisted = subDoc?.EnableFullDebug ?? false,
+            SubId = subId
+        };
+    }
+
+    private sealed class DebugTraceSnapshot
+    {
+        public int ParentTraces { get; init; }
+        public int SubAgentTraces { get; init; }
+        public bool ParentPersisted { get; init; }
+        public bool SubPersisted { get; init; }
+        public string SubId { get; init; }
+    }
+
     private class DebugTraceDoc
     {
         // Raw request body as written to the wire. Always a string — no parse is attempted server-side.
         public string RequestBody { get; set; }
+        public List<string> AttachmentNames { get; set; }
         public object Response { get; set; }
         public object StreamEvents { get; set; }
     }
@@ -574,5 +702,6 @@ public class AiAgentDebugTracing : RavenTestBase
     private class ConversationDocShape
     {
         public bool EnableFullDebug { get; set; }
+        public HashSet<string> SubConversationIds { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentDebugTracing.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentDebugTracing.cs
@@ -1,0 +1,453 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Raven.Client;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Raven.Server.ServerWide.Context;
+using AiTestData = SlowTests.Server.Documents.AI.GenAi.Data;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent;
+
+public class AiAgentDebugTracing : RavenTestBase
+{
+    public AiAgentDebugTracing(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class OutputSchema
+    {
+        public static readonly OutputSchema Instance = new();
+        public string Answer = "Answer to the user question";
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task DebugTracesCreatedWhenEnabled(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("debug-test-agent", config.ConnectionStringName,
+            "You are a helpful assistant. Answer concisely.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}"
+        };
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/",
+            creationOptions: null, enableFullDebug: true);
+        chat.SetUserPrompt("What is 2+2?");
+        var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        var stats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
+        Assert.True(stats.Collections.TryGetValue(Constants.Documents.Collections.AiAgentConversationDebugCollection, out long count));
+        Assert.True(count == 1);
+
+        using var session = store.OpenAsyncSession();
+        var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
+        Assert.True(tracesList.Count == 1);
+
+        var first = tracesList.First();
+        Assert.NotNull(first.Request);
+        Assert.NotNull(first.Response);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task NoDebugTracesWhenNotEnabled(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("debug-test-agent", config.ConnectionStringName,
+            "You are a helpful assistant. Answer concisely.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}"
+        };
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/", creationOptions: null);
+        chat.SetUserPrompt("What is 2+2?");
+        var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        var stats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
+        Assert.False(stats.Collections.ContainsKey(Constants.Documents.Collections.AiAgentConversationDebugCollection));
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task EnableFullDebug_FlippedOnExistingConversation_TracesOnlyNextTurn(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("debug-test-agent", config.ConnectionStringName,
+            "You are a helpful assistant. Answer concisely.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}"
+        };
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        // Turn 1: debug NOT enabled — no traces should be written.
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/", creationOptions: null);
+        chat.SetUserPrompt("What is 2+2?");
+        await chat.RunAsync<OutputSchema>(CancellationToken.None);
+
+        var statsAfterTurn1 = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
+        Assert.False(statsAfterTurn1.Collections.ContainsKey(Constants.Documents.Collections.AiAgentConversationDebugCollection));
+
+        // Flip EnableFullDebug by patching the conversation document directly —
+        // this is what a user would do in Studio to enable tracing mid-conversation.
+        await store.Operations.SendAsync(new PatchOperation(
+            chat.Id,
+            changeVector: null,
+            patch: new PatchRequest { Script = "this.EnableFullDebug = true;" },
+            patchIfMissing: null));
+
+        // Turn 2: same conversation, EnableFullDebug now persisted on the document.
+        // A fresh handle with no change vector is used so the server skips the CV check
+        // (the patch above changed the document's CV).
+        var chat2 = store.AI.Conversation(createResult.Identifier, chat.Id, creationOptions: null, changeVector: null);
+        chat2.SetUserPrompt("What is 3+3?");
+        await chat2.RunAsync<OutputSchema>(CancellationToken.None);
+
+        var statsAfterTurn2 = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
+        Assert.True(statsAfterTurn2.Collections.TryGetValue(Constants.Documents.Collections.AiAgentConversationDebugCollection, out long count));
+        Assert.True(count == 1);
+
+        using var session = store.OpenAsyncSession();
+        var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
+        Assert.True(tracesList.Count == 1);
+        Assert.NotNull(tracesList.First().Request);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task EnableFullDebug_QueryStringOverride_FlipsPersistedAttributeFromFalseToTrue(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("debug-test-agent", config.ConnectionStringName,
+            "You are a helpful assistant. Answer concisely.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}"
+        };
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        // Turn 1: no override on a brand-new conversation — should persist as false (default).
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/", creationOptions: null);
+        chat.SetUserPrompt("What is 2+2?");
+        await chat.RunAsync<OutputSchema>(CancellationToken.None);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<ConversationDocShape>(chat.Id);
+            Assert.NotNull(doc);
+            Assert.False(doc.EnableFullDebug, "Expected EnableFullDebug=false persisted on a fresh conversation with no override");
+        }
+
+        // Turn 2: same conversation, ?enableFullDebug=true — must flip persisted false → true
+        // AND must take effect on this turn (traces are written).
+        var chat2 = store.AI.Conversation(createResult.Identifier, chat.Id,
+            creationOptions: null, changeVector: null, enableFullDebug: true);
+        chat2.SetUserPrompt("What is 3+3?");
+        await chat2.RunAsync<OutputSchema>(CancellationToken.None);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<ConversationDocShape>(chat.Id);
+            Assert.NotNull(doc);
+            Assert.True(doc.EnableFullDebug, "Expected EnableFullDebug=true persisted after ?enableFullDebug=true");
+
+            var traces = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
+            Assert.True(traces.Count == 1, "Expected at least one trace document after the turn that flipped the flag on");
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task EnableFullDebug_QueryStringOverride_FlipsPersistedAttributeFromTrueToFalse(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("debug-test-agent", config.ConnectionStringName,
+            "You are a helpful assistant. Answer concisely.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}"
+        };
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        // Turn 1: ?enableFullDebug=true on a brand-new conversation — must persist as true.
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/",
+            creationOptions: null, enableFullDebug: true);
+        chat.SetUserPrompt("What is 2+2?");
+        await chat.RunAsync<OutputSchema>(CancellationToken.None);
+
+        int tracesAfterTurn1;
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<ConversationDocShape>(chat.Id);
+            Assert.NotNull(doc);
+            Assert.True(doc.EnableFullDebug, "Expected EnableFullDebug=true persisted after ?enableFullDebug=true");
+
+            tracesAfterTurn1 = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).Count();
+            Assert.True(tracesAfterTurn1 == 1);
+        }
+
+        // Turn 2: same conversation, ?enableFullDebug=false — must flip persisted true → false
+        // AND the override must be honored on this turn (no new traces written).
+        var chat2 = store.AI.Conversation(createResult.Identifier, chat.Id,
+            creationOptions: null, changeVector: null, enableFullDebug: false);
+        chat2.SetUserPrompt("What is 3+3?");
+        await chat2.RunAsync<OutputSchema>(CancellationToken.None);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<ConversationDocShape>(chat.Id);
+            Assert.NotNull(doc);
+            Assert.False(doc.EnableFullDebug, "Expected EnableFullDebug=false persisted after ?enableFullDebug=false");
+
+            var tracesAfterTurn2 = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).Count();
+            Assert.Equal(tracesAfterTurn1, tracesAfterTurn2);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task EnableFullDebug_WithAttachment_PersistsRequestWithAttachmentPayload(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("debug-test-agent", config.ConnectionStringName,
+            "You are a helpful assistant. Describe images concisely.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}"
+        };
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/",
+            creationOptions: null, enableFullDebug: true);
+        chat.AddAttachment("heart.png", new MemoryStream(Convert.FromBase64String(AiTestData.HeartPngBase64)), "image/png");
+        chat.SetUserPrompt("What do you see in this image?");
+        var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        using var session = store.OpenAsyncSession();
+        var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
+        Assert.True(tracesList.Count == 1);
+
+        // The request payload must be present — it carries the base64-encoded image inline.
+        Assert.NotNull(tracesList.First().Request);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task EnableFullDebug_Streaming_PersistsStreamEvents(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("debug-test-agent", config.ConnectionStringName,
+            "You are a helpful assistant. Answer concisely.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}"
+        };
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/",
+            creationOptions: null, enableFullDebug: true);
+        chat.SetUserPrompt("What is 2+2?");
+
+        var streamedChunks = new List<string>();
+        var r = await chat.StreamAsync<OutputSchema>(
+            nameof(OutputSchema.Answer),
+            chunk =>
+            {
+                streamedChunks.Add(chunk);
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+        Assert.Equal(AiConversationResult.Done, r.Status);
+        Assert.True(streamedChunks.Count > 0, "Expected at least one streamed chunk from the provider");
+
+        using var session = store.OpenAsyncSession();
+        var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
+        Assert.True(tracesList.Count == 1);
+
+        var first = tracesList.First();
+        Assert.NotNull(first.Request);
+        Assert.Null(first.Response);        // streaming populates StreamEvents, not Response
+        Assert.NotNull(first.StreamEvents); // at least one SSE event was captured
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task EnableFullDebug_WithQueryTool_PersistsOneTracePerLlmCall(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new { Name = "Widget A", Price = 9.99 }, "Products/1");
+            await session.StoreAsync(new { Name = "Widget B", Price = 19.99 }, "Products/2");
+            await session.SaveChangesAsync();
+        }
+
+        var agent = new AiAgentConfiguration("debug-query-agent", config.ConnectionStringName,
+            "You are a helpful product assistant. Use the SearchProducts tool whenever the user asks about available products.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}",
+            Queries =
+            [
+                new AiAgentToolQuery("SearchProducts", "Search for available products", "from Products")
+                {
+                    ParametersSampleObject = "{}"
+                }
+            ]
+        };
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/",
+            creationOptions: null, enableFullDebug: true);
+        chat.SetUserPrompt("What products do you have available?");
+        var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        using var session2 = store.OpenAsyncSession();
+        var tracesList = (await session2.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
+
+        // At least 2 LLM calls: one that returned a tool call, one with the final answer.
+        Assert.True(tracesList.Count == 2, $"Expected at least 2 trace documents, got {tracesList.Count}");
+        Assert.All(tracesList, t => Assert.NotNull(t.Request));
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task EnableFullDebug_WithActionTool_PersistsOneTracePerLlmCall(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("debug-action-agent", config.ConnectionStringName,
+            "You are a helpful pricing assistant. Use the GetPrice tool to look up the price of any item the user asks about.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}",
+            Actions =
+            [
+                new AiAgentToolAction
+                {
+                    Name = "GetPrice",
+                    Description = "Get the current price of an item",
+                    ParametersSampleObject = "{\"item\":\"item name\"}"
+                }
+            ]
+        };
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/",
+            creationOptions: null, enableFullDebug: true);
+        chat.Handle<object>("GetPrice", _ => "the price is $9.99");
+        chat.SetUserPrompt("What is the price of a widget?");
+        var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        using var session = store.OpenAsyncSession();
+        var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
+
+        // At least 2 LLM calls: one that requested the action tool, one with the final answer.
+        Assert.True(tracesList.Count == 2, $"Expected at least 2 trace documents, got {tracesList.Count}");
+        Assert.All(tracesList, t => Assert.NotNull(t.Request));
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public async Task EnableFullDebug_FailedLlmCall_TracesStillPersisted()
+    {
+        using var store = GetDocumentStore();
+
+        var agentConfig = new AiAgentConfiguration("debug-fail-agent", "fake-connection",
+            "You are a helpful assistant.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}"
+        };
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        string conversationDocId = null;
+
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        {
+            var handler = new ExposableMockLlmHandler(Server.ServerStore, database,
+                onRequest: _ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent("{\"error\":{\"message\":\"We could not parse the JSON body of your request.\",\"type\":\"invalid_request_error\",\"param\":null,\"code\":null}}")
+                })
+            {
+                Authentication = null
+            };
+
+            handler.Initialize(agentConfig, "chats/", new RequestBody
+            {
+                CreationOptions = new AiConversationCreationOptions(),
+                UserPrompt = "What is 2+2?"
+            }, changeVector: null, enableFullDebugOverride: true);
+
+            await Assert.ThrowsAnyAsync<Exception>(() => handler.HandleRequest(context, CancellationToken.None));
+            conversationDocId = handler.ConversationDocId;
+        }
+
+        Assert.NotNull(conversationDocId);
+
+        // Despite the LLM failure the finally block must have persisted whatever traces were captured.
+        var stats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
+        Assert.True(stats.Collections.TryGetValue(Constants.Documents.Collections.AiAgentConversationDebugCollection, out long count),
+            "Expected the debug-trace collection to exist after a failed turn with EnableFullDebug=true");
+        Assert.True(count == 1);
+
+        using var session = store.OpenAsyncSession();
+        var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{conversationDocId}/{AiDebugTrace.TraceSegment}/")).ToList();
+        Assert.True(tracesList.Count == 1, $"Expected at least one trace document under '{conversationDocId}/{AiDebugTrace.TraceSegment}/'");
+        Assert.NotNull(tracesList.First().Request);
+    }
+
+    // Subclass that exposes the conversation document ID so the test can load the trace docs by prefix.
+    private class ExposableMockLlmHandler(
+        Raven.Server.ServerWide.ServerStore server,
+        DocumentDatabase database,
+        Func<JObject, HttpResponseMessage> onRequest = null)
+        : MockLlmConversationHandler(server, database, onRequest)
+    {
+        public string ConversationDocId => _document?.Id;
+    }
+
+    private class DebugTraceDoc
+    {
+        public object Request { get; set; }
+        public object Response { get; set; }
+        public object StreamEvents { get; set; }
+    }
+
+    private class ConversationDocShape
+    {
+        public bool EnableFullDebug { get; set; }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentDebugTracing.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentDebugTracing.cs
@@ -51,7 +51,7 @@ public class AiAgentDebugTracing : RavenTestBase
         var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
 
         var chat = store.AI.Conversation(createResult.Identifier, "chats/",
-            creationOptions: null, enableFullDebug: true);
+            creationOptions: null, debug: true);
         chat.SetUserPrompt("What is 2+2?");
         var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
         Assert.Equal(AiConversationResult.Done, r.Status);
@@ -94,7 +94,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task EnableFullDebug_FlippedOnExistingConversation_TracesOnlyNextTurn(Options options, GenAiConfiguration config)
+    public async Task Debug_FlippedOnExistingConversation_TracesOnlyNextTurn(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -114,15 +114,15 @@ public class AiAgentDebugTracing : RavenTestBase
         var statsAfterTurn1 = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
         Assert.False(statsAfterTurn1.Collections.ContainsKey(Constants.Documents.Collections.AiAgentConversationDebugCollection));
 
-        // Flip EnableFullDebug by patching the conversation document directly —
+        // Flip Debug by patching the conversation document directly —
         // this is what a user would do in Studio to enable tracing mid-conversation.
         await store.Operations.SendAsync(new PatchOperation(
             chat.Id,
             changeVector: null,
-            patch: new PatchRequest { Script = "this.EnableFullDebug = true;" },
+            patch: new PatchRequest { Script = "this.Debug = true;" },
             patchIfMissing: null));
 
-        // Turn 2: same conversation, EnableFullDebug now persisted on the document.
+        // Turn 2: same conversation, Debug now persisted on the document.
         // A fresh handle with no change vector is used so the server skips the CV check
         // (the patch above changed the document's CV).
         var chat2 = store.AI.Conversation(createResult.Identifier, chat.Id, creationOptions: null, changeVector: null);
@@ -141,7 +141,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task EnableFullDebug_QueryStringOverride_FlipsPersistedAttributeFromFalseToTrue(Options options, GenAiConfiguration config)
+    public async Task Debug_QueryStringOverride_FlipsPersistedAttributeFromFalseToTrue(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -162,13 +162,13 @@ public class AiAgentDebugTracing : RavenTestBase
         {
             var doc = await session.LoadAsync<ConversationDocShape>(chat.Id);
             Assert.NotNull(doc);
-            Assert.False(doc.EnableFullDebug, "Expected EnableFullDebug=false persisted on a fresh conversation with no override");
+            Assert.False(doc.Debug, "Expected Debug=false persisted on a fresh conversation with no override");
         }
 
-        // Turn 2: same conversation, ?enableFullDebug=true — must flip persisted false → true
+        // Turn 2: same conversation, ?debug=true — must flip persisted false → true
         // AND must take effect on this turn (traces are written).
         var chat2 = store.AI.Conversation(createResult.Identifier, chat.Id,
-            creationOptions: null, changeVector: null, enableFullDebug: true);
+            creationOptions: null, changeVector: null, debug: true);
         chat2.SetUserPrompt("What is 3+3?");
         await chat2.RunAsync<OutputSchema>(CancellationToken.None);
 
@@ -176,7 +176,7 @@ public class AiAgentDebugTracing : RavenTestBase
         {
             var doc = await session.LoadAsync<ConversationDocShape>(chat.Id);
             Assert.NotNull(doc);
-            Assert.True(doc.EnableFullDebug, "Expected EnableFullDebug=true persisted after ?enableFullDebug=true");
+            Assert.True(doc.Debug, "Expected Debug=true persisted after ?debug=true");
 
             var traces = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
             Assert.True(traces.Count == 1, "Expected at least one trace document after the turn that flipped the flag on");
@@ -185,7 +185,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task EnableFullDebug_QueryStringOverride_FlipsPersistedAttributeFromTrueToFalse(Options options, GenAiConfiguration config)
+    public async Task Debug_QueryStringOverride_FlipsPersistedAttributeFromTrueToFalse(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -197,9 +197,9 @@ public class AiAgentDebugTracing : RavenTestBase
         };
         var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
 
-        // Turn 1: ?enableFullDebug=true on a brand-new conversation — must persist as true.
+        // Turn 1: ?debug=true on a brand-new conversation — must persist as true.
         var chat = store.AI.Conversation(createResult.Identifier, "chats/",
-            creationOptions: null, enableFullDebug: true);
+            creationOptions: null, debug: true);
         chat.SetUserPrompt("What is 2+2?");
         await chat.RunAsync<OutputSchema>(CancellationToken.None);
 
@@ -208,16 +208,16 @@ public class AiAgentDebugTracing : RavenTestBase
         {
             var doc = await session.LoadAsync<ConversationDocShape>(chat.Id);
             Assert.NotNull(doc);
-            Assert.True(doc.EnableFullDebug, "Expected EnableFullDebug=true persisted after ?enableFullDebug=true");
+            Assert.True(doc.Debug, "Expected Debug=true persisted after ?debug=true");
 
             tracesAfterTurn1 = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).Count();
             Assert.True(tracesAfterTurn1 == 1);
         }
 
-        // Turn 2: same conversation, ?enableFullDebug=false — must flip persisted true → false
+        // Turn 2: same conversation, ?debug=false — must flip persisted true → false
         // AND the override must be honored on this turn (no new traces written).
         var chat2 = store.AI.Conversation(createResult.Identifier, chat.Id,
-            creationOptions: null, changeVector: null, enableFullDebug: false);
+            creationOptions: null, changeVector: null, debug: false);
         chat2.SetUserPrompt("What is 3+3?");
         await chat2.RunAsync<OutputSchema>(CancellationToken.None);
 
@@ -225,7 +225,7 @@ public class AiAgentDebugTracing : RavenTestBase
         {
             var doc = await session.LoadAsync<ConversationDocShape>(chat.Id);
             Assert.NotNull(doc);
-            Assert.False(doc.EnableFullDebug, "Expected EnableFullDebug=false persisted after ?enableFullDebug=false");
+            Assert.False(doc.Debug, "Expected Debug=false persisted after ?debug=false");
 
             var tracesAfterTurn2 = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).Count();
             Assert.Equal(tracesAfterTurn1, tracesAfterTurn2);
@@ -234,7 +234,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task EnableFullDebug_WithAttachment_PersistsAttachmentNames(Options options, GenAiConfiguration config)
+    public async Task Debug_WithAttachment_PersistsAttachmentNames(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -247,7 +247,7 @@ public class AiAgentDebugTracing : RavenTestBase
         var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
 
         var chat = store.AI.Conversation(createResult.Identifier, "chats/",
-            creationOptions: null, enableFullDebug: true);
+            creationOptions: null, debug: true);
         chat.AddAttachment("heart.png", new MemoryStream(Convert.FromBase64String(AiTestData.HeartPngBase64)), "image/png");
         chat.SetUserPrompt("What do you see in this image?");
         var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
@@ -267,7 +267,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task EnableFullDebug_Streaming_PersistsStreamEvents(Options options, GenAiConfiguration config)
+    public async Task Debug_Streaming_PersistsStreamEvents(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -280,7 +280,7 @@ public class AiAgentDebugTracing : RavenTestBase
         var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
 
         var chat = store.AI.Conversation(createResult.Identifier, "chats/",
-            creationOptions: null, enableFullDebug: true);
+            creationOptions: null, debug: true);
         chat.SetUserPrompt("What is 2+2?");
 
         var streamedChunks = new List<string>();
@@ -307,7 +307,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task EnableFullDebug_WithQueryTool_PersistsOneTracePerLlmCall(Options options, GenAiConfiguration config)
+    public async Task Debug_WithQueryTool_PersistsOneTracePerLlmCall(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -334,7 +334,7 @@ public class AiAgentDebugTracing : RavenTestBase
         var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
 
         var chat = store.AI.Conversation(createResult.Identifier, "chats/",
-            creationOptions: null, enableFullDebug: true);
+            creationOptions: null, debug: true);
         chat.SetUserPrompt("What products do you have available?");
         var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
         Assert.Equal(AiConversationResult.Done, r.Status);
@@ -349,7 +349,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task EnableFullDebug_WithActionTool_PersistsOneTracePerLlmCall(Options options, GenAiConfiguration config)
+    public async Task Debug_WithActionTool_PersistsOneTracePerLlmCall(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -371,7 +371,7 @@ public class AiAgentDebugTracing : RavenTestBase
         var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
 
         var chat = store.AI.Conversation(createResult.Identifier, "chats/",
-            creationOptions: null, enableFullDebug: true);
+            creationOptions: null, debug: true);
         chat.Handle<object>("GetPrice", _ => "the price is $9.99");
         chat.SetUserPrompt("What is the price of a widget?");
         var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
@@ -386,7 +386,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public async Task EnableFullDebug_FailedLlmCall_TracesStillPersisted()
+    public async Task Debug_FailedLlmCall_TracesStillPersisted()
     {
         using var store = GetDocumentStore();
 
@@ -414,7 +414,7 @@ public class AiAgentDebugTracing : RavenTestBase
             {
                 CreationOptions = new AiConversationCreationOptions(),
                 UserPrompt = "What is 2+2?"
-            }, changeVector: null, enableFullDebugOverride: true);
+            }, changeVector: null, debugOverride: true);
 
             await Assert.ThrowsAnyAsync<Exception>(() => handler.HandleRequest(context, CancellationToken.None));
             conversationDocId = handler.ConversationDocId;
@@ -425,7 +425,7 @@ public class AiAgentDebugTracing : RavenTestBase
         // Despite the LLM failure the finally block must have persisted whatever traces were captured.
         var stats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
         Assert.True(stats.Collections.TryGetValue(Constants.Documents.Collections.AiAgentConversationDebugCollection, out long count),
-            "Expected the debug-trace collection to exist after a failed turn with EnableFullDebug=true");
+            "Expected the debug-trace collection to exist after a failed turn with Debug=true");
         Assert.True(count == 1);
 
         using var session = store.OpenAsyncSession();
@@ -435,7 +435,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public async Task EnableFullDebug_RequestSerializationThrowsMidWrite_PartialRequestBodyPersisted()
+    public async Task Debug_RequestSerializationThrowsMidWrite_PartialRequestBodyPersisted()
     {
         using var store = GetDocumentStore();
 
@@ -473,7 +473,7 @@ public class AiAgentDebugTracing : RavenTestBase
             {
                 CreationOptions = new AiConversationCreationOptions(),
                 UserPrompt = "What is 2+2?"
-            }, changeVector: null, enableFullDebugOverride: true);
+            }, changeVector: null, debugOverride: true);
 
             await Assert.ThrowsAnyAsync<Exception>(() => handler.HandleRequest(context, CancellationToken.None));
             conversationDocId = handler.ConversationDocId;
@@ -483,7 +483,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
         var stats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
         Assert.True(stats.Collections.TryGetValue(Constants.Documents.Collections.AiAgentConversationDebugCollection, out long count),
-            "Expected the debug-trace collection to exist after a mid-write failure with EnableFullDebug=true");
+            "Expected the debug-trace collection to exist after a mid-write failure with Debug=true");
         Assert.True(count == 1);
 
         using var session = store.OpenAsyncSession();
@@ -500,19 +500,19 @@ public class AiAgentDebugTracing : RavenTestBase
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true })]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { null })]
-    public async Task EnableFullDebug_PropagatesToSubAgent(Options options, GenAiConfiguration config, bool? enableFullDebug)
+    public async Task Debug_PropagatesToSubAgent(Options options, GenAiConfiguration config, bool? debug)
     {
         using var store = await CreateStoreWithSubAgentArithmetic(options, config);
 
         const string conversationId = "chats/propagation-test";
 
-        // Null case: we need the parent doc to already have EnableFullDebug=true persisted so the
+        // Null case: we need the parent doc to already have Debug=true persisted so the
         // null override actually has something to preserve. Drive a non-arithmetic warm-up turn
         // that won't invoke the sub-agent, then the real turn below uses the null override.
-        if (enableFullDebug == null)
+        if (debug == null)
         {
             var warmup = store.AI.Conversation(_parentAgentIdentifier, conversationId,
-                creationOptions: null, enableFullDebug: true);
+                creationOptions: null, debug: true);
             warmup.SetUserPrompt("Just say hi. Do not call any tools.");
             await warmup.RunAsync<OutputSchema>(CancellationToken.None);
 
@@ -522,12 +522,12 @@ public class AiAgentDebugTracing : RavenTestBase
             using var s = store.OpenAsyncSession();
             var warmupDoc = await s.LoadAsync<ConversationDocShape>(conversationId);
             Assert.NotNull(warmupDoc);
-            Assert.True(warmupDoc.EnableFullDebug, "warm-up should persist EnableFullDebug=true");
+            Assert.True(warmupDoc.Debug, "warm-up should persist Debug=true");
             Assert.Empty(warmupDoc.SubConversationIds);
         }
 
         var chat = store.AI.Conversation(_parentAgentIdentifier, conversationId,
-            creationOptions: null, changeVector: null, enableFullDebug: enableFullDebug);
+            creationOptions: null, changeVector: null, debug: debug);
         chat.SetUserPrompt("What is 2+2?");
         var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
         Assert.Equal(AiConversationResult.Done, r.Status);
@@ -536,7 +536,7 @@ public class AiAgentDebugTracing : RavenTestBase
         Assert.NotNull(snap.SubId);
 
         // true OR null-after-true-warmup -> tracing on; false -> tracing off.
-        var expectTracing = enableFullDebug != false;
+        var expectTracing = debug != false;
         Assert.Equal(expectTracing, snap.ParentPersisted);
         Assert.Equal(expectTracing, snap.SubPersisted);
 
@@ -549,7 +549,7 @@ public class AiAgentDebugTracing : RavenTestBase
             //     the warm-up turn ("just say hi" -> single LLM call, no tool dispatch).
             // A real LLM may occasionally do an extra reflection / re-dispatch round, so we use
             // lower bounds rather than equality.
-            var minParentTraces = enableFullDebug == null ? 3 : 2;
+            var minParentTraces = debug == null ? 3 : 2;
             Assert.True(snap.ParentTraces >= minParentTraces,
                 $"expected >= {minParentTraces} parent trace docs, got {snap.ParentTraces}");
             Assert.True(snap.SubAgentTraces >= 1,
@@ -568,7 +568,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task EnableFullDebug_MultipleAttachments_PersistsAllNamesInOrder(Options options, GenAiConfiguration config)
+    public async Task Debug_MultipleAttachments_PersistsAllNamesInOrder(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -581,7 +581,7 @@ public class AiAgentDebugTracing : RavenTestBase
         var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
 
         var chat = store.AI.Conversation(createResult.Identifier, "chats/",
-            creationOptions: null, enableFullDebug: true);
+            creationOptions: null, debug: true);
 
         chat.AddAttachment("heart.png", new MemoryStream(Convert.FromBase64String(AiTestData.HeartPngBase64)), "image/png");
         chat.AddAttachment("star.png", new MemoryStream(Convert.FromBase64String(AiTestData.StarPngBase64)), "image/png");
@@ -675,8 +675,8 @@ public class AiAgentDebugTracing : RavenTestBase
         {
             ParentTraces = parentTraces,
             SubAgentTraces = subTraces,
-            ParentPersisted = parentDoc.EnableFullDebug,
-            SubPersisted = subDoc?.EnableFullDebug ?? false,
+            ParentPersisted = parentDoc.Debug,
+            SubPersisted = subDoc?.Debug ?? false,
             SubId = subId
         };
     }
@@ -701,7 +701,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
     private class ConversationDocShape
     {
-        public bool EnableFullDebug { get; set; }
+        public bool Debug { get; set; }
         public HashSet<string> SubConversationIds { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentDebugTracing.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentDebugTracing.cs
@@ -15,11 +15,12 @@ using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Server.Documents;
+using Raven.Server.Documents.AI;
 using Raven.Server.Documents.Handlers.AI.Agents;
 using Raven.Server.ServerWide.Context;
-using AiTestData = SlowTests.Server.Documents.AI.GenAi.Data;
 using Tests.Infrastructure;
 using Xunit;
+using AiTestData = SlowTests.Server.Documents.AI.GenAi.Data;
 
 namespace SlowTests.Server.Documents.AI.AiAgent;
 
@@ -64,7 +65,7 @@ public class AiAgentDebugTracing : RavenTestBase
         Assert.True(tracesList.Count == 1);
 
         var first = tracesList.First();
-        Assert.NotNull(first.Request);
+        Assert.NotNull(first.RequestBody);
         Assert.NotNull(first.Response);
     }
 
@@ -135,7 +136,7 @@ public class AiAgentDebugTracing : RavenTestBase
         using var session = store.OpenAsyncSession();
         var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
         Assert.True(tracesList.Count == 1);
-        Assert.NotNull(tracesList.First().Request);
+        Assert.NotNull(tracesList.First().RequestBody);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
@@ -257,7 +258,7 @@ public class AiAgentDebugTracing : RavenTestBase
         Assert.True(tracesList.Count == 1);
 
         // The request payload must be present — it carries the base64-encoded image inline.
-        Assert.NotNull(tracesList.First().Request);
+        Assert.NotNull(tracesList.First().RequestBody);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
@@ -295,7 +296,7 @@ public class AiAgentDebugTracing : RavenTestBase
         Assert.True(tracesList.Count == 1);
 
         var first = tracesList.First();
-        Assert.NotNull(first.Request);
+        Assert.NotNull(first.RequestBody);
         Assert.Null(first.Response);        // streaming populates StreamEvents, not Response
         Assert.NotNull(first.StreamEvents); // at least one SSE event was captured
     }
@@ -339,7 +340,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
         // At least 2 LLM calls: one that returned a tool call, one with the final answer.
         Assert.True(tracesList.Count == 2, $"Expected at least 2 trace documents, got {tracesList.Count}");
-        Assert.All(tracesList, t => Assert.NotNull(t.Request));
+        Assert.All(tracesList, t => Assert.NotNull(t.RequestBody));
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
@@ -377,7 +378,7 @@ public class AiAgentDebugTracing : RavenTestBase
 
         // At least 2 LLM calls: one that requested the action tool, one with the final answer.
         Assert.True(tracesList.Count == 2, $"Expected at least 2 trace documents, got {tracesList.Count}");
-        Assert.All(tracesList, t => Assert.NotNull(t.Request));
+        Assert.All(tracesList, t => Assert.NotNull(t.RequestBody));
     }
 
     [RavenFact(RavenTestCategory.Ai)]
@@ -426,22 +427,146 @@ public class AiAgentDebugTracing : RavenTestBase
         using var session = store.OpenAsyncSession();
         var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{conversationDocId}/{AiDebugTrace.TraceSegment}/")).ToList();
         Assert.True(tracesList.Count == 1, $"Expected at least one trace document under '{conversationDocId}/{AiDebugTrace.TraceSegment}/'");
-        Assert.NotNull(tracesList.First().Request);
+        Assert.NotNull(tracesList.First().RequestBody);
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public async Task EnableFullDebug_RequestSerializationThrowsMidWrite_PartialRequestBodyPersisted()
+    {
+        using var store = GetDocumentStore();
+
+        var agentConfig = new AiAgentConfiguration("debug-partial-agent", "fake-connection",
+            "You are a helpful assistant.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}"
+        };
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        string conversationDocId = null;
+
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        {
+            // Inject a ModifyPayload that writes some bytes then throws. The `finally` block in
+            // CreateCompletionRequest must still capture whatever made it to the buffer
+            // (RequestBody is the raw bytes, always — no parse is attempted).
+            var handler = new ExposableMockLlmHandler(Server.ServerStore, database,
+                onRequest: null,
+                configureClient: client =>
+                {
+                    client.ForTestingPurposesOnly().ModifyPayload = w =>
+                    {
+                        w.WriteStartObject();
+                        w.WritePropertyName("model");
+                        w.WriteString("partial-mock");
+                        throw new InvalidOperationException("simulated mid-write failure");
+                    };
+                })
+            {
+                Authentication = null
+            };
+
+            handler.Initialize(agentConfig, "chats/", new RequestBody
+            {
+                CreationOptions = new AiConversationCreationOptions(),
+                UserPrompt = "What is 2+2?"
+            }, changeVector: null, enableFullDebugOverride: true);
+
+            await Assert.ThrowsAnyAsync<Exception>(() => handler.HandleRequest(context, CancellationToken.None));
+            conversationDocId = handler.ConversationDocId;
+        }
+
+        Assert.NotNull(conversationDocId);
+
+        var stats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
+        Assert.True(stats.Collections.TryGetValue(Constants.Documents.Collections.AiAgentConversationDebugCollection, out long count),
+            "Expected the debug-trace collection to exist after a mid-write failure with EnableFullDebug=true");
+        Assert.True(count == 1);
+
+        using var session = store.OpenAsyncSession();
+        var tracesList = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{conversationDocId}/{AiDebugTrace.TraceSegment}/")).ToList();
+        Assert.True(tracesList.Count == 1);
+
+        var body = tracesList.First().RequestBody;
+        Assert.NotNull(body);
+        // The partial bytes that were written before the throw must be present — raw, possibly invalid JSON.
+        Assert.Contains("partial-mock", body);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task EnableFullDebug_PropagatesToSubAgent(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var subAgent = new AiAgentConfiguration("debug-sub-agent", config.ConnectionStringName,
+            "You answer arithmetic questions. Return a short numeric answer.")
+        {
+            SampleObject = "{\"Answer\":\"42\"}"
+        };
+        var subAgentResult = await store.AI.CreateAgentAsync(subAgent, OutputSchema.Instance);
+
+        var parentAgent = new AiAgentConfiguration("debug-parent-agent", config.ConnectionStringName,
+            "Delegate any arithmetic question to the math sub-agent and return its answer.")
+        {
+            SampleObject = "{\"Answer\":\"answer here\"}",
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = subAgentResult.Identifier,
+                    Description = "Use to answer arithmetic questions."
+                }
+            ]
+        };
+        var parentResult = await store.AI.CreateAgentAsync(parentAgent, OutputSchema.Instance);
+
+        var chat = store.AI.Conversation(parentResult.Identifier, "chats/",
+            creationOptions: null, enableFullDebug: true);
+        chat.SetUserPrompt("What is 2+2?");
+        var r = await chat.RunAsync<OutputSchema>(CancellationToken.None);
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        // Traces should exist for the parent conversation AND for at least one sub-agent conversation.
+        var stats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
+        Assert.True(stats.Collections.TryGetValue(Constants.Documents.Collections.AiAgentConversationDebugCollection, out long count));
+        Assert.True(count >= 2, $"Expected at least 2 trace documents (parent + sub-agent), got {count}");
+
+        using var session = store.OpenAsyncSession();
+        var parentTraces = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
+        Assert.True(parentTraces.Count >= 1, "Expected at least one trace under the parent conversation prefix.");
+
+        var allTraces = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/")).ToList();
+        // Sub-agent conversations have IDs of the form `{parent.Id}/{paramsHash}` and their traces
+        // are nested under `{parent.Id}/{paramsHash}/{TraceSegment}/...`.
+        var subAgentTraces = allTraces.Count - parentTraces.Count;
+        Assert.True(subAgentTraces >= 1, $"Expected at least one trace under a sub-agent conversation prefix; got {subAgentTraces}.");
     }
 
     // Subclass that exposes the conversation document ID so the test can load the trace docs by prefix.
+    // Also allows the test to configure the MockLlm right after it is created (e.g. to inject
+    // a ModifyPayload hook that fails serialization mid-write).
     private class ExposableMockLlmHandler(
         Raven.Server.ServerWide.ServerStore server,
         DocumentDatabase database,
-        Func<JObject, HttpResponseMessage> onRequest = null)
+        Func<JObject, HttpResponseMessage> onRequest = null,
+        Action<MockLlm> configureClient = null)
         : MockLlmConversationHandler(server, database, onRequest)
     {
         public string ConversationDocId => _document?.Id;
+
+        protected internal override ChatCompletionClient CreateClient()
+        {
+            var client = (MockLlm)base.CreateClient();
+            configureClient?.Invoke(client);
+            return client;
+        }
     }
 
     private class DebugTraceDoc
     {
-        public object Request { get; set; }
+        // Raw request body as written to the wire. Always a string — no parse is attempted server-side.
+        public string RequestBody { get; set; }
         public object Response { get; set; }
         public object StreamEvents { get; set; }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26012/Enable-Debug-for-conversation

### Additional description

Adds a debug mode for AI agent conversations. When EnableFullDebug is enabled — either saved on the conversation document or overridden per-request via ?enableFullDebug=true|false — every request sent to the LLM provider and its response are saved to the @conversations-debug collection (one document per model call, ID: {conversationId}/request-trace/{etag}). Trace documents inherit the conversation's TTL and are saved even if the turn fails.

The override is sticky — it is written back to the conversation document and applies to all future turns until changed again.

Open item: GenAI tracing behavior is not yet decided - need to be discussed.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
