### PR TITLE
RavenDB-26564 - Custom Build

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -931,7 +931,17 @@ namespace Raven.Server.Documents
         {
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Starting dispose");
 
-            _databaseShutdown.Cancel();
+            try
+            {
+                _databaseShutdown.Cancel();
+            }
+            catch (AggregateException)
+            {
+                // _databaseShutdown.Cancel() fires registered cancellation callbacks synchronously.
+                // Some callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync) may throw
+                // We must catch it so the rest of the cleanup can proceed.
+                // CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException, it is the only exception type it throws
+            }
 
             _serverStore.Server.ServerCertificateChanged -= OnCertificateChange;
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -935,12 +935,14 @@ namespace Raven.Server.Documents
             {
                 _databaseShutdown.Cancel();
             }
-            catch (AggregateException)
+            catch (AggregateException e)
             {
                 // _databaseShutdown.Cancel() fires registered cancellation callbacks synchronously.
                 // Some callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync) may throw
                 // We must catch it so the rest of the cleanup can proceed.
                 // CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException, it is the only exception type it throws
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"{nameof(AggregateException)} during _databaseShutdown.Cancel() while disposing the {nameof(DocumentDatabase)}: {Name}", e);
             }
 
             _serverStore.Server.ServerCertificateChanged -= OnCertificateChange;

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -658,18 +658,16 @@ namespace Raven.Server.Documents.Replication.Incoming
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"Disposing IncomingReplicationHandler ({FromToString})");
 
-                // RavenDB-26564: _cts.Cancel() fires registered cancellation callbacks synchronously.
-                // ParseToMemoryAsync registers stream.Dispose via token.Register(stream.Dispose).
-                // If the connection is half-open, the callback tries to flush buffered data to a dead
-                // socket, which blocks then throws SocketException. CancellationTokenSource wraps this
-                // in AggregateException. We must catch it so the cleanup below can run — otherwise we
-                // leak the TCP socket, temp files, and leave the background thread stuck.
                 try
                 {
                     _cts.Cancel();
                 }
