### PR TITLE
RavenDB-26585 fix license-assertion tests

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -401,7 +401,7 @@ public sealed partial class ClusterStateMachine
         }
 
         if (databaseRecord.Revisions.Default != null && databaseRecord.Revisions.Default.Disabled == false)
-            AssertCollectionRevisionLimits("Default", databaseRecord.Revisions.Default, maxRevisionsToKeep, maxRevisionAgeToKeepInDays);
+            AssertCollectionRevisionLimits(collectionName: null, databaseRecord.Revisions.Default, maxRevisionsToKeep, maxRevisionAgeToKeepInDays);
 
         if (databaseRecord.Revisions.Collections == null)
             return;
@@ -417,13 +417,17 @@ public sealed partial class ClusterStateMachine
 
     private static void AssertCollectionRevisionLimits(string collectionName, RevisionsCollectionConfiguration configuration, int? maxRevisionsToKeep, int? maxRevisionAgeToKeepInDays)
     {
+        var scope = collectionName == null
+            ? "for the default revisions configuration"
+            : $"for collection '{collectionName}'";
+
         if (configuration.MinimumRevisionsToKeep != null &&
             maxRevisionsToKeep != null &&
             configuration.MinimumRevisionsToKeep > maxRevisionsToKeep)
         {
             throw new LicenseLimitException(LimitType.RevisionsConfiguration,
                 $"The defined minimum revisions to keep '{configuration.MinimumRevisionsToKeep}' " +
-                $"for collection '{collectionName}' exceeds the licensed one '{maxRevisionsToKeep}'");
+                $"{scope} exceeds the licensed one '{maxRevisionsToKeep}'");
         }
 
         if (configuration.MinimumRevisionAgeToKeep != null &&
@@ -432,7 +436,7 @@ public sealed partial class ClusterStateMachine
         {
             throw new LicenseLimitException(LimitType.RevisionsConfiguration,
                 $"The defined minimum revisions age to keep '{configuration.MinimumRevisionAgeToKeep}' " +
-                $"for collection '{collectionName}' exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
+                $"{scope} exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
         }
     }
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -233,6 +233,8 @@ public sealed partial class ClusterStateMachine
 
         AssertClusterSizeAndCores(serverStore, newLicenseLimits);
 
+        var emptySubscriptionExclusions = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var databaseName in serverStore.Cluster.GetDatabaseNames(context))
         {
             var databaseRecord = serverStore.Cluster.ReadDatabase(context, ShardHelper.ToDatabaseName(databaseName));
@@ -246,11 +248,7 @@ public sealed partial class ClusterStateMachine
             AssertSorters(databaseRecord, newLicenseLimits, context, items, type);
             AssertAnalyzers(databaseRecord, newLicenseLimits, context, items, type);
             AssertDatabaseClientConfiguration(databaseRecord, newLicenseLimits, context);
-            if (AssertClientConfiguration(newLicenseLimits, context) == false && databaseRecord.Client is { Disabled: false })
-                throw new LicenseLimitException(LimitType.ClientConfiguration, "Your license doesn't support adding the client configuration.");
             AssertDatabaseStudioConfiguration(databaseRecord, newLicenseLimits, context);
-            if (AssertServerWideStudioConfiguration(newLicenseLimits, context) == false && databaseRecord.Studio is { Disabled: false })
-                throw new LicenseLimitException(LimitType.StudioConfiguration, "Your license doesn't support adding the studio configuration.");
             AssertQueueSink(databaseRecord, newLicenseLimits, context);
             AssertDataArchival(databaseRecord, newLicenseLimits, context);
             AssertEncryptionLicenseLimits(databaseRecord, newLicenseLimits, context);
@@ -274,7 +272,15 @@ public sealed partial class ClusterStateMachine
             AssertDocumentsCompressionLicenseLimits(databaseRecord, newLicenseLimits, context);
             AssertRemoteAttachmentsConfiguration(databaseRecord, newLicenseLimits, context);
             AssertSchemaValidationConfiguration(databaseRecord, newLicenseLimits, context);
+
+            var perDbExclusions = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                { databaseRecord.DatabaseName, new List<string>() }
+            };
+            AssertNumberOfSubscriptionsPerDatabaseLimits(newLicenseLimits, items, context, perDbExclusions);
         }
