### PR TITLE
RavenDB-26641 Support full document replacement in Cluster-Wide transactions

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -812,6 +812,18 @@ namespace Raven.Client
             public const long InvalidOperationId = -1;
         }
 
+        internal sealed class ChangeVector
+        {
+            private ChangeVector()
+            {
+            }
+
+            internal const string RaftTag = "RAFT";
+            internal const string TrxnTag = "TRXN";
+            internal const string SinkTag = "SINK";
+            internal const string MoveTag = "MOVE";
+        }
+
         internal sealed class CompareExchange
         {
             private CompareExchange()

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -75,6 +75,12 @@ namespace Raven.Client.Documents.Session
                     }
                 }
 
+                if (changeVector != null)
+                {
+                    _missingDocumentsToAtomicGuardIndex ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    _missingDocumentsToAtomicGuardIndex[documentId] = changeVector;
+                }
+
                 return changeVector;
             }
         }
@@ -154,7 +160,9 @@ namespace Raven.Client.Documents.Session
                 && existing.Id != null
                 && existing.Id.Equals(documentId, StringComparison.OrdinalIgnoreCase) == false)
             {
-                throw new NonUniqueObjectException("Attempted to associate a different object with id '" + existing.Id + "'.");
+                throw new NonUniqueObjectException(
+                    $"Attempted to associate a different object with id '{documentId}'. " +
+                    $"The entity is already tracked with id '{existing.Id}'.");
             }
 
             // Same entity, same ID → just update the atomic guard CV
@@ -176,10 +184,8 @@ namespace Raven.Client.Documents.Session
 
             session.GenerateEntityIdOnTheClient.TrySetIdentity(entity, documentId);
 
-            var conventions = session.RequestExecutor.Conventions;
             var metadata = InMemoryDocumentSessionOperations.CreateDocumentMetadata(entity,
-                conventions.GetCollectionName(entity),
-                conventions.GetClrTypeName(entity));
+                session.RequestExecutor.Conventions);
 
             session.StoreEntityInUnitOfWork(documentId, entity, atomicGuardChangeVector, metadata, ConcurrencyCheckMode.Auto);
         }

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -64,18 +64,20 @@ namespace Raven.Client.Documents.Session
 
                 var value = await _session.Operations.SendAsync(
                     new GetCompareExchangeValueOperation<BlittableJsonReaderObject>(atomicGuardKey, materializeMetadata: false),
-                    sessionInfo: _session._sessionInfo, token: token).ConfigureAwait(false);
+                    sessionInfo: _session.SessionInfo, token: token).ConfigureAwait(false);
 
                 if (value == null)
                     return null;
 
-                if (value.Index > 0)
+                changeVector = value.ChangeVector;
+
+                if (changeVector == null && value.Index > 0)
                 {
                     var clusterTransactionId = _session.SessionInfo?.ClusterTransactionId;
                     if (clusterTransactionId == null)
-                        return null; // can't compute change vector without cluster tx id
+                        return null;
 
-                    changeVector = $"TRXN:{value.Index}-{clusterTransactionId}";
+                    changeVector = $"{Constants.ChangeVector.TrxnTag}:{value.Index}-{clusterTransactionId}";
                 }
 
                 if (changeVector != null)
@@ -183,10 +185,10 @@ namespace Raven.Client.Documents.Session
 
             // Check for deferred commands
             if (session.DeferredCommandsDictionary.ContainsKey((documentId, CommandType.ClientAnyCommand, null)))
-                throw new InvalidOperationException("Can't store document, there is a deferred command registered for this document in the session. Document id: " + documentId);
+                throw new InvalidOperationException("Can't store document, there is a deferred command registered for this document in the session. Document ID: " + documentId);
 
             if (session.DeletedEntities.Contains(entity))
-                throw new InvalidOperationException("Can't store object, it was already deleted in this session. Document id: " + documentId);
+                throw new InvalidOperationException("Can't store object, it was already deleted in this session. Document ID: " + documentId);
 
             session.GenerateEntityIdOnTheClient.TrySetIdentity(entity, documentId);
 

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Session.Operations.Lazy;
+using Raven.Client.Exceptions.Documents.Session;
 using Raven.Client.Json.Serialization;
 using Raven.Client.Util;
 using Sparrow.Json;
