### PR TITLE
RavenDB-26279 Suppress background sync/flush errors when env is being disposed. Switch Dispose's cts.Cancel() to SafeCancel.

### DIFF
--- a/src/Voron/GlobalFlushingBehavior.cs
+++ b/src/Voron/GlobalFlushingBehavior.cs
@@ -118,7 +118,7 @@ namespace Voron
                     continue;
                 }
 
-                if (env.Disposed)
+                if (env.IsDisposing || env.Disposed)
                     continue;
 
                 if (force == false && envSyncReq.Value.IsRequired == false &&
@@ -159,7 +159,7 @@ namespace Voron
         private void SyncEnvironment(EnvSyncReq req)
         {
             var storageEnvironment = req.Env;
-            if (storageEnvironment == null || storageEnvironment.Disposed || storageEnvironment.Options.ManualSyncing)
+            if (storageEnvironment == null || storageEnvironment.IsDisposing || storageEnvironment.Disposed || storageEnvironment.Options.ManualSyncing)
                 return;
 
             try
@@ -171,6 +171,9 @@ namespace Voron
             }
             catch (Exception e)
             {
+                if (storageEnvironment.IsDisposing || storageEnvironment.Disposed)
+                    return;
+
                 if (_log.IsOperationsEnabled)
                     _log.Operations($"Failed to sync data file for {storageEnvironment.Options.BasePath}", e);
                 storageEnvironment.Options.SetCatastrophicFailure(ExceptionDispatchInfo.Capture(e));
@@ -229,9 +232,10 @@ namespace Voron
                 ThreadPool.QueueUserWorkItem(env =>
                 {
                     var storageEnvironment = ((StorageEnvironment)env);
+
                     try
                     {
-                        if (storageEnvironment.Disposed)
+                        if (storageEnvironment.IsDisposing || storageEnvironment.Disposed)
                             return;
 
                         storageEnvironment.BackgroundFlushWritesToDataFile();
@@ -239,6 +243,9 @@ namespace Voron
                     }
                     catch (Exception e)
                     {
+                        if (storageEnvironment.IsDisposing || storageEnvironment.Disposed)
+                            return;
+
                         if (_log.IsOperationsEnabled)
                             _log.Operations($"Failed to flush {storageEnvironment.Options.BasePath}", e);
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -117,6 +117,9 @@ namespace Voron
         public DateTime LastWorkTime;
 
         public bool Disposed;
+
+        public bool IsDisposing => _cancellationTokenSource.IsCancellationRequested || _envDispose.IsSet;
+
         private readonly Logger _log;
         public static int MaxConcurrentFlushes = 10; // RavenDB-5221
         public int TimeToSyncAfterFlushInSec;
@@ -483,11 +486,10 @@ namespace Voron
 
         public void Dispose()
         {
-
             if (_envDispose.IsSet)
                 return; // already disposed
 
-            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.SafeCancel(_log, $"Disposing {Options}");
             try
             {
                 SelfReference.Owner = null;


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26279

### Additional description

The only way I see the catastrophic exception could happen is that the directory got removed by while it was already enqueued and started being processed by background flush/sync operations.

The `GlobalFlushingBehavior` already does a pre-checks but neither re-checks at the catch, which is exactly the hole:

https://github.com/ravendb/ravendb/blob/07a6fa7a736f00b20d1e33ebf224e7f024da9023/src/Voron/GlobalFlushingBehavior.cs#L162-L163

https://github.com/ravendb/ravendb/blob/07a6fa7a736f00b20d1e33ebf224e7f024da9023/src/Voron/GlobalFlushingBehavior.cs#L234-L235

Both `GlobalFlushingBehavior` catch sites (sync and flush) now early-return when `storageEnvironment.IsDisposing` (or `storageEnvironment.Dispose`) - teardown collateral isn't a Voron-level catastrophe.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