+
+        AssertNumberOfSubscriptionsPerClusterLimits(newLicenseLimits, items, context, emptySubscriptionExclusions);
     }
 
     private void AssertMultiNodeSharding(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
@@ -295,7 +301,7 @@ public sealed partial class ClusterStateMachine
             if (licenseStatus.MaxReplicationFactorForSharding != null && topology.ReplicationFactor > licenseStatus.MaxReplicationFactorForSharding)
             {
                 throw new LicenseLimitException(LimitType.Sharding,
-                    $"Your license doesn't allow to use a replication factor of more than {topology.ReplicationFactor} for sharding");
+                    $"Your license doesn't allow a replication factor higher than {licenseStatus.MaxReplicationFactorForSharding} for sharding (got {topology.ReplicationFactor}).");
             }
 
             foreach (var nodeTag in topology.AllNodes)
@@ -313,14 +319,11 @@ public sealed partial class ClusterStateMachine
 
     private void AssertStaticIndexesCount(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, Table items, string type)
     {
-        var maxStaticIndexesPerDatabase = licenseStatus.MaxNumberOfStaticIndexesPerDatabase;
-        if (maxStaticIndexesPerDatabase is null or < 0)
-            return;
-
         if (databaseRecord.Indexes == null)
             return;
 
-        if (maxStaticIndexesPerDatabase is >= 0 && databaseRecord.Indexes?.Count > maxStaticIndexesPerDatabase)
+        var maxStaticIndexesPerDatabase = licenseStatus.MaxNumberOfStaticIndexesPerDatabase;
+        if (maxStaticIndexesPerDatabase is >= 0 && databaseRecord.Indexes.Count > maxStaticIndexesPerDatabase)
         {
             if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
                 return;
@@ -333,7 +336,7 @@ public sealed partial class ClusterStateMachine
         if (maxStaticIndexesPerCluster is null or < 0)
             return;
 
-        var totalStaticIndexesCount = GetTotal(DatabaseRecordElementType.StaticIndex, databaseRecord.DatabaseName, context, items, type) + databaseRecord.Indexes?.Count;
+        var totalStaticIndexesCount = GetTotal(DatabaseRecordElementType.StaticIndex, databaseRecord.DatabaseName, context, items, type) + databaseRecord.Indexes.Count;
         if (totalStaticIndexesCount <= maxStaticIndexesPerCluster)
             return;
 
@@ -397,6 +400,9 @@ public sealed partial class ClusterStateMachine
             throw new LicenseLimitException(LimitType.RevisionsConfiguration, "Your license doesn't allow the creation of a default configuration for revisions.");
         }
 
+        if (databaseRecord.Revisions.Default != null && databaseRecord.Revisions.Default.Disabled == false)
+            AssertCollectionRevisionLimits("Default", databaseRecord.Revisions.Default, maxRevisionsToKeep, maxRevisionAgeToKeepInDays);
+
         if (databaseRecord.Revisions.Collections == null)
             return;
 
@@ -405,23 +411,28 @@ public sealed partial class ClusterStateMachine
             if (revisionPerCollectionConfiguration.Value.Disabled)
                 continue;
 
-            if (revisionPerCollectionConfiguration.Value.MinimumRevisionsToKeep != null &&
-                maxRevisionsToKeep != null &&
-                revisionPerCollectionConfiguration.Value.MinimumRevisionsToKeep > maxRevisionsToKeep)
-            {
-                throw new LicenseLimitException(LimitType.RevisionsConfiguration,
-                    $"The defined minimum revisions to keep '{revisionPerCollectionConfiguration.Value.MinimumRevisionsToKeep}' " +
-                    $"for collection '{revisionPerCollectionConfiguration.Key}' exceeds the licensed one '{maxRevisionsToKeep}'");
-            }
+            AssertCollectionRevisionLimits(revisionPerCollectionConfiguration.Key, revisionPerCollectionConfiguration.Value, maxRevisionsToKeep, maxRevisionAgeToKeepInDays);
+        }
+    }
 