@@ -72,12 +73,6 @@ namespace Raven.Client.Documents.Session
                     {
                         changeVector = $"TRXN:{value.Index}-{clusterTransactionId}";
                     }
-                }
-
-                if (changeVector != null)
-                {
-                    _missingDocumentsToAtomicGuardIndex ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                    _missingDocumentsToAtomicGuardIndex[documentId] = changeVector;
                 }
 
                 return changeVector;
@@ -159,8 +154,7 @@ namespace Raven.Client.Documents.Session
                 && existing.Id != null
                 && existing.Id.Equals(documentId, StringComparison.OrdinalIgnoreCase) == false)
             {
-                throw new InvalidOperationException(
-                    $"Cannot store the same entity (id: {existing.Id}) with a different id ({documentId})");
+                throw new NonUniqueObjectException("Attempted to associate a different object with id '" + existing.Id + "'.");
             }
 
             // Same entity, same ID → just update the atomic guard CV
@@ -173,9 +167,7 @@ namespace Raven.Client.Documents.Session
             // ID already tracked → throw (caller should use a clean session)
             if (session.DocumentsById.TryGetValue(documentId, out _))
             {
-                throw new InvalidOperationException(
-                    $"Document '{documentId}' is already tracked in this session. " +
-                    "Use Load() + modify properties, or open a fresh session.");
+                throw new NonUniqueObjectException("Attempted to associate a different object with id '" + documentId + "'.");
             }
 
             // Check for deferred commands
@@ -185,14 +177,9 @@ namespace Raven.Client.Documents.Session
             session.GenerateEntityIdOnTheClient.TrySetIdentity(entity, documentId);
 
             var conventions = session.RequestExecutor.Conventions;
-            var metadata = new DynamicJsonValue();
-            var collectionName = conventions.GetCollectionName(entity);
-            if (collectionName != null)
-                metadata[Constants.Documents.Metadata.Collection] = collectionName;
-
-            var clrType = conventions.GetClrTypeName(entity);
-            if (clrType != null)
-                metadata[Constants.Documents.Metadata.RavenClrType] = clrType;
+            var metadata = InMemoryDocumentSessionOperations.CreateDocumentMetadata(entity,
+                conventions.GetCollectionName(entity),
+                conventions.GetClrTypeName(entity));
 
             session.StoreEntityInUnitOfWork(documentId, entity, atomicGuardChangeVector, metadata, ConcurrencyCheckMode.Auto);
         }
@@ -718,12 +705,12 @@ namespace Raven.Client.Documents.Session
         /// Stores the given entity under the specified document ID, replacing any existing document content
         /// in a cluster-wide transaction.
         ///
-        /// Unlike session.Store(), this does NOT throw NonUniqueObjectException when a different entity
-        /// instance is already tracked for the same ID. Instead, it throws if the document ID is
-        /// already tracked (callers should use a clean session).
+        /// Unlike session.Store(), this allows storing a different entity instance for the same document ID
+        /// as long as the document is not already tracked in this session.
+        /// If the document ID or entity is already tracked, a <see cref="NonUniqueObjectException"/> is thrown.
         ///
-        /// The atomic guard change vector must be provided — obtain it via GetCompareExchangeValueAsync()
-        /// for "rvn-atomic/{documentId}".
+        /// The atomic guard change vector must be provided — obtain it via
+        /// <see cref="IClusterTransactionOperationsAsync.GetAtomicGuardAsync"/>.
         /// </summary>
         /// <param name="documentId">The document ID to store under</param>
         /// <param name="entity">The entity to store</param>

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -47,6 +47,43 @@ namespace Raven.Client.Documents.Session
             return _missingDocumentsToAtomicGuardIndex.TryGetValue(docId, out changeVector);
         }
 
