### PR TITLE
RavenDB-26100 Fix TcpConnectionOptions leaks

### DIFF
--- a/src/Raven.Server/Documents/Replication/AbstractReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/AbstractReplicationLoader.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Replication
         where TContextPool : JsonContextPoolBase<TOperationContext>
         where TOperationContext : JsonOperationContext
     {
-        private readonly ReaderWriterLockSlim _locker = new ReaderWriterLockSlim();
+        protected readonly ReaderWriterLockSlim _locker = new ReaderWriterLockSlim();
         private int _replicationStatsId;
         private readonly string _databaseName;
         public readonly TContextPool ContextPool;

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -260,8 +260,12 @@ namespace Raven.Server.Documents.Replication.Incoming
                     {
                         stats.Complete();
                     }
-                    
+
                     InvokeOnFailed(e);
+                }
+                else
+                {
+                    OnCancellation(e);
                 }
             }
         }
@@ -618,6 +622,11 @@ namespace Raven.Server.Documents.Replication.Incoming
         protected abstract void InvokeOnAttachmentStreamsReceived(int attachmentStreamCount);
 
         protected abstract void InvokeOnFailed(Exception exception);
+
+        protected virtual void OnCancellation(Exception e)
+        {
+            // by default, do nothing - the handler will be cleaned up by the replication loader during dispose
+        }
 
         protected abstract Task HandleBatchAsync(TOperationContext context, DataForReplicationCommand batch, long lastEtag);
 

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -205,6 +205,10 @@ namespace Raven.Server.Documents.Replication.Outgoing
                         _tcpConnectionOptions.DatabaseContext?.RunningTcpConnections.Add(_tcpConnectionOptions);
 
                         // Re-check: shutdown may have landed between the check above and the Add.
+                        // This narrows but does NOT eliminate the race - cancellation can still land
+                        // after this check returns. The RunningTcpConnections drain in
+                        // DocumentDatabase.Dispose / ShardedDatabaseContext.Dispose is the real
+                        // safety net for that residual window.
                         if (_cts.IsCancellationRequested)
                         {
                             _tcpConnectionOptions.Dispose();
@@ -888,9 +892,9 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 {
                     _tcpConnectionOptions?.Dispose();
                 }
-                catch
+                catch (ObjectDisposedException)
                 {
-                    // idempotent + defensive
+                    // expected on idempotent re-dispose - matches the sibling _cts.Dispose() block above
                 }
             }
         }

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -193,8 +193,24 @@ namespace Raven.Server.Documents.Replication.Outgoing
                     using (_interruptibleRead)
                     {
                         InitialHandshake();
+
+                        // Mirror RavenServer.DispatchDatabaseTcpConnection's check
+                        if (_cts.IsCancellationRequested)
+                        {
+                            _tcpConnectionOptions.Dispose();
+                            return;
+                        }
+
                         _tcpConnectionOptions.DocumentDatabase?.RunningTcpConnections.Add(_tcpConnectionOptions);
                         _tcpConnectionOptions.DatabaseContext?.RunningTcpConnections.Add(_tcpConnectionOptions);
+
+                        // Re-check: shutdown may have landed between the check above and the Add.
+                        if (_cts.IsCancellationRequested)
+                        {
+                            _tcpConnectionOptions.Dispose();
+                            return;
+                        }
+
                         Replicate();
                     }
                 }
@@ -830,39 +846,53 @@ namespace Raven.Server.Documents.Replication.Outgoing
             if (_disposed.Raise() == false)
                 return;
 
