### PR TITLE
RavenDB-26518 Delete collection from Studio handler lacks Audit Log write + RavenDB-26519 Audit Log: Record unfiltered Delete/Patch by Query operations (v7.2)

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/AbstractStudioCollectionHandlerProcessorForDeleteCollection.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/AbstractStudioCollectionHandlerProcessorForDeleteCollection.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Server.Json;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Handlers.Processors.Studio
 {
@@ -43,6 +44,14 @@ namespace Raven.Server.Documents.Handlers.Processors.Studio
             await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
             {
                 writer.WriteOperationIdAndNodeTag(context, operationId, ServerStore.NodeTag);
+            }
+
+            if (RavenLogManager.Instance.IsAuditEnabled)
+            {
+                var target = excludeIds.Count == 0
+                    ? $"Documents in collection '{collectionName}'"
+                    : $"Documents in collection '{collectionName}' (excluding {excludeIds.Count} ids)";
+                RequestHandler.LogAuditForDatabase("DELETE", target);
             }
 
             ScheduleDeleteCollection(context, returnToContextPool, collectionName, excludeIds, operationId);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/AbstractShardedOperationQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/AbstractShardedOperationQueriesHandlerProcessor.cs
@@ -11,6 +11,7 @@ using Raven.Server.Documents.Queries;
 using Raven.Server.NotificationCenter;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Sparrow.Logging;
 using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Queries;
@@ -49,6 +50,19 @@ internal abstract class AbstractShardedOperationQueriesHandlerProcessor : Abstra
         var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
 
         var op = GetOperation(query, operationId, options);
+
+        if (RavenLogManager.Instance.IsAuditEnabled)
+        {
+            var logAction = op.Type switch
+            {
+                OperationType.UpdateByQuery => "UPDATE",
+                OperationType.DeleteByQuery => "DELETE",
+                OperationType.DeleteByCollection => "DELETE",
+                _ => op.Type.ToString().ToUpper()
+            };
+
+            RequestHandler.LogAuditForDatabase(logAction, $"Documents matching the query: {query}");
+        }
 
         var task = RequestHandler.DatabaseContext.Operations
             .AddRemoteOperation<OperationIdResult, BulkOperationResult, BulkInsertProgress>(

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForDelete.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Queries/ShardedQueriesHandlerProcessorForDelete.cs
@@ -20,6 +20,6 @@ internal sealed class ShardedQueriesHandlerProcessorForDelete : AbstractShardedO
 
     protected override (Func<JsonOperationContext, int, RavenCommand<OperationIdResult>> CommandFactory, OperationType Type) GetOperation(IndexQueryServerSide query, long operationId, QueryOperationOptions options)
     {
-        return ((c, shardNumber) => new DeleteByQueryOperation.DeleteByQueryCommand<BlittableJsonReaderObject>(DocumentConventions.DefaultForServer, query, options, operationId), OperationType.UpdateByQuery);
+        return ((c, shardNumber) => new DeleteByQueryOperation.DeleteByQueryCommand<BlittableJsonReaderObject>(DocumentConventions.DefaultForServer, query, options, operationId), OperationType.DeleteByQuery);
     }
 }

--- a/test/SlowTests/SlowTests/Issues/RavenDB_26518.cs
+++ b/test/SlowTests/SlowTests/Issues/RavenDB_26518.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Server.Documents.Commands.Studio;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.SlowTests.Issues
+{
+    public class RavenDB_26518 : DisableParallelTestBase
+    {
+        public RavenDB_26518(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private sealed class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [RavenTheory(RavenTestCategory.Security | RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task StudioCollectionDelete_ShouldWriteAuditLine(Options options)
+        {
+            var (auditLogPath, adminCert) = AuditLogTestHelper.SetupAuditLoggedServer(this);
+            options.AdminCertificate = adminCert;
+            options.ClientCertificate = adminCert;
+
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "alice" });
+                session.Store(new User { Name = "bob" });
+                session.SaveChanges();
+            }
+
+            await store.Operations.SendAsync(new DeleteStudioCollectionOperation(operationId: null, collectionName: "Users", excludeIds: null));
+
+            var line = await AuditLogTestHelper.WaitForAuditLineAsync(auditLogPath,
+                l => l.Contains("DELETE") && l.Contains("Documents in collection 'Users'"));
+
+            Assert.NotNull(line);
+        }
+
+        [RavenTheory(RavenTestCategory.Security | RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task StudioCollectionDelete_AllDocs_ShouldWriteAuditLine(Options options)
+        {
+            var (auditLogPath, adminCert) = AuditLogTestHelper.SetupAuditLoggedServer(this);
+            options.AdminCertificate = adminCert;
+            options.ClientCertificate = adminCert;
+
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "alice" });
+                session.SaveChanges();
+            }
+
+            await store.Operations.SendAsync(new DeleteStudioCollectionOperation(operationId: null, collectionName: "@all_docs", excludeIds: null));
+
+            var line = await AuditLogTestHelper.WaitForAuditLineAsync(auditLogPath,
+                l => l.Contains("DELETE") && l.Contains("Documents in collection '@all_docs'"));
+
+            Assert.NotNull(line);
+        }
+
+        [RavenTheory(RavenTestCategory.Security | RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task StudioCollectionDelete_WithExcludeIds_ShouldIncludeExclusionCount(Options options)
+        {
+            var (auditLogPath, adminCert) = AuditLogTestHelper.SetupAuditLoggedServer(this);
+            options.AdminCertificate = adminCert;
+            options.ClientCertificate = adminCert;
+
+            using var store = GetDocumentStore(options);
+
+            string keepId;
+            using (var session = store.OpenSession())
+            {
+                var keep = new User { Name = "keep" };
+                session.Store(new User { Name = "drop" });
+                session.Store(keep);
+                session.SaveChanges();
+                keepId = keep.Id;
+            }
+
+            await store.Operations.SendAsync(new DeleteStudioCollectionOperation(operationId: null, collectionName: "Users", excludeIds: new List<string> { keepId }));
+
+            var line = await AuditLogTestHelper.WaitForAuditLineAsync(auditLogPath,
+                l => l.Contains("DELETE")
+                     && l.Contains("Documents in collection 'Users'")
+                     && l.Contains("(excluding 1 ids)"));
+
+            Assert.NotNull(line);
+        }
+    }
+}

--- a/test/SlowTests/SlowTests/Issues/RavenDB_26519.cs
+++ b/test/SlowTests/SlowTests/Issues/RavenDB_26519.cs
@@ -1,0 +1,77 @@
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.SlowTests.Issues
+{
+    public class RavenDB_26519 : DisableParallelTestBase
+    {
+        public RavenDB_26519(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private sealed class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [RavenTheory(RavenTestCategory.Security | RavenTestCategory.Querying)]
+        [RavenData("from Users", DatabaseMode = RavenDatabaseMode.Sharded)]
+        [RavenData("from @all_docs", DatabaseMode = RavenDatabaseMode.Sharded)]
+        public async Task DeleteByQuery_Sharded_ShouldWriteAuditLine(Options options, string query)
+        {
+            var (auditLogPath, adminCert) = AuditLogTestHelper.SetupAuditLoggedServer(this);
+            options.AdminCertificate = adminCert;
+            options.ClientCertificate = adminCert;
+
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "alice" });
+                session.Store(new User { Name = "bob" });
+                session.SaveChanges();
+            }
+
+            var op = await store.Operations.SendAsync(new DeleteByQueryOperation(new IndexQuery { Query = query }));
+            await op.WaitForCompletionAsync(System.TimeSpan.FromMinutes(1));
+
+            // Sharded mode transitively verifies the OperationType fix: if the sharded delete
+            // handler still reported UpdateByQuery, the verb here would render as "UPDATE".
+            var line = await AuditLogTestHelper.WaitForAuditLineAsync(auditLogPath,
+                l => l.Contains("DELETE") && l.Contains($"Documents matching the query: {query}"));
+
+            Assert.NotNull(line);
+        }
+
+        [RavenTheory(RavenTestCategory.Security | RavenTestCategory.Querying | RavenTestCategory.Patching)]
+        [RavenData("from Users update { this.Patched = true }", DatabaseMode = RavenDatabaseMode.Sharded)]
+        [RavenData("from @all_docs update { this.Patched = true }", DatabaseMode = RavenDatabaseMode.Sharded)]
+        public async Task PatchByQuery_Sharded_ShouldWriteAuditLine(Options options, string query)
+        {
+            var (auditLogPath, adminCert) = AuditLogTestHelper.SetupAuditLoggedServer(this);
+            options.AdminCertificate = adminCert;
+            options.ClientCertificate = adminCert;
+
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "alice" });
+                session.Store(new User { Name = "bob" });
+                session.SaveChanges();
+            }
+
+            var op = await store.Operations.SendAsync(new PatchByQueryOperation(new IndexQuery { Query = query }));
+            await op.WaitForCompletionAsync(System.TimeSpan.FromMinutes(1));
+
+            var line = await AuditLogTestHelper.WaitForAuditLineAsync(auditLogPath,
+                l => l.Contains("UPDATE") && l.Contains($"Documents matching the query: {query}"));
+
+            Assert.NotNull(line);
+        }
+    }
+}