+        internal async Task<string> GetAtomicGuardAsyncInternal(string documentId, CancellationToken token = default)
+        {
+            if (TryGetMissingAtomicGuardFor(documentId, out var changeVector))
+                return changeVector;
+
+            var atomicGuardKey = ClusterWideTransactionHelper.GetAtomicGuardKey(documentId);
+
+            using (_session.AsyncTaskHolder())
+            {
+                _session.IncrementRequestCount();
+
+                var value = await _session.Operations.SendAsync(
+                    new GetCompareExchangeValueOperation<BlittableJsonReaderObject>(atomicGuardKey, materializeMetadata: false),
+                    sessionInfo: _session._sessionInfo, token: token).ConfigureAwait(false);
+
+                if (value == null)
+                    return null;
+
+                if (value.Index > 0)
+                {
+                    var clusterTransactionId = _session.SessionInfo?.ClusterTransactionId;
+                    if (clusterTransactionId != null)
+                    {
+                        changeVector = $"TRXN:{value.Index}-{clusterTransactionId}";
+                    }
+                }
+
+                if (changeVector != null)
+                {
+                    _missingDocumentsToAtomicGuardIndex ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    _missingDocumentsToAtomicGuardIndex[documentId] = changeVector;
+                }
+
+                return changeVector;
+            }
+        }
+
         internal int NumberOfTrackedCompareExchangeValues => _state.Count;
 
         protected ClusterTransactionOperationsBase(InMemoryDocumentSessionOperations session)
@@ -102,6 +139,62 @@ namespace Raven.Client.Documents.Session
             _state.Clear();
             _compareExchangeIncludes.Clear();
             _missingDocumentsToAtomicGuardIndex?.Clear();
+        }
+
+        public void Store(string documentId, object entity, string atomicGuardChangeVector)
+        {
+            if (entity == null)
+                throw new ArgumentNullException(nameof(entity));
+
+            if (string.IsNullOrWhiteSpace(documentId))
+                throw new ArgumentNullException(nameof(documentId));
+
+            var session = _session;
+
+            if (session.NoTracking)
+                throw new InvalidOperationException("Cannot store entity. Entity tracking is disabled in this session.");
+
+            // Entity already tracked under a DIFFERENT id → error (same semantics as StoreInternal)
+            if (session.DocumentsByEntity.TryGetValue(entity, out var existing)
+                && existing.Id != null
+                && existing.Id.Equals(documentId, StringComparison.OrdinalIgnoreCase) == false)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot store the same entity (id: {existing.Id}) with a different id ({documentId})");
+            }
+
+            // Same entity, same ID → just update the atomic guard CV
+            if (existing != null)
+            {
+                existing.ChangeVector = atomicGuardChangeVector;
+                return;
+            }
+
+            // ID already tracked → throw (caller should use a clean session)
+            if (session.DocumentsById.TryGetValue(documentId, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Document '{documentId}' is already tracked in this session. " +
+                    "Use Load() + modify properties, or open a fresh session.");
+            }
+
+            // Check for deferred commands
+            if (session.DeferredCommandsDictionary.ContainsKey((documentId, CommandType.ClientAnyCommand, null)))
+                throw new InvalidOperationException("Can't store document, there is a deferred command registered for this document in the session. Document id: " + documentId);
+
+            session.GenerateEntityIdOnTheClient.TrySetIdentity(entity, documentId);
+
+            var conventions = session.RequestExecutor.Conventions;
+            var metadata = new DynamicJsonValue();
+            var collectionName = conventions.GetCollectionName(entity);
+            if (collectionName != null)
+                metadata[Constants.Documents.Metadata.Collection] = collectionName;
+
+            var clrType = conventions.GetClrTypeName(entity);
+            if (clrType != null)
+                metadata[Constants.Documents.Metadata.RavenClrType] = clrType;
+
+            session.StoreEntityInUnitOfWork(documentId, entity, atomicGuardChangeVector, metadata, ConcurrencyCheckMode.Auto);
         }
 
         protected async Task<CompareExchangeValue<T>> GetCompareExchangeValueAsyncInternal<T>(string key, CancellationToken token = default)
@@ -620,6 +713,22 @@ namespace Raven.Client.Documents.Session
         /// <param name="key">Cross cluster unique key</param>
         /// <param name="item">The Value to be stored</param>
         CompareExchangeValue<T> CreateCompareExchangeValue<T>(string key, T value);
