### PR TITLE
RavenDB-26651 - Fix cluster transactions silently skipped after snapshot restore or database file reattach to a new server

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -657,6 +657,16 @@ namespace Raven.Server.Documents
                 tree.Add(LastCompletedClusterTransactionIndexSlice, indexSlice);
         }
 
+        public void ResetLastCompletedClusterTransactionIndex()
+        {
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (var tx = context.OpenWriteTransaction())
+            {
+                SetLastCompletedClusterTransactionIndex(context, 0);
+                tx.Commit();
+            }
+        }
+
         public static string ReadLastFixedCounterKey(Transaction tx)
         {
             if (tx == null)

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -48,6 +48,13 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
         protected override async Task RestoreAsync()
         {
+            using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (var tx = context.OpenWriteTransaction())
+            {
+                Database.DocumentsStorage.SetLastCompletedClusterTransactionIndex(context, 0);
+                tx.Commit();
+            }
+
             await RestoreFromSmugglerFileAsync(Progress, Database, _firstFile, Context, RestoreConfiguration.MaxReadOpsPerSecond);
             await HandleSubscriptionFromSnapshot(FilesToRestore, RestoreSettings.Subscriptions, DatabaseName, Database);
             await SmugglerRestoreAsync(Database, Context, Database.Smuggler.CreateDestinationForSnapshotRestore(RestoreSettings.Subscriptions));

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -48,12 +48,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
         protected override async Task RestoreAsync()
         {
-            using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            using (var tx = context.OpenWriteTransaction())
-            {
-                Database.DocumentsStorage.SetLastCompletedClusterTransactionIndex(context, 0);
-                tx.Commit();
-            }
+            Database.DocumentsStorage.ResetLastCompletedClusterTransactionIndex();
 
             await RestoreFromSmugglerFileAsync(Progress, Database, _firstFile, Context, RestoreConfiguration.MaxReadOpsPerSecond);
             await HandleSubscriptionFromSnapshot(FilesToRestore, RestoreSettings.Subscriptions, DatabaseName, Database);

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -12,7 +12,6 @@ using Raven.Client;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
-using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Corax;
@@ -53,7 +52,6 @@ using Sparrow.Logging;
 using Sparrow.Server;
 using Voron;
 using Voron.Util.Settings;
-using static Lucene.Net.Documents.Field;
 using BackupUtils = Raven.Server.Utils.BackupUtils;
 using Index = Raven.Server.Documents.Indexes.Index;
 using Size = Sparrow.Size;
@@ -377,23 +375,9 @@ namespace Raven.Server.Web.System
                 var options = InitializeOptions.SkipLoadingDatabaseRecord;
                 documentDatabase.Initialize(options);
 
-                SetLastCompletedClusterTransactionIndex(documentDatabase);
+                documentDatabase.DocumentsStorage.ResetLastCompletedClusterTransactionIndex();
 
-                RecreateIndexes(documentDatabase);
-            }
-                    
-            void SetLastCompletedClusterTransactionIndex(DocumentDatabase documentDatabase)
-            {
-                using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                using (var tx = context.OpenWriteTransaction())
-                {
-                    documentDatabase.DocumentsStorage.SetLastCompletedClusterTransactionIndex(context, 0);
-                    tx.Commit();
-                }
-            }
-
-            void RecreateIndexes(DocumentDatabase documentDatabase)
-            {
+                // recrate the indexes on the new database
                 if (Directory.Exists(indexesPath) == false)
                     return;
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -282,7 +282,7 @@ namespace Raven.Server.Web.System
                             && Server.ServerStore.Cluster.DatabaseExists(rawDatabaseRecord.DatabaseName) == false)
                         {
                             using (await ServerStore.DatabasesLandlord.UnloadAndLockDatabase(rawDatabaseRecord.DatabaseName, "Checking if database state needs to be updated (including recreating indexes)"))
-                                RecreateDatabase(rawDatabaseRecord.DatabaseName, databaseRecord);
+                                RecreateDatabase(rawDatabaseRecord.DatabaseName, databaseRecord, rawDatabaseRecord.Settings);
                         }
                     }
                 }
@@ -344,12 +344,12 @@ namespace Raven.Server.Web.System
             return false;
         }
 
