### PR TITLE
RavenDB-24524 Fix Directory.Move failure when src/dst differ on \\?\ long-path prefix

### DIFF
--- a/src/Raven.Server/Utils/IOExtensions.cs
+++ b/src/Raven.Server/Utils/IOExtensions.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Raven.Client.Exceptions;
 using Sparrow.Platform;
 using Sparrow.Server.Platform.Posix;
+using Voron.Util.Settings;
 
 namespace Raven.Server.Utils
 {
@@ -81,6 +82,9 @@ namespace Raven.Server.Utils
 
         public static void MoveDirectory(string src, string dst)
         {
+            if (PlatformDetails.RunningOnWindows)
+                (src, dst) = NormalizeLongPathPrefixOnWindows(src, dst);
+
             for (var i = 0; i < Retries; i++)
             {
                 try
@@ -218,6 +222,22 @@ namespace Raven.Server.Utils
                 AfterGc(null, (path, sw.Elapsed, attempt));
 
             Thread.Sleep(100);
+        }
+
+
+        private static (string Src, string Dst) NormalizeLongPathPrefixOnWindows(string src, string dst)
+        {
+            Debug.Assert(PlatformDetails.RunningOnWindows);
+
+            var srcHasPrefix = src.StartsWith(PathUtil.LongPathPrefixWindows, StringComparison.OrdinalIgnoreCase);
+            var dstHasPrefix = dst.StartsWith(PathUtil.LongPathPrefixWindows, StringComparison.OrdinalIgnoreCase);
+
+            if (srcHasPrefix == dstHasPrefix)
+                return (src, dst);
+
+            return srcHasPrefix
+                ? (src, PathUtil.LongPathPrefixWindows + dst)
+                : (PathUtil.LongPathPrefixWindows + src, dst);
         }
     }
 }

--- a/src/Voron/Util/Settings/PathSettingBase.cs
+++ b/src/Voron/Util/Settings/PathSettingBase.cs
@@ -68,6 +68,8 @@ namespace Voron.Util.Settings
     
     public sealed class PathUtil
     {
+        public const string LongPathPrefixWindows = @"\\?\";
+
         public static string ToFullPath(string inputPath, string baseDataDirFullPath = null)
         {
             var path = Environment.ExpandEnvironmentVariables(inputPath);
@@ -82,8 +84,8 @@ namespace Voron.Util.Settings
 
             if (result.Length >= 260 && 
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                result.StartsWith(@"\\?\") == false)
-                result = @"\\?\" + result;
+                result.StartsWith(LongPathPrefixWindows) == false)
+                result = LongPathPrefixWindows + result;
 
             var resultRoot = Path.GetPathRoot(result);
             if (resultRoot != result && (result.EndsWith(@"\") || result.EndsWith("/")))

--- a/test/SlowTests.Issues/Issues/RavenDB_24524.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_24524.cs
@@ -1,0 +1,57 @@
+﻿using System.IO;
+using FastTests;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24524 : NoDisposalNeeded
+{
+    public RavenDB_24524(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Core, RavenPlatform.Windows)]
+    public void MoveDirectory_ShouldSucceed_WhenSourceAndDestinationDifferOnLongPathPrefix()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "RavenDB_24524_" + Path.GetRandomFileName());
+        var srcDir = Path.Combine(root, "src");
+        var dstDir = Path.Combine(root, "dst");
+
+        try
+        {
+            Directory.CreateDirectory(srcDir);
+            File.WriteAllText(Path.Combine(srcDir, "marker.txt"), "hello");
+
+            // Force the mismatch: pass one path with the \\?\ prefix and the other without.
+            // Without the fix, Directory.Move throws because Path.GetPathRoot returns different
+            // roots for "\\?\D:\..." vs "D:\...".
+            var srcWithPrefix = @"\\?\" + srcDir;
+            var dstWithoutPrefix = dstDir;
+
+            IOExtensions.MoveDirectory(srcWithPrefix, dstWithoutPrefix);
+
+            Assert.False(Directory.Exists(srcDir), "Source directory should no longer exist after move.");
+            Assert.True(Directory.Exists(dstDir), "Destination directory should exist after move.");
+            Assert.Equal("hello", File.ReadAllText(Path.Combine(dstDir, "marker.txt")));
+
+            // And the symmetric case: dst prefixed, src not.
+            var srcDir2 = Path.Combine(root, "src2");
+            var dstDir2 = Path.Combine(root, "dst2");
+            Directory.CreateDirectory(srcDir2);
+            File.WriteAllText(Path.Combine(srcDir2, "marker.txt"), "world");
+
+            IOExtensions.MoveDirectory(srcDir2, @"\\?\" + dstDir2);
+
+            Assert.False(Directory.Exists(srcDir2));
+            Assert.True(Directory.Exists(dstDir2));
+            Assert.Equal("world", File.ReadAllText(Path.Combine(dstDir2, "marker.txt")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24524

### Additional description

Normalize the `\\?\` prefix on both arguments inside `IOExtensions.MoveDirectory` before delegating to Directory.Move, which requires src and dst to share the same path root. `PathUtil.ToFullPath` applies the prefix per-path based on a 260-char threshold, so two related paths can end up on opposite sides of it and disagree on root.

Operations that could be affected:
* index compaction
* database compaction
* side-by-side index replacement

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
