### PR TITLE
RavenDB-26178: CanAddArtificialActionsToConversation fixed flaky test

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/ArtificalActions.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/ArtificalActions.cs
@@ -36,11 +36,11 @@ public class ArtificalActions(ITestOutputHelper output) : RavenTestBase(output)
             new AiConversationCreationOptions().AddParameter("company", "companies/90-A"));
 
         chat.AddArtificialActionWithResponse("GetUserAllergies", "Gluten, Lactose");
-        chat.SetUserPrompt("Should I get some cheese?");
+        chat.SetUserPrompt("Should I get regular cheese?");
         var r = await chat.RunAsync<ModelAnswer>(CancellationToken.None);
 
         Assert.Equal(AiConversationResult.Done, r.Status);
-        Assert.False(r.Answer.Recommend);
+        Assert.False(r.Answer.Recommend, r.Answer.Reason);
     }
 
     private record ModelAnswer(bool Recommend, string Reason);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26178/SlowTests.Server.Documents.AI.AiAgent.ArtificalActions.CanAddArtificialActionsToConversationoptions-DatabaseMode-Single-config

### Additional description

The test was flaky and fixed by using another prompt that generate more stable results.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