-        private void RecreateDatabase(string databaseName, DatabaseRecord databaseRecord)
+        private void RecreateDatabase(string databaseName, DatabaseRecord databaseRecord, Dictionary<string, string> settings)
         {
-            if (Server.ServerStore.Cluster.DatabaseExists(databaseRecord.DatabaseName))
+            if (Server.ServerStore.Cluster.DatabaseExists(databaseName))
                 return;
 
-            var databaseConfiguration = ServerStore.DatabasesLandlord.CreateDatabaseConfiguration(databaseName, true, true, true, databaseRecord);
+            var databaseConfiguration = DatabasesLandlord.CreateDatabaseConfiguration(ServerStore, databaseName, settings);
             var indexesPath = databaseConfiguration.Indexing.StoragePath.FullPath;
             if (databaseConfiguration.Indexing.RunInMemory ||
                 (Directory.Exists(databaseConfiguration.Core.DataDirectory.FullPath) == false) && Directory.Exists(indexesPath) == false)

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -279,7 +279,7 @@ namespace Raven.Server.Web.System
                     {
                         if (ServerStore.DatabasesLandlord.IsDatabaseLoaded(rawDatabaseRecord.DatabaseName) == false)
                         {
-                            using (await ServerStore.DatabasesLandlord.UnloadAndLockDatabase(rawDatabaseRecord.DatabaseName, "Checking if we need to recreate indexes"))
+                            using (await ServerStore.DatabasesLandlord.UnloadAndLockDatabase(rawDatabaseRecord.DatabaseName, "Checking if database state needs to be updated (including recreating indexes)"))
                                 RecreateDatabase(rawDatabaseRecord.DatabaseName, databaseRecord);
                         }
                     }
@@ -345,8 +345,9 @@ namespace Raven.Server.Web.System
         private void RecreateDatabase(string databaseName, DatabaseRecord databaseRecord)
         {
             var databaseConfiguration = ServerStore.DatabasesLandlord.CreateDatabaseConfiguration(databaseName, true, true, true, databaseRecord);
+            var indexesPath = databaseConfiguration.Indexing.StoragePath.FullPath;
             if (databaseConfiguration.Indexing.RunInMemory ||
-                (Directory.Exists(databaseConfiguration.Indexing.StoragePath.FullPath) == false && Directory.Exists(databaseConfiguration.Core.DataDirectory.FullPath) == false))
+                (Directory.Exists(databaseConfiguration.Core.DataDirectory.FullPath) == false) && Directory.Exists(indexesPath) == false)
             {
                 return;
             }
@@ -375,8 +376,6 @@ namespace Raven.Server.Web.System
 
                 RecreateIndexes(documentDatabase);
             }
