### PR TITLE
RavenDB-21192 Fixed flaky tests for ETL and AI tasks errors observability

### DIFF
--- a/test/InterversionTests/AttachmentsTests.cs
+++ b/test/InterversionTests/AttachmentsTests.cs
@@ -107,10 +107,10 @@ namespace InterversionTests
 
                 Etl.AddEtl(store, configuration, connectionString);
 
-                IEnumerable<TaskItemErrorTableValue> errors = null;
+                IEnumerable<TaskProcessErrorTableValue> errors = null;
                 Assert.True(await WaitForValueAsync(async () =>
                 {
-                    errors = await Etl.GetItemLoadErrorsAsync(store.Database, configuration);
+                    errors = await Etl.GetProcessLoadErrorsAsync(store.Database, configuration);
 
                     return errors.Any();
                 }, true, 60_000, interval: 322));

--- a/test/SlowTests.Issues/Issues/RavenDB-21192.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21192.cs
@@ -2156,6 +2156,13 @@ public class RavenDB_21192_Multinode : ClusterTestBase
             Assert.Empty(otherItemErrors);
         }
 
+        // Ensure mentor's ETL state is persisted before mentor change, otherwise the new mentor may start with stale ChangeVector and reprocess phase 1 documents.
+        Assert.True(WaitForValue(() =>
+        {
+            var state = EtlProcess.GetProcessState(mentorDatabase, taskName, "embeddings-transform-script");
+            return state.LastProcessedEtagPerDbId.Count > 0;
+        }, true, timeout: 30_000));
+
         var newMentorTag = nodes[1].ServerStore.NodeTag;
         configuration.MentorNode = newMentorTag;
         store.Maintenance.Send(new UpdateEmbeddingsGenerationOperation(addResult.TaskId, configuration));

--- a/test/SlowTests.Issues/Issues/RavenDB-21192.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21192.cs
@@ -1998,22 +1998,17 @@ public class RavenDB_21192_Multinode : ClusterTestBase
         var mentorNode = nodes[0];
         var mentorDatabase = await GetDatabase(mentorNode, srcDatabaseName);
         
+        int transformationErrors = 0, loadSuccesses = 0;
         Assert.True(WaitForValue(() =>
         {
             var process = mentorDatabase.EtlLoader.Processes.FirstOrDefault(x => x.Name == $"{etlName}/{transformationName}");
-            return process?.Statistics.TransformationErrors >= 5;
-        }, true, timeout: 30_000));
+            transformationErrors = process?.Statistics.TransformationErrors ?? 0;
+            loadSuccesses = process?.Statistics.LoadSuccesses ?? 0;
+            return transformationErrors >= 5 && loadSuccesses >= 3;
+        }, true, timeout: 30_000), $"Expected TransformationErrors >= 5 (got {transformationErrors}) and LoadSuccesses >= 3 (got {loadSuccesses})");
 
-        Assert.True(WaitForValue(() =>
-        {
-            var process = mentorDatabase.EtlLoader.Processes.FirstOrDefault(x => x.Name == $"{etlName}/{transformationName}");
-            return process?.Statistics.LoadSuccesses >= 3;
-        }, true, timeout: 30_000));
+        await WaitAndAssertForValueAsync(() => mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl, $"{etlName}/{transformationName}").Count, 5, timeout: 30_000);
 
-        Assert.True(WaitForValue(() => mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl,$"{etlName}/{transformationName}").Count == 5, true, timeout: 30_000));
-        var mentorItemErrors = mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl,$"{etlName}/{transformationName}");
-        Assert.Equal(5, mentorItemErrors.Count);
-        
         for (int i = 1; i < clusterSize; i++)
         {
             var otherDatabase = await GetDatabase(nodes[i], srcDatabaseName);
@@ -2028,10 +2023,7 @@ public class RavenDB_21192_Multinode : ClusterTestBase
         var newMentorNode = nodes[1];
         var newMentorDatabase = await GetDatabase(newMentorNode, srcDatabaseName);
         
-        Assert.True(WaitForValue(() =>
-        {
-            return newMentorDatabase.EtlLoader.Processes.Any(x => x.Name == $"{etlName}/{transformationName}");
-        }, true, timeout: 30_000));
+        await WaitAndAssertForValueAsync(() => newMentorDatabase.EtlLoader.Processes.Any(x => x.Name == $"{etlName}/{transformationName}"), true, timeout: 30_000);
 
         using (var session = src.OpenSession())
         {
@@ -2040,26 +2032,26 @@ public class RavenDB_21192_Multinode : ClusterTestBase
 
             session.SaveChanges();
         }
-        
+
+        transformationErrors = 0;
         Assert.True(WaitForValue(() =>
         {
             var process = newMentorDatabase.EtlLoader.Processes.FirstOrDefault(x => x.Name == $"{etlName}/{transformationName}");
-            return process?.Statistics.TransformationErrors >= 7;
-        }, true, timeout: 30_000));
+            transformationErrors = process?.Statistics.TransformationErrors ?? 0;
+            return transformationErrors >= 7;
+        }, true, timeout: 30_000), $"Expected TransformationErrors >= 7 on new mentor, but got {transformationErrors}");
 
-        Assert.True(WaitForValue(() => newMentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl,$"{etlName}/{transformationName}").Count == 7, true, timeout: 30_000));
-        var newMentorItemErrors = newMentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl,$"{etlName}/{transformationName}");
-        Assert.Equal(7, newMentorItemErrors.Count);
+        await WaitAndAssertForValueAsync(() => newMentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl, $"{etlName}/{transformationName}").Count, 7, timeout: 30_000);
 
