### PR TITLE
RavenDB-26377 - Kafka connection test exception notification trims stacktrace

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestAzureQueueStorageConnection.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestAzureQueueStorageConnection.cs
@@ -47,6 +47,8 @@ internal sealed class
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
+                var errorJson = JsonConvert.SerializeObject(new { Message = ex.Message, Error = ex.ToString() });
+
                 await using (var writer =
                              new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                 {
@@ -54,7 +56,7 @@ internal sealed class
                         new DynamicJsonValue
                         {
                             [nameof(NodeConnectionTestResult.Success)] = false,
-                            [nameof(NodeConnectionTestResult.Error)] = ex.ToString()
+                            [nameof(NodeConnectionTestResult.Error)] = errorJson
                         });
                 }
             }

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestKafkaConnection.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestKafkaConnection.cs
@@ -92,13 +92,15 @@ namespace Raven.Server.Documents.ETL.Providers.Queue.Handlers.Processors
                     if (logDetails is not null)
                         error += $"{Environment.NewLine}LOGS:{Environment.NewLine}{logDetails}";
 
+                    var errorJson = JsonConvert.SerializeObject(new { Message = ex.Message, Error = error });
+
                     await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                     {
                         context.Write(writer,
                             new DynamicJsonValue
                             {
                                 [nameof(NodeConnectionTestResult.Success)] = false,
-                                [nameof(NodeConnectionTestResult.Error)] = error
+                                [nameof(NodeConnectionTestResult.Error)] = errorJson
                             });
                     }
                 }

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestRabbitMqConnection.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestRabbitMqConnection.cs
@@ -46,13 +46,15 @@ namespace Raven.Server.Documents.ETL.Providers.Queue.Handlers.Processors
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                 {
+                    var errorJson = JsonConvert.SerializeObject(new { Message = ex.Message, Error = ex.ToString() });
+
                     await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                     {
                         context.Write(writer,
                             new DynamicJsonValue
                             {
                                 [nameof(NodeConnectionTestResult.Success)] = false,
-                                [nameof(NodeConnectionTestResult.Error)] = ex.ToString()
+                                [nameof(NodeConnectionTestResult.Error)] = errorJson
                             });
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26377

### Additional description

<img width="939" height="622" alt="image" src="https://github.com/user-attachments/assets/d3f8a281-b5d9-4f4e-851f-840c859334ad" />

<img width="1002" height="637" alt="image" src="https://github.com/user-attachments/assets/0f10b818-6f9f-4eb3-902d-367b7d704c6b" />

<img width="1002" height="777" alt="image" src="https://github.com/user-attachments/assets/98158ca4-37c9-4b5d-ae37-da648b1b1ae1" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