-            if (revisionPerCollectionConfiguration.Value.MinimumRevisionAgeToKeep != null &&
-                maxRevisionAgeToKeepInDays != null &&
-                revisionPerCollectionConfiguration.Value.MinimumRevisionAgeToKeep.Value.TotalDays > maxRevisionAgeToKeepInDays)
-            {
-                throw new LicenseLimitException(LimitType.RevisionsConfiguration,
-                    $"The defined minimum revisions age to keep '{revisionPerCollectionConfiguration.Value.MinimumRevisionAgeToKeep}' " +
-                    $"for collection '{revisionPerCollectionConfiguration.Key}' exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
-            }
+    private static void AssertCollectionRevisionLimits(string collectionName, RevisionsCollectionConfiguration configuration, int? maxRevisionsToKeep, int? maxRevisionAgeToKeepInDays)
+    {
+        if (configuration.MinimumRevisionsToKeep != null &&
+            maxRevisionsToKeep != null &&
+            configuration.MinimumRevisionsToKeep > maxRevisionsToKeep)
+        {
+            throw new LicenseLimitException(LimitType.RevisionsConfiguration,
+                $"The defined minimum revisions to keep '{configuration.MinimumRevisionsToKeep}' " +
+                $"for collection '{collectionName}' exceeds the licensed one '{maxRevisionsToKeep}'");
+        }
+
+        if (configuration.MinimumRevisionAgeToKeep != null &&
+            maxRevisionAgeToKeepInDays != null &&
+            configuration.MinimumRevisionAgeToKeep.Value.TotalDays > maxRevisionAgeToKeepInDays)
+        {
+            throw new LicenseLimitException(LimitType.RevisionsConfiguration,
+                $"The defined minimum revisions age to keep '{configuration.MinimumRevisionAgeToKeep}' " +
+                $"for collection '{collectionName}' exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
         }
     }
 
@@ -432,7 +443,7 @@ public sealed partial class ClusterStateMachine
         if (minPeriodForExpirationInHours == null || databaseRecord.Expiration == null || databaseRecord.Expiration.Disabled)
             return;
 
-        var deleteFrequencyInSec = databaseRecord.Expiration?.DeleteFrequencyInSec ?? ExpiredDocumentsCleaner.DefaultDeleteFrequencyInSec;
+        var deleteFrequencyInSec = databaseRecord.Expiration.DeleteFrequencyInSec ?? ExpiredDocumentsCleaner.DefaultDeleteFrequencyInSec;
         var deleteFrequency = new TimeSetting(deleteFrequencyInSec, TimeUnit.Seconds);
         var minPeriodForExpiration = new TimeSetting(minPeriodForExpirationInHours.Value, TimeUnit.Hours);
 
@@ -571,6 +582,9 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.QueueSinks == null || databaseRecord.QueueSinks.Count == 0)
             return;
 
+        if (databaseRecord.QueueSinks.All(x => x.Disabled))
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
             return;
 
@@ -636,14 +650,14 @@ public sealed partial class ClusterStateMachine
             }
         };
 
+        var licenseStatus = serverStore.LicenseManager.LicenseStatus;
         var includeRevisions = putSubscriptionCommand.IncludesRevisions();
-        if (AssertSubscriptionRevisionFeatureLimits(serverStore, includeRevisions, context))
+        AssertSubscriptionRevisionFeatureLimits(licenseStatus, includeRevisions, context);
+
+        if (AssertNumberOfSubscriptionsPerDatabaseLimits(licenseStatus, items, context, subscriptionsNamesPerDatabase))
             return;
 
-        if (AssertNumberOfSubscriptionsPerDatabaseLimits(serverStore, items, context, subscriptionsNamesPerDatabase))
-            return;
-
-        AssertNumberOfSubscriptionsPerClusterLimits(serverStore, items, context, subscriptionsNamesPerDatabase);
+        AssertNumberOfSubscriptionsPerClusterLimits(licenseStatus, items, context, subscriptionsNamesPerDatabase);
     }
 
     private List<T> AssertSubscriptionsBatchLicenseLimits<T>(ServerStore serverStore, Table items, BlittableJsonReaderArray subscriptionCommands, string type,
@@ -671,23 +685,23 @@ public sealed partial class ClusterStateMachine
                 includesRevisions = true;
         }
 
-        if (AssertSubscriptionRevisionFeatureLimits(serverStore, includesRevisions, context) == false)
+        var licenseStatus = serverStore.LicenseManager.LicenseStatus;
+        AssertSubscriptionRevisionFeatureLimits(licenseStatus, includesRevisions, context);
+
+        if (AssertNumberOfSubscriptionsPerDatabaseLimits(licenseStatus, items, context, subscriptionsNamesPerDatabase))
             return putSubscriptionCommandsList;
 