--- a/test/Tests.Infrastructure/AuditLogTestHelper.cs
+++ b/test/Tests.Infrastructure/AuditLogTestHelper.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.Config;
+
+namespace Tests.Infrastructure
+{
+    /// <summary>Audit-log assertions for tests that exercise audit-emitting endpoints.</summary>
+    public static class AuditLogTestHelper
+    {
+        private static readonly TimeSpan DefaultPollTimeout = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(200);
+
+        /// <summary>Fresh temp directory for audit output. Not registered for test cleanup —
+        /// LoggingSource.AuditLog is a process-static singleton that holds the file handle open
+        /// across server restarts, which would break NewDataPath cleanup.</summary>
+        public static string GetTempAuditLogPath()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "RavenDB-AuditLog-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        /// <summary>customSettings entry enabling audit logging into <paramref name="auditLogPath"/>.</summary>
+        public static Dictionary<string, string> BuildAuditLogSettings(string auditLogPath)
+        {
+            if (string.IsNullOrEmpty(auditLogPath))
+                throw new ArgumentException("Audit log path must not be null or empty.", nameof(auditLogPath));
+
+            Directory.CreateDirectory(auditLogPath);
+
+            return new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Security.AuditLogPath)] = auditLogPath
+            };
+        }
+
+        /// <summary>One-call setup: secured server + fresh audit dir + cluster-admin client cert.
+        /// Audit logging needs a secured (HTTPS) server, so we cannot share one across tests.</summary>
+        public static (string auditLogPath, X509Certificate2 adminCert) SetupAuditLoggedServer(RavenTestBase parent)
+        {
+            var auditLogPath = GetTempAuditLogPath();
+            var certificates = parent.Certificates.SetupServerAuthentication(customSettings: BuildAuditLogSettings(auditLogPath));
+            var adminCert = parent.Certificates.RegisterClientCertificate(
+                certificates.ServerCertificateForCommunication.Value,
+                certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(),
+                SecurityClearance.ClusterAdmin);
+            return (auditLogPath, adminCert);
+        }
+
+        /// <summary>Polls until a line matching <paramref name="predicate"/> appears, or throws on timeout.</summary>
+        public static async Task<string> WaitForAuditLineAsync(string auditLogPath, Func<string, bool> predicate, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            if (predicate == null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            var deadline = DateTime.UtcNow + (timeout ?? DefaultPollTimeout);
+            List<string> lastSeen = null;
+
+            while (DateTime.UtcNow < deadline)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                lastSeen = ReadAuditLines(auditLogPath);
+                var match = lastSeen.FirstOrDefault(predicate);
+                if (match != null)
+                    return match;
+
+                await Task.Delay(PollInterval, cancellationToken).ConfigureAwait(false);
+            }
+
+            var contents = lastSeen == null || lastSeen.Count == 0
+                ? "(no audit log files or all empty)"
+                : string.Join(Environment.NewLine, lastSeen);
+
+            throw new TimeoutException(
+                $"Timed out after {(timeout ?? DefaultPollTimeout).TotalSeconds:F1}s waiting for a matching audit log line in '{auditLogPath}'.{Environment.NewLine}" +
+                $"Audit log contents at timeout:{Environment.NewLine}{contents}");
+        }
+
+        /// <summary>Snapshot of every line in every *.log file in the directory.
+        /// LoggingSource names files <c>{yyyy-MM-dd-HH-mm}.{seq:000}.log</c> and rotates on size/day,
+        /// so we glob — pinning to a single filename is fragile.</summary>
+        public static List<string> ReadAuditLines(string auditLogPath)
+        {
+            if (string.IsNullOrEmpty(auditLogPath))
+                throw new ArgumentException("Audit log path must not be null or empty.", nameof(auditLogPath));
+            if (Directory.Exists(auditLogPath) == false)
+                throw new DirectoryNotFoundException($"Audit log directory '{auditLogPath}' does not exist. Misconfigured test — use BuildAuditLogSettings to create and wire the path.");
+
+            var result = new List<string>();
+
+            foreach (var file in Directory.EnumerateFiles(auditLogPath, "*.log", SearchOption.TopDirectoryOnly))
+            {
+                try
+                {
+                    using var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                    using var reader = new StreamReader(stream);
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                        result.Add(line);
+                }
+                catch (IOException)
+                {
+                    // file locked or rotating — retry on next poll
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // same — transient
+                }
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26519/Audit-Log-Record-unfiltered-Delete-Patch-by-Query-operations
https://issues.hibernatingrhinos.com/issue/RavenDB-26518/Delete-collection-from-Studio-handler-lacks-Audit-Log-write

### Additional description

| Operation | Single-node | Sharded |
|---|---|---|
| Studio "Delete documents" (incl. `@all_docs`) | ✅ Fixed in RavenDB-26518 | ✅ Fixed in RavenDB-26518  |
| `DELETE /queries` (`from <Coll>` or `from @all_docs`) | ✅ pre-existing | ✅ Fixed in RavenDB-26519 |
| `PATCH /queries` (`from <Coll> update {...}` or `from @all_docs update {...}`) | ✅ pre-existing | ✅ Fixed in RavenDB-26519 |

Every collection-scoped destructive operation now emits an audit line on both topologies.
Tested every path within new AuditLogTests that need additional cert setup. Provided helper for this.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using \`Documentation Required\` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable \`private\`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using \`QA Required\` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using \`Studio Required\` tag.
- [x] No UI work is needed