### PR TITLE
RavenDB-26644 Add option to disable S3 ChecksumValidation

### DIFF
--- a/src/Raven.Client/Documents/Attachments/RemoteAttachmentsS3Settings.cs
+++ b/src/Raven.Client/Documents/Attachments/RemoteAttachmentsS3Settings.cs
@@ -115,6 +115,20 @@ public sealed class RemoteAttachmentsS3Settings : IS3Settings, IRemoteAttachment
     public string RemoteFolderName { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to disable checksum validation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property disables checksum validation for S3 uploads.
+    /// Checksum Validation ensures data integrity and should not be disabled if not necessary.
+    /// </para>
+    /// <para>
+    /// Set this to <c>true</c> if your S3-compatible storage does not support modern object integrity checks.
+    /// </para>
+    /// </remarks>
+    public bool DisableChecksumValidation { get; set; }
+
+    /// <summary>
     /// Gets or sets the name of the S3 bucket where attachments will be stored.
     /// </summary>
     /// <remarks>
@@ -216,7 +230,7 @@ public sealed class RemoteAttachmentsS3Settings : IS3Settings, IRemoteAttachment
 
     internal bool HasSettings()
     {
-        // Minimal enabling condition – bucket must be set.
+        // Minimal enabling condition ï¿½ bucket must be set.
         return string.IsNullOrWhiteSpace(BucketName) == false;
     }
 
@@ -231,7 +245,8 @@ public sealed class RemoteAttachmentsS3Settings : IS3Settings, IRemoteAttachment
             [nameof(RemoteFolderName)] = RemoteFolderName,
             [nameof(BucketName)] = BucketName,
             [nameof(CustomServerUrl)] = CustomServerUrl,
-            [nameof(ForcePathStyle)] = ForcePathStyle
+            [nameof(ForcePathStyle)] = ForcePathStyle,
+            [nameof(DisableChecksumValidation)] = DisableChecksumValidation
         };
 
         if (StorageClass.HasValue)
@@ -248,6 +263,7 @@ public sealed class RemoteAttachmentsS3Settings : IS3Settings, IRemoteAttachment
         hc.Add(RemoteFolderName);
         hc.Add(CustomServerUrl);
         hc.Add(ForcePathStyle);
+        hc.Add(DisableChecksumValidation);
         hc.Add(StorageClass);
         hc.Add(AwsAccessKey);
         hc.Add(AwsSecretKey);
@@ -267,6 +283,7 @@ public sealed class RemoteAttachmentsS3Settings : IS3Settings, IRemoteAttachment
                RemoteFolderName == other.RemoteFolderName &&
                CustomServerUrl == other.CustomServerUrl &&
                ForcePathStyle == other.ForcePathStyle &&
+               DisableChecksumValidation == other.DisableChecksumValidation &&
                StorageClass == other.StorageClass &&
                AwsAccessKey == other.AwsAccessKey &&
                AwsSecretKey == other.AwsSecretKey &&

--- a/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
@@ -223,6 +223,8 @@ namespace Raven.Client.Documents.Operations.Backups
         public bool ForcePathStyle { get; set; }
 
         public S3StorageClass? StorageClass { get; set; }
+        
+        public bool DisableChecksumValidation { get; set; }
 
         public S3Settings()
         {
@@ -236,6 +238,7 @@ namespace Raven.Client.Documents.Operations.Backups
             BucketName = settings.BucketName;
             CustomServerUrl = settings.CustomServerUrl;
             ForcePathStyle = settings.ForcePathStyle;
+            DisableChecksumValidation = settings.DisableChecksumValidation;
             AwsRegionName = settings.AwsRegionName;
             AwsAccessKey = settings.AwsAccessKey;
             AwsSecretKey = settings.AwsSecretKey;
@@ -280,6 +283,9 @@ namespace Raven.Client.Documents.Operations.Backups
             if (other.ForcePathStyle != ForcePathStyle)
                 return false;
 
+            if (other.DisableChecksumValidation != DisableChecksumValidation)
+                return false;
+
             if (other.StorageClass != StorageClass)
                 return false;
 
@@ -292,6 +298,7 @@ namespace Raven.Client.Documents.Operations.Backups
             djv[nameof(BucketName)] = BucketName;
             djv[nameof(CustomServerUrl)] = CustomServerUrl;
             djv[nameof(ForcePathStyle)] = ForcePathStyle;
+            djv[nameof(DisableChecksumValidation)] = DisableChecksumValidation;
 
             if (StorageClass.HasValue)
                 djv[nameof(StorageClass)] = StorageClass.Value;
@@ -305,6 +312,7 @@ namespace Raven.Client.Documents.Operations.Backups
             djv[nameof(BucketName)] = BucketName;
             djv[nameof(CustomServerUrl)] = CustomServerUrl;
             djv[nameof(ForcePathStyle)] = ForcePathStyle;
+            djv[nameof(DisableChecksumValidation)] = DisableChecksumValidation;
             
             if (StorageClass.HasValue)
                 djv[nameof(StorageClass)] = StorageClass.Value;

--- a/src/Raven.Client/Documents/Operations/Backups/IS3Settings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/IS3Settings.cs
@@ -50,4 +50,9 @@ public interface IS3Settings
     /// Gets or sets the remote folder path.
     /// </summary>
     public string RemoteFolderName { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to disable checksum validation.
+    /// </summary>
+    public bool DisableChecksumValidation { get; set; }
 }

--- a/src/Raven.Client/Extensions/RemoteAttachmentExtensions.cs
+++ b/src/Raven.Client/Extensions/RemoteAttachmentExtensions.cs
@@ -87,6 +87,7 @@ internal static class RemoteAttachmentExtensions
             BucketName = settings.BucketName,
             CustomServerUrl = settings.CustomServerUrl,
             ForcePathStyle = settings.ForcePathStyle,
+            DisableChecksumValidation = settings.DisableChecksumValidation,
             StorageClass = settings.StorageClass
         };
     }
@@ -129,6 +130,7 @@ internal static class RemoteAttachmentExtensions
             BucketName = settings.BucketName,
             CustomServerUrl = settings.CustomServerUrl,
             ForcePathStyle = settings.ForcePathStyle,
+            DisableChecksumValidation = settings.DisableChecksumValidation,
             StorageClass = settings.StorageClass,
             Disabled = false // ensure enabled for direct upload use-case
         };

--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -30,6 +30,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
         private AmazonS3Client _client;
         internal readonly string _bucketName;
         private readonly bool _usingCustomServerUrl;
+        private  readonly bool _disableChecksumValidation;
         public readonly string RemoteFolderName;
 
         public readonly string Region;
@@ -66,6 +67,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             else
             {
                 _usingCustomServerUrl = true;
+                _disableChecksumValidation = s3Settings.DisableChecksumValidation;
 
                 config = new AmazonS3Config
                 {
@@ -95,7 +97,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             _bucketName = s3Settings.BucketName;
             RemoteFolderName = s3Settings.RemoteFolderName;
             Region = s3Settings.AwsRegionName == null ? string.Empty : s3Settings.AwsRegionName.ToLower();
-            _storageClass = s3Settings.StorageClass?.ToAmazonS3StorageClass() ?? Amazon.S3.S3StorageClass.Standard;;
+            _storageClass = s3Settings.StorageClass?.ToAmazonS3StorageClass() ?? Amazon.S3.S3StorageClass.Standard;
+            
             _progress = progress;
             _cancellationToken = cancellationToken;
         }
@@ -112,7 +115,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
 
         public IMultiPartUploader GetUploader(string key, Dictionary<string, string> metadata)
         {
-            return new AwsS3MultiPartUploader(_client, _bucketName, _storageClass, _progress, key, metadata, _cancellationToken);
+            return new AwsS3MultiPartUploader(_client, _bucketName, _storageClass, _disableChecksumValidation, _progress, key, metadata, _cancellationToken);
         }
 
         public async Task PutObjectAsync(string key, Stream stream, Dictionary<string, string> metadata)
@@ -132,7 +135,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                 {
                     _progress?.UploadProgress.ChangeType(UploadType.Chunked);
 
-                    var multiPartUploader = new AwsS3MultiPartUploader(_client, _bucketName, _storageClass, _progress, key, metadata, _cancellationToken);
+                    var multiPartUploader = new AwsS3MultiPartUploader(_client, _bucketName, _storageClass, _disableChecksumValidation, _progress, key, metadata, _cancellationToken);
 
                     await multiPartUploader.InitializeAsync();
 
@@ -159,7 +162,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                         _progress?.UploadProgress.ChangeState(UploadState.Uploading);
                         _progress?.UploadProgress.UpdateUploaded(args.IncrementTransferred);
                         _progress?.OnUploadProgress?.Invoke();
-                    }
+                    },
+                    DisableDefaultChecksumValidation = _disableChecksumValidation
                 };
 
                 FillMetadata(request.Metadata, metadata);

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupConfigurationHelper.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupConfigurationHelper.cs
@@ -95,6 +95,7 @@ namespace Raven.Server.Documents.PeriodicBackup
 
             AssertBackupConfigurationInternal(configuration);
             AssertDirectUpload(configuration, localConfiguration);