-            var timeout = _server.Engine.TcpConnectionTimeout;
-            if (Logger.IsInfoEnabled)
-                Logger.Info($"Disposing {GetType().FullName} ({FromToString}) [Timeout:{timeout}]");
-
-            OnBeforeDispose();
-
-            _cts.Cancel();
-
-            _tcpConnectionOptions.Dispose();
-            DisposeTcpClient();
-
-            _connectionDisposed.Set();
-
-            if (_longRunningSendingWork != null && _longRunningSendingWork != PoolOfThreads.LongRunningWork.Current)
-            {
-                while (_longRunningSendingWork.Join((int)timeout.TotalMilliseconds) == false)
-                {
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Waited {timeout} for timeout to occur, but still this thread is keep on running. Will wait another {timeout} ");
-                    DisposeTcpClient();
-                }
-            }
-
             try
             {
-                _cts.Dispose();
-            }
-            catch (ObjectDisposedException)
-            {
-                //was already disposed? we don't care, we are disposing
-            }
+                var timeout = _server.Engine.TcpConnectionTimeout;
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Disposing {GetType().FullName} ({FromToString}) [Timeout:{timeout}]");
 
-            _connectionDisposed.Dispose();
+                OnBeforeDispose();
+
+                _cts.Cancel();
+
+                DisposeTcpClient();
+
+                _connectionDisposed.Set();
+
+                if (_longRunningSendingWork != null && _longRunningSendingWork != PoolOfThreads.LongRunningWork.Current)
+                {
+                    while (_longRunningSendingWork.Join((int)timeout.TotalMilliseconds) == false)
+                    {
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info($"Waited {timeout} for timeout to occur, but still this thread is keep on running. Will wait another {timeout} ");
+                        DisposeTcpClient();
+                    }
+                }
+
+                try
+                {
+                    _cts.Dispose();
+                }
+                catch (ObjectDisposedException)
+                {
+                    //was already disposed? we don't care, we are disposing
+                }
+
+                _connectionDisposed.Dispose();
+            }
+            finally
+            {
+                // Idempotent — safe even if Dispose() above already ran.
+                try
+                {
+                    _tcpConnectionOptions?.Dispose();
+                }
+                catch
+                {
+                    // idempotent + defensive
+                }
+            }
         }
 
         private void DisposeTcpClient()

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -205,10 +205,6 @@ namespace Raven.Server.Documents.Replication.Outgoing
                         _tcpConnectionOptions.DatabaseContext?.RunningTcpConnections.Add(_tcpConnectionOptions);
 
                         // Re-check: shutdown may have landed between the check above and the Add.
-                        // This narrows but does NOT eliminate the race - cancellation can still land
-                        // after this check returns. The RunningTcpConnections drain in
-                        // DocumentDatabase.Dispose / ShardedDatabaseContext.Dispose is the real
-                        // safety net for that residual window.
                         if (_cts.IsCancellationRequested)
                         {
                             _tcpConnectionOptions.Dispose();
@@ -892,9 +888,9 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 {
                     _tcpConnectionOptions?.Dispose();
                 }
-                catch (ObjectDisposedException)
+                catch
                 {
-                    // expected on idempotent re-dispose - matches the sibling _cts.Dispose() block above
+                    // idempotent + defensive
                 }
             }
         }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -537,9 +537,9 @@ namespace Raven.Server.Documents.Replication
                 {
                 }
             }
-            catch (ObjectDisposedException)
+            catch
             {
-                // expected on idempotent re-dispose
+                // ignored
             }
         }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -537,9 +537,9 @@ namespace Raven.Server.Documents.Replication
                 {
                 }
             }
-            catch
+            catch (ObjectDisposedException)
             {
-                // ignored
+                // expected on idempotent re-dispose
             }
         }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -626,7 +626,7 @@ namespace Raven.Server.Documents.Replication
             newIncoming.Failed += OnIncomingReceiveFailed;
 
             // Cooperate with ReplicationLoader.Dispose() which takes the write lock and iterates _incoming.
-            // Without this guard a handler can race into _incoming after Dispose iterated and end up orphaned
+            // Without this guard a handler can race into _incoming after Dispose iterated and end up orphaned.
             if (_locker.TryEnterReadLock(0) == false)
             {
                 // the db being disposed
@@ -634,6 +634,7 @@ namespace Raven.Server.Documents.Replication
                 return;
             }
 