-        if (AssertNumberOfSubscriptionsPerDatabaseLimits(serverStore, items, context, subscriptionsNamesPerDatabase))
-            return putSubscriptionCommandsList;
-
-        AssertNumberOfSubscriptionsPerClusterLimits(serverStore, items, context, subscriptionsNamesPerDatabase);
+        AssertNumberOfSubscriptionsPerClusterLimits(licenseStatus, items, context, subscriptionsNamesPerDatabase);
         return putSubscriptionCommandsList;
     }
 
     private bool AssertNumberOfSubscriptionsPerDatabaseLimits(
-        ServerStore serverStore,
+        LicenseStatus licenseStatus,
         Table items,
         ClusterOperationContext context,
         IReadOnlyDictionary<string, List<string>> subscriptionsNamesPerDatabase)
     {
-        var maxSubscriptionsPerDatabase = serverStore.LicenseManager.LicenseStatus.MaxNumberOfSubscriptionsPerDatabase;
+        var maxSubscriptionsPerDatabase = licenseStatus.MaxNumberOfSubscriptionsPerDatabase;
         if (maxSubscriptionsPerDatabase is not >= 0)
             return false;
 
@@ -706,12 +720,12 @@ public sealed partial class ClusterStateMachine
     }
 
     private bool AssertNumberOfSubscriptionsPerClusterLimits(
-        ServerStore serverStore,
+        LicenseStatus licenseStatus,
         Table items,
         ClusterOperationContext context,
         IReadOnlyDictionary<string, List<string>> subscriptionsNamesPerDatabase)
     {
-        var maxSubscriptionsPerCluster = serverStore.LicenseManager.LicenseStatus.MaxNumberOfSubscriptionsPerCluster;
+        var maxSubscriptionsPerCluster = licenseStatus.MaxNumberOfSubscriptionsPerCluster;
         if (maxSubscriptionsPerCluster is not >= 0)
             return false;
 
@@ -727,20 +741,20 @@ public sealed partial class ClusterStateMachine
                 });
 
         var subscriptionCommandsCount = subscriptionsNamesPerDatabase.Sum(x => x.Value.Count);
-        if (clusterSubscriptionsCounts + subscriptionCommandsCount > maxSubscriptionsPerCluster == false)
+        if (clusterSubscriptionsCounts + subscriptionCommandsCount > maxSubscriptionsPerCluster)
             throw new LicenseLimitException(LimitType.Subscriptions,
                 $"The maximum number of subscriptions per cluster cannot exceed the limit of: {maxSubscriptionsPerCluster}");
 
         return false;
     }
 
-    private bool AssertSubscriptionRevisionFeatureLimits(ServerStore serverStore, bool includeRevisions, ClusterOperationContext context)
+    private void AssertSubscriptionRevisionFeatureLimits(LicenseStatus licenseStatus, bool includeRevisions, ClusterOperationContext context)
     {
-        if (serverStore.LicenseManager.LicenseStatus.HasRevisionsInSubscriptions || includeRevisions == false)
-            return true;
+        if (licenseStatus.HasRevisionsInSubscriptions || includeRevisions == false)
+            return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
-            return true;
+            return;
 
         throw new LicenseLimitException(LimitType.Subscriptions,
             "Your license doesn't include the subscription revisions feature.");
@@ -836,7 +850,7 @@ public sealed partial class ClusterStateMachine
 
             case LicenseAttribute.ClientConfiguration:
                 if (serverStore.LicenseManager.LicenseStatus.HasClientConfiguration == false)
-                    throw new LicenseLimitException(LimitType.ServerWideBackups, "Your license doesn't support adding server wide Client Configuration .");
+                    throw new LicenseLimitException(LimitType.ClientConfiguration, "Your license doesn't support adding server wide Client Configuration.");
 
                 break;
         }
@@ -854,6 +868,8 @@ public sealed partial class ClusterStateMachine
         {
             if (AssertPeriodicBackup(licenseStatus) == false)
                 throw new LicenseLimitException(LimitType.PeriodicBackup, "Your license doesn't support adding periodic backups.");
+
+            return;
         }
 
         var backupTypes = LicenseManager.GetBackupTypes(databaseRecord.PeriodicBackups);
@@ -949,7 +965,7 @@ public sealed partial class ClusterStateMachine
         }
 
         if (databaseRecord.ExternalReplications.Any(exRep => exRep.DelayReplicationFor != TimeSpan.Zero))
