### PR TITLE
RavenDB-26039 Allow setup of node as passive in secured setup

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
@@ -120,7 +120,7 @@ public static class SettingsZipFileHelper
                 
                 ModifySettingsJson(parameters.SetupInfo, parameters.Progress.SetupActionSteps, ref settingsJson);
 
-                if (parameters.SetupInfo.Environment != StudioConfiguration.StudioEnvironment.None)
+                if (parameters.SetupInfo.Environment != StudioConfiguration.StudioEnvironment.None && parameters.SetupInfo.StartAsPassive == false)
                 {
                     if (parameters.OnPutServerWideStudioConfigurationValues != null && parameters.ZipOnly == false)
                         await parameters.OnPutServerWideStudioConfigurationValues(parameters.SetupInfo.Environment);
@@ -146,6 +146,10 @@ public static class SettingsZipFileHelper
                 settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certPath ?? certificateFileName;
                 if (string.IsNullOrEmpty(parameters.SetupInfo.Password) == false)
                     settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Security.CertificatePassword)] = parameters.SetupInfo.Password;
+                
+                if (parameters.SetupInfo.StartAsPassive && parameters.CompleteClusterConfigurationResult.ClientCert != null)
+                    settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Security.WellKnownAdminCertificates)] =
+                        parameters.CompleteClusterConfigurationResult.ClientCert.Thumbprint;
 
                 foreach (var node in parameters.SetupInfo.NodeSetupInfos)
                 {
@@ -332,7 +336,7 @@ public static class SettingsZipFileHelper
                 
                 ModifySettingsJson(parameters.UnsecuredSetupInfo, parameters.Progress.SetupActionSteps, ref settingsJson);
 
-                if (parameters.UnsecuredSetupInfo.Environment != StudioConfiguration.StudioEnvironment.None && parameters.ZipOnly == false)
+                if (parameters.UnsecuredSetupInfo.Environment != StudioConfiguration.StudioEnvironment.None && parameters.ZipOnly == false && parameters.UnsecuredSetupInfo.StartAsPassive == false)
                 {
                     if (parameters.OnPutServerWideStudioConfigurationValues != null)
                         await parameters.OnPutServerWideStudioConfigurationValues(parameters.UnsecuredSetupInfo.Environment);
@@ -359,8 +363,7 @@ public static class SettingsZipFileHelper
                     var modifiedJsonObj = context.ReadObject(currentNodeSettingsJson, "modified-settings-json");
 
                     var indentedJson = JsonStringHelper.Indent(modifiedJsonObj.ToString());
-                    var firstNodeTag = parameters.UnsecuredSetupInfo.NodeSetupInfos.Keys.First();
-                    if ((node.Key == parameters.UnsecuredSetupInfo.LocalNodeTag || node.Key == firstNodeTag) && parameters.UnsecuredSetupInfo.ZipOnly == false)
+                    if (node.Key == parameters.UnsecuredSetupInfo.LocalNodeTag && parameters.UnsecuredSetupInfo.ZipOnly == false)
                     {
                         try
                         {

--- a/src/Raven.Server/Commercial/SetupInfo.cs
+++ b/src/Raven.Server/Commercial/SetupInfo.cs
@@ -68,6 +68,11 @@ namespace Raven.Server.Commercial
         {
             var exceptions = new List<Exception>();
 
+            if (StartAsPassive && ZipOnly)
+            {
+                exceptions.Add(new InvalidOperationException($"{nameof(StartAsPassive)} is not supported when generating a setup package ({nameof(ZipOnly)} is true). The passive flag affects how the local node bootstraps, which doesn't apply to a package consumed by other nodes."));
+            }
+
             if (License == null)
             {
                 exceptions.Add(new InvalidOperationException($"{nameof(License)} must be set"));
@@ -120,6 +125,9 @@ namespace Raven.Server.Commercial
             }
             
             parameters.PackageOutputPath = Path.ChangeExtension(parameters.PackageOutputPath, Path.GetExtension(parameters.PackageOutputPath)?.ToLower());
+
+            if (exceptions.Count > 0)
+                throw new AggregateException($"{nameof(SetupInfo)} validation exceptions list: ", exceptions);
         }
 
         public override async Task<byte[]> GenerateZipFile(CreateSetupPackageParameters parameters)
@@ -160,6 +168,11 @@ namespace Raven.Server.Commercial
         public override void ValidateInfo(CreateSetupPackageParameters parameters)
         {
             List<Exception> exceptions = new ();
+
+            if (StartAsPassive && ZipOnly)
+            {
+                exceptions.Add(new InvalidOperationException($"{nameof(StartAsPassive)} is not supported when generating a setup package ({nameof(ZipOnly)} is true). The passive flag affects how the local node bootstraps, which doesn't apply to a package consumed by other nodes."));
+            }
 
             if (NodeSetupInfos is null || NodeSetupInfos.Any() == false)
             {
@@ -210,7 +223,6 @@ namespace Raven.Server.Commercial
             
             if (exceptions.Count > 0)
                 throw new AggregateException($"{nameof(UnsecuredSetupInfo)} validation exceptions list: ", exceptions);
-
         }
 
         public override async Task<byte[]> GenerateZipFile(CreateSetupPackageParameters parameters)

--- a/src/Raven.Server/Commercial/SetupInfo.cs
+++ b/src/Raven.Server/Commercial/SetupInfo.cs
@@ -160,11 +160,14 @@ namespace Raven.Server.Commercial
         public override void ValidateInfo(CreateSetupPackageParameters parameters)
         {
             List<Exception> exceptions = new ();
-            
+
             if (NodeSetupInfos is null || NodeSetupInfos.Any() == false)
             {
                 exceptions.Add(new InvalidOperationException($"{nameof(NodeSetupInfos)} must be set"));
             }
+            
+            if (LocalNodeTag is null && NodeSetupInfos is { Count: > 0 })
+                LocalNodeTag = NodeSetupInfos.Keys.First();
 
             foreach (var tag in NodeSetupInfos.Keys.Where(tag => SetupWizardUtils.IsValidNodeTag(tag) == false))
             {

--- a/src/Raven.Server/Commercial/SetupInfoBase.cs
+++ b/src/Raven.Server/Commercial/SetupInfoBase.cs
@@ -18,10 +18,11 @@ public abstract class SetupInfoBase
     public Dictionary<string, NodeInfo> NodeSetupInfos { get; set; }
     public string LocalNodeTag { get; set; }
     public bool ZipOnly { get; set; }
-    
+    public bool StartAsPassive { get; set; }
+
     public abstract Task<byte[]> GenerateZipFile(CreateSetupPackageParameters parameters);
     public abstract void ValidateInfo(CreateSetupPackageParameters parameters);
-    
+
     public virtual DynamicJsonValue ToJson()
     {
         return new DynamicJsonValue
@@ -31,6 +32,7 @@ public abstract class SetupInfoBase
             [nameof(NodeSetupInfos)] = DynamicJsonValue.Convert(NodeSetupInfos),
             [nameof(LocalNodeTag)] = LocalNodeTag,
             [nameof(License)] = License?.ToJson(),
+            [nameof(StartAsPassive)] = StartAsPassive,
         };
     }
 }

--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -1166,16 +1166,16 @@ namespace Raven.Server.Commercial
                         throw new InvalidOperationException("Failed to delete previous cluster topology during setup.", e);
                     }
 
-                    if (unsecuredSetupInfo.LocalNodeTag != null)
+                    if (unsecuredSetupInfo.StartAsPassive == false)
                     {
                         await serverStore.EnsureNotPassiveAsync(publicServerUrl, unsecuredSetupInfo.LocalNodeTag);
-                        
+
+                        await DeleteAllExistingCertificates(serverStore);
+
                         if (unsecuredSetupInfo.License != null)
                             await serverStore.LicenseManager.ActivateAsync(unsecuredSetupInfo.License, RaftIdGenerator.DontCareId);
                     }
 
-                    await DeleteAllExistingCertificates(serverStore);
-                    
                     serverStore.HasFixedPort = unsecuredSetupInfo.NodeSetupInfos[localNodeTag].Port != 0;
                 },
                 AddNodeToCluster = async nodeTag =>
@@ -1234,13 +1234,16 @@ namespace Raven.Server.Commercial
                         throw new InvalidOperationException("Failed to delete previous cluster topology during setup.", e);
                     }
 
-                    await serverStore.EnsureNotPassiveAsync(publicServerUrl, setupInfo.LocalNodeTag);
+                    if (setupInfo.StartAsPassive == false)
+                    {
+                        await serverStore.EnsureNotPassiveAsync(publicServerUrl, setupInfo.LocalNodeTag);
 
-                    await DeleteAllExistingCertificates(serverStore);
-                    
-                    await serverStore.EnsureNotPassiveAsync(skipLicenseActivation: true);
-                    if (setupInfo.License != null)
-                        await serverStore.LicenseManager.ActivateAsync(setupInfo.License, RaftIdGenerator.DontCareId);
+                        await DeleteAllExistingCertificates(serverStore);
+
+                        await serverStore.EnsureNotPassiveAsync(skipLicenseActivation: true);
+                        if (setupInfo.License != null)
+                            await serverStore.LicenseManager.ActivateAsync(setupInfo.License, RaftIdGenerator.DontCareId);
+                    }
 
                     serverStore.HasFixedPort = setupInfo.NodeSetupInfos[localNodeTag].Port != 0;
                 },

--- a/src/Raven.Server/Commercial/SetupWizard/SetupWizardUtils.cs
+++ b/src/Raven.Server/Commercial/SetupWizard/SetupWizardUtils.cs
@@ -36,10 +36,10 @@ public static class SetupWizardUtils
                 serverCertBytes = Convert.FromBase64String(base64);
                 serverCert = CertificateLoaderUtil.CreateCertificate(serverCertBytes, parameters.SetupInfo.Password, CertificateLoaderUtil.FlagsForExport);
 
-                var localNodeTag = parameters.SetupInfo.LocalNodeTag ?? parameters.SetupInfo.NodeSetupInfos.Keys.FirstOrDefault();
+                var localNodeTag = parameters.SetupInfo.LocalNodeTag;
                 if (localNodeTag is null)
                 {
-                    throw new InvalidOperationException($"Could not determine {nameof(localNodeTag)}");
+                    throw new InvalidOperationException($"{nameof(parameters.SetupInfo.LocalNodeTag)} must be set");
                 }
 
                 publicServerUrl = CertificateUtils.GetServerUrlFromCertificate(serverCert,
@@ -49,7 +49,7 @@ public static class SetupWizardUtils
                     parameters.SetupInfo.NodeSetupInfos[localNodeTag].TcpPort,
                     out _,
                     out domainFromCert);
-                
+
                 domain = (parameters.SetupMode == SetupMode.Secured)
                     ? domainFromCert.ToLower()
                     : parameters.SetupInfo.Domain.ToLower();
@@ -65,18 +65,18 @@ public static class SetupWizardUtils
                     parameters.CertificateValidationKeyUsages,
                     parameters.Progress);
 
