### PR TITLE
RavenDB-26384 RavenDB ETL: Cannot test 'Document ID Postfix'

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
@@ -248,7 +248,7 @@
                             <label class="control-label"><strong>Document ID postfix:</strong></label>
                             <div class="flex-grow margin-left">
                                 <input type="text" class="form-control" placeholder="Enter Document ID postfix (optional)" autocomplete="off"
-                                       data-bind="textInput: documentIdPostfix, disable: $root.enableTestArea()" />
+                                       data-bind="textInput: documentIdPostfix" />
                             </div>
                         </div>
                         <div class="margin-bottom-sm margin-top-sm">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26384 

### Additional description

<img width="1375" height="1054" alt="image" src="https://github.com/user-attachments/assets/a06c8f35-de8f-4a60-81dd-6ae559cc6d48" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
