### PR TITLE
RavenDB-26107 Exit TxMerger immediately on database shutdown cancellation 

### DIFF
--- a/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
@@ -94,7 +94,7 @@ namespace Raven.Server.Documents.TransactionMerger
 
         public int NumberOfQueuedOperations => _operations.Count;
 
-        private string TransactionMergerThreadName => $"'{_resourceName}' TxMT";
+        internal string TransactionMergerThreadName => $"'{_resourceName}' TxMT";
 
         public void Start()
         {
@@ -185,6 +185,10 @@ namespace Raven.Server.Documents.TransactionMerger
 
                         MergeTransactionsOnce();
                     }
+                    return;
+                }
+                catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+                {
                     return;
                 }
                 catch (OperationCanceledException)

--- a/test/SlowTests/Server/TransactionMergerTests.cs
+++ b/test/SlowTests/Server/TransactionMergerTests.cs
@@ -11,6 +11,7 @@ using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Server.Utils;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -156,6 +157,44 @@ from TestObjs as o where o.Prop = null update
                 Indexes.WaitForIndexing(store);
                 var patchCount = await session.Query<TestObj>().Where(o => o.Prop == "Changed").CountAsync();
                 Assert.Equal(docCount, patchCount);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task RavenDB_26107_TxMergerShouldExitWhenDatabaseShutdownIsCanceled()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                RunInMemory = false
+            });
+
+            var database = await GetDatabase(store.Database);
+            var txMergerThreadName = database.TxMerger.TransactionMergerThreadName;
+
+            Assert.True(WaitForValue(() => ThreadNames.FullThreadNames.Any(x => x.Value == txMergerThreadName), true),
+                $"TxMerger thread '{txMergerThreadName}' was not started.");
+
+            using var enteredDispose = new ManualResetEventSlim();
+            using var allowDisposeToContinue = new ManualResetEventSlim();
+            using var _ = database.ForTestingPurposesOnly().CallDuringDocumentDatabaseInternalDispose(() =>
+            {
+                enteredDispose.Set();
+                allowDisposeToContinue.Wait();
+            });
+
+            var disposeTask = Task.Run(database.Dispose);
+
+            try
+            {
+                Assert.True(enteredDispose.Wait(TimeSpan.FromSeconds(15)), "Database dispose did not start.");
+
+                Assert.False(WaitForValue(() => ThreadNames.FullThreadNames.Any(x => x.Value == txMergerThreadName), false),
+                    $"TxMerger thread '{txMergerThreadName}' did not exit after database shutdown was canceled.");
+            }
+            finally
+            {
+                allowDisposeToContinue.Set();
+                await disposeTask;
             }
         }
 

--- a/test/StressTests/Rachis/SubscriptionFailoverWithWaitingChainsStress.cs
+++ b/test/StressTests/Rachis/SubscriptionFailoverWithWaitingChainsStress.cs
@@ -125,7 +125,7 @@ namespace StressTests.Rachis
                     await GenerateWaitingSubscriptions(cdeArray.GetArray(), store, i, workerTasks, cluster.Nodes, cts.Token);
                 }
 
-                _ = Task.Run(async () => await ContinuouslyGenerateDocs(DocsBatchSize, store, cts.Token), cts.Token);
+                var generateDocsTask = Task.Run(async () => await ContinuouslyGenerateDocs(DocsBatchSize, store, cts.Token), cts.Token);
 
                 var dbNodesCountToToggle = Math.Max(Math.Min(dBGroupSize - 1, dBGroupSize / 2 + 1), 1);
                 var nodesToToggle = store.GetRequestExecutor().TopologyNodes.Select(x => x.ClusterTag).Take(dbNodesCountToToggle).ToList();
@@ -153,6 +153,15 @@ namespace StressTests.Rachis
                 }
 
                 await Task.WhenAll(workerTasks);
+
+                cts.Cancel();
+                try
+                {
+                    await generateDocsTask;
+                }
+                catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                {
+                }
             }
         }
 


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26107

### Additional description


This PR fixes a TxMerger shutdown race where the database shutdown token could be canceled while the TxMerger thread was idle and waiting for work.

In that case:

`_waitHandle.Wait(_shutdown)`

throws `OperationCanceledException`. Previously, the exception was swallowed by the outer `catch (OperationCanceledException)`, which caused the outer `while (true)` loop to restart. 

`TxMerger.Dispose()` is not immediately after `_databaseShutdown.Cancel()`. There is work before it:

- GenerateOfflineDatabaseInfo();
- Drain all requests for up to 60 seconds unless SkipDrainAllRequests;
- Acquire _databaseStateChange.Locker, up to 5 seconds;
- Dispose storage space monitor subscription;
- Dispose running TCP connections;

Since `_runTransactions` is only set to `false` later, when `TxMerger.Dispose()` is reached, the TxMerger thread could remain alive after database shutdown had already started.

A TxMerger thread that remains alive during shutdown can keep database resources alive longer than expected and contribute to intermittent cleanup failures such as:

`IOException: The process cannot access the file 'db.lock' because it is being used by another process`

## Fix

The fix makes the TxMerger thread exit immediately when the cancellation comes from the TxMerger/database shutdown token.

## Test coverage

Added a regression test for `RavenDB-26107` that:

1. Starts a database and waits for its TxMerger thread to be registered.
2. Starts database disposal.
3. Blocks disposal immediately after `_databaseShutdown.Cancel()` and before `TxMerger.Dispose()` runs.
4. Verifies the TxMerger thread exits due to shutdown cancellation alone.

The test fails without the TxMerger fix and passes with it.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