-                if (parameters.SetupInfo.ZipOnly == false)
+                if (parameters.SetupInfo.ZipOnly == false && parameters.SetupInfo.StartAsPassive == false)
                 {
                     await ValidateCertificateFileWriteAccess();
-                    
+
                     foreach (var node in parameters.SetupInfo.NodeSetupInfos)
                     {
-                        if (node.Key == parameters.SetupInfo.LocalNodeTag)
+                        if (node.Key == localNodeTag)
                             continue;
 
                         parameters.Progress?.AddInfo($"Adding node '{node.Key}' to the cluster.");
                         parameters.OnProgress?.Invoke(parameters.Progress);
-                        
+
                         parameters.SetupInfo.NodeSetupInfos[node.Key].PublicServerUrl = CertificateUtils.GetServerUrlFromCertificate(serverCert,
                             parameters.SetupInfo, node.Key,
                             node.Value.Port,
@@ -111,7 +111,7 @@ public static class SetupWizardUtils
 
                 Debug.Assert(selfSignedCertificate != null);
 
-                if (parameters.PutCertificateInCluster != null && parameters.SetupInfo.RegisterClientCert && parameters.SetupInfo.ZipOnly == false)
+                if (parameters.PutCertificateInCluster != null && parameters.SetupInfo.RegisterClientCert && parameters.SetupInfo.ZipOnly == false && parameters.SetupInfo.StartAsPassive == false)
                     await parameters.PutCertificateInCluster(selfSignedCertificate, certificateDefinition);
 
                 clientCert = CertificateLoaderUtil.CreateCertificate(certBytes, flags: CertificateLoaderUtil.FlagsForPersist);
@@ -165,15 +165,19 @@ public static class SetupWizardUtils
 
         foreach ((_, NodeInfo node) in parameters.UnsecuredSetupInfo.NodeSetupInfos)
             node.PublicServerUrl = string.Join(";", node.Addresses.Select(ip => SettingsZipFileHelper.IpAddressToUrl(ip, node.Port, scheme: "http")));
-        
-        (string localNodeTag, NodeInfo nodeInfo) = nodeSetupInfos.First();
+
+        var localNodeTag = parameters.UnsecuredSetupInfo.LocalNodeTag;
+        if (localNodeTag is null)
+            throw new InvalidOperationException($"{nameof(parameters.UnsecuredSetupInfo.LocalNodeTag)} must be set");
+
+        var nodeInfo = nodeSetupInfos[localNodeTag];
 
         try
         {
             if (parameters.OnBeforeAddingNodesToCluster != null && zipOnly == false )
                 await parameters.OnBeforeAddingNodesToCluster(nodeInfo.PublicServerUrl, localNodeTag);
-                
-            if (zipOnly == false)
+
+            if (zipOnly == false && parameters.UnsecuredSetupInfo.StartAsPassive == false)
             {
                 foreach (var node in nodeSetupInfos)
                 {
@@ -182,7 +186,7 @@ public static class SetupWizardUtils
 
                     parameters.Progress?.AddInfo($"Adding node '{node.Key}' to the cluster.");
                     parameters.OnProgress?.Invoke(parameters.Progress);
-                        
+
                     if (parameters.AddNodeToCluster != null)
                         await parameters.AddNodeToCluster(node.Key);
                 }

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardFinishStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardFinishStep.tsx
@@ -428,7 +428,8 @@ function CompletedSummary() {
     const { getStudioUrl } = useSetupWizardFinishUtils();
 
     const isSettingCluster = nodeAddressStep.nodes.length > 1 || method === "usePackage";
-    const localNodeTag = nodeAddressStep.nodes?.[0]?.nodeTag ?? nodeTag;
+    const localNode = nodeAddressStep.nodes?.[0];
+    const localNodeTag = localNode?.nodeTag ?? nodeTag;
     const isSetupUnsecured = securityOption === "none" || (method === "usePackage" && !isZipSecure);
     const isSetupPackage = method === "createPackage";
     const showInfoAboutInstalledCertificate = !isSetupUnsecured && !isSetupPackage;
@@ -652,7 +653,6 @@ function useSetupWizardFinishUtils() {
 
     const getUnsecuredDto = (): Raven.Server.Commercial.UnsecuredSetupInfo => {
         const localNode = getLocalNode();
-        const isPassive = localNode.isPassive;
 
         return {
             AutoIndexingEngineType: additionalSettingsStep.isAdvancedSettingsVisible
@@ -669,16 +669,18 @@ function useSetupWizardFinishUtils() {
                 ? additionalSettingsStep.staticIndexingEngineType
                 : null,
             EnableExperimentalFeatures: additionalSettingsStep.postgresqlIntegration,
-            LocalNodeTag: isPassive ? null : localNode.nodeTag,
-            Environment: isPassive ? null : additionalSettingsStep.studioEnvironment,
+            LocalNodeTag: localNode.nodeTag,
+            Environment: additionalSettingsStep.studioEnvironment,
             License: licenseKeyStep.key == "" ? null : JSON.parse(licenseKeyStep.key),
             ZipOnly: setupMethodStep.method === "createPackage",
+            StartAsPassive: localNode.isPassive ?? false,
             NodeSetupInfos: getNodeSetupInfos(),
         };
     };
 
     const getSecuredDto = (): Raven.Server.Commercial.SetupInfo => {
         const { adminCertificateExpirationTime } = additionalSettingsStep;
+        const localNode = getLocalNode();
 
         const ClientCertNotAfter = adminCertificateExpirationTime
             ? moment.utc().add(additionalSettingsStep.adminCertificateExpirationTime, "months").format()
@@ -704,12 +706,13 @@ function useSetupWizardFinishUtils() {
             Email: domainStep.email,
             Domain: domainStep.domain,
             RootDomain: domainStep.rootDomain,
-            LocalNodeTag: getLocalNode().nodeTag,
+            LocalNodeTag: localNode.nodeTag,
             RegisterClientCert: true, // it should be always true. we should detect if same cert is installed and if no then install
             Certificate: selfSignedCertificateStep.certificate,
             Password: selfSignedCertificateStep.password,
             ClientCertNotAfter,
             ZipOnly: setupMethodStep.method === "createPackage",
+            StartAsPassive: localNode.isPassive ?? false,
             NodeSetupInfos: getNodeSetupInfos(),
         };
     };

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
@@ -618,9 +618,10 @@ function NodeDetailsPanelEdit({
                                 <PopoverWithHoverWrapper
                                     message={
                                         <SetupWizardInfoPopover
-                                            description="When enabled, the node starts in passive mode and does not join a cluster. 
-                                                This is useful when the node is meant for monitoring, initialization, or handling setup tasks without participating in cluster operations. 
-                                                It can also be used to isolate the node for testing or debugging."
+                                            description="When enabled, the node starts in passive mode and does not join a cluster.
+                                                This is useful when the node is meant for monitoring, initialization, or handling setup tasks without participating in cluster operations.
+                                                It can also be used to isolate the node for testing or debugging.
+                                                The node will leave passive state when a cluster operation is performed on it, such as creating a database or adding it to a cluster."
                                             ravenLinkHash="2WV7N1"
                                         />
                                     }

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
@@ -326,7 +326,6 @@ function NodeDetailsPanelHeader({ control, index, onRemove, editNodeForm }: Node
             dnsName: securityOption === "ownCertificate" ? formData.dnsName : null,
             nodeUrl: handleNodeUrl(formData),
             httpPort: formData.httpPort == null ? (securityOption === "none" ? 8080 : 443) : formData.httpPort,
-            nodeTag: formData.isPassive ? null : formData.nodeTag,
             isEditing: false,
             isNewlyAdded: false,
         });
@@ -359,7 +358,7 @@ function NodeDetailsPanelHeader({ control, index, onRemove, editNodeForm }: Node
         }
     };
 
-    const isPassiveVisible = securityOption === "none" && method !== "createPackage" && nodes.length === 1;
+    const isPassiveVisible = method !== "createPackage" && nodes.length === 1;
 
     return (
         <RichPanelHeader>
@@ -597,7 +596,7 @@ function NodeDetailsPanelEdit({
     const { isExternalRequired } = useHostnameDetectionSideEffects({ editNodeForm, parentControl });
 
     const isDNSVisible = securityOption === "ownCertificate" && !isWildcardCertificate;
-    const isPassiveVisible = securityOption === "none" && setupMethod !== "createPackage" && nodes.length === 1;
+    const isPassiveVisible = setupMethod !== "createPackage" && nodes.length === 1;
 
     const canCustomizeExternalIpsAndPorts = securityOption === "letsEncrypt";
     const canCustomizeExternalTcpPorts = securityOption === "ownCertificate";

--- a/src/Raven.Studio/typescript/models/wizard/serverSetup.ts
+++ b/src/Raven.Studio/typescript/models/wizard/serverSetup.ts
@@ -147,15 +147,16 @@ class serverSetup {
         });
         
         return {
-            AutoIndexingEngineType: null, 
-            DataDirectory: null, 
+            AutoIndexingEngineType: null,
+            DataDirectory: null,
             SetupCertificatePath: null,
-            LogsPath: null, 
+            LogsPath: null,
             License: null,
             StaticIndexingEngineType: null,
             EnableExperimentalFeatures: this.useExperimentalFeatures(),
-            LocalNodeTag: !this.startNodeAsPassive() ? this.localNodeTag() : null,
-            Environment: !this.startNodeAsPassive() ? this.environment() : null,
+            LocalNodeTag: this.localNodeTag(),
+            Environment: this.environment(),
+            StartAsPassive: this.startNodeAsPassive(),
             ZipOnly: this.onlyCreateZipFile(),
             NodeSetupInfos: nodesInfo
         }
@@ -168,10 +169,10 @@ class serverSetup {
         });
 
         return {
-            AutoIndexingEngineType: null, 
-            DataDirectory: null, 
-            SetupCertificatePath: null, 
-            LogsPath: null, 
+            AutoIndexingEngineType: null,
+            DataDirectory: null,
+            SetupCertificatePath: null,
+            LogsPath: null,
             StaticIndexingEngineType: null,
             EnableExperimentalFeatures: this.useExperimentalFeatures(),
             Environment: this.environment(),
@@ -184,6 +185,7 @@ class serverSetup {
             Certificate: this.certificate().certificate(),
             Password: this.certificate().certificatePassword(),
             ClientCertNotAfter: this.certificate().expirationDateFormatted(),
+            StartAsPassive: false,
             ZipOnly: this.onlyCreateZipFile(),
             NodeSetupInfos: nodesInfo
         };

--- a/test/SlowTests/Tools/SetupUnsecuredClusterUsingRvn.cs
+++ b/test/SlowTests/Tools/SetupUnsecuredClusterUsingRvn.cs
@@ -36,6 +36,7 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
         {
             Environment = StudioConfiguration.StudioEnvironment.Testing,
             ZipOnly = false,
+            LocalNodeTag = "A",
             NodeSetupInfos = new Dictionary<string,NodeInfo>()
             {
                 ["A"] = new() { Port = port, TcpPort = tcpPort, Addresses = new List<string> { "127.0.0.1" } },
@@ -120,6 +121,7 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
         {
             Environment = StudioConfiguration.StudioEnvironment.Testing,
             ZipOnly = false,
+            LocalNodeTag = "A",
             NodeSetupInfos = new Dictionary<string,NodeInfo>()
             {
                 ["A"] = new() { Port = portA, TcpPort = tcpPortA, Addresses = new List<string> { "127.0.0.1" } },


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26039/Allow-setup-of-node-as-passive-in-secured-setup

### Additional description

We want to support setting up a passive node in secure (Let's Encrypt and own certificate) setup

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