+            bool added = false;
             try
             {
                 if (GetCancellationToken().IsCancellationRequested)
@@ -650,7 +651,7 @@ namespace Raven.Server.Documents.Replication
                 {
                     newIncoming.Start();
                     IncomingReplicationAdded?.Invoke(newIncoming);
-                    ForceTryReconnectAll();
+                    added = true;
                 }
                 else
                 {
@@ -665,6 +666,10 @@ namespace Raven.Server.Documents.Replication
             {
                 _locker.ExitReadLock();
             }
+
+            // Must be outside the read lock, because reconnect happens under lock
+            if (added)
+                ForceTryReconnectAll();
         }
 
         internal void AddAndStartOutgoingReplication(ReplicationNode node)

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -50,7 +50,6 @@ namespace Raven.Server.Documents.Replication
 
         private readonly Timer _reconnectAttemptTimer;
         private long _reconnectInProgress;
-        private readonly ReaderWriterLockSlim _locker = new ReaderWriterLockSlim();
 
         public event Action<IncomingReplicationHandler> IncomingReplicationAdded;
 
@@ -499,23 +498,49 @@ namespace Raven.Server.Documents.Replication
                 outgoingReplication.PathsToSend = DetailedReplicationHubAccess.Preferred(header.ReplicationHubAccess.AllowedHubToSinkPaths, header.ReplicationHubAccess.AllowedSinkToHubPaths);
             }
 
-            if (_outgoing.TryAdd(outgoingReplication) == false)
+            if (_locker.TryEnterReadLock(0) == false)
+            {
+                // db is being disposed
+                DisposeConnection(tcpConnectionOptions, outgoingReplication);
+                return;
+            }
+
+            try
+            {
+                if (GetCancellationToken().IsCancellationRequested || _outgoing.TryAdd(outgoingReplication) == false)
+                {
+                    DisposeConnection(tcpConnectionOptions, outgoingReplication);
+                    return;
+                }
+
+                outgoingReplication.Failed += OnOutgoingSendingFailed;
+                outgoingReplication.SuccessfulTwoWaysCommunication += OnOutgoingSendingSucceeded;
+                outgoingReplication.SuccessfulReplication += ResetReplicationFailuresInfo;
+
+                // tcp ownership - the tcp is passed as a scope of the replication so that it can be properly disposed.
+                // StartPullReplicationAsHub launches a long-running thread and returns — safe to hold the read lock across it.
+                outgoingReplication.StartPullReplicationAsHub(tcpConnectionOptions, tcpConnectionOptions.Stream, supportedVersions);
+                OutgoingReplicationAdded?.Invoke(outgoingReplication);
+            }
+            finally
+            {
+                _locker.ExitReadLock();
+            }
+        }
+
+        private static void DisposeConnection(TcpConnectionOptions tcpConnectionOptions, OutgoingPullReplicationHandlerAsHub outgoingReplication)
+        {
+            try
             {
                 using (tcpConnectionOptions)
                 using (outgoingReplication)
                 {
-
                 }
-                return;
             }
-
-            outgoingReplication.Failed += OnOutgoingSendingFailed;
-            outgoingReplication.SuccessfulTwoWaysCommunication += OnOutgoingSendingSucceeded;
-            outgoingReplication.SuccessfulReplication += ResetReplicationFailuresInfo;
-
-            // tcp ownership - the tcp is passed as a scope of the replication so that it can be properly disposed.
-            outgoingReplication.StartPullReplicationAsHub(tcpConnectionOptions, tcpConnectionOptions.Stream, supportedVersions);
-            OutgoingReplicationAdded?.Invoke(outgoingReplication);
+            catch
+            {
+                // ignored
+            }
         }
 
         public void RunPullReplicationAsSink(
@@ -543,8 +568,31 @@ namespace Raven.Server.Documents.Replication
                 PoolOfThreads.PooledThread.ResetCurrentThreadName();
                 Thread.CurrentThread.Name = ThreadNames.GetNameToUse(ThreadNames.ForPullReplicationAsSink($"Pull Replication as Sink from {destination.Database} at {destination.Url}", destination.Database, destination.Url));
 
-                _incoming[newIncoming.ConnectionInfo.SourceDatabaseId] = newIncoming;
-                IncomingReplicationAdded?.Invoke(newIncoming);
+                // Cooperate with ReplicationLoader.Dispose — see CreateIncomingInstance for the full rationale.
+                if (_locker.TryEnterReadLock(0) == false)
+                {
+                    newIncoming.Dispose();
+                    return;
+                }
+
+                try
+                {
+                    if (GetCancellationToken().IsCancellationRequested)
+                    {
+                        newIncoming.Dispose();
+                        return;
+                    }
+
+                    _incoming[newIncoming.ConnectionInfo.SourceDatabaseId] = newIncoming;
+                    IncomingReplicationAdded?.Invoke(newIncoming);
+                }
+                finally
+                {
+                    _locker.ExitReadLock();
+                }
+
+                // DoIncomingReplication runs the blocking receive loop on this thread — must be outside the
+                // read lock so Dispose can acquire the write lock when shutdown is triggered.
                 newIncoming.DoIncomingReplication();
 
                 void RetryPullReplication(IncomingReplicationHandler instance, Exception e)
@@ -577,23 +625,45 @@ namespace Raven.Server.Documents.Replication
             var newIncoming = CreateIncomingReplicationHandler(tcpConnectionOptions, buffer, pullReplicationParams);
             newIncoming.Failed += OnIncomingReceiveFailed;
 
-            // need to safeguard against two concurrent connection attempts
-            var current = _incoming.AddOrUpdate(newIncoming.ConnectionInfo.SourceDatabaseId, newIncoming,
-                (_, val) => val.IsDisposed ? newIncoming : val);
-
-            if (current == newIncoming)
+            // Cooperate with ReplicationLoader.Dispose() which takes the write lock and iterates _incoming.
+            // Without this guard a handler can race into _incoming after Dispose iterated and end up orphaned
+            if (_locker.TryEnterReadLock(0) == false)
             {
-                newIncoming.Start();
-                IncomingReplicationAdded?.Invoke(newIncoming);
-                ForceTryReconnectAll();
-            }
-            else
-            {
-                if (_logger.IsInfoEnabled)
-                {
-                    _logger.Info("you can't add two identical connections.", new InvalidOperationException("you can't add two identical connections."));
-                }
+                // the db being disposed
                 newIncoming.Dispose();
+                return;
+            }
+
+            try
+            {
+                if (GetCancellationToken().IsCancellationRequested)
+                {
+                    newIncoming.Dispose();
+                    return;
+                }
+
+                // need to safeguard against two concurrent connection attempts
+                var current = _incoming.AddOrUpdate(newIncoming.ConnectionInfo.SourceDatabaseId, newIncoming,
+                    (_, val) => val.IsDisposed ? newIncoming : val);
+
+                if (current == newIncoming)
+                {
+                    newIncoming.Start();
+                    IncomingReplicationAdded?.Invoke(newIncoming);
+                    ForceTryReconnectAll();
+                }
+                else
+                {
+                    if (_logger.IsInfoEnabled)
+                    {
+                        _logger.Info("you can't add two identical connections.", new InvalidOperationException("you can't add two identical connections."));
+                    }
+                    newIncoming.Dispose();
+                }
+            }
+            finally
+            {
+                _locker.ExitReadLock();
             }
         }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -111,7 +111,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             _parent.CleanAndDisposeConnection(this);
 
             if (Logger.IsInfoEnabled)
-                Logger.Info($"Sharded incoming replication handler has been cancelled. ({FromToString})");
+                Logger.Info($"Sharded incoming replication handler has been cancelled. ({FromToString})", e);
         }
 
         protected override void HandleHeartbeatMessage(TransactionOperationContext jsonOperationContext, BlittableJsonReaderObject blittableJsonReaderObject)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -111,7 +111,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             _parent.CleanAndDisposeConnection(this);
 
             if (Logger.IsInfoEnabled)