+
+        /// <summary>
+        /// Stores the given entity under the specified document ID, replacing any existing document content
+        /// in a cluster-wide transaction.
+        ///
+        /// Unlike session.Store(), this does NOT throw NonUniqueObjectException when a different entity
+        /// instance is already tracked for the same ID. Instead, it throws if the document ID is
+        /// already tracked (callers should use a clean session).
+        ///
+        /// The atomic guard change vector must be provided — obtain it via GetCompareExchangeValueAsync()
+        /// for "rvn-atomic/{documentId}".
+        /// </summary>
+        /// <param name="documentId">The document ID to store under</param>
+        /// <param name="entity">The entity to store</param>
+        /// <param name="atomicGuardChangeVector">The change vector of the atomic guard (rvn-atomic/{documentId})</param>
+        void Store(string documentId, object entity, string atomicGuardChangeVector);
     }
 
     public interface IClusterTransactionOperations : IClusterTransactionOperationsBase
@@ -705,6 +814,15 @@ namespace Raven.Client.Documents.Session
 
         /// <inheritdoc cref="IClusterTransactionOperations.Lazily"/> 
         ILazyClusterTransactionOperationsAsync Lazily { get; }
+
+        /// <summary>
+        /// Fetches the atomic guard change vector for the given document ID.
+        /// The returned string can be passed to <see cref="IClusterTransactionOperationsBase.Store"/>.
+        /// </summary>
+        /// <param name="documentId">The document ID</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The atomic guard change vector for the document, or null if the document has no atomic guard</returns>
+        Task<string> GetAtomicGuardAsync(string documentId, CancellationToken token = default);
     }
 
     public interface ILazyClusterTransactionOperationsAsync
@@ -758,6 +876,11 @@ namespace Raven.Client.Documents.Session
         Task<Dictionary<string, CompareExchangeValue<T>>> IClusterTransactionOperationsAsync.GetCompareExchangeValuesAsync<T>(string[] keys, CancellationToken token)
         {
             return GetCompareExchangeValuesAsyncInternal<T>(keys, token);
+        }
+
+        Task<string> IClusterTransactionOperationsAsync.GetAtomicGuardAsync(string documentId, CancellationToken token)
+        {
+            return GetAtomicGuardAsyncInternal(documentId, token);
         }
 
         Lazy<Task<Dictionary<string, CompareExchangeValue<T>>>> ILazyClusterTransactionOperationsAsync.GetCompareExchangeValuesAsync<T>(string[] keys, Action<Dictionary<string, CompareExchangeValue<T>>> onEval, CancellationToken token)

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -50,6 +50,9 @@ namespace Raven.Client.Documents.Session
 
         internal async Task<string> GetAtomicGuardAsyncInternal(string documentId, CancellationToken token = default)
         {
+            if (string.IsNullOrWhiteSpace(documentId))
+                throw new ArgumentNullException(nameof(documentId));
+
             if (TryGetMissingAtomicGuardFor(documentId, out var changeVector))
                 return changeVector;
 
@@ -69,10 +72,10 @@ namespace Raven.Client.Documents.Session
                 if (value.Index > 0)
                 {
                     var clusterTransactionId = _session.SessionInfo?.ClusterTransactionId;
-                    if (clusterTransactionId != null)
-                    {
-                        changeVector = $"TRXN:{value.Index}-{clusterTransactionId}";
-                    }
+                    if (clusterTransactionId == null)
+                        return null; // can't compute change vector without cluster tx id
+
+                    changeVector = $"TRXN:{value.Index}-{clusterTransactionId}";
                 }
 
                 if (changeVector != null)
@@ -181,6 +184,9 @@ namespace Raven.Client.Documents.Session
             // Check for deferred commands
             if (session.DeferredCommandsDictionary.ContainsKey((documentId, CommandType.ClientAnyCommand, null)))
                 throw new InvalidOperationException("Can't store document, there is a deferred command registered for this document in the session. Document id: " + documentId);
+
+            if (session.DeletedEntities.Contains(entity))
+                throw new InvalidOperationException("Can't store object, it was already deleted in this session. Document id: " + documentId);
 
             session.GenerateEntityIdOnTheClient.TrySetIdentity(entity, documentId);
 
@@ -711,16 +717,18 @@ namespace Raven.Client.Documents.Session
         /// Stores the given entity under the specified document ID, replacing any existing document content
         /// in a cluster-wide transaction.
         ///
-        /// Unlike session.Store(), this allows storing a different entity instance for the same document ID
-        /// as long as the document is not already tracked in this session.
-        /// If the document ID or entity is already tracked, a <see cref="NonUniqueObjectException"/> is thrown.
+        /// If the same entity instance is already tracked under a different ID, or a different entity
+        /// is already tracked under the same ID, a <see cref="NonUniqueObjectException"/> is thrown.
+        /// If the same entity is already tracked under the same ID, the atomic guard change vector
+        /// is updated on the existing tracking without re-storing.
         ///
         /// The atomic guard change vector must be provided — obtain it via
-        /// <see cref="IClusterTransactionOperationsAsync.GetAtomicGuardAsync"/>.
+        /// <c>session.Advanced.ClusterTransaction.GetAtomicGuardAsync(documentId)</c>.
+        /// Pass <see cref="string.Empty"/> for new documents with no existing atomic guard.
         /// </summary>
         /// <param name="documentId">The document ID to store under</param>
         /// <param name="entity">The entity to store</param>
-        /// <param name="atomicGuardChangeVector">The change vector of the atomic guard (rvn-atomic/{documentId})</param>
+        /// <param name="atomicGuardChangeVector">The change vector of the atomic guard (rvn-atomic/{documentId}), or <see cref="string.Empty"/> for new documents</param>
         void Store(string documentId, object entity, string atomicGuardChangeVector);
     }
 

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -795,7 +795,7 @@ more responsive application.
             AssertNoNonUniqueInstance(entity, id);
 
             var collectionName = _requestExecutor.Conventions.GetCollectionName(entity);
