### PR TITLE
RavenDB-26512 - Studio does not render dual change vectors correctly

### DIFF
--- a/src/Raven.Studio/typescript/common/changeVectorUtils.ts
+++ b/src/Raven.Studio/typescript/common/changeVectorUtils.ts
@@ -1,54 +1,65 @@
-﻿/// <reference path="../../typings/tsd.d.ts" />
+/// <reference path="../../typings/tsd.d.ts" />
 
 import typeUtils = require("common/typeUtils");
 
 class changeVectorUtils {
 
     static shouldUseLongFormat(changeVectors: string[]) {
-        const parsedVectors = changeVectors.flatMap(x => changeVectorUtils.parse(x));
-        
-        const byTag = _.groupBy(parsedVectors, (x: { tag: string}) => x.tag);
-        
-        return Object.values(byTag).some((forTag: any) => forTag.map((x: typeof parsedVectors[0]) => x.dbId).length > 1);
+        const parsedVectors = changeVectors.flatMap(x => changeVectorUtils.parseEntries(x));
+
+        const byTag = _.groupBy(parsedVectors, (x: changeVectorEntryItem) => x.tag);
+
+        return Object.values(byTag).some((forTag: changeVectorEntryItem[]) => forTag.map((x) => x.dbId).length > 1);
     }
-    
-    private static parse(input: string) {
-        if (!input) {
+
+    private static parsePart(part: string) {
+        if (!part) {
             return [];
         }
-        
-        let tokens = input.split(",")
-                          .map(cvEntry => changeVectorUtils.parseChangeVectorEntry(cvEntry));
-        
+
+        let tokens = part.split(",")
+                         .map(cvEntry => changeVectorUtils.parseChangeVectorEntry(cvEntry));
+
         tokens = typeUtils.sortBy(tokens, x => x.tag);
 
         return tokens;
     }
-    
+
+    private static parseEntries(input: string) {
+        return changeVectorUtils.parsePart(input?.replaceAll("|", ",") ?? "");
+    }
+
     static formatChangeVector(input: string, useLongChangeVectorFormat: boolean): changeVectorItem[] {
         //A:1066-8Bk5eyIYfES1TzuU6TnzPg, C:1066-iazDDYGWiUmj8AwW4jgjYA, E:1066-m9yioKcvEkGny6tfKJo3Tw, B:1068-5hNdZ22Up0e+KkaU7u2VUg, D:1066-OHQUXCEyYU6VE
-        const tokens = changeVectorUtils.parse(input);
-       
-        if (useLongChangeVectorFormat) {
-            return tokens.map((x): changeVectorItem => {
-                return {
-                    fullFormat: x.original,
-                    shortFormat: `${x.tag}:${x.etag}-${x.dbId.substring(0, 4)}...`
-                };
-            });
-        } else {
-            return tokens.map((x): changeVectorItem => {
-                return {
-                    fullFormat: x.original,
-                    shortFormat: `${x.tag}:${x.etag}`
-                };
-            });
+        if (!input) {
+            return [];
         }
+
+        const toItem = (x: ReturnType<typeof changeVectorUtils.parseChangeVectorEntry>): changeVectorItem => ({
+            fullFormat: x.original,
+            shortFormat: useLongChangeVectorFormat
+                ? `${x.tag}:${x.etag}-${x.dbId.substring(0, 4)}...`
+                : `${x.tag}:${x.etag}`
+        });
+
+        const pipeIndex = input.indexOf("|");
+        if (pipeIndex === -1) {
+            return changeVectorUtils.parsePart(input).map(toItem);
+        }
+
+        // Dual CV format: "Order|Version" — merge boundary tokens into one badge e.g. "B:18|A:12"
+        const orderItems = changeVectorUtils.parsePart(input.substring(0, pipeIndex)).map(toItem);
+        const versionItems = changeVectorUtils.parsePart(input.substring(pipeIndex + 1)).map(toItem);
+        const bridge: changeVectorItem = {
+            fullFormat: `${orderItems.at(-1).fullFormat} | ${versionItems[0].fullFormat}`,
+            shortFormat: `${orderItems.at(-1).shortFormat} | ${versionItems[0].shortFormat}`
+        };
+        return [...orderItems.slice(0, -1), bridge, ...versionItems.slice(1)];
     }
 
     static formatChangeVectorAsShortString(input: string) {
         //A:1066-8Bk5eyIYfES1TzuU6TnzPg, C:1066-iazDDYGWiUmj8AwW4jgjYA, E:1066-m9yioKcvEkGny6tfKJo3Tw, B:1068-5hNdZ22Up0e+KkaU7u2VUg, D:1066-OHQUXCEyYU6VE
-        const tokens = changeVectorUtils.parse(input);
+        const tokens = changeVectorUtils.parseEntries(input);
         return tokens.map(x => `${x.tag}:${x.etag}`).join(", ");
     }
     
@@ -57,19 +68,19 @@ class changeVectorUtils {
         return tokens.dbId;
     }
     
-    private static parseChangeVectorEntry(cvEntry: string) {
+    private static parseChangeVectorEntry(cvEntry: string): changeVectorEntryItem {
         const trimmedValue = cvEntry.trim();
 
         const [tag, rest] = trimmedValue.split(":", 2);
         const [etag, dbId] = rest.split("-", 2);
 
         return {
-            tag: tag,
-            etag: etag,
-            dbId: dbId,
+            tag,
+            etag,
+            dbId,
             original: trimmedValue
         };
     }
-} 
+}
 
 export = changeVectorUtils;

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -66,6 +66,13 @@ interface changeVectorItem {
     shortFormat: string;
 }
 
+interface changeVectorEntryItem {
+    tag: string;
+    etag: string;
+    dbId: string;
+    original: string;
+}
+
 interface IndexErrorPerDocument {
     Document: string;
     Error: string;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26512 

### Additional description

<img width="404" height="225" alt="image" src="https://github.com/user-attachments/assets/ec49b12a-525f-4100-8218-e0268fd79cbc" />

<img width="437" height="256" alt="image" src="https://github.com/user-attachments/assets/5fdaee2c-c13b-434f-9f78-9ec7780ad968" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