-                Logger.Info($"Sharded incoming replication handler has been cancelled. ({FromToString})", e);
+                Logger.Info($"Sharded incoming replication handler has been cancelled. ({FromToString})");
         }
 
         protected override void HandleHeartbeatMessage(TransactionOperationContext jsonOperationContext, BlittableJsonReaderObject blittableJsonReaderObject)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -99,6 +99,12 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
         protected override void InvokeOnFailed(Exception exception) => _parent.InvokeOnFailed(this, exception);
 
+        protected override void OnCancellation(Exception e)
+        {
+            // Always dispose so the per-shard outgoing handlers (and their TcpConnectionOptions) are cleaned up.
+            InvokeOnFailed(e);
+        }
+
         protected override void HandleHeartbeatMessage(TransactionOperationContext jsonOperationContext, BlittableJsonReaderObject blittableJsonReaderObject)
         {
             blittableJsonReaderObject.TryGet(nameof(ReplicationMessageHeader.DatabaseChangeVector), out _lastAcceptedChangeVectorDuringHeartbeat);

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -97,12 +97,21 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
         protected override void EnsureNotDeleted() => _parent.EnsureNotDeleted(_parent.Server.NodeTag);
 
-        protected override void InvokeOnFailed(Exception exception) => _parent.InvokeOnFailed(this, exception);
+        protected override void InvokeOnFailed(Exception exception)
+        {
+            _parent.CleanAndDisposeConnection(this);
+
+            if (Logger.IsInfoEnabled)
+                Logger.Info($"Sharded incoming replication handler has thrown an unhandled exception. ({FromToString})", exception);
+        }
 
         protected override void OnCancellation(Exception e)
         {
             // Always dispose so the per-shard outgoing handlers (and their TcpConnectionOptions) are cleaned up.
-            InvokeOnFailed(e);
+            _parent.CleanAndDisposeConnection(this);
+
+            if (Logger.IsInfoEnabled)
+                Logger.Info($"Sharded incoming replication handler has been cancelled. ({FromToString})");
         }
 
         protected override void HandleHeartbeatMessage(TransactionOperationContext jsonOperationContext, BlittableJsonReaderObject blittableJsonReaderObject)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -45,6 +45,20 @@ namespace Raven.Server.Documents.Sharding.Handlers
             DestinationDatabaseName = node.Database;
         }
 
