### PR TITLE
RavenDB-26452 Snapshot & fork AI Conversations

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/ConversationsRevisionsConfigPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/ConversationsRevisionsConfigPanel.tsx
@@ -1,0 +1,125 @@
+import {
+    RichPanel,
+    RichPanelHeader,
+    RichPanelInfo,
+    RichPanelName,
+    RichPanelActions,
+    RichPanelDetails,
+    RichPanelDetailItem,
+} from "components/common/RichPanel";
+import Button from "react-bootstrap/Button";
+import { Icon } from "components/common/Icon";
+import { DocumentRevisionsConfig, documentRevisionsActions } from "./store/documentRevisionsSlice";
+import { documentRevisionsSelectors } from "./store/documentRevisionsSliceSelectors";
+import { useAppDispatch, useAppSelector } from "components/store";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
+import generalUtils from "common/generalUtils";
+import { useEventsCollector } from "components/hooks/useEventsCollector";
+
+interface ConversationsRevisionsConfigPanelProps {
+    config: DocumentRevisionsConfig;
+    onEdit: () => void;
+}
+
+export default function ConversationsRevisionsConfigPanel({ config, onEdit }: ConversationsRevisionsConfigPanelProps) {
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
+    const dispatch = useAppDispatch();
+    const { reportEvent } = useEventsCollector();
+
+    const originalConfig = useAppSelector(documentRevisionsSelectors.originalConfig(config.Name));
+    const isModified = !_.isEqual(originalConfig, config);
+
+    const formattedMinimumRevisionAgeToKeep = config.MinimumRevisionAgeToKeep
+        ? generalUtils.formatTimeSpan(generalUtils.timeSpanToSeconds(config.MinimumRevisionAgeToKeep) * 1000, true)
+        : null;
+
+    const isDetailsVisible =
+        config.MinimumRevisionsToKeep != null ||
+        config.MinimumRevisionAgeToKeep != null ||
+        config.PurgeOnDelete ||
+        config.MaximumRevisionsToDeleteUponDocumentUpdate != null;
+
+    return (
+        <RichPanel className="flex-row">
+            <div className="flex-grow-1">
+                <RichPanelHeader className={!isDetailsVisible ? "h-100" : undefined}>
+                    <RichPanelInfo>
+                        <RichPanelName>
+                            {config.Name}
+                            {isModified && <span className="text-warning ms-1">*</span>}
+                        </RichPanelName>
+                    </RichPanelInfo>
+                    {hasDatabaseAdminAccess && (
+                        <RichPanelActions>
+                            <Button variant="secondary" onClick={onEdit} title="Edit this revision configuration">
+                                <Icon icon="edit" margin="m-0" />
+                            </Button>
+                            <Button
+                                variant="danger"
+                                onClick={() => {
+                                    reportEvent("revisions", "remove");
+                                    dispatch(documentRevisionsActions.configDeleted(config.Name));
+                                }}
+                                title="Delete this revision configuration"
+                            >
+                                <Icon icon="trash" margin="m-0" />
+                            </Button>
+                        </RichPanelActions>
+                    )}
+                </RichPanelHeader>
+                {isDetailsVisible && (
+                    <RichPanelDetails>
+                        {config.MinimumRevisionsToKeep != null && (
+                            <RichPanelDetailItem
+                                label={
+                                    <>
+                                        <Icon icon="documents" />
+                                        Keep
+                                    </>
+                                }
+                            >
+                                {config.MinimumRevisionsToKeep} revisions
+                            </RichPanelDetailItem>
+                        )}
+                        {formattedMinimumRevisionAgeToKeep && (
+                            <RichPanelDetailItem
+                                label={
+                                    <>
+                                        <Icon icon="clock" />
+                                        Retention time
+                                    </>
+                                }
+                            >
+                                {formattedMinimumRevisionAgeToKeep}
+                            </RichPanelDetailItem>
+                        )}
+                        {config.PurgeOnDelete && (
+                            <RichPanelDetailItem
+                                label={
+                                    <>
+                                        <Icon icon="trash" />
+                                        Purge on delete
+                                    </>
+                                }
+                            >
+                                Yes
+                            </RichPanelDetailItem>
+                        )}
+                        {config.MaximumRevisionsToDeleteUponDocumentUpdate != null && (
+                            <RichPanelDetailItem
+                                label={
+                                    <>
+                                        <Icon icon="trash" />
+                                        Max to delete on update
+                                    </>
+                                }
+                            >
+                                {config.MaximumRevisionsToDeleteUponDocumentUpdate}
+                            </RichPanelDetailItem>
+                        )}
+                    </RichPanelDetails>
+                )}
+            </div>
+        </RichPanel>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.spec.tsx
@@ -26,7 +26,7 @@ describe("DocumentRevisions", () => {
             <DefaultDocumentRevisions canSetupDefaultRevisionsConfiguration={false} />
         );
 
-        const addDefaultButton = screen.getAllByRole("button", { name: /Add new/ })[0];
+        const addDefaultButton = screen.getByTestId("add-default-config-button");
         expect(addDefaultButton).toBeDisabled();
     });
 });

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -17,6 +17,7 @@ import { documentRevisionsSelectors } from "./store/documentRevisionsSliceSelect
 import { useAppDispatch, useAppSelector } from "components/store";
 import { LoadError } from "components/common/LoadError";
 import DocumentRevisionsConfigPanel from "./DocumentRevisionsConfigPanel";