-
-            return;
                     
             void SetLastCompletedClusterTransactionIndex(DocumentDatabase documentDatabase)
             {
@@ -390,7 +389,9 @@ namespace Raven.Server.Web.System
 
             void RecreateIndexes(DocumentDatabase documentDatabase)
             {
-                var indexesPath = databaseConfiguration.Indexing.StoragePath.FullPath;
+                if (Directory.Exists(indexesPath) == false)
+                    return;
+
                 var sideBySideIndexes = new Dictionary<string, IndexDefinition>();
 
                 foreach (var indexPath in Directory.GetDirectories(indexesPath))

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -53,6 +53,7 @@ using Sparrow.Logging;
 using Sparrow.Server;
 using Voron;
 using Voron.Util.Settings;
+using static Lucene.Net.Documents.Field;
 using BackupUtils = Raven.Server.Utils.BackupUtils;
 using Index = Raven.Server.Documents.Indexes.Index;
 using Size = Sparrow.Size;
@@ -277,7 +278,8 @@ namespace Raven.Server.Web.System
                 {
                     foreach (var rawDatabaseRecord in raw.AsShardsOrNormal())
                     {
-                        if (ServerStore.DatabasesLandlord.IsDatabaseLoaded(rawDatabaseRecord.DatabaseName) == false)
+                        if (ServerStore.DatabasesLandlord.IsDatabaseLoaded(rawDatabaseRecord.DatabaseName) == false
+                            && Server.ServerStore.Cluster.DatabaseExists(rawDatabaseRecord.DatabaseName) == false)
                         {
                             using (await ServerStore.DatabasesLandlord.UnloadAndLockDatabase(rawDatabaseRecord.DatabaseName, "Checking if database state needs to be updated (including recreating indexes)"))
                                 RecreateDatabase(rawDatabaseRecord.DatabaseName, databaseRecord);
@@ -344,6 +346,9 @@ namespace Raven.Server.Web.System
 
         private void RecreateDatabase(string databaseName, DatabaseRecord databaseRecord)
         {
+            if (Server.ServerStore.Cluster.DatabaseExists(databaseRecord.DatabaseName))
+                return;
+
             var databaseConfiguration = ServerStore.DatabasesLandlord.CreateDatabaseConfiguration(databaseName, true, true, true, databaseRecord);
             var indexesPath = databaseConfiguration.Indexing.StoragePath.FullPath;
             if (databaseConfiguration.Indexing.RunInMemory ||

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -348,12 +348,8 @@ namespace Raven.Server.Web.System
                 return;
 
             var databaseConfiguration = DatabasesLandlord.CreateDatabaseConfiguration(ServerStore, databaseName, settings);
-            var indexesPath = databaseConfiguration.Indexing.StoragePath.FullPath;
-            if (databaseConfiguration.Indexing.RunInMemory ||
-                (Directory.Exists(databaseConfiguration.Core.DataDirectory.FullPath) == false) && Directory.Exists(indexesPath) == false)
-            {
+            if (databaseConfiguration.Core.RunInMemory)
                 return;
-            }
 
             var addToInitLog = new Action<LogMode, string>((logMode, txt) =>
             {
@@ -378,12 +374,12 @@ namespace Raven.Server.Web.System
                 documentDatabase.DocumentsStorage.ResetLastCompletedClusterTransactionIndex();
 
                 // recrate the indexes on the new database
-                if (Directory.Exists(indexesPath) == false)
+                if (databaseConfiguration.Indexing.RunInMemory || Directory.Exists(databaseConfiguration.Indexing.StoragePath.FullPath) == false)
                     return;
 
                 var sideBySideIndexes = new Dictionary<string, IndexDefinition>();
 
-                foreach (var indexPath in Directory.GetDirectories(indexesPath))
+                foreach (var indexPath in Directory.GetDirectories(databaseConfiguration.Indexing.StoragePath.FullPath))
                 {
                     Index index = null;
                     try

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -280,7 +280,7 @@ namespace Raven.Server.Web.System
                         if (ServerStore.DatabasesLandlord.IsDatabaseLoaded(rawDatabaseRecord.DatabaseName) == false)
                         {
                             using (await ServerStore.DatabasesLandlord.UnloadAndLockDatabase(rawDatabaseRecord.DatabaseName, "Checking if we need to recreate indexes"))
-                                RecreateIndexes(rawDatabaseRecord.DatabaseName, databaseRecord);
+                                RecreateDatabase(rawDatabaseRecord.DatabaseName, databaseRecord);
                         }
                     }
                 }
@@ -342,11 +342,11 @@ namespace Raven.Server.Web.System
             return false;
         }
 
-        private void RecreateIndexes(string databaseName, DatabaseRecord databaseRecord)
+        private void RecreateDatabase(string databaseName, DatabaseRecord databaseRecord)
         {
             var databaseConfiguration = ServerStore.DatabasesLandlord.CreateDatabaseConfiguration(databaseName, true, true, true, databaseRecord);
             if (databaseConfiguration.Indexing.RunInMemory ||
-                Directory.Exists(databaseConfiguration.Indexing.StoragePath.FullPath) == false)
+                (Directory.Exists(databaseConfiguration.Indexing.StoragePath.FullPath) == false && Directory.Exists(databaseConfiguration.Core.DataDirectory.FullPath) == false))
             {
                 return;
             }
@@ -371,6 +371,25 @@ namespace Raven.Server.Web.System
                 var options = InitializeOptions.SkipLoadingDatabaseRecord;
                 documentDatabase.Initialize(options);
 
+                SetLastCompletedClusterTransactionIndex(documentDatabase);
+
+                RecreateIndexes(documentDatabase);
+            }
+
+            return;
+                    
+            void SetLastCompletedClusterTransactionIndex(DocumentDatabase documentDatabase)
+            {
+                using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    documentDatabase.DocumentsStorage.SetLastCompletedClusterTransactionIndex(context, 0);
+                    tx.Commit();
+                }
+            }
+
+            void RecreateIndexes(DocumentDatabase documentDatabase)
+            {
                 var indexesPath = databaseConfiguration.Indexing.StoragePath.FullPath;
                 var sideBySideIndexes = new Dictionary<string, IndexDefinition>();
 

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2415,5 +2415,53 @@ select incl(c)"
         {
             public IEnumerable<object> Results { get; set; }
         }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionAfterAttachingDatabaseFilesToNewServer()
+        {
+            var dbPath = NewDataPath(suffix: "DatabaseFiles");
+            var dbName = GetDatabaseName();
+            const string docId = "users/new";
+
+            using (var store = GetDocumentStore(new Options
+                   {
+                       RunInMemory = false,
+                       Path = dbPath,
+                       ModifyDatabaseName = _ => dbName
+                   }))
+            {
+                for (int i = 0; i < 16; i++)
+                {
+                    using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                    {
+                        await session.StoreAsync(new User { Name = $"User{i}" }, $"users/{i}");
+                        await session.SaveChangesAsync();
+                    }
+                }
+            }
+
+            using (var server = GetNewServer())
+            using (var store = GetDocumentStore(new Options
+            {
+                Server = server,
+                RunInMemory = false,
+                Path = dbPath,
+                ModifyDatabaseName = _ => dbName
+            }))
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    await session.StoreAsync(new User { Name = "NewUser" }, docId);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var user = await session.LoadAsync<User>(docId);
+                    Assert.NotNull(user);
+                    Assert.Equal("NewUser", user.Name);
+                }
+            }
+        }
     }
 }

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2463,5 +2463,57 @@ select incl(c)"
                 }
             }
         }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.Sharding)]