-                catch (Exception)
+                catch (AggregateException)
                 {
+                    // _cts.Cancel() fires registered cancellation callbacks synchronously.
+                    // Some callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync) may throw
+                    // We must catch it so the rest of the cleanup can proceed.
+                    // CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException, it is the only exception type it throws
                 }
 
                 try

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -657,7 +657,20 @@ namespace Raven.Server.Documents.Replication.Incoming
             {
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"Disposing IncomingReplicationHandler ({FromToString})");
-                _cts.Cancel();
+
+                // RavenDB-26564: _cts.Cancel() fires registered cancellation callbacks synchronously.
+                // ParseToMemoryAsync registers stream.Dispose via token.Register(stream.Dispose).
+                // If the connection is half-open, the callback tries to flush buffered data to a dead
+                // socket, which blocks then throws SocketException. CancellationTokenSource wraps this
+                // in AggregateException. We must catch it so the cleanup below can run — otherwise we
+                // leak the TCP socket, temp files, and leave the background thread stuck.
+                try
+                {
+                    _cts.Cancel();
+                }
+                catch (Exception)
+                {
+                }
 
                 try
                 {
@@ -666,6 +679,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                 catch (Exception)
                 {
                 }
+
                 try
                 {
                     _stream.Dispose();
@@ -673,6 +687,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                 catch (Exception)
                 {
                 }
+
                 try
                 {
                     _tcpClient.Dispose();

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -662,12 +662,14 @@ namespace Raven.Server.Documents.Replication.Incoming
                 {
                     _cts.Cancel();
                 }
-                catch (AggregateException)
+                catch (AggregateException e)
                 {
                     // _cts.Cancel() fires registered cancellation callbacks synchronously.
                     // Some callbacks (e.g. stream.Dispose registered via token.Register in ParseToMemoryAsync) may throw
                     // We must catch it so the rest of the cleanup can proceed.
                     // CancellationTokenSource.Cancel() wraps all callback exceptions in AggregateException, it is the only exception type it throws
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{nameof(AggregateException)} during _cts.Cancel() while disposing of {nameof(IncomingReplicationHandler)} ({FromToString})", e);
                 }
 
                 try

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -760,7 +760,26 @@ namespace Raven.Server.Documents.Replication
 
                 IncomingReplicationRemoved?.Invoke(incoming);
 
-                value.Dispose();
+                // RavenDB-26564: if the old handler is already disposed (e.g. from a previous failed attempt),
+                // skip re-invocation — DisposeOnce<SingleAttempt> would immediately re-throw the cached exception.
+                if (value.IsDisposed == false)
+                {
+                    try
+                    {
+                        value.Dispose();
+                    }
+                    catch (Exception e)
+                    {
+                        // RavenDB-26564: a half-open TCP connection can cause Dispose to throw when the
+                        // dispose path tries to flush buffered data to a dead socket. We must not let this
+                        // prevent the new connection from being accepted. The stale entry in _incoming will
+                        // be replaced by the subsequent AddOrUpdate in CreateIncomingInstance (which checks
+                        // IsDisposed on the existing value).
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info($"Failed to dispose the existing incoming replication handler from {incoming.FromToString}. " +
+                                         $"Proceeding to accept the new connection.", e);
+                    }
+                }
             }
         }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -760,25 +760,18 @@ namespace Raven.Server.Documents.Replication
 
                 IncomingReplicationRemoved?.Invoke(incoming);
 
-                // RavenDB-26564: if the old handler is already disposed (e.g. from a previous failed attempt),
-                // skip re-invocation — DisposeOnce<SingleAttempt> would immediately re-throw the cached exception.
-                if (value.IsDisposed == false)
+                try
                 {
-                    try
-                    {
-                        value.Dispose();
-                    }
-                    catch (Exception e)
-                    {
-                        // RavenDB-26564: a half-open TCP connection can cause Dispose to throw when the
-                        // dispose path tries to flush buffered data to a dead socket. We must not let this
-                        // prevent the new connection from being accepted. The stale entry in _incoming will
-                        // be replaced by the subsequent AddOrUpdate in CreateIncomingInstance (which checks
-                        // IsDisposed on the existing value).
-                        if (_logger.IsInfoEnabled)
-                            _logger.Info($"Failed to dispose the existing incoming replication handler from {incoming.FromToString}. " +
-                                         $"Proceeding to accept the new connection.", e);
-                    }
+                    value.Dispose();
+                }
+                catch (Exception e)
+                {
+                    // RavenDB-26564: precautionary catch — the primary fix is in DisposeInternal
+                    // where _cts.Cancel() is now guarded. This ensures that even if Dispose fails
+                    // for an unexpected reason, the new connection is still accepted.
+                    if (_logger.IsOperationsEnabled)
+                        _logger.Operations($"Failed to dispose the existing incoming replication handler from {incoming.FromToString}. " +
+                                     $"Proceeding to accept the new connection.", e);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-26441.cs
+++ b/test/SlowTests/Issues/RavenDB-26441.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26441 : RavenTestBase
+{
+    public RavenDB_26441(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Replication)]
+    public async Task UnloadDatabase_WhenDatabaseShutdownRegisterCallerThrow_ShouldBeAbleToLoad()
+    {
+        using var server = GetNewServer(new ServerCreationOptions
+        {
+            CustomSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "1",
+                [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "1",
+                [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
+            }
+        });
+
+        string databaseName;
+        using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false, DeleteDatabaseOnDispose = false }))
+        {
+            databaseName = store.Database;
+            var db = await GetDatabase(server, databaseName);
+            db.DatabaseShutdown.Register(() => throw new Exception("Artificial exception"));
+        }
+
+        await AssertWaitForValueAsync(async () => server.ServerStore.IdleDatabases.Count, 1);
+
+        using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false, CreateDatabase = false, ModifyDatabaseName = _ => databaseName }))
+        {
+            using var session = store.OpenAsyncSession();
+            await session.LoadAsync<object>("randomId"); // forces us to load the database, and if the exception from the DatabaseShutdown register is not handled, it will fail to load
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26564/Stale-half-open-TCP-connection-in-incoming-replication-handler-causes-permanent-self-sustaining-failure-loop

### Additional description

On top of 6.2.15 with the following fix: https://github.com/ravendb/ravendb/pull/22769

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
