### PR TITLE
RavenDB-26530 - Responsible node for AI Conversation

### DIFF
--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -28,6 +28,7 @@ internal class AiConversation : IAiConversationOperations
     private readonly List<AiAgentArtificialActionResponse> _artificialActions = [];
     private readonly List<ContentPart> _promptParts = [];
     private string _changeVector;
+    private readonly string _nodeTag;
     private readonly List<ICommandData> _attachmentsCommands = new();
     private StringBuilder _jsonBuffer;
     private StringWriter _jsonWriter;
@@ -39,7 +40,7 @@ internal class AiConversation : IAiConversationOperations
     private readonly Dictionary<string, HandleActionDelegate> _invocations = new();
     private readonly HashSet<string> _dispatchedToolIds = new();
 
-    public AiConversation(AiOperations aiOperations, string agentId, string conversationId, AiConversationCreationOptions options, string changeVector)
+    public AiConversation(AiOperations aiOperations, string agentId, string conversationId, AiConversationCreationOptions options, string changeVector, string nodeTag = null)
     {
         ValidationMethods.AssertNotNullOrEmpty(aiOperations, nameof(aiOperations));
         ValidationMethods.AssertNotNullOrEmpty(agentId, nameof(agentId));
@@ -50,6 +51,7 @@ internal class AiConversation : IAiConversationOperations
         _conversationId = conversationId;
         _options = options;
         _changeVector = changeVector;
+        _nodeTag = nodeTag;
     }
     
     public void AddAttachment(string name, Stream stream, string contentType)
@@ -299,7 +301,7 @@ internal class AiConversation : IAiConversationOperations
                 Status = AiConversationResult.Done
             };
         }
-        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _promptParts, [.. _actionResponses.Values], _artificialActions, _options, _changeVector, _attachmentsCommands, streamPropertyPath, streamedChunksCallback);
+        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _promptParts, [.. _actionResponses.Values], _artificialActions, _options, _changeVector, _attachmentsCommands, streamPropertyPath, streamedChunksCallback, _nodeTag);
 
         try
         {

--- a/src/Raven.Client/Documents/AI/AiOperations.cs
+++ b/src/Raven.Client/Documents/AI/AiOperations.cs
@@ -145,6 +145,7 @@ public class AiOperations
     /// <param name="conversationId">The unique identifier for the conversation.</param>
     /// <param name="creationOptions">Options for creating the conversation.</param>
     /// <param name="changeVector">An optional change vector for concurrency control.</param>
-    public IAiConversationOperations Conversation(string agentId, string conversationId, AiConversationCreationOptions creationOptions, string changeVector = null) => 
-        new AiConversation(this, agentId, conversationId, creationOptions, changeVector);
+    /// <param name="nodeTag">An optional cluster node tag to route every request for this conversation to a specific node (Responsible/Mentor node).</param>
+    public IAiConversationOperations Conversation(string agentId, string conversationId, AiConversationCreationOptions creationOptions, string changeVector = null, string nodeTag = null) =>
+        new AiConversation(this, agentId, conversationId, creationOptions, changeVector, nodeTag);
 }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -33,6 +33,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     private readonly string _streamPropertyPath;
     private readonly Func<string, Task> _streamedChunksCallback;
     private readonly List<ICommandData> _attachmentsCommands;
+    private readonly string _nodeTag;
 
     /// <summary>
     /// Initializes a new conversation step for the specified agent and conversation.
@@ -109,6 +110,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     /// <param name="changeVector">Optional expected change vector for optimistic concurrency on the conversation document.</param>
     /// <param name="streamPropertyPath">The JSON path of the property to stream back to the client.</param>
     /// <param name="streamedChunksCallback">The callback function invoked when a new chunk of streamed data arrives.</param>