+        public async Task ClusterTransactionAfterAttachingShardedDatabaseFilesToNewServer()
+        {
+            var dbPath = NewDataPath(suffix: "DatabaseFiles");
+            var dbName = GetDatabaseName();
+            const string docId = "users/new";
+
+            using (var server = GetNewServer())
+            {
+                var options = Sharding.GetOptionsForCluster(server, shards: 2, shardReplicationFactor: 1, orchestratorReplicationFactor: 1);
+                options.RunInMemory = false;
+                options.Path = dbPath;
+                options.ModifyDatabaseName = _ => dbName;
+
+                using (var store = GetDocumentStore(options))
+                {
+                    for (int i = 0; i < 16; i++)
+                    {
+                        using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                        {
+                            await session.StoreAsync(new User { Name = $"User{i}" }, $"users/{i}");
+                            await session.SaveChangesAsync();
+                        }
+                    }
+                }
+            }
+
+            using (var server = GetNewServer())
+            {
+                var options = Sharding.GetOptionsForCluster(server, shards: 2, shardReplicationFactor: 1, orchestratorReplicationFactor: 1);
+                options.RunInMemory = false;
+                options.Path = dbPath;
+                options.ModifyDatabaseName = _ => dbName;
+
+                using (var store = GetDocumentStore(options))
+                {
+                    using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                    {
+                        await session.StoreAsync(new User { Name = "NewUser" }, docId);
+                        await session.SaveChangesAsync();
+                    }
+
+                    using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                    {
+                        var user = await session.LoadAsync<User>(docId);
+                        Assert.NotNull(user);
+                        Assert.Equal("NewUser", user.Name);
+                    }
+                }
+            }
+        }
     }
 }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Backups.Sharding;
 using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server.Config;
@@ -655,6 +656,98 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             {
                 var user = session.Load<User>("users/1");
                 Assert.Null(user);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.BackupExportImport)]
+        public async Task ClusterTransactionAfterSnapshotRestoreOnNewServer()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var db2Name = GetDatabaseName();
+
+            const string userId = "users/1";
+            using (var server = GetNewServer())
+            {
+                var db1Name = GetDatabaseName();
+                using (var store1 = GetDocumentStore(new Options { Server = server, ModifyDatabaseName = _ => db1Name }))
+                {
+                    for (int i = 0; i < 16; i++)
+                    {
+                        using (var session = store1.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                        {
+                            await session.StoreAsync(new User { Name = $"User{i}" }, $"users/{i}");
+                            await session.SaveChangesAsync();
+                        }
+                    }
+                }
+
+                using (var store2 = GetDocumentStore(new Options { Server = server, ModifyDatabaseName = _ => db2Name }))
+                {
+                    using (var session = store2.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                    {
+                        await session.StoreAsync(new User { Name = "SingleUser" }, userId);
+                        await session.SaveChangesAsync();
+                    }
+
+                    var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
+                    await Backup.UpdateConfigAndRunBackupAsync(server, config, store2);
+                }
+            }
+
+            using var newServer = GetNewServer();
+
+            var restoredDbName = GetDatabaseName();
+            var backupLocation = Directory.GetDirectories(backupPath).First();
+
+            using (var newStore = GetDocumentStore(new Options { Server = newServer, CreateDatabase = false, ModifyDatabaseName = _ => db2Name }))
+            using (Backup.RestoreDatabase(newStore, new RestoreBackupConfiguration
+            {
+                BackupLocation = backupLocation,
+                DatabaseName = restoredDbName
+            }))
+
+            using (var restoredStore = GetDocumentStore(new Options { Server = newServer, CreateDatabase = false, ModifyDatabaseName = _ => restoredDbName }))
+            {
+                var user2 = new User { Id = "users/2", Name = "Grisha" };
+                var user3 = new User { Id = "users/3", Name = "Igal" };
+
+                using (var session = restoredStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    await session.StoreAsync(user2);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = restoredStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    await session.StoreAsync(user3);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = restoredStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var user = await session.LoadAsync<User>(user2.Id);
+                    Assert.NotNull(user);
+                    Assert.Equal(user2.Name, user.Name);
+
+                    user = await session.LoadAsync<User>("users/3");
+                    Assert.NotNull(user);
+                    Assert.Equal(user3.Name, user.Name);
+                }
+
+                using (var session = restoredStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var user = await session.LoadAsync<User>("users/1");
+                    Assert.Equal("SingleUser", user.Name);
+                    user.Name = "Grisha";
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = restoredStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var user = await session.LoadAsync<User>(userId);
+                    Assert.NotNull(user);
+                    Assert.Equal("Grisha", user.Name);
+                }
             }
         }
     }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Backups.Sharding;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server.Config;