+            AssertS3Configuration(configuration);
 
             var retentionPolicy = configuration.RetentionPolicy;
             if (retentionPolicy != null && retentionPolicy.Disabled == false)
@@ -141,6 +142,18 @@ namespace Raven.Server.Documents.PeriodicBackup
 
             var backupToLocalFolder = BackupConfiguration.CanBackupUsing(configuration.LocalSettings);
             GetBackupDestinationForDirectUpload(backupToLocalFolder, configuration, localConfiguration); // will throw if destination isn't set correctly
+        }
+        
+        private static void AssertS3Configuration(PeriodicBackupConfiguration configuration)
+        {
+            var s3Settings = configuration.S3Settings;
+            if (s3Settings != null && s3Settings.Disabled == false)
+            {
+                if (s3Settings.CustomServerUrl == null && s3Settings.DisableChecksumValidation == true)
+                {
+                    throw new ArgumentException($"{nameof(s3Settings.DisableChecksumValidation)} can't be set to true if {nameof(s3Settings.CustomServerUrl)} is null");
+                }
+            }
         }
 
         internal static BackupConfiguration.BackupDestination GetBackupDestinationForDirectUpload(bool backupToLocalFolder, BackupConfiguration configuration, Config.Categories.BackupConfiguration localConfiguration)

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupConfigurationHelper.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupConfigurationHelper.cs
@@ -149,7 +149,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             var s3Settings = configuration.S3Settings;
             if (s3Settings != null && s3Settings.Disabled == false)
             {
-                if (s3Settings.CustomServerUrl == null && s3Settings.DisableChecksumValidation == true)
+                if (string.IsNullOrWhiteSpace(s3Settings.CustomServerUrl) && s3Settings.DisableChecksumValidation == true)
                 {
                     throw new ArgumentException($"{nameof(s3Settings.DisableChecksumValidation)} can't be set to true if {nameof(s3Settings.CustomServerUrl)} is null");
                 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Util;
 using Raven.Server.Documents.PeriodicBackup.Aws;
 using S3StorageClass = Amazon.S3.S3StorageClass;
 
@@ -17,6 +16,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
     private readonly AmazonS3Client _client;
     private readonly string _bucketName;
     private readonly S3StorageClass _storageClass;
+    private readonly bool _disableChecksumValidation;
     private readonly Progress _progress;
     private readonly string _key;
     private readonly Dictionary<string, string> _metadata;
@@ -26,12 +26,13 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
     private int _partNumber;
     private List<PartETag> _partEtags;
 
-    public AwsS3MultiPartUploader(AmazonS3Client client, string bucketName, S3StorageClass storageClass, Progress progress, string key,
-        Dictionary<string, string> metadata, CancellationToken cancellationToken)
+    public AwsS3MultiPartUploader(AmazonS3Client client, string bucketName, S3StorageClass storageClass, bool disableChecksumValidation, 
+        Progress progress, string key, Dictionary<string, string> metadata, CancellationToken cancellationToken)
     {
         _client = client;
         _bucketName = bucketName;
         _storageClass = storageClass;
+        _disableChecksumValidation = disableChecksumValidation;
         _progress = progress;
         _key = key;
         _metadata = metadata;
@@ -84,6 +85,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
                 PartNumber = _partNumber++,
                 PartSize = size,
                 UploadId = _uploadId,
+                DisableDefaultChecksumValidation =  _disableChecksumValidation,
                 StreamTransferProgress = (_, args) =>
                 {
                     _progress?.UploadProgress.ChangeState(UploadState.Uploading);

--- a/src/Raven.Studio/typescript/components/common/formDestinations/AmazonS3.tsx
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/AmazonS3.tsx
@@ -97,11 +97,7 @@ export default function AmazonS3() {
                                             <span className="d-flex gap-1 align-items-center">
                                                 Disable Checksum Validation
                                                 <PopoverWithHoverWrapper
-                                                    message={
-                                                        <>
-                                                            Disables S3 checksum validation for uploads
-                                                        </>
-                                                    }
+                                                    message={<>Disables S3 checksum validation for uploads</>}
                                                 >
                                                     <Icon icon="info" color="info" />
                                                 </PopoverWithHoverWrapper>

--- a/src/Raven.Studio/typescript/components/common/formDestinations/AmazonS3.tsx
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/AmazonS3.tsx
@@ -87,6 +87,27 @@ export default function AmazonS3() {
                                             </span>
                                         </FormSwitch>
                                     )}
+                                    {formValues.isUseCustomHost && (
+                                        <FormSwitch
+                                            control={control}
+                                            name={getName("disableChecksumValidation")}
+                                            className="w-100"
+                                            color="secondary"
+                                        >
+                                            <span className="d-flex gap-1 align-items-center">
+                                                Disable Checksum Validation
+                                                <PopoverWithHoverWrapper
+                                                    message={
+                                                        <>
+                                                            Disables S3 checksum validation for uploads
+                                                        </>
+                                                    }
+                                                >
+                                                    <Icon icon="info" color="info" />
+                                                </PopoverWithHoverWrapper>
+                                            </span>
+                                        </FormSwitch>
+                                    )}
                                 </div>
                                 <div className="vstack gap-3 mt-2">
                                     {formValues.isUseCustomHost && (

--- a/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsMapsFromDto.ts
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsMapsFromDto.ts
@@ -83,6 +83,7 @@ export const defaultS3FormData: S3Destination = {
     isUseCustomHost: false,
     customServerUrl: null,
     forcePathStyle: false,
+    disableChecksumValidation: false,
     bucketName: null,
 };
 
@@ -97,6 +98,7 @@ function mapS3FromDto(dto: Raven.Client.Documents.Operations.Backups.S3Settings)
         isUseCustomHost: dto.CustomServerUrl != null,
         customServerUrl: dto.CustomServerUrl,
         forcePathStyle: dto.ForcePathStyle,
+        disableChecksumValidation: dto.DisableChecksumValidation,
         bucketName: dto.BucketName,
     };
 }

--- a/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsMapsToDto.ts
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsMapsToDto.ts
@@ -58,7 +58,9 @@ export function mapS3ToDto(destination: S3Destination): Raven.Client.Documents.O
         !destination.config.isOverrideConfig && destination.isUseCustomHost ? destination.forcePathStyle : undefined;
 
     const disableChecksumValidation =
-        !destination.config.isOverrideConfig && destination.isUseCustomHost ? destination.disableChecksumValidation : undefined;
+        !destination.config.isOverrideConfig && destination.isUseCustomHost
+            ? destination.disableChecksumValidation
+            : undefined;
 
     return {
         ...mapBackupSettingsToDto(destination),

--- a/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsMapsToDto.ts
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsMapsToDto.ts
@@ -57,11 +57,15 @@ export function mapS3ToDto(destination: S3Destination): Raven.Client.Documents.O
     const forcePathStyle =
         !destination.config.isOverrideConfig && destination.isUseCustomHost ? destination.forcePathStyle : undefined;
 
+    const disableChecksumValidation =
+        !destination.config.isOverrideConfig && destination.isUseCustomHost ? destination.disableChecksumValidation : undefined;
+
     return {
         ...mapBackupSettingsToDto(destination),
         ...mapAmazonToDto(destination),
         CustomServerUrl: customServerUrl,
         ForcePathStyle: forcePathStyle,
+        DisableChecksumValidation: disableChecksumValidation,
         BucketName: destination.bucketName,
     };
 }

--- a/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsTypes.ts
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsTypes.ts
@@ -26,6 +26,7 @@ export interface S3Destination extends FormDestinationDataBase, AmazonDestinatio
     bucketName?: string;
     customServerUrl?: string;
     forcePathStyle?: boolean;
+    disableChecksumValidation?: boolean;
     isUseCustomHost?: boolean;
 }
 

--- a/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsValidation.ts
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsValidation.ts
@@ -119,6 +119,7 @@ export const s3Schema = yupObjectSchema<WithoutAmazonAndBase<S3Destination>>({
                     ),
         }),
     forcePathStyle: yup.boolean(),
+    disableChecksumValidation: yup.boolean(),
     isUseCustomHost: yup.boolean(),
     customServerUrl: yup
         .string()

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils.ts
@@ -148,8 +148,10 @@ const mapS3ToDto = (
         !destination.config.isOverrideConfig && destination.isUseCustomHost ? destination.forcePathStyle : undefined;
 
     const disableChecksumValidation =
-        !destination.config.isOverrideConfig && destination.isUseCustomHost ? destination.disableChecksumValidation : undefined;
-    
+        !destination.config.isOverrideConfig && destination.isUseCustomHost
+            ? destination.disableChecksumValidation
+            : undefined;
+
     return {
         ...mapAmazonToDto(destination),
         CustomServerUrl: customServerUrl,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils.ts
@@ -76,6 +76,7 @@ function mapFromDto(dto: RemoteAttachmentsConfiguration): RemoteAttachmentsFormD
                         isUseCustomHost: s3Config.CustomServerUrl != null,
                         customServerUrl: s3Config.CustomServerUrl,
                         forcePathStyle: s3Config.ForcePathStyle,
+                        disableChecksumValidation: s3Config.DisableChecksumValidation,
                         storageClass: s3Config.StorageClass,
                     },
                     azure: null,
@@ -146,10 +147,14 @@ const mapS3ToDto = (
     const forcePathStyle =
         !destination.config.isOverrideConfig && destination.isUseCustomHost ? destination.forcePathStyle : undefined;
 
+    const disableChecksumValidation =
+        !destination.config.isOverrideConfig && destination.isUseCustomHost ? destination.disableChecksumValidation : undefined;
+    
     return {
         ...mapAmazonToDto(destination),
         CustomServerUrl: customServerUrl,
         ForcePathStyle: forcePathStyle,
+        DisableChecksumValidation: disableChecksumValidation,
         BucketName: destination.bucketName,
         StorageClass: destination.storageClass,
     };

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupDataUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupDataUtils.ts
@@ -242,7 +242,7 @@ function getSourceDto(
                     GetBackupConfigurationScript: null,
                     CustomServerUrl: data.isUseCustomHost ? data.customHost : null,
                     ForcePathStyle: data.isUseCustomHost && data.isForcePathStyle,
-                    DisableChecksumValidation: data.isUseCustomHost && data.isDisableChecksumValidation
+                    DisableChecksumValidation: data.isUseCustomHost && data.isDisableChecksumValidation,
                 } satisfies S3Settings,
             };
         }

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupDataUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupDataUtils.ts
@@ -39,6 +39,7 @@ const defaultValues: FormData = {
             amazonS3: {
                 isUseCustomHost: false,
                 isForcePathStyle: false,
+                isDisableChecksumValidation: false,
                 customHost: "",
                 accessKey: "",
                 secretKey: "",
@@ -220,6 +221,7 @@ function getSourceDto(
                     Disabled: false,
                     CustomServerUrl: null,
                     ForcePathStyle: false,
+                    DisableChecksumValidation: false,
                     GetBackupConfigurationScript: null,
                 } satisfies S3Settings,
             };
@@ -240,6 +242,7 @@ function getSourceDto(
                     GetBackupConfigurationScript: null,
                     CustomServerUrl: data.isUseCustomHost ? data.customHost : null,
                     ForcePathStyle: data.isUseCustomHost && data.isForcePathStyle,
+                    DisableChecksumValidation: data.isUseCustomHost && data.isDisableChecksumValidation
                 } satisfies S3Settings,
             };
         }

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupValidation.ts
@@ -95,6 +95,7 @@ const ravenCloudSource = yup.object({
 const amazonS3Source = yup.object({
     isUseCustomHost: yup.boolean(),
     isForcePathStyle: yup.boolean(),
+    isDisableChecksumValidation: yup.boolean(),
     customHost: yup.string().when(["isUseCustomHost", "$sourceType"], {
         is: (isUseCustomHost: boolean, sourceType: RestoreSource) => isUseCustomHost && sourceType === "amazonS3",
         then: (schema) => schema.trim().strict().required(),

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/BackupSourceAmazonS3.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/BackupSourceAmazonS3.tsx
@@ -219,6 +219,7 @@ function SourceRestorePoint({ index, remove }: RestorePointElementProps) {
                 AwsSessionToken: amazonS3Data.sessionToken,
                 CustomServerUrl: amazonS3Data.isUseCustomHost ? amazonS3Data.customHost : null,
                 ForcePathStyle: amazonS3Data.isUseCustomHost && amazonS3Data.isForcePathStyle,
+                DisableChecksumValidation: amazonS3Data.isUseCustomHost && amazonS3Data.isDisableChecksumValidation,
                 Disabled: false,
                 GetBackupConfigurationScript: null,
             },
@@ -236,6 +237,7 @@ function SourceRestorePoint({ index, remove }: RestorePointElementProps) {
         amazonS3Data.isUseCustomHost,
         amazonS3Data.customHost,
         amazonS3Data.isForcePathStyle,
+        amazonS3Data.isDisableChecksumValidation,
         isSharded,
     ]);
 

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/BackupSourceRavenCloud.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/BackupSourceRavenCloud.tsx
@@ -133,7 +133,7 @@ function SourceRestorePoint({ index, remove }: RestorePointElementProps) {
                 GetBackupConfigurationScript: null,
                 CustomServerUrl: null, // TODO RavenDB-14716
                 ForcePathStyle: false,
-                DisableChecksumValidation: false
+                DisableChecksumValidation: false,
             },
             true,
             isSharded ? index : undefined

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/BackupSourceRavenCloud.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/BackupSourceRavenCloud.tsx
@@ -133,6 +133,7 @@ function SourceRestorePoint({ index, remove }: RestorePointElementProps) {
                 GetBackupConfigurationScript: null,
                 CustomServerUrl: null, // TODO RavenDB-14716
                 ForcePathStyle: false,
+                DisableChecksumValidation: false
             },
             true,
             isSharded ? index : undefined

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -1073,6 +1073,7 @@ return docs[0];`,
                     AwsRegionName: "eu-central-1",
                     CustomServerUrl: "",
                     ForcePathStyle: false,
+                    DisableChecksumValidation: false,
                     RemoteFolderName: "",
                 },
                 AzureSettings: {

--- a/src/Raven.Studio/typescript/test/stubs/ResourcesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/ResourcesStubs.ts
@@ -101,6 +101,7 @@ export class ResourcesStubs {
             Expires: moment().add(2, "hours").toString(),
             CustomServerUrl: null,
             ForcePathStyle: false,
+            DisableChecksumValidation: false,
             Disabled: false,
             GetBackupConfigurationScript: null,
         };

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/s3Settings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/s3Settings.ts
@@ -176,7 +176,7 @@ class s3Settings extends amazonSettings {
         dto.BucketName = this.bucketName();
         dto.CustomServerUrl = !this.hasConfigurationScript() && this.useCustomS3Host() ? this.customServerUrl() : undefined;
         dto.ForcePathStyle = !this.hasConfigurationScript() && this.useCustomS3Host() ? this.forcePathStyle() : false;
-        dto.DisableChecksumValidation = !this.hasConfigurationScript() && this.useCustomS3Host ? this.disableChecksumValidation() : false;
+        dto.DisableChecksumValidation = !this.hasConfigurationScript() && this.useCustomS3Host() ? this.disableChecksumValidation() : false;
         dto.StorageClass = this.storageClass();
         
         return genUtils.trimProperties(dto, ["CustomServerUrl", "RemoteFolderName", "AwsRegionName", "AwsAccessKey", "AwsSessionToken"]);

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/s3Settings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/s3Settings.ts
@@ -17,6 +17,7 @@ class s3Settings extends amazonSettings {
     useCustomS3Host = ko.observable<boolean>();
     customServerUrl = ko.observable<string>();
     forcePathStyle = ko.observable<boolean>();
+    disableChecksumValidation = ko.observable<boolean>();
     accessKeyPropertyName: KnockoutComputed<string>;
     secretKeyPropertyName: KnockoutComputed<string>;
     isSecretHidden = ko.observable<boolean>(true);
@@ -34,6 +35,7 @@ class s3Settings extends amazonSettings {
         this.bucketName(dto.BucketName);
         this.customServerUrl(dto.CustomServerUrl);
         this.forcePathStyle(dto.ForcePathStyle);
+        this.disableChecksumValidation(dto.DisableChecksumValidation);
         this.useCustomS3Host(!!dto.CustomServerUrl);
         this.targetOperation = targetOperation;
         this.storageClass(dto.StorageClass ?? "Standard");
@@ -51,6 +53,7 @@ class s3Settings extends amazonSettings {
             this.selectedAwsRegion,
             this.customServerUrl,
             this.forcePathStyle,
+            this.disableChecksumValidation,
             this.useCustomS3Host,
             this.storageClass,
             
@@ -173,6 +176,7 @@ class s3Settings extends amazonSettings {
         dto.BucketName = this.bucketName();
         dto.CustomServerUrl = !this.hasConfigurationScript() && this.useCustomS3Host() ? this.customServerUrl() : undefined;
         dto.ForcePathStyle = !this.hasConfigurationScript() && this.useCustomS3Host() ? this.forcePathStyle() : false;
+        dto.DisableChecksumValidation = !this.hasConfigurationScript() && this.useCustomS3Host ? this.disableChecksumValidation() : false;
         dto.StorageClass = this.storageClass();
         
         return genUtils.trimProperties(dto, ["CustomServerUrl", "RemoteFolderName", "AwsRegionName", "AwsAccessKey", "AwsSessionToken"]);
@@ -189,6 +193,7 @@ class s3Settings extends amazonSettings {
             RemoteFolderName: null,
             GetBackupConfigurationScript: null,
             ForcePathStyle: false,
+            DisableChecksumValidation: false,
             CustomServerUrl: null,
             StorageClass: "Standard",
         }, allowedRegions, targetOperation);

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/s3Settings.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/s3Settings.html
@@ -10,6 +10,17 @@
             </small>
         </div>
     </div>
+    <div class="col-xs-offset-12 col-sm-offset-6 col-lg-offset-4">
+        <div class="toggle margin-left">
+            <input id="disableChecksumValidation" type="checkbox" data-bind="checked: disableChecksumValidation">
+            <label for="disableChecksumValidation">Disable Checksum Validation</label>
+            <small data-toggle="tooltip"
+                   data-animation="true"
+                   title="Disables S3 checksum validation for uploads">
+                <i class="icon-info text-info"></i>
+            </small>
+        </div>
+    </div>
 </div>
 
 <div class="row margin-bottom" data-bind="validationElement: customServerUrl, collapse: useCustomS3Host">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26644

### Additional description

Adds option to disable S3 checksum validation to support older S3 compatible storage systems.

S3 uses checksums to ensure data integrity. The amazon S3 client library does this by default.
Some S3 compatible object storages only support older MD5 based checksums.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
