### PR TITLE
RavenDB-25926 Fix GetLazyStringTempComparisonBuffer len computation

### DIFF
--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -184,13 +184,11 @@ namespace Sparrow.Json
         
         private static byte[] GetLazyStringTempComparisonBuffer(int charCount)
         {
-            if (_lazyStringTempComparisonBuffer == null || _lazyStringTempComparisonBuffer.Length < charCount * 5)
-            {
-                var sizeInBytes = Encodings.Utf8.GetMaxByteCount(charCount);
-
-                if (_lazyStringTempComparisonBuffer == null || _lazyStringTempComparisonBuffer.Length < charCount)
-                    _lazyStringTempComparisonBuffer = new byte[Bits.NextAllocationSize(sizeInBytes)];
-            }
+            // Inlined from Encodings.Utf8.GetMaxByteCount(charCount) to avoid virtual dispatch indirection.
+            var sizeInBytes = (charCount + 1) * 3;
+            Debug.Assert(sizeInBytes >= Encodings.Utf8.GetMaxByteCount(charCount));
+            if (_lazyStringTempComparisonBuffer == null || _lazyStringTempComparisonBuffer.Length < sizeInBytes)
+                _lazyStringTempComparisonBuffer = new byte[Bits.NextAllocationSize(sizeInBytes)];
             return _lazyStringTempComparisonBuffer;
         }
 
@@ -263,13 +261,11 @@ namespace Sparrow.Json
             if (_string != null)
                 return string.Compare(_string, other, StringComparison.Ordinal);
 
-            var sizeInBytes = Encodings.Utf8.GetMaxByteCount(other.Length);
-
             var buffer = GetLazyStringTempComparisonBuffer(other.Length);
             fixed (char* pOther = other)
             fixed (byte* pBuffer = buffer)
             {
-                var tmpSize = Encodings.Utf8.GetBytes(pOther, other.Length, pBuffer, sizeInBytes);
+                var tmpSize = Encodings.Utf8.GetBytes(pOther, other.Length, pBuffer, buffer.Length);
                 return Compare(pBuffer, tmpSize);
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25926

### Additional description
`GetLazyStringTempComparisonBuffer` had two bugs in its double-check sizing logic:

  1. The outer guard used `charCount * 5` as the assumed UTF-8 max size, but the correct value is `(charCount + 1) * 3`.                                    
  2. The inner check compared `buffer.Length < charCount` (char units) instead of `buffer.Length < sizeInBytes` (byte units), potentially returning a buffer too small to hold the UTF-8 encoding of the input — for example, a 3-char
  string of `€` needs 9 bytes but the buffer could be returned with only 8.

  The fix replaces the double-check with a single correct check using `(charCount + 1) * 3`, which is exactly what `Encodings.Utf8.GetMaxByteCount` computes internally, inlined to avoid the virtual dispatch overhead. A `Debug.Assert` is
   added to catch any future divergence if the encoding's fallback behaviour changes.

  Also removed a now-redundant `GetMaxByteCount` call in `CompareTo(string)`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