-            var metadata = CreateDocumentMetadata(entity, collectionName, _requestExecutor.Conventions.GetClrTypeName(entity));
+            var metadata = CreateDocumentMetadata(entity, _requestExecutor.Conventions);
 
             if (id != null)
                 _knownMissingIds.Remove(id);
@@ -803,12 +803,14 @@ more responsive application.
             StoreEntityInUnitOfWork(id, entity, changeVector, metadata, forceConcurrencyCheck);
         }
 
-        internal static DynamicJsonValue CreateDocumentMetadata(object entity, string collectionName, string clrType)
+        internal static DynamicJsonValue CreateDocumentMetadata(object entity, DocumentConventions conventions)
         {
             var metadata = new DynamicJsonValue();
+            var collectionName = conventions.GetCollectionName(entity);
             if (collectionName != null)
                 metadata[Constants.Documents.Metadata.Collection] = collectionName;
 
+            var clrType = conventions.GetClrTypeName(entity);
             if (clrType != null)
                 metadata[Constants.Documents.Metadata.RavenClrType] = clrType;
 

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -795,18 +795,24 @@ more responsive application.
             AssertNoNonUniqueInstance(entity, id);
 
             var collectionName = _requestExecutor.Conventions.GetCollectionName(entity);
-            var metadata = new DynamicJsonValue();
-            if (collectionName != null)
-                metadata[Constants.Documents.Metadata.Collection] = collectionName;
-
-            var clrType = _requestExecutor.Conventions.GetClrTypeName(entity);
-            if (clrType != null)
-                metadata[Constants.Documents.Metadata.RavenClrType] = clrType;
+            var metadata = CreateDocumentMetadata(entity, collectionName, _requestExecutor.Conventions.GetClrTypeName(entity));
 
             if (id != null)
                 _knownMissingIds.Remove(id);
 
             StoreEntityInUnitOfWork(id, entity, changeVector, metadata, forceConcurrencyCheck);
+        }
+
+        internal static DynamicJsonValue CreateDocumentMetadata(object entity, string collectionName, string clrType)
+        {
+            var metadata = new DynamicJsonValue();
+            if (collectionName != null)
+                metadata[Constants.Documents.Metadata.Collection] = collectionName;
+
+            if (clrType != null)
+                metadata[Constants.Documents.Metadata.RavenClrType] = clrType;
+
+            return metadata;
         }
 
         public Task StoreAsync(object entity, CancellationToken token = default(CancellationToken))

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -794,7 +794,6 @@ more responsive application.
             // to detect if they generate duplicates.
             AssertNoNonUniqueInstance(entity, id);
 