+import ConversationsRevisionsConfigPanel from "./ConversationsRevisionsConfigPanel";
 import useBoolean from "components/hooks/useBoolean";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { useAsyncCallback } from "react-async-hook";
@@ -60,6 +61,7 @@ export default function DocumentRevisions() {
     const defaultDocumentsConfig = useAppSelector(documentRevisionsSelectors.defaultDocumentsConfig);
     const defaultConflictsConfig = useAppSelector(documentRevisionsSelectors.defaultConflictsConfig);
     const collectionConfigs = useAppSelector(documentRevisionsSelectors.collectionConfigs);
+    const conversationsConfig = useAppSelector(documentRevisionsSelectors.conversationsConfig);
     const isAnyModified = useAppSelector(documentRevisionsSelectors.isAnyModified);
 
     const canSetupDefaultRevisionsConfiguration = useAppSelector(
@@ -114,7 +116,10 @@ export default function DocumentRevisions() {
         const promises = [
             databasesService.saveRevisionsConfiguration(databaseName, {
                 Default: mapToDto(defaultDocumentsConfig),
-                Collections: Object.fromEntries(collectionConfigs.map((x) => [x.Name, mapToDto(x)])),
+                Collections: {
+                    ...Object.fromEntries(collectionConfigs.map((x) => [x.Name, mapToDto(x)])),
+                    ...(conversationsConfig ? { "@conversations": mapToDto(conversationsConfig) } : {}),
+                },
             }),
             databasesService.saveRevisionsForConflictsConfiguration(databaseName, mapToDto(defaultConflictsConfig)),
         ];
@@ -227,6 +232,50 @@ export default function DocumentRevisions() {
                             </StickyHeader>
                         )}
 
+                        <div className="mt-5">
+                            <HrHeader
+                                right={
+                                    hasDatabaseAdminAccess && !conversationsConfig ? (
+                                        <Button
+                                            variant="info"
+                                            size="sm"
+                                            className="rounded-pill"
+                                            title="Create a revision configuration for AI conversation snapshots"
+                                            onClick={() =>
+                                                onEditRevision({
+                                                    taskType: "new",
+                                                    configType: "conversations",
+                                                    onConfirm: (config) =>
+                                                        dispatch(documentRevisionsActions.configAdded(config)),
+                                                })
+                                            }
+                                        >
+                                            <Icon icon="plus" />
+                                            Add new
+                                        </Button>
+                                    ) : null
+                                }
+                            >
+                                <Icon icon="ai" />
+                                AI Conversations
+                            </HrHeader>
+                            {conversationsConfig ? (
+                                <ConversationsRevisionsConfigPanel
+                                    config={conversationsConfig}
+                                    onEdit={() =>
+                                        onEditRevision({
+                                            taskType: "edit",
+                                            configType: "conversations",
+                                            config: conversationsConfig,
+                                            onConfirm: (config) =>
+                                                dispatch(documentRevisionsActions.configEdited(config)),
+                                        })
+                                    }
+                                />
+                            ) : (
+                                <EmptySet>No ai conversation specific configuration has been defined</EmptySet>
+                            )}
+                        </div>
                         <div className="mt-5">
                             <HrHeader
                                 right={

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -286,12 +286,13 @@ export default function DocumentRevisions() {
                                                 message: "Your license does not allow you to set up default policy.",
                                             }}
                                         >
-                                            <div id="add-default-config-button">
+                                            <div>
                                                 <Button
                                                     variant="info"
                                                     size="sm"
                                                     className="rounded-pill"
                                                     title="Create a default revision configuration for all (non-conflicting) documents"
+                                                    data-testid="add-default-config-button"
                                                     onClick={() =>
                                                         onEditRevision({
                                                             taskType: "new",

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -41,6 +41,7 @@ import activeDatabaseTracker from "common/shell/activeDatabaseTracker";
 import Button from "react-bootstrap/Button";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import { getDatabaseAccessRequiredMessage } from "components/utils/accessUtils";
 
 interface EditRevisionData {
     onConfirm: (config: DocumentRevisionsConfig) => void;
@@ -235,12 +236,24 @@ export default function DocumentRevisions() {
                         <div className="mt-5">
                             <HrHeader
                                 right={
-                                    hasDatabaseAdminAccess && !conversationsConfig ? (
+                                    <ConditionalPopover
+                                        conditions={[
+                                            {
+                                                isActive: !hasDatabaseAdminAccess,
+                                                message: getDatabaseAccessRequiredMessage("DatabaseAdmin"),
+                                            },
+                                            {
+                                                isActive: !!conversationsConfig,
+                                                message: "A conversation revision configuration already exists.",
+                                            },
+                                        ]}
+                                    >
                                         <Button
                                             variant="info"
                                             size="sm"
                                             className="rounded-pill"
                                             title="Create a revision configuration for AI conversation snapshots"
+                                            disabled={!hasDatabaseAdminAccess || !!conversationsConfig}
                                             onClick={() =>
                                                 onEditRevision({
                                                     taskType: "new",
@@ -253,7 +266,7 @@ export default function DocumentRevisions() {
                                             <Icon icon="plus" />
                                             Add new
                                         </Button>
-                                    ) : null
+                                    </ConditionalPopover>
                                 }
                             >
                                 <Icon icon="ai" />
@@ -279,36 +292,46 @@ export default function DocumentRevisions() {
                         <div className="mt-5">
                             <HrHeader
                                 right={
-                                    hasDatabaseAdminAccess && !defaultDocumentsConfig ? (
-                                        <ConditionalPopover
-                                            conditions={{
+                                    <ConditionalPopover
+                                        conditions={[
+                                            {
+                                                isActive: !hasDatabaseAdminAccess,
+                                                message: getDatabaseAccessRequiredMessage("DatabaseAdmin"),
+                                            },
+                                            {
+                                                isActive: !!defaultDocumentsConfig,
+                                                message: "A default document revision configuration already exists.",
+                                            },
+                                            {
                                                 isActive: !canSetupDefaultRevisionsConfiguration,
                                                 message: "Your license does not allow you to set up default policy.",
-                                            }}
+                                            },
+                                        ]}
+                                    >
+                                        <Button
+                                            variant="info"
+                                            size="sm"
+                                            className="rounded-pill"
+                                            title="Create a default revision configuration for all (non-conflicting) documents"
+                                            data-testid="add-default-config-button"
+                                            disabled={
+                                                !hasDatabaseAdminAccess ||
+                                                !!defaultDocumentsConfig ||
+                                                !canSetupDefaultRevisionsConfiguration
+                                            }
+                                            onClick={() =>
+                                                onEditRevision({
+                                                    taskType: "new",
+                                                    configType: "defaultDocument",
+                                                    onConfirm: (config) =>
+                                                        dispatch(documentRevisionsActions.configAdded(config)),
+                                                })
+                                            }
                                         >
-                                            <div>
-                                                <Button
-                                                    variant="info"
-                                                    size="sm"
-                                                    className="rounded-pill"
-                                                    title="Create a default revision configuration for all (non-conflicting) documents"
-                                                    data-testid="add-default-config-button"
-                                                    onClick={() =>
-                                                        onEditRevision({
-                                                            taskType: "new",
-                                                            configType: "defaultDocument",
-                                                            onConfirm: (config) =>
-                                                                dispatch(documentRevisionsActions.configAdded(config)),
-                                                        })
-                                                    }
-                                                    disabled={!canSetupDefaultRevisionsConfiguration}
-                                                >
-                                                    <Icon icon="plus" />
-                                                    Add new
-                                                </Button>
-                                            </div>
-                                        </ConditionalPopover>
-                                    ) : null
+                                            <Icon icon="plus" />
+                                            Add new
+                                        </Button>
+                                    </ConditionalPopover>
                                 }
                             >
                                 <Icon icon="default" />
@@ -354,12 +377,18 @@ export default function DocumentRevisions() {
                         <div className="mt-5">
                             <HrHeader
                                 right={
-                                    hasDatabaseAdminAccess ? (
+                                    <ConditionalPopover
+                                        conditions={{
+                                            isActive: !hasDatabaseAdminAccess,
+                                            message: getDatabaseAccessRequiredMessage("DatabaseAdmin"),
+                                        }}
+                                    >
                                         <Button
                                             variant="info"
                                             size="sm"
                                             className="rounded-pill"
                                             title="Create a revision configuration for a specific collection"
+                                            disabled={!hasDatabaseAdminAccess}
                                             onClick={() =>
                                                 onEditRevision({
                                                     taskType: "new",
@@ -372,7 +401,7 @@ export default function DocumentRevisions() {
                                             <Icon icon="plus" />
                                             Add new
                                         </Button>
-                                    ) : null
+                                    </ConditionalPopover>
                                 }
                             >
                                 <Icon icon="documents" />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisionsValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisionsValidation.ts
@@ -38,8 +38,11 @@ const editCollectionConfigSchema = yup.object({
 });
 
 const editConfigSchema = editCollectionConfigSchema.omit(["collectionName"]);
+const conversationsConfigSchema = editCollectionConfigSchema.omit(["collectionName", "disabled"]);
 
 export const documentRevisionsConfigYupResolver = yupResolver(editConfigSchema);
 export const documentRevisionsCollectionConfigYupResolver = yupResolver(editCollectionConfigSchema);
+export const documentRevisionsConversationsConfigYupResolver = yupResolver(conversationsConfigSchema);
 
 export type EditDocumentRevisionsCollectionConfig = yup.InferType<typeof editCollectionConfigSchema>;
+export type EditDocumentRevisionsConversationsConfig = yup.InferType<typeof conversationsConfigSchema>;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
@@ -5,9 +5,10 @@ import Form from "react-bootstrap/Form";
 import { FormDurationPicker, FormInput, FormLabel, FormSelectCreatable, FormSwitch } from "components/common/Form";
 import { SubmitHandler, useForm, useWatch } from "react-hook-form";
 import {
-    EditDocumentRevisionsCollectionConfig,
     documentRevisionsCollectionConfigYupResolver,
     documentRevisionsConfigYupResolver,
+    documentRevisionsConversationsConfigYupResolver,
+    EditDocumentRevisionsCollectionConfig,
 } from "components/pages/database/settings/documentRevisions/DocumentRevisionsValidation";
 import { useDirtyFlag } from "hooks/useDirtyFlag";
 import assertUnreachable from "components/utils/assertUnreachable";
@@ -51,6 +52,7 @@ export default function EditRevision(props: EditRevisionProps) {
     const { toggle, configType, taskType, config, onConfirm } = props;
 
     const isForNewCollection: boolean = configType === "collectionSpecific" && taskType === "new";
+    const isConversations: boolean = configType === "conversations";
 
     const revisionsToKeepLimit = useAppSelector(licenseSelectors.statusValue("MaxNumberOfRevisionsToKeep"));
     const revisionsAgeInDaysLimit = useAppSelector(licenseSelectors.statusValue("MaxNumberOfRevisionAgeToKeepInDays"));
@@ -67,9 +69,7 @@ export default function EditRevision(props: EditRevisionProps) {
         }));
 
     const { control, formState, setValue, handleSubmit, watch } = useForm<EditDocumentRevisionsCollectionConfig>({
-        resolver: isForNewCollection
-            ? documentRevisionsCollectionConfigYupResolver
-            : documentRevisionsConfigYupResolver,
+        resolver: getYupResolver(configType, isForNewCollection),
         mode: "all",
         defaultValues: getInitialValues(config, revisionsToKeepLimit),
     });
@@ -166,7 +166,9 @@ export default function EditRevision(props: EditRevisionProps) {
                                     name="minimumRevisionsToKeep"
                                     placeholder="Enter number of revisions to keep"
                                 />
-                                {isRevisionsToKeepLimitTooLowWarning && <LimitTooLowWarning limit={revisionsDelta} />}
+                                {!isConversations && isRevisionsToKeepLimitTooLowWarning && (
+                                    <LimitTooLowWarning limit={revisionsDelta} />
+                                )}
                             </InputGroup>
                             {!isDefaultConflicts &&
                             revisionsToKeepLimit > 0 &&
@@ -195,7 +197,7 @@ export default function EditRevision(props: EditRevisionProps) {
                                     Your license allows max {revisionsAgeInDaysLimit} days retention time
                                 </RichAlert>
                             ) : null}
-                            {isRevisionsToKeepByAgeLimitWarning && (
+                            {!isConversations && isRevisionsToKeepByAgeLimitWarning && (
                                 <LimitTooLowWarning
                                     limit={generalUtils.formatTimeSpan(revisionsByAgeDelta * 1000, true)}
                                 />
@@ -219,15 +221,25 @@ export default function EditRevision(props: EditRevisionProps) {
                             )}
                         </>
                     )}
-                    {isRevisionsToKeepLimitNotSetWarning && <LimitNotSetWarning />}
+                    {!isConversations && isRevisionsToKeepLimitNotSetWarning && <LimitNotSetWarning />}
                     <RichAlert variant="primary" title="Summary" className="mt-2">
                         <ul className="m-0 ps-2 vstack gap-1">
-                            <li>
-                                A revision will be created anytime a document is created
-                                {formValues.isPurgeOnDeleteEnabled ? " or modified." : ", modified, or deleted."}
-                            </li>
+                            {isConversations ? (
+                                <li>
+                                    Snapshot revisions are only created explicitly via the snapshot API, not
+                                    automatically on document save.
+                                </li>
+                            ) : (
+                                <li>
+                                    A revision will be created anytime a document is created
+                                    {formValues.isPurgeOnDeleteEnabled ? " or modified." : ", modified, or deleted."}
+                                </li>
+                            )}
                             {formValues.isPurgeOnDeleteEnabled ? (
-                                <li>When a document is deleted all its revisions will be removed.</li>
+                                <li>
+                                    When a {isConversations ? "conversation " : ""}document is deleted all its revisions
+                                    will be removed.
+                                </li>
                             ) : (
                                 <li>
                                     Revisions of a deleted document can be accessed in the{" "}
@@ -326,6 +338,17 @@ function LimitNotSetWarning() {
     );
 }
 
+function getYupResolver(configType: EditRevisionConfigType, isForNewCollection: boolean) {
+    if (isForNewCollection) {
+        return documentRevisionsCollectionConfigYupResolver;
+    }
+    if (configType === "conversations") {
+        return documentRevisionsConversationsConfigYupResolver;
+    }
+
+    return documentRevisionsConfigYupResolver;
+}
+
 function getSubmitIcon(taskType: EditRevisionTaskType): IconName {
     switch (taskType) {
         case "new":
@@ -349,6 +372,9 @@ function getTitle(taskType: EditRevisionTaskType, configType: EditRevisionConfig
             break;
         case "defaultConflicts":
             suffix = "default conflicts revisions configuration";
+            break;
+        case "conversations":
+            suffix = "AI conversations revision configuration";
             break;
         default:
             assertUnreachable(configType);
@@ -398,6 +424,7 @@ function mapToDocumentRevisionsConfig(
     configType: EditRevisionConfigType
 ): DocumentRevisionsConfig {
     let name: DocumentRevisionsConfigName = null;
+    let disabled: boolean = formData.disabled;
 
     switch (configType) {
         case "collectionSpecific":
@@ -409,13 +436,17 @@ function mapToDocumentRevisionsConfig(
         case "defaultConflicts":
             name = documentRevisionsConfigNames.defaultConflicts;
             break;
+        case "conversations":
+            name = documentRevisionsConfigNames.conversations;
+            disabled = true;
+            break;
         default:
             assertUnreachable(configType);
     }
 
     return {
         Name: name,
-        Disabled: formData.disabled,
+        Disabled: disabled,
         MaximumRevisionsToDeleteUponDocumentUpdate: formData.isMaximumRevisionsToDeleteUponDocumentUpdateEnabled
             ? formData.maximumRevisionsToDeleteUponDocumentUpdate
             : null,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/store/documentRevisionsSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/store/documentRevisionsSlice.ts
@@ -20,11 +20,11 @@ export interface DocumentRevisionsConfig extends RevisionsCollectionConfiguratio
 export interface DocumentRevisionsState {
     loadStatus: loadStatus;
     selectedConfigNames: DocumentRevisionsConfigName[];
-    configs: EntityState<DocumentRevisionsConfig, string>;
-    originalConfigs: EntityState<DocumentRevisionsConfig, string>;
+    configs: EntityState<DocumentRevisionsConfig, DocumentRevisionsConfigName>;
+    originalConfigs: EntityState<DocumentRevisionsConfig, DocumentRevisionsConfigName>;
 }
 
-const configsAdapter = createEntityAdapter<DocumentRevisionsConfig, string>({
+const configsAdapter = createEntityAdapter<DocumentRevisionsConfig, DocumentRevisionsConfigName>({
     selectId: (config) => config.Name,
 });
 
@@ -65,9 +65,9 @@ export const documentRevisionsSlice = createSlice({
         },
         allSelectedConfigNamesToggled: (state) => {
             if (state.selectedConfigNames.length === 0) {
-                state.selectedConfigNames = (
-                    configsSelectors.selectIds(state.configs) as DocumentRevisionsConfigName[]
-                ).filter((name) => name !== documentRevisionsConfigNames.conversations);
+                state.selectedConfigNames = configsSelectors
+                    .selectIds(state.configs)
+                    .filter((name) => name !== documentRevisionsConfigNames.conversations);
             } else {
                 state.selectedConfigNames = [];
             }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/store/documentRevisionsSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/store/documentRevisionsSlice.ts
@@ -6,6 +6,7 @@ import { loadStatus } from "components/models/common";
 export const documentRevisionsConfigNames = {
     defaultConflicts: "Conflicting Document Defaults",
     defaultDocument: "Document Defaults",
+    conversations: "@conversations",
 } as const;
 
 export type DocumentRevisionsConfigName =
@@ -64,7 +65,9 @@ export const documentRevisionsSlice = createSlice({
         },
         allSelectedConfigNamesToggled: (state) => {
             if (state.selectedConfigNames.length === 0) {
-                state.selectedConfigNames = configsSelectors.selectIds(state.configs) as DocumentRevisionsConfigName[];
+                state.selectedConfigNames = (
+                    configsSelectors.selectIds(state.configs) as DocumentRevisionsConfigName[]
+                ).filter((name) => name !== documentRevisionsConfigNames.conversations);
             } else {
                 state.selectedConfigNames = [];
             }
@@ -79,30 +82,38 @@ export const documentRevisionsSlice = createSlice({
         selectedConfigsDeleted: (state) => {
             configsAdapter.removeMany(
                 state.configs,
-                state.selectedConfigNames.filter((name) => name !== documentRevisionsConfigNames.defaultConflicts)
+                state.selectedConfigNames.filter(
+                    (name) =>
+                        name !== documentRevisionsConfigNames.defaultConflicts &&
+                        name !== documentRevisionsConfigNames.conversations
+                )
             );
             state.selectedConfigNames = [];
         },
         selectedConfigsDisabled: (state) => {
             configsAdapter.updateMany(
                 state.configs,
-                state.selectedConfigNames.map((name) => ({
-                    id: name,
-                    changes: {
-                        Disabled: true,
-                    },
-                }))
+                state.selectedConfigNames
+                    .filter((name) => name !== documentRevisionsConfigNames.conversations)
+                    .map((name) => ({
+                        id: name,
+                        changes: {
+                            Disabled: true,
+                        },
+                    }))
             );
         },
         selectedConfigsEnabled: (state) => {
             configsAdapter.updateMany(
                 state.configs,
-                state.selectedConfigNames.map((name) => ({
-                    id: name,
-                    changes: {
-                        Disabled: false,
-                    },
-                }))
+                state.selectedConfigNames
+                    .filter((name) => name !== documentRevisionsConfigNames.conversations)
+                    .map((name) => ({
+                        id: name,
+                        changes: {
+                            Disabled: false,
+                        },
+                    }))
             );
         },
         configsSaved: (state) => {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/store/documentRevisionsSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/store/documentRevisionsSliceSelectors.ts
@@ -16,13 +16,17 @@ const defaultDocumentsConfig = (store: RootState) =>
 const defaultConflictsConfig = (store: RootState) =>
     configsSelectors.selectById(store.documentRevisions.configs, documentRevisionsConfigNames.defaultConflicts);
 
+const conversationsConfig = (store: RootState) =>
+    configsSelectors.selectById(store.documentRevisions.configs, documentRevisionsConfigNames.conversations);
+
 const collectionConfigs = createSelector(
     (store: RootState) => configsSelectors.selectAll(store.documentRevisions.configs),
     (configs) =>
         configs.filter(
             (x) =>
                 x.Name !== documentRevisionsConfigNames.defaultConflicts &&
-                x.Name !== documentRevisionsConfigNames.defaultDocument
+                x.Name !== documentRevisionsConfigNames.defaultDocument &&
+                x.Name !== documentRevisionsConfigNames.conversations
         )
 );
 
@@ -44,6 +48,7 @@ export const documentRevisionsSelectors = {
     loadStatus,
     defaultDocumentsConfig,
     defaultConflictsConfig,
+    conversationsConfig,
     collectionConfigs,
     allConfigsNames,
     selectedConfigNames,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26452

### Additional description

*NOTE*: This is based off of https://github.com/ravendb/ravendb/pull/22619 and require it.
You can see just those changes on top of that PR here: https://github.com/ayende/ravendb/pull/4709

This part of PR is a copy of https://github.com/ravendb/ravendb/pull/22714, also includes required studio work

STUDIO PART:

<img width="1637" height="1152" alt="image1" src="https://github.com/user-attachments/assets/12fadabc-8d77-4f4a-882c-f5dc1c939bf5" />

<img width="874" height="698" alt="image2" src="https://github.com/user-attachments/assets/64bd158f-9cd7-4d51-a3fe-cf29d0ff1e8c" />

<img width="1600" height="1159" alt="image3" src="https://github.com/user-attachments/assets/dec26160-985d-4c60-a9be-5f11ad2b5718" />


#### What

Adds the ability to snapshot AI conversation state and fork (or rewind) conversations from those snapshots. Users can branch a conversation from any previous turn, creating "what-if" explorations without losing the original conversation history.

#### How snapshots work

When `SnapshotBeforeRunning` is enabled on `AiConversationCreationOptions`, the server creates a forced revision of the conversation document and all sub-conversation documents (recursively via `SubConversationIds`) before processing each user prompt. Snapshot creation happens after request validation (`TryHandleActionResponses`) but before the LLM call — invalid requests (e.g., action responses combined with a user prompt) are rejected without creating orphan revisions. Snapshots only apply to user prompts, attachments, and artificial actions — not to action response handling.

The revision change vectors are collected into an opaque JSON token (`SnapshotToken`) returned on `AiAnswer<T>`. The token contains the conversation ID, a timestamp from the root revision's `LastModified`, and a flat list of revision entries for the root and all transitive sub-conversations. 

Snapshots can also be created independently via `CreateSnapshotAsync()` without running a turn.

`ForceCreateRevision()` was added to `RevisionsStorage` as a public method, consolidating the force-revision logic.

#### How forking works

`ForkConversationAsync(snapshotToken, newConversationId, expectedChangeVector)` loads the revisions referenced by the token and validates them:
- **Scope check**: each revision ID must be the root conversation or start with `{rootId}/`
- **Collection check**: must belong to `@conversations`
- **Root presence**: the token must contain the root conversation revision

The fork then writes new documents with adjusted sub-conversation ID prefixes (only the leading prefix is replaced — deeper occurrences are preserved). `OpenActionCalls` entries referencing sub-conversations via `SubConversationId` are also adjusted. Attachments are copied from each revision using `CopyAttachment` with `AttachmentType.Revision`. Existing attachments on the target are deleted.

When forking to an existing conversation ID (rewind-in-place), orphaned sub-conversations are deleted recursively via `SubConversationIds` traversal with a visited set to handle cycles. The fork supports an optional `expectedChangeVector` parameter, verified only on the root document. The token itself is trusted — there is no trust boundary between generation and consumption.

#### Snapshot listing

`GetConversationSnapshotsAsync()` returns available snapshots with cursor-based paging by date. It lists all revisions (not just force-created ones) since users may also have collection-level revisions configured. Sub-conversation revisions are collected recursively; missing ones are skipped, producing partial but usable tokens.

#### Purging

`PurgeConversationSnapshotsAsync()` deletes revisions for the conversation and all its sub-conversations (discovered via `SubConversationIds` recursion). The root document is validated to belong to `@conversations`. Supports an optional `before` date for selective purge — revisions older than the cutoff are collected during iteration, then deleted individually via `DeleteRevision` with a single `lastModifiedTicks` for the batch. Without a date, `ForceDeleteAllRevisionsFor` is used.

Snapshot retention is managed by the standard `RevisionsConfiguration` on the `@conversations` collection — no separate retention mechanism.

#### Client API

- `AiConversationCreationOptions.SnapshotBeforeRunning` — flag to create snapshots before each turn (equivalent to `CreateSnapshotAsync()` + `RunAsync()` in a single roundtrip)
- `AiAnswer<T>.SnapshotToken` — opaque token for forking
- `AiOperations.ForkConversationAsync(snapshotToken, newConversationId, expectedChangeVector)` — fork or rewind
- `AiOperations.CreateSnapshotAsync(conversationId)` — snapshot without running a turn (throws if conversation doesn't exist)
- `AiOperations.GetConversationSnapshotsAsync(conversationId, before, pageSize)` — list with cursor paging
- `AiOperations.PurgeConversationSnapshotsAsync(conversationId)` / `PurgeConversationSnapshotsAsync(conversationId, before)` — delete all or before a date (exclusive)
- `AiForkConversationResult` — returns `ConversationId` + `ChangeVector`
- `AiConversationSnapshot` — returns `Token` + `CreatedAt`

#### Server endpoints

- `POST /databases/*/ai/agent/fork` — fork a conversation
- `POST /databases/*/ai/agent/snapshots` — create a snapshot
- `GET /databases/*/ai/agent/snapshots` — list snapshots (with `before` and `pageSize` query params)
- `DELETE /databases/*/ai/agent/snapshots` — purge snapshots (with optional `before` query param)
- Sharded handler stubs for all endpoints

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