-        mentorItemErrors = mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl,$"{etlName}/{transformationName}");
+        var mentorItemErrors = mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl, $"{etlName}/{transformationName}");
         Assert.Equal(5, mentorItemErrors.Count);
-        
+
         newMentorDatabase.TaskErrorsStorage.DeleteErrorsOfTask($"{etlName}/{transformationName}", TaskCategory.Etl);
-        
-        newMentorItemErrors = newMentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl,$"{etlName}/{transformationName}");
+
+        var newMentorItemErrors = newMentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl, $"{etlName}/{transformationName}");
         Assert.Empty(newMentorItemErrors);
-        
-        mentorItemErrors = mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl,$"{etlName}/{transformationName}");
+
+        mentorItemErrors = mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Etl, $"{etlName}/{transformationName}");
         Assert.Equal(5, mentorItemErrors.Count);
     }
     
@@ -2139,29 +2131,30 @@ public class RavenDB_21192_Multinode : ClusterTestBase
         var mentorNode = nodes[0];
         var mentorDatabase = await GetDatabase(mentorNode, databaseName);
 
+        int transformationErrors = 0, loadSuccesses = 0;
         Assert.True(WaitForValue(() =>
         {
             var process = mentorDatabase.EtlLoader.Processes.FirstOrDefault(x => x.Name == processName);
-            return process?.Statistics.TransformationErrors >= 5 && process?.Statistics.LoadSuccesses >= 3;
-        }, true, timeout: 30_000));
+            transformationErrors = process?.Statistics.TransformationErrors ?? 0;
+            loadSuccesses = process?.Statistics.LoadSuccesses ?? 0;
+            return transformationErrors >= 5 && loadSuccesses >= 3;
+        }, true, timeout: 30_000), $"Expected TransformationErrors >= 5 (got {transformationErrors}) and LoadSuccesses >= 3 (got {loadSuccesses})");
 
-        Assert.True(WaitForValue(() => mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai,processName).Count == 5, true, timeout: 30_000));
-        var mentorItemErrors = mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai,processName);
-        Assert.Equal(5, mentorItemErrors.Count);
+        await WaitAndAssertForValueAsync(() => mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai, processName).Count, 5, timeout: 30_000);
 
         for (int i = 1; i < clusterSize; i++)
         {
             var otherDatabase = await GetDatabase(nodes[i], databaseName);
-            var otherItemErrors = otherDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai,processName);
+            var otherItemErrors = otherDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai, processName);
             Assert.Empty(otherItemErrors);
         }
 
         // Ensure mentor's ETL state is persisted before mentor change, otherwise the new mentor may start with stale ChangeVector and reprocess phase 1 documents.
-        Assert.True(WaitForValue(() =>
+        await WaitAndAssertForValueAsync(() =>
         {
             var state = EtlProcess.GetProcessState(mentorDatabase, taskName, "embeddings-transform-script");
             return state.LastProcessedEtagPerDbId.Count > 0;
-        }, true, timeout: 30_000));
+        }, true, timeout: 30_000);
 
         var newMentorTag = nodes[1].ServerStore.NodeTag;
         configuration.MentorNode = newMentorTag;
@@ -2170,10 +2163,7 @@ public class RavenDB_21192_Multinode : ClusterTestBase
         var newMentorNode = nodes[1];
         var newMentorDatabase = await GetDatabase(newMentorNode, databaseName);
 
-        Assert.True(WaitForValue(() =>
-        {
-            return newMentorDatabase.EtlLoader.Processes.Any(x => x.Name == processName);
-        }, true, timeout: 30_000));
+        await WaitAndAssertForValueAsync(() => newMentorDatabase.EtlLoader.Processes.Any(x => x.Name == processName), true, timeout: 30_000);
 
         using (var session = store.OpenSession())
         {
@@ -2183,25 +2173,25 @@ public class RavenDB_21192_Multinode : ClusterTestBase
             session.SaveChanges();
         }
 
+        transformationErrors = 0;
         Assert.True(WaitForValue(() =>
         {
             var process = newMentorDatabase.EtlLoader.Processes.FirstOrDefault(x => x.Name == processName);
-            return process?.Statistics.TransformationErrors >= 7;
-        }, true, timeout: 30_000));
+            transformationErrors = process?.Statistics.TransformationErrors ?? 0;
+            return transformationErrors >= 7;
+        }, true, timeout: 30_000), $"Expected TransformationErrors >= 7 on new mentor, but got {transformationErrors}");
 
-        Assert.True(WaitForValue(() => newMentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai,processName).Count == 7, true, timeout: 30_000));
-        var newMentorItemErrors = newMentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai,processName);
-        Assert.Equal(7, newMentorItemErrors.Count);
+        await WaitAndAssertForValueAsync(() => newMentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai, processName).Count, 7, timeout: 30_000);
 
-        mentorItemErrors = mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai,processName);
+        var mentorItemErrors = mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai, processName);
         Assert.Equal(5, mentorItemErrors.Count);
 
         newMentorDatabase.TaskErrorsStorage.DeleteErrorsOfTask(processName, TaskCategory.Ai);
 
-        newMentorItemErrors = newMentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai,processName);
+        var newMentorItemErrors = newMentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai, processName);
         Assert.Empty(newMentorItemErrors);
 
-        mentorItemErrors = mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai,processName);
+        mentorItemErrors = mentorDatabase.TaskErrorsStorage.ReadItemErrorsOfTask(TaskCategory.Ai, processName);
         Assert.Equal(5, mentorItemErrors.Count);
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21192/Redesign-ETL-error-handling

### Additional description

Fixed flaky multinode test where new mentor node of ETL task would sometimes process more documents than it's expected to.
Additionaly made assertions more meaningful.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