+        protected override void HandleReplicationErrors(Action replicationAction)
+        {
+            try
+            {
+                base.HandleReplicationErrors(replicationAction);
+            }
+            finally
+            {
+                // The parent awaits _firstChangeVector in GetInitialHandshakeResponseFromShardsAsync.
+                // If we exited via cancellation, OnFailed was skipped — set it here so the await unblocks.
+                _firstChangeVector.TrySetCanceled();
+            }
+        }
+
         protected override void Replicate()
         {
             ReplicationBatch batch = null;

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -54,8 +54,10 @@ namespace Raven.Server.Documents.Sharding.Handlers
             finally
             {
                 // The parent awaits _firstChangeVector in GetInitialHandshakeResponseFromShardsAsync.
-                // If we exited via cancellation, OnFailed was skipped — set it here so the await unblocks.
-                _firstChangeVector.TrySetCanceled();
+                // If we exited before the TCS was completed (cancellation or early exit), cancel it
+                // so the await unblocks. Guard against cancelling an already-completed TCS.
+                if (_firstChangeVector.Task.IsCompleted == false)
+                    _firstChangeVector.TrySetCanceled();
             }
         }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -54,10 +54,8 @@ namespace Raven.Server.Documents.Sharding.Handlers
             finally
             {
                 // The parent awaits _firstChangeVector in GetInitialHandshakeResponseFromShardsAsync.
-                // If we exited before the TCS was completed (cancellation or early exit), cancel it
-                // so the await unblocks. Guard against cancelling an already-completed TCS.
-                if (_firstChangeVector.Task.IsCompleted == false)
-                    _firstChangeVector.TrySetCanceled();
+                // If we exited via cancellation, OnFailed was skipped — set it here so the await unblocks.
+                _firstChangeVector.TrySetCanceled();
             }
         }
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -63,20 +63,41 @@ namespace Raven.Server.Documents.Sharding
 
             private void AddAndStartIncomingInstance(ShardedIncomingReplicationHandler newIncoming)
             {
-                var current = _incoming.AddOrUpdate(newIncoming.ConnectionInfo.SourceDatabaseId, newIncoming,
-                    (_, val) => val.IsDisposed ? newIncoming : val);
-
-                if (current == newIncoming)
+                // Synchronize with AbstractReplicationLoader.Dispose, which iterates _incoming under the write lock.
+                if (_locker.TryEnterReadLock(0) == false)
                 {
-                    newIncoming.Start();
-                }
-                else
-                {
-                    if (_logger.IsInfoEnabled)
-                    {
-                        _logger.Info("you can't add two identical connections.", new InvalidOperationException("you can't add two identical connections."));
-                    }
+                    // db is being disposed — don't orphan
                     newIncoming.Dispose();
+                    return;
+                }
+
+                try
+                {
+                    if (GetCancellationToken().IsCancellationRequested)
+                    {
+                        newIncoming.Dispose();
+                        return;
+                    }
+
+                    var current = _incoming.AddOrUpdate(newIncoming.ConnectionInfo.SourceDatabaseId, newIncoming,
+                        (_, val) => val.IsDisposed ? newIncoming : val);
+
+                    if (current == newIncoming)
+                    {
+                        newIncoming.Start();
+                    }
+                    else
+                    {
+                        if (_logger.IsInfoEnabled)
+                        {
+                            _logger.Info("you can't add two identical connections.", new InvalidOperationException("you can't add two identical connections."));
+                        }
+                        newIncoming.Dispose();
+                    }
+                }
+                finally
+                {
+                    _locker.ExitReadLock();
                 }
             }
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -148,14 +148,11 @@ namespace Raven.Server.Documents.Sharding
                 }
             }
 