@@ -666,32 +667,30 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             var db2Name = GetDatabaseName();
 
             const string userId = "users/1";
-            using (var server = GetNewServer())
+            var user1 = new User { Id = userId, Name = "SingleUser" };
+            var db1Name = GetDatabaseName();
+            using (var store1 = GetDocumentStore(new Options { ModifyDatabaseName = _ => db1Name }))
             {
-                var db1Name = GetDatabaseName();
-                using (var store1 = GetDocumentStore(new Options { Server = server, ModifyDatabaseName = _ => db1Name }))
+                for (int i = 0; i < 16; i++)
                 {
-                    for (int i = 0; i < 16; i++)
+                    using (var session = store1.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                     {
-                        using (var session = store1.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
-                        {
-                            await session.StoreAsync(new User { Name = $"User{i}" }, $"users/{i}");
-                            await session.SaveChangesAsync();
-                        }
-                    }
-                }
-
-                using (var store2 = GetDocumentStore(new Options { Server = server, ModifyDatabaseName = _ => db2Name }))
-                {
-                    using (var session = store2.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
-                    {
-                        await session.StoreAsync(new User { Name = "SingleUser" }, userId);
+                        await session.StoreAsync(new User { Name = $"User{i}" }, $"users/{i}");
                         await session.SaveChangesAsync();
                     }
-
-                    var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
-                    await Backup.UpdateConfigAndRunBackupAsync(server, config, store2);
                 }
+            }
+
+            using (var store2 = GetDocumentStore(new Options { ModifyDatabaseName = _ => db2Name }))
+            {
+                using (var session = store2.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    await session.StoreAsync(user1);
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store2);
             }
 
             using var newServer = GetNewServer();
@@ -708,6 +707,12 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var restoredStore = GetDocumentStore(new Options { Server = newServer, CreateDatabase = false, ModifyDatabaseName = _ => restoredDbName }))
             {
+                using (var session = restoredStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    await session.StoreAsync(user1);
+                    await Assert.ThrowsAsync<ClusterTransactionConcurrencyException>(async () => await session.SaveChangesAsync());
+                }
+
                 var user2 = new User { Id = "users/2", Name = "Grisha" };
                 var user3 = new User { Id = "users/3", Name = "Igal" };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26651/Cluster-transactions-fail-after-restoring-a-snapshot-backup-to-a-new-server

### Additional description

When a database is moved to a new server (via snapshot restore or by attaching existing data files), the `LastCompletedClusterTransactionIndex` stored in the database reflects the source cluster's Raft index. The new server's cluster starts from a lower index, so the cluster transaction processor incorrectly believes it has already executed those transactions and silently skips them - meaning new cluster-wide writes on the restored/reattached database appear to succeed but are never actually applied.

#### Two scenarios are fixed:

  - Snapshot restore (`RestoreSnapshotTask`): Reset `LastCompletedClusterTransactionIndex` to 0 before importing the snapshot data, so the new cluster processes cluster transactions from scratch.
  - Database file reattach (`AdminDatabasesHandler`): Apply the same reset when existing database files are attached to a newserver via `PUT /admin/databases`. Also fixed the existence check to correctly detect the database directory (previously
only checked the indexes path - now checks both indexes and data directory paths).

Both fixes include regression tests: one verifying that cluster transactions execute correctly after restore/reattach, and one verifying that a `ClusterTransactionConcurrencyException` is raised when a conflicting document is stored after restore (proving compare-exchange guards are active).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