-            throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding External Replication.");
+            throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding Delayed External Replication.");
 
         if (updateDatabaseCommand != null && updateDatabaseCommand is UpdateExternalReplicationCommand uerc2)
         {
@@ -1221,11 +1237,11 @@ public sealed partial class ClusterStateMachine
             return;
         var clusterSize = serverStore.GetClusterTopology().AllNodes.Count;
         if (clusterSize > licenseStatus.MaxClusterSize)
-            throw new LicenseLimitException(LimitType.ClusterSize, $"Your license support {licenseStatus.MaxClusterSize} cluster Size, while your cluster size is : {clusterSize}.");
+            throw new LicenseLimitException(LimitType.ClusterSize, $"Your license supports a cluster size of {licenseStatus.MaxClusterSize}, while the current cluster size is {clusterSize}.");
 
         var maxCores = licenseStatus.MaxCores;
         if (clusterSize > maxCores)
-            throw new LicenseLimitException(LimitType.Cores, $"Your license support {maxCores} limit, while the current cluster size is: {clusterSize}!");
+            throw new LicenseLimitException(LimitType.Cores, $"Your license is limited to {maxCores} cores, while the current cluster has {clusterSize} nodes (each node requires at least one core).");
     }
 
     private void AssertSnmp(ServerStore serverStore, LicenseStatus licenseStatus)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -633,7 +633,7 @@ public sealed partial class ClusterStateMachine
                         total += rawRecord.CountOfAnalyzers;
                         break;
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(type), type, null);
+                        throw new ArgumentOutOfRangeException(nameof(resultType), resultType, null);
                 }
             }
 
@@ -1130,10 +1130,10 @@ public sealed partial class ClusterStateMachine
         if (licenseStatus.HasAiAgent)
             return;
 
-        if (databaseRecord.AiAgents.All(x => x.Disabled))
+        if (databaseRecord.AiAgents.Count == 0)
             return;
 
-        if (databaseRecord.AiAgents.All(x => false))
+        if (databaseRecord.AiAgents.All(x => x.Disabled))
             return;
 
         throw new LicenseLimitException(LimitType.AiAgent, "Your license doesn't support using the AI Agent feature.");

--- a/test/SlowTests.Issues/Issues/RavenDB-26585.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26585.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Commercial;
+using Raven.Client.ServerWide.Operations;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -57,7 +58,11 @@ namespace SlowTests.Issues
                     // Before the fix, restoring even a single subscription threw:
                     //   "The maximum number of subscriptions per cluster cannot exceed the limit of: 15"
                     // because of the inverted `>` check. After the fix this should succeed.
-                    RunRestore(store, backupPath);
+                    using (RunRestore(store, backupPath, out var restoredDatabase))
+                    {
+                        var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 10, database: restoredDatabase);
+                        Assert.Contains(subscriptions, s => s.SubscriptionName == "Sub1");
+                    }
                 }
             }
             finally
@@ -228,7 +233,11 @@ namespace SlowTests.Issues
                 {
                     await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
-                    RunRestore(store, backupPath);
+                    using (RunRestore(store, backupPath, out var restoredDatabase))
+                    {
+                        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(restoredDatabase));
+                        Assert.Contains(record.QueueSinks, x => x.Name == "DisabledQueueSink");
+                    }
                 }
             }
             finally
@@ -308,6 +317,9 @@ namespace SlowTests.Issues
                     var store = GetDocumentStore();
                     stores.Add(store);
 
+
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
                     await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
                     {
                         Name = "Sub_a",
@@ -343,7 +355,7 @@ namespace SlowTests.Issues
                 KafkaConnectionSettings = new KafkaConnectionSettings { BootstrapServers = "localhost:9092" }
             };
             var putCs = await store.Maintenance.SendAsync(new PutConnectionStringOperation<QueueConnectionString>(connectionString));
-            Assert.NotNull(putCs.RaftCommandIndex);
+            Assert.True(putCs.RaftCommandIndex > 0);
 
             var configuration = new QueueSinkConfiguration
             {
@@ -366,15 +378,18 @@ namespace SlowTests.Issues
             Assert.NotEqual(0, addResult.TaskId);
         }
 
