### PR TITLE
RavenDB-26139: fixed flaky test

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
@@ -107,8 +107,8 @@ public class RavenDB_24984 : RavenTestBase
         Assert.Equal(AiConversationResult.Done, result.Status);
 
         var lastToolResult = lastNumber - 1;
-        Console.WriteLine(result.Answer.Answer);
-        Assert.Equal(lastToolResult.ToString(), result.Answer.Answer);
+        Assert.False(string.IsNullOrEmpty(result.Answer.Answer),
+            "Model must produce some final answer after tool-iteration cap is reached");
         Assert.Equal(maxModelIterationsPerCall, lastToolResult);
 
         using (var session = store.OpenSession())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26139/SlowTests.Server.Documents.AI.AiAgent.RavenDB24984.ShouldStopUsingToolsWhenMaxModelIterationsPerCallIsReachedoptions

### Additional description

**It isn't a server bug. The cap worked.**
When sent the 6th request with tool_choice: "none" plus a user prompt that explicitly says "call the 'MyTool' tool until it returns a value >= 10", the model has two competing signals:

1. The system prompt: "set Answer to exactly the last tool value as plain text."
2. The user's standing request to keep calling MyTool, with tools now disabled.
In this run the model picked (2) and effectively apologized — "I don't have access to external tools rig..." — instead of looking back at the 5 tool results already in history and surfacing "5".

That's inherent LLM non‑determinism on a live OpenAI call. The same conversation, model, and parameters can produce that apology one day and "5" the next, especially under tool‑forced‑off conditions where the model interprets "no tools" as "I can't satisfy this request" rather than "use what's already in context".

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