+    /// <param name="nodeTag">Optional cluster node tag to route this command to. When null, the command uses the regular topology selection.</param>
     public RunConversationOperation(string agentId,
         string conversationId,
         IEnumerable<ContentPart> promptParts,
@@ -117,7 +119,8 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         AiConversationCreationOptions options,
         string changeVector,
         string streamPropertyPath,
-        Func<string, Task> streamedChunksCallback)
+        Func<string, Task> streamedChunksCallback,
+        string nodeTag = null)
     {
         ValidationMethods.AssertNotNullOrEmpty(agentId, nameof(agentId));
         ValidationMethods.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
@@ -134,6 +137,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
 
         _streamPropertyPath = streamPropertyPath;
         _streamedChunksCallback = streamedChunksCallback;
+        _nodeTag = nodeTag;
     }
 
     public RunConversationOperation(string agentId,
@@ -145,8 +149,9 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         string changeVector,
         List<ICommandData> attachmentsCommands,
         string streamPropertyPath,
-        Func<string, Task> streamedChunksCallback)
-        : this(agentId, conversationId, promptParts, actionResponses, artificialActions, options, changeVector, streamPropertyPath, streamedChunksCallback)
+        Func<string, Task> streamedChunksCallback,
+        string nodeTag = null)
+        : this(agentId, conversationId, promptParts, actionResponses, artificialActions, options, changeVector, streamPropertyPath, streamedChunksCallback, nodeTag)
     {
         _attachmentsCommands = attachmentsCommands;
     }
@@ -173,7 +178,10 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     /// </summary>
     public virtual RavenCommand<ConversationResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
-        return new RunConversationOperationCommand(this, conventions);
+        return new RunConversationOperationCommand(this, conventions)
+        {
+            SelectedNodeTag = _nodeTag
+        };
     }
 
     internal class RunConversationOperationCommand : RavenCommand<ConversationResult<TSchema>>, IRaftCommand

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26530.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26530.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent;
+
+public class RavenDB_26530 : ReplicationTestBase
+{
+    public RavenDB_26530(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task CanRouteConversationToEachSelectedNodeInClusterOf3(Options options, GenAiConfiguration config)
+    {
+        var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
+        using var store = GetDocumentStore(new Options
+        {
+            Server = leader,
+            ReplicationFactor = 3,
+            Path = options?.Path,
+            ModifyDatabaseRecord = options?.ModifyDatabaseRecord,
+        });
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("node-routing-agent", config.ConnectionStringName,
+            "You are a brief assistant. Reply with a short greeting.");
+        var agentId = (await store.AI.CreateAgentAsync(agent, SimpleAnswer.Instance)).Identifier;
+
+        // Block document replication between nodes so every conversation document stays on
+        // the node it was written to — its change vector then contains only that node's tag.
+        using var r = await GetReplicationManagerAsync(store, store.Database, options.DatabaseMode, breakReplication: true, servers: nodes);
+
+        foreach (var node in nodes)
+        {
+            var tag = node.ServerStore.NodeTag;
+
+            var chat = store.AI.Conversation(agentId, $"chats/{tag}-",
+                new AiConversationCreationOptions(),
+                changeVector: null,
+                nodeTag: tag);
+            chat.SetUserPrompt("Say hello.");
+
+            var result = await chat.RunAsync<SimpleAnswer>(CancellationToken.None);
+
+            Assert.Equal(AiConversationResult.Done, result.Status);
+            Assert.NotNull(result.Answer);
+            Assert.NotNull(chat.Id);
+
+            AssertChangeVectorHasOnlyTag(chat.ChangeVector, tag);
+        }
+        r.Mend();
+    }
+
+    private static void AssertChangeVectorHasOnlyTag(string changeVector, string expectedTag)
+    {
+        Assert.NotNull(changeVector);
+        var entries = changeVector
+            .Split(',')
+            .Select(e => e.Trim())
+            .Where(e => string.IsNullOrEmpty(e) == false)
+            .ToList();
+
+        Assert.Single(entries);
+        Assert.StartsWith($"{expectedTag}:", entries[0]);
+    }
+
+    private class SimpleAnswer
+    {
+        public static SimpleAnswer Instance = new();
+        public string Answer = "the answer to the user question";
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26530/Responsible-node-for-AI-Conversation

### Additional description

Add an optional `nodeTag` to `store.AI.Conversation(...)` that flows through `AiConversation → RunConversationOperation → SelectedNodeTag` on the `RavenCommand`, pinning the conversation to the chosen node (null keeps default routing).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