-        private void RunRestore(DocumentStore store, string backupPath)
+        private IDisposable RunRestore(DocumentStore store, string backupPath) => RunRestore(store, backupPath, out _);
+
+        private IDisposable RunRestore(DocumentStore store, string backupPath, out string restoredDatabase)
         {
+            restoredDatabase = store.Database + "_restored";
             var configuration = new RestoreBackupConfiguration
             {
-                DatabaseName = store.Database + "_restored",
+                DatabaseName = restoredDatabase,
                 BackupLocation = Directory.GetDirectories(backupPath).First()
             };
 
-            Backup.RestoreDatabase(store, configuration);
+            return Backup.RestoreDatabase(store, configuration);
         }
 
         private static async Task RunBackup(DocumentStore store, string backupPath)

--- a/test/SlowTests.Issues/Issues/RavenDB-26585.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26585.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL.Queue;
+using Raven.Client.Documents.Operations.QueueSink;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Commercial;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26585 : ClusterTestBase
+    {
+        public RavenDB_26585(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // ========================================================================
+        // Fix AssertNumberOfSubscriptionsPerClusterLimits had an inverted
+        // condition (`> max == false`) that caused a LicenseLimitException even
+        // when the cluster's subscription count was well below the limit.
+        // ========================================================================
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport | RavenTestCategory.Subscriptions)]
+        public async Task RestoreWithSubscriptionsOnCommunityLicenseShouldNotFail()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                    {
+                        Name = "Sub1",
+                        Query = "from Users"
+                    });
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    // Before the fix, restoring even a single subscription threw:
+                    //   "The maximum number of subscriptions per cluster cannot exceed the limit of: 15"
+                    // because of the inverted `>` check. After the fix this should succeed.
+                    RunRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(backupPath))
+                    Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport | RavenTestCategory.Subscriptions)]
+        public async Task ImportingSubscriptionsOnCommunityLicenseShouldNotFail()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                    {
+                        Name = "ImportSub",
+                        Query = "from Users"
+                    });
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                    var subs = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
+                    Assert.Contains(subs, s => s.SubscriptionName == "ImportSub");
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Subscriptions)]
+        public async Task SinglePutSubscriptionEnforcesPerDatabaseLimitOnCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                var maxPerDatabase = Server.ServerStore.LicenseManager.LicenseStatus.MaxNumberOfSubscriptionsPerDatabase;
+                Assert.NotNull(maxPerDatabase);
+                Assert.True(maxPerDatabase.Value > 0,
+                    $"Expected community license to define a positive per-database subscription limit, got {maxPerDatabase}.");
+
+                // Create exactly the maximum allowed - this should succeed via the single-Put path.
+                for (var i = 0; i < maxPerDatabase.Value; i++)
+                {
+                    await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                    {
+                        Name = $"Sub_{i}",
+                        Query = "from Users"
+                    });
+                }
+
+                // The next single put should trigger the per-database limit.
+                // Before the fix, count checks were skipped on the single-Put path
+                // and this would (incorrectly) succeed.
+                var ex = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                    {
+                        Name = "Sub_OverLimit",
+                        Query = "from Users"
+                    });
+                });
+
+                Assert.Equal(LimitType.Subscriptions, ex.LimitType);
+                Assert.Contains("per database", ex.Message);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes)]
+        public async Task StaticIndexCreationOnCommunityLicenseStillWorks()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Item { Name = "x" });
+                    session.SaveChanges();
+                }
+
+                await new Items_ByName().ExecuteAsync(store);
+
+                Indexes.WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var found = session.Query<Item, Items_ByName>().Count();
+                    Assert.Equal(1, found);
+                }
+            }
+        }
+
+
+        // ========================================================================
+        // Fix  AssertQueueSink used to throw whenever any QueueSink existed in
+        // the database record, even if every entry was disabled. 
+        // ========================================================================
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledQueueSinkOnCommunityLicenseShouldNotFail()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await SetupDisabledQueueSink(store);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    // Before the fix this throws LicenseLimitException(QueueSink) even though
+                    // the imported queue sink is disabled.
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreWithDisabledQueueSinkOnCommunityLicenseShouldNotFail()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await SetupDisabledQueueSink(store);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    RunRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(backupPath))
+                    Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Revisions)]
+        public async Task LicenseDowngradeWithDefaultRevisionsConfigurationIsRejected()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                // Configure a Default with a high MinimumRevisionsToKeep and a large age.
+                // Exact values are picked to clearly exceed any per-license cap.
+                var configuration = new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = false,
+                        MinimumRevisionsToKeep = 10_000,
+                        MinimumRevisionAgeToKeep = TimeSpan.FromDays(10_000)
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+
+                // Switching to community must be rejected with a RevisionsConfiguration limit type.
+                // (Either because community doesn't allow Default at all, or — if it does — because
+                // the Default's values exceed the license cap. Either path now ends in the same
+                // limit type after the Default-validation fix.)
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.RevisionsConfiguration);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Subscriptions)]
+        public async Task LicenseDowngradeOverPerDatabaseSubscriptionCapIsRejected()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                for (var i = 0; i < 10; i++)
+                {
+                    await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                    {
+                        Name = $"DowngradeSub_{i}",
+                        Query = "from Users"
+                    });
+                }
+
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.Subscriptions);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Subscriptions)]
+        public async Task LicenseDowngradeOverPerClusterSubscriptionCapIsRejected()
+        {
+            DoNotReuseServer();
+
+            // Spread subscriptions across multiple databases so we trip the per-cluster
+            // cap (community: 15) without each database individually busting the per-DB cap.
+            var stores = new List<DocumentStore>();
+            try
+            {
+                // 10 databases x 2 subs = 20 total subs across the cluster, comfortably over
+                // the community per-cluster cap of 15.
+                for (var dbIndex = 0; dbIndex < 10; dbIndex++)
+                {
+                    var store = GetDocumentStore();
+                    stores.Add(store);
+
+                    await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                    {
+                        Name = "Sub_a",
+                        Query = "from Users"
+                    });
+                    await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                    {
+                        Name = "Sub_b",
+                        Query = "from Users"
+                    });
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                }
+
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.Subscriptions);
+            }
+            finally
+            {
+                foreach (var s in stores)
+                    s.Dispose();
+            }
+        }
+
+        // ------------------------------------------------------------------------
+        // Helpers
+        // ------------------------------------------------------------------------
+
+        private async Task SetupDisabledQueueSink(DocumentStore store)
+        {
+            var connectionString = new QueueConnectionString
+            {
+                Name = "QueueSinkConn",
+                BrokerType = QueueBrokerType.Kafka,
+                KafkaConnectionSettings = new KafkaConnectionSettings { BootstrapServers = "localhost:9092" }
+            };
+            var putCs = await store.Maintenance.SendAsync(new PutConnectionStringOperation<QueueConnectionString>(connectionString));
+            Assert.NotNull(putCs.RaftCommandIndex);
+
+            var configuration = new QueueSinkConfiguration
+            {
+                Disabled = true,
+                Name = "DisabledQueueSink",
+                ConnectionStringName = "QueueSinkConn",
+                BrokerType = QueueBrokerType.Kafka,
+                Scripts =
+                {
+                    new QueueSinkScript
+                    {
+                        Name = "Script",
+                        Queues = new List<string> { "my-queue" },
+                        Script = "this.Foo = 1;"
+                    }
+                }
+            };
+
+            var addResult = await store.Maintenance.SendAsync(new AddQueueSinkOperation<QueueConnectionString>(configuration));
+            Assert.NotEqual(0, addResult.TaskId);
+        }
+
+        private void RunRestore(DocumentStore store, string backupPath)
+        {
+            var configuration = new RestoreBackupConfiguration
+            {
+                DatabaseName = store.Database + "_restored",
+                BackupLocation = Directory.GetDirectories(backupPath).First()
+            };
+
+            Backup.RestoreDatabase(store, configuration);
+        }
+
+        private static async Task RunBackup(DocumentStore store, string backupPath)
+        {
+            var operation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+            {
+                BackupType = BackupType.Backup,
+                LocalSettings = new LocalSettings
+                {
+                    FolderPath = backupPath
+                }
+            }));
+
+            await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
+        }
+
+        private class Item
+        {
+            public string Name { get; set; }
+        }
+
+        private class Items_ByName : AbstractIndexCreationTask<Item>
+        {
+            public Items_ByName()
+            {
+                Map = items => from i in items select new { i.Name };
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26585

### Additional description

 Fixed a handful of license-assertion bugs (wrong/inverted checks, missing validations, misleading error messages) in ClusterStateMachine.License.cs and added tests in RavenDB-26585.cs to cover them.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
