### PR TITLE
RavenDB-26518 Delete collection from Studio handler lacks Audit Log write + RavenDB-26519 Audit Log: Record unfiltered Delete/Patch by Query operations (v6.2)

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/AbstractStudioCollectionHandlerProcessorForDeleteCollection.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/AbstractStudioCollectionHandlerProcessorForDeleteCollection.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Server.Json;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Handlers.Processors.Studio
 {
@@ -43,6 +44,14 @@ namespace Raven.Server.Documents.Handlers.Processors.Studio
             await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
             {
                 writer.WriteOperationIdAndNodeTag(context, operationId, ServerStore.NodeTag);
+            }
+
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+            {
+                var target = excludeIds.Count == 0
+                    ? $"Documents in collection '{collectionName}'"
+                    : $"Documents in collection '{collectionName}' (excluding {excludeIds.Count} ids)";
+                RequestHandler.LogAuditFor(RequestHandler.DatabaseName, "DELETE", target);
             }
 
             ScheduleDeleteCollection(context, returnToContextPool, collectionName, excludeIds, operationId);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/AbstractShardedOperationQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/AbstractShardedOperationQueriesHandlerProcessor.cs
@@ -11,6 +11,7 @@ using Raven.Server.Documents.Queries;
 using Raven.Server.NotificationCenter;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Sparrow.Logging;
 using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Queries;
@@ -49,6 +50,19 @@ internal abstract class AbstractShardedOperationQueriesHandlerProcessor : Abstra
         var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
 
         var op = GetOperation(query, operationId, options);
+
+        if (LoggingSource.AuditLog.IsInfoEnabled)
+        {
+            var logAction = op.Type switch
+            {
+                OperationType.UpdateByQuery => "UPDATE",
+                OperationType.DeleteByQuery => "DELETE",
+                OperationType.DeleteByCollection => "DELETE",
+                _ => op.Type.ToString().ToUpper()
+            };
+
+            RequestHandler.LogAuditFor(RequestHandler.DatabaseName, logAction, $"Documents matching the query: {query}");
+        }
 
         var task = RequestHandler.DatabaseContext.Operations
             .AddRemoteOperation<OperationIdResult, BulkOperationResult, BulkInsertProgress>(

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForDelete.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForDelete.cs
@@ -20,6 +20,6 @@ internal sealed class ShardedQueriesHandlerProcessorForDelete : AbstractShardedO
 
     protected override (Func<JsonOperationContext, int, RavenCommand<OperationIdResult>> CommandFactory, OperationType Type) GetOperation(IndexQueryServerSide query, long operationId, QueryOperationOptions options)
     {
-        return ((c, shardNumber) => new DeleteByQueryOperation.DeleteByQueryCommand<BlittableJsonReaderObject>(DocumentConventions.DefaultForServer, query, options, operationId), OperationType.UpdateByQuery);
+        return ((c, shardNumber) => new DeleteByQueryOperation.DeleteByQueryCommand<BlittableJsonReaderObject>(DocumentConventions.DefaultForServer, query, options, operationId), OperationType.DeleteByQuery);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26519/Audit-Log-Record-unfiltered-Delete-Patch-by-Query-operations
https://issues.hibernatingrhinos.com/issue/RavenDB-26518/Delete-collection-from-Studio-handler-lacks-Audit-Log-write

### Additional description

| Operation | Single-node | Sharded |
|---|---|---|
| Studio "Delete documents" (incl. `@all_docs`) | ✅ Fixed in RavenDB-26518 | ✅ Fixed in RavenDB-26518  |
| `DELETE /queries` (`from <Coll>` or `from @all_docs`) | ✅ pre-existing | ✅ Fixed in RavenDB-26519 |
| `PATCH /queries` (`from <Coll> update {...}` or `from @all_docs update {...}`) | ✅ pre-existing | ✅ Fixed in RavenDB-26519 |

Every collection-scoped destructive operation now emits an audit line on both topologies.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