-            var collectionName = _requestExecutor.Conventions.GetCollectionName(entity);
             var metadata = CreateDocumentMetadata(entity, _requestExecutor.Conventions);
 
             if (id != null)

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -861,7 +861,7 @@ more responsive application.
 
         protected abstract Task<string> GenerateIdAsync(object entity);
 
-        protected virtual void StoreEntityInUnitOfWork(string id, object entity, string changeVector, DynamicJsonValue metadata,
+        protected internal virtual void StoreEntityInUnitOfWork(string id, object entity, string changeVector, DynamicJsonValue metadata,
             ConcurrencyCheckMode forceConcurrencyCheck)
         {
             if (id != null)

--- a/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
+++ b/src/Raven.Server/Documents/Replication/ChangeVectorParser.cs
@@ -2,15 +2,16 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using Raven.Client;
 
 namespace Raven.Server.Documents.Replication
 {
     public static class ChangeVectorParser
     {
-        public const string RaftTag = "RAFT";
-        public const string TrxnTag = "TRXN";
-        public const string SinkTag = "SINK";
-        public const string MoveTag = "MOVE";
+        public const string RaftTag = Constants.ChangeVector.RaftTag;
+        public const string TrxnTag = Constants.ChangeVector.TrxnTag;
+        public const string SinkTag = Constants.ChangeVector.SinkTag;
+        public const string MoveTag = Constants.ChangeVector.MoveTag;
 
         public static readonly int RaftInt = RaftTag.ParseNodeTag();
         public static readonly int TrxnInt = TrxnTag.ParseNodeTag();

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingMigrationReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingMigrationReplicationHandler.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client.Documents.Replication.Messages;
+﻿using Raven.Client;
+using Raven.Client.Documents.Replication.Messages;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.TcpHandlers;
@@ -15,7 +16,7 @@ namespace Raven.Server.Documents.Replication.Incoming
         private readonly long _currentMigrationIndex;
         private ShardedDocumentDatabase _shardedDatabase;
 
-        public const string MigrationTag = "MOVE";
+        public const string MigrationTag = Constants.ChangeVector.MoveTag;
 
         public IncomingMigrationReplicationHandler(TcpConnectionOptions options, ReplicationLatestEtagRequest replicatedLastEtag, ShardReplicationLoader parent,
             JsonOperationContext.MemoryBuffer bufferToCopy, ReplicationLatestEtagRequest.ReplicationType replicationType, long migrationIndex) : base(options, replicatedLastEtag, parent, bufferToCopy, replicationType)

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2405,10 +2405,9 @@ select incl(c)"
                 TransactionMode = TransactionMode.ClusterWide
             }))
             {
-                // No atomic guard exists yet, so GetAtomicGuardAsync returns null.
-                // Store with a null atomic guard creates a new document.
+                // Empty string means NEW document (no existing atomic guard)
                 session.Advanced.ClusterTransaction
-                    .Store("users/1", new User { Name = "NewDoc" }, atomicGuardChangeVector: null);
+                    .Store("users/1", new User { Name = "NewDoc" }, atomicGuardChangeVector: string.Empty);
 
                 await session.SaveChangesAsync();
             }
@@ -2418,6 +2417,34 @@ select incl(c)"
                 var loaded = await session.LoadAsync<User>("users/1");
                 Assert.NotNull(loaded);
                 Assert.Equal("NewDoc", loaded.Name);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionStore_EmptyGuardFailsOnExistingDocument()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                await session.StoreAsync(new User { Name = "Karmel" }, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                // Empty string means NEW but the document already exists → concurrency error
+                session.Advanced.ClusterTransaction
+                    .Store("users/1", new User { Name = "Indych" }, atomicGuardChangeVector: string.Empty);
+
+                await Assert.ThrowsAsync<ClusterTransactionConcurrencyException>(() =>
+                    session.SaveChangesAsync());
             }
         }
 

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2395,6 +2395,210 @@ select incl(c)"
         }
         
         [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task CanReplaceDocumentUsingClusterTransactionStore()
+        {
+            using var store = GetDocumentStore();
+            var user1 = new User { Name = "Karmel" };
+            var user2 = new User { Name = "Indych" };
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                await session.StoreAsync(user1, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            // Verify initial state
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<User>("users/1");
+                Assert.Equal("Karmel", loaded.Name);
+            }
+
+            // Replace the document using the new Store API
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                var atomicGuard = await session.Advanced.ClusterTransaction
+                    .GetAtomicGuardAsync("users/1");
+                Assert.NotNull(atomicGuard);
+
+                session.Advanced.ClusterTransaction
+                    .Store("users/1", user2, atomicGuard);
+
+                await session.SaveChangesAsync();
+            }
+
+            // Verify the document was replaced
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<User>("users/1");
+                Assert.Equal("Indych", loaded.Name);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionStore_ThrowsWhenDocumentIdAlreadyTracked()
+        {
+            using var store = GetDocumentStore();
+            var user1 = new User { Name = "Karmel" };
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                await session.StoreAsync(user1, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                // Track the document by loading it
+                await session.LoadAsync<User>("users/1");
+
+                var atomicGuard = await session.Advanced.ClusterTransaction
+                    .GetAtomicGuardAsync("users/1");
+
+                var user2 = new User { Name = "Indych" };
+                var ex = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    session.Advanced.ClusterTransaction
+                        .Store("users/1", user2, atomicGuard);
+                });
+                Assert.Contains("already tracked", ex.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionStore_ThrowsWhenEntityTrackedUnderDifferentId()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                var user = new User { Name = "Karmel" };
+                await session.StoreAsync(user, "users/1");
+                await session.SaveChangesAsync();
+
+                var atomicGuard = await session.Advanced.ClusterTransaction
+                    .GetAtomicGuardAsync("users/2");
+
+                var ex = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    session.Advanced.ClusterTransaction
+                        .Store("users/2", user, atomicGuard);
+                });
+                Assert.Contains("different id", ex.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionStore_ThrowsOnStaleAtomicGuard()
+        {
+            using var store = GetDocumentStore();
+            var user1 = new User { Name = "Karmel" };
+            var user2 = new User { Name = "Indych" };
+            var user3 = new User { Name = "Oren" };
+
+            // First transaction: store the document
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                await session.StoreAsync(user1, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            // Get the atomic guard in a session that won't save
+            string staleGuard;
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                staleGuard = await session.Advanced.ClusterTransaction
+                    .GetAtomicGuardAsync("users/1");
+            }
+
+            // Second transaction: modify the document, updating the atomic guard
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                var loaded = await session.LoadAsync<User>("users/1");
+                loaded.Name = "Indych";
+                await session.SaveChangesAsync();
+            }
+
+            // Third transaction: try to replace with the stale guard
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                session.Advanced.ClusterTransaction
+                    .Store("users/1", user3, staleGuard);
+
+                await Assert.ThrowsAsync<ClusterTransactionConcurrencyException>(() =>
+                    session.SaveChangesAsync());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionStore_PolymorphicReplacement()
+        {
+            using var store = GetDocumentStore();
+            var user = new User { Name = "Karmel", Age = 30 };
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                await session.StoreAsync(user, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            // Replace User with a different type (TestObj)
+            var replacement = new TestObj { Id = "users/1", Prop = "swapped" };
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                var atomicGuard = await session.Advanced.ClusterTransaction
+                    .GetAtomicGuardAsync("users/1");
+
+                session.Advanced.ClusterTransaction
+                    .Store("users/1", replacement, atomicGuard);
+
+                await session.SaveChangesAsync();
+            }
+
+            // Verify the document now has TestObj shape
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<TestObj>("users/1");
+                Assert.NotNull(loaded);
+                Assert.Equal("swapped", loaded.Prop);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task TestCase()
         {
             using var store = GetDocumentStore();

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -18,6 +18,7 @@ using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Documents.Session;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
@@ -2393,7 +2394,33 @@ select incl(c)"
                 Assert.Equal(count, await session.Query<TestObj>().CountAsync());
             }
         }
-        
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionStore_CanStoreNewDocument()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                // No atomic guard exists yet, so GetAtomicGuardAsync returns null.
+                // Store with a null atomic guard creates a new document.
+                session.Advanced.ClusterTransaction
+                    .Store("users/1", new User { Name = "NewDoc" }, atomicGuardChangeVector: null);
+
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<User>("users/1");
+                Assert.NotNull(loaded);
+                Assert.Equal("NewDoc", loaded.Name);
+            }
+        }
+
         [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task CanReplaceDocumentUsingClusterTransactionStore()
         {
@@ -2468,12 +2495,11 @@ select incl(c)"
                     .GetAtomicGuardAsync("users/1");
 
                 var user2 = new User { Name = "Indych" };
-                var ex = Assert.Throws<InvalidOperationException>(() =>
+                Assert.Throws<NonUniqueObjectException>(() =>
                 {
                     session.Advanced.ClusterTransaction
                         .Store("users/1", user2, atomicGuard);
                 });
-                Assert.Contains("already tracked", ex.Message);
             }
         }
 
@@ -2494,12 +2520,11 @@ select incl(c)"
                 var atomicGuard = await session.Advanced.ClusterTransaction
                     .GetAtomicGuardAsync("users/2");
 
-                var ex = Assert.Throws<InvalidOperationException>(() =>
+                Assert.Throws<NonUniqueObjectException>(() =>
                 {
                     session.Advanced.ClusterTransaction
                         .Store("users/2", user, atomicGuard);
                 });
-                Assert.Contains("different id", ex.Message);
             }
         }
 
