### PR TITLE
RavenDB-26602 Add QueryTimings subscope for embedding fetch during vector.search

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -628,7 +628,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 OrderMetadata[] orderByFields;
 
                 CoraxQueryBuilder.Parameters builderParameters;
-                using (queryTimings?.For(nameof(QueryTimingsScope.Names.Corax), start: false)?.Start())
+                using (var coraxTimings = queryTimings?.For(nameof(QueryTimingsScope.Names.Corax), start: false)?.Start())
                 {
                     IDisposable releaseServerContext = null;
                     IDisposable closeServerTransaction = null;
@@ -643,7 +643,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                         }
 
                         builderParameters = new CoraxQueryBuilder.Parameters(IndexSearcher, _allocator, serverContext, documentsContext, query, _index,
-                            query.QueryParameters, QueryBuilderFactories, _fieldMappings, fieldsToFetch, highlightings.Terms, (int)take, deduplicationDisabled: false, indexReadOperation: this, token: token, queryTime: queryTime);
+                            query.QueryParameters, QueryBuilderFactories, _fieldMappings, fieldsToFetch, highlightings.Terms, (int)take, deduplicationDisabled: false, indexReadOperation: this, token: token, queryTime: queryTime, queryTimings: coraxTimings);
 
                         using (closeServerTransaction)
                         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.Parameters.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.Parameters.cs
@@ -6,6 +6,7 @@ using Corax.Querying;
 using Corax.Querying.Matches;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
+using Raven.Server.Documents.Queries.Timings;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Server;
@@ -40,12 +41,14 @@ public partial class CoraxQueryBuilder
         public StreamingOptimization StreamingDisabled;
         public readonly bool IsVectorSingleClause;
         public readonly QueryTimeScope QueryTime;
+        public readonly QueryTimingsScope QueryTimings;
 
         internal Parameters(IndexSearcher searcher, ByteStringContext allocator, TransactionOperationContext serverContext, DocumentsOperationContext documentsContext,
             IndexQueryServerSide query, Index index, BlittableJsonReaderObject queryParameters, QueryBuilderFactories factories, IndexFieldsMapping indexFieldsMapping,
-            FieldsToFetch fieldsToFetch, Dictionary<string, CoraxHighlightingTermIndex> highlightingTerms, int take, bool deduplicationDisabled, IndexReadOperationBase indexReadOperation = null, List<string> buildSteps = null, QueryTimeScope queryTime = null, CancellationToken token = default)
+            FieldsToFetch fieldsToFetch, Dictionary<string, CoraxHighlightingTermIndex> highlightingTerms, int take, bool deduplicationDisabled, IndexReadOperationBase indexReadOperation = null, List<string> buildSteps = null, QueryTimeScope queryTime = null, QueryTimingsScope queryTimings = null, CancellationToken token = default)
         {
             QueryTime = queryTime;
+            QueryTimings = queryTimings;
             IndexSearcher = searcher;
             ServerContext = serverContext;
             Query = query;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -15,6 +15,7 @@ using Raven.Server.Documents.Indexes.Persistence.Corax.QueryOptimizer;
 using Raven.Server.Documents.Indexes.VectorSearch;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
+using Raven.Server.Documents.Queries.Timings;
 using Sparrow;
 using Sparrow.Json;
 
@@ -411,28 +412,31 @@ public static partial class CoraxQueryBuilder
             
             ReadOnlyMemory<ReadOnlyMemory<byte>> embeddingValues;
 
-            switch (valueType)
+            using (builderParameters.QueryTimings?.For(nameof(QueryTimingsScope.Names.Embeddings), start: false)?.Start())
             {
-                case ValueTokenType.String:
-                    embeddingValues = embeddingsGenerator
-                        .GetEmbeddingsForQuery(builderParameters.DocumentsContext, embeddingsTaskId, value.ToString());
-                    break;
-                case ValueTokenType.Parameter:
+                switch (valueType)
                 {
-                    if (value is not BlittableJsonReaderArray bjra)
-                        throw new InvalidQueryException($"Expected array as parameter of vector.search({fieldName}) method, got '{value.GetType().FullName}' type instead.");
-                
-                    var values = new string[bjra.Length];
+                    case ValueTokenType.String:
+                        embeddingValues = embeddingsGenerator
+                            .GetEmbeddingsForQuery(builderParameters.DocumentsContext, embeddingsTaskId, value.ToString());
+                        break;
+                    case ValueTokenType.Parameter:
+                    {
+                        if (value is not BlittableJsonReaderArray bjra)
+                            throw new InvalidQueryException($"Expected array as parameter of vector.search({fieldName}) method, got '{value.GetType().FullName}' type instead.");
 
-                    for (var i = 0; i < values.Length; i++)
-                        values[i] = bjra[i].ToString();
-                
-                    embeddingValues = embeddingsGenerator
-                        .GetEmbeddingsForQuery(builderParameters.DocumentsContext, embeddingsTaskId, values);
-                    break;
+                        var values = new string[bjra.Length];
+
+                        for (var i = 0; i < values.Length; i++)
+                            values[i] = bjra[i].ToString();
+
+                        embeddingValues = embeddingsGenerator
+                            .GetEmbeddingsForQuery(builderParameters.DocumentsContext, embeddingsTaskId, values);
+                        break;
+                    }
+                    default:
+                        throw new NotSupportedException($"Unexpected value type provided as parameter to vector.search({fieldName}) method. Got '{value.GetType().FullName}' type.");
                 }
-                default:
-                    throw new NotSupportedException($"Unexpected value type provided as parameter to vector.search({fieldName}) method. Got '{value.GetType().FullName}' type.");
             }
             
             var queryingVectorOption = new VectorOptions

--- a/src/Raven.Server/Documents/Queries/Timings/QueryTimingsScope.cs
+++ b/src/Raven.Server/Documents/Queries/Timings/QueryTimingsScope.cs
@@ -36,6 +36,7 @@ namespace Raven.Server.Documents.Queries.Timings
             public static string Cluster;
             public static string Reduce;
             public static string Paging;
+            public static string Embeddings;
         }
 
         private QueryInspectionNode _queryPlan;

--- a/src/Raven.Studio/wwwroot/Content/css/pages/query.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/query.less
@@ -326,6 +326,7 @@
         .color-def(~'storage', @color-3-2);
         .color-def(~'lucene', @color-4);
         .color-def(~'corax', @color-4);
+        .color-def(~'embeddings', @color-4-1);
         .color-def(~'includes', @color-4-2);
         .color-def(~'fill', @color-5);
         .color-def(~'gather', @color-5-2);


### PR DESCRIPTION
### Issue link

[RavenDB-26602](https://issues.hibernatingrhinos.com/issue/RavenDB-26602) Add QueryTimings subscope for embedding fetch during vector.search

### Additional description

The core part of this PR is just a wrap of a `switch` for getting embedding with a timing. The ceremony contains adding QueryTimings to the query builder parameters. Also added different color for this scope in Timings view.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