-            public void InvokeOnFailed(ShardedIncomingReplicationHandler handler, Exception e)
+            internal void CleanAndDisposeConnection(ShardedIncomingReplicationHandler handler)
             {
                 using (handler)
                 {
                     _incoming.TryRemove(handler.ConnectionInfo.SourceDatabaseId, out _);
-
-                    if (_logger.IsInfoEnabled)
-                        _logger.Info($"Sharded incoming replication handler has thrown an unhandled exception. ({handler.FromToString})", e);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -244,12 +244,10 @@ namespace Raven.Server.Documents.Sharding
 
             exceptionAggregator.Execute(() => Replication?.Dispose());
 
+            // Mirror DocumentDatabase.Dispose: drain any TcpConnectionOptions still tracked here as a safety net.
             foreach (var connection in RunningTcpConnections)
             {
-                exceptionAggregator.Execute(() =>
-                {
-                    connection.Dispose();
-                });
+                exceptionAggregator.Execute(connection.Dispose);
             }
 
             exceptionAggregator.Execute(() => ShardExecutor?.Dispose());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26100

### Additional description

This pull request introduces several improvements and bug fixes to the replication subsystem, focusing on safe resource management, robust shutdown handling, and improved synchronization to prevent race conditions and resource leaks. The changes mainly revolve around the proper disposal of replication handlers and TCP connections, especially during database shutdown or cancellation scenarios.

**Key changes include:**

### Synchronization and Shutdown Safety

* Switched the `_locker` from private to protected in `AbstractReplicationLoader` and removed redundant declarations in derived classes, ensuring consistent lock usage for synchronizing access to replication handler collections. [[1]](diffhunk://#diff-22f58be10a282953fba62a8e594b9fe40d7c73edcd52116f0183a27e95122417L38-R38) [[2]](diffhunk://#diff-b74f5da5c5fd0d1945f933bb2b4e716932fff828242ae2708755c31020353ae6L53)
* Updated methods that add incoming and outgoing replication handlers (`CreatePullReplicationAsHub`, `RunPullReplicationAsSink`, `CreateIncomingInstance`, and sharded equivalents) to acquire a read lock before modifying handler collections, and to check for cancellation before proceeding. If the lock cannot be acquired or cancellation is requested, handlers and connections are disposed immediately to avoid orphaned resources. [[1]](diffhunk://#diff-b74f5da5c5fd0d1945f933bb2b4e716932fff828242ae2708755c31020353ae6L502-R512) [[2]](diffhunk://#diff-b74f5da5c5fd0d1945f933bb2b4e716932fff828242ae2708755c31020353ae6R521-R544) [[3]](diffhunk://#diff-b74f5da5c5fd0d1945f933bb2b4e716932fff828242ae2708755c31020353ae6R571-R595) [[4]](diffhunk://#diff-b74f5da5c5fd0d1945f933bb2b4e716932fff828242ae2708755c31020353ae6R628-R645) [[5]](diffhunk://#diff-b74f5da5c5fd0d1945f933bb2b4e716932fff828242ae2708755c31020353ae6L588-R654) [[6]](diffhunk://#diff-b74f5da5c5fd0d1945f933bb2b4e716932fff828242ae2708755c31020353ae6R665-R673) [[7]](diffhunk://#diff-f8fed1699d7b2d5d673274db858691a5438202e6b31057ab0ad222add6ba9e46R66-R81) [[8]](diffhunk://#diff-f8fed1699d7b2d5d673274db858691a5438202e6b31057ab0ad222add6ba9e46R98-R102)

### Resource Disposal Improvements

* Refactored disposal logic in `AbstractOutgoingReplicationHandler.Dispose` to ensure TCP connections are always disposed, even if exceptions occur or if `Dispose` is called multiple times. This includes moving disposal into a `finally` block and making the operation idempotent and defensive. [[1]](diffhunk://#diff-2367b92efe5fe1e1a7319f5805aa8c9afb6b41a6fa0cb18028ac9514674fe9e2R849-R850) [[2]](diffhunk://#diff-2367b92efe5fe1e1a7319f5805aa8c9afb6b41a6fa0cb18028ac9514674fe9e2L841) [[3]](diffhunk://#diff-2367b92efe5fe1e1a7319f5805aa8c9afb6b41a6fa0cb18028ac9514674fe9e2R884-R896)
* Added a static `DisposeConnection` helper to centralize and simplify the disposal of both TCP connection options and outgoing replication handlers in error scenarios.

### Cancellation and Error Handling

* Introduced the `OnCancellation` virtual method in `AbstractIncomingReplicationHandler`, allowing derived classes to handle cancellation events explicitly. The default implementation does nothing, but sharded handlers override it to ensure proper cleanup. [[1]](diffhunk://#diff-78aee360cb8c1e7ab75714fd6e01a37ef6489c47215b3bd71106f86fa160f475R266-R269) [[2]](diffhunk://#diff-78aee360cb8c1e7ab75714fd6e01a37ef6489c47215b3bd71106f86fa160f475R626-R630) [[3]](diffhunk://#diff-6b2c34e36ebb82b7c652e3c0c1e53a185d4c17db9ebdb7a2b5022ae37fcfb239R102-R107)
* In sharded outgoing replication, ensured that the `_firstChangeVector` task is cancelled if replication exits due to cancellation, preventing potential deadlocks in code awaiting this task.

### Robustness in Replication Loops

* Added additional cancellation checks in the outgoing replication handshake and connection registration logic to prevent adding connections or starting replication if shutdown is in progress, reducing the risk of resource leaks or inconsistent state.

### Miscellaneous Improvements

* Ensured that all tracked `TcpConnectionOptions` are disposed in `ShardedDatabaseContext.Dispose`, mirroring the logic in `DocumentDatabase.Dispose` for consistency and safety.

These changes collectively harden the replication infrastructure against race conditions, improve shutdown reliability, and ensure that resources are not leaked during cancellation or disposal events.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