@@ -2508,8 +2533,6 @@ select incl(c)"
         {
             using var store = GetDocumentStore();
             var user1 = new User { Name = "Karmel" };
-            var user2 = new User { Name = "Indych" };
-            var user3 = new User { Name = "Oren" };
 
             // First transaction: store the document
             using (var session = store.OpenAsyncSession(new SessionOptions
@@ -2550,7 +2573,7 @@ select incl(c)"
             }))
             {
                 session.Advanced.ClusterTransaction
-                    .Store("users/1", user3, staleGuard);
+                    .Store("users/1", new User { Name = "Oren" }, staleGuard);
 
                 await Assert.ThrowsAsync<ClusterTransactionConcurrencyException>(() =>
                     session.SaveChangesAsync());

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2649,6 +2649,70 @@ select incl(c)"
         }
 
         [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionStore_SameEntitySameId_UpdatesAtomicGuardCV()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                var user = new User { Name = "Karmel" };
+
+                // Store via cluster transaction Store with empty guard (new document)
+                session.Advanced.ClusterTransaction
+                    .Store("users/1", user, atomicGuardChangeVector: string.Empty);
+
+                // Store the same entity again with a different guard value → should just update the CV
+                session.Advanced.ClusterTransaction
+                    .Store("users/1", user, atomicGuardChangeVector: "updated-cv");
+
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<User>("users/1");
+                Assert.NotNull(loaded);
+                Assert.Equal("Karmel", loaded.Name);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionStore_ThrowsWhenDeferredCommandExists()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                await session.StoreAsync(new User { Name = "Karmel" }, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                var atomicGuard = await session.Advanced.ClusterTransaction
+                    .GetAtomicGuardAsync("users/1");
+
+                // Defer a delete command for users/1
+                session.Advanced.Defer(new Raven.Client.Documents.Commands.Batches.DeleteCommandData("users/1", null));
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    session.Advanced.ClusterTransaction
+                        .Store("users/1", new User { Name = "Indych" }, atomicGuard);
+                });
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task TestCase()
         {
             using var store = GetDocumentStore();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26641

Fixes: https://github.com/ravendb/ravendb/issues/22812

### Additional description

Adds `Store(string documentId, object entity, string atomicGuardChangeVector)` on `IClusterTransactionOperationsBase` to allow full document replacement in cluster-wide transactions.

Currently, attempting to replace a tracked document with a new object instance in a `ClusterWide` session fails with `NonUniqueObjectException`. The new method:
- Bypasses this check when the session is clean (throws if the ID is already tracked)
- Accepts the atomic guard change vector explicitly — obtained via `GetAtomicGuardAsync(string documentId)` (new method on `IClusterTransactionOperationsAsync`)
- Supports cross-collection replacement (polymorphic entities)

Related GitHub issue: https://github.com/ravendb/ravendb/issues/22812

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed