### PR TITLE
RavenDB-22254: Index heaviness grade

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexHeavinessGrade.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexHeavinessGrade.cs
@@ -2,6 +2,23 @@ using System.Collections.Generic;
 
 namespace Raven.Client.Documents.Indexes
 {
+    public enum IndexStaticGrade
+    {
+        Simple,
+        Moderate,
+        Complex,
+        VeryComplex
+    }
+
+    public enum IndexFullGrade
+    {
+        Lightweight,
+        Moderate,
+        Heavy,
+        VeryHeavy,
+        Extreme
+    }
+
     /// <summary>
     /// Represents the computed heaviness grade for an index, quantifying its expected resource impact.
     /// </summary>
@@ -21,14 +38,14 @@ namespace Raven.Client.Documents.Indexes
         public double FullScore { get; set; }
 
         /// <summary>
-        /// Human-readable label for the static score: Simple, Moderate, Complex, Very Complex
+        /// Grade label for the static score.
         /// </summary>
-        public string StaticGradeLabel { get; set; }
+        public IndexStaticGrade StaticGradeLabel { get; set; }
 
         /// <summary>
-        /// Human-readable label for the full score: Light, Moderate, Heavy, Very Heavy, Extreme
+        /// Grade label for the full score.
         /// </summary>
-        public string FullGradeLabel { get; set; }
+        public IndexFullGrade FullGradeLabel { get; set; }
 
         /// <summary>
         /// Individual penalty contributions that made up the static score.

--- a/src/Raven.Client/Documents/Indexes/IndexHeavinessGrade.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexHeavinessGrade.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+
+namespace Raven.Client.Documents.Indexes
+{
+    /// <summary>
+    /// Represents the computed heaviness grade for an index, quantifying its expected resource impact.
+    /// </summary>
+    public sealed class IndexHeavinessGrade
+    {
+        /// <summary>
+        /// Static score based solely on the index definition. Server-independent and additive.
+        /// Can be compared across different servers and environments.
+        /// </summary>
+        public int StaticScore { get; set; }
+
+        /// <summary>
+        /// Full score that takes into account data scale (collection size, average document size)
+        /// and runtime observations. Reflects actual resource impact on this specific server.
+        /// Formula: StaticScore × DataScaleMultiplier + RuntimePenalties
+        /// </summary>
+        public double FullScore { get; set; }
+
+        /// <summary>
+        /// Human-readable label for the static score: Simple, Moderate, Complex, Very Complex
+        /// </summary>
+        public string StaticGradeLabel { get; set; }
+
+        /// <summary>
+        /// Human-readable label for the full score: Light, Moderate, Heavy, Very Heavy, Extreme
+        /// </summary>
+        public string FullGradeLabel { get; set; }
+
+        /// <summary>
+        /// Individual penalty contributions that made up the static score.
+        /// </summary>
+        public List<IndexHeavinessPenalty> StaticPenalties { get; set; }
+
+        /// <summary>
+        /// Individual penalty contributions from runtime observations.
+        /// </summary>
+        public List<IndexHeavinessPenalty> RuntimePenalties { get; set; }
+
+        /// <summary>
+        /// Data scale multiplier applied to the static score (CollectionSizeFactor × DocumentSizeFactor).
+        /// A value of 1.0 is the baseline (1K–10K documents, 1–10KB average size).
+        /// </summary>
+        public double DataScaleMultiplier { get; set; }
+    }
+
+    /// <summary>
+    /// Describes a single penalty contribution to an index heaviness score.
+    /// </summary>
+    public sealed class IndexHeavinessPenalty
+    {
+        /// <summary>
+        /// Short description of the penalty reason.
+        /// </summary>
+        public string Reason { get; set; }
+
+        /// <summary>
+        /// The numeric value of this penalty.
+        /// </summary>
+        public double Score { get; set; }
+    }
+}

--- a/src/Raven.Client/Documents/Indexes/IndexStats.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexStats.cs
@@ -172,6 +172,12 @@ namespace Raven.Client.Documents.Indexes
 
         public IndexingPerformanceBasicStats LastBatchStats { get; set; }
 
+        /// <summary>
+        /// Heaviness grade quantifying the expected resource impact of this index.
+        /// Computed from the index definition (static score) and data scale/runtime factors (full score).
+        /// </summary>
+        public IndexHeavinessGrade HeavinessGrade { get; set; }
+
         public sealed class MemoryStats
         {
             public MemoryStats()

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -118,6 +118,13 @@ namespace Raven.Server.Documents.Handlers
                 await processor.ExecuteAsync();
         }
 
+        [RavenAction("/databases/*/indexes/heaviness/analyze", "POST", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        public async Task AnalyzeHeaviness()
+        {
+            using (var processor = new IndexHandlerProcessorForAnalyzeHeaviness(this))
+                await processor.ExecuteAsync();
+        }
+
         [RavenAction("/databases/*/indexes/staleness", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task Stale()
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForAnalyzeHeaviness.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForAnalyzeHeaviness.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Json;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.Processors.Indexes;
+
+internal sealed class IndexHandlerProcessorForAnalyzeHeaviness : AbstractDatabaseHandlerProcessor<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    public IndexHandlerProcessorForAnalyzeHeaviness([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
+        using (var json = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "index/definition"))
+        {
+            IndexDefinition indexDefinition = JsonDeserializationServer.IndexDefinition(json);
+
+            if (indexDefinition == null || indexDefinition.Maps.Count == 0)
+                throw new BadRequestException("Index definition must contain at least one map.");
+
+            var collections = IndexDefinitionHeavinessAnalyzer.ExtractCollectionsFromMaps(indexDefinition);
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(indexDefinition, collections);
+
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(grade);
+                writer.WriteObject(context.ReadObject(djv, "index/heaviness-grade"));
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForAnalyzeHeaviness.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForAnalyzeHeaviness.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Json;
@@ -28,7 +30,37 @@ internal sealed class IndexHandlerProcessorForAnalyzeHeaviness : AbstractDatabas
                 throw new BadRequestException("Index definition must contain at least one map.");
 
             var collections = IndexDefinitionHeavinessAnalyzer.ExtractCollectionsFromMaps(indexDefinition);
-            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(indexDefinition, collections);
+            IndexHeavinessGrade staticGrade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(indexDefinition, collections);
+
+            IndexHeavinessGrade grade = staticGrade;
+            var db = RequestHandler.Database;
+            if (db != null)
+            {
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext docsContext))
+                using (docsContext.OpenReadTransaction())
+                {
+                    IndexDefinitionHeavinessAnalyzer.CollectionDataProvider provider = collectionName =>
+                    {
+                        if (string.Equals(collectionName, Raven.Client.Constants.Documents.Collections.AllDocumentsCollection, StringComparison.OrdinalIgnoreCase))
+                        {
+                            long totalCount = 0;
+                            long totalSize = 0;
+                            foreach (string name in db.DocumentsStorage.GetCollectionsNames(docsContext))
+                            {
+                                CollectionDetails details = db.DocumentsStorage.GetCollectionDetails(docsContext, name);
+                                totalCount += details.CountOfDocuments;
+                                totalSize += details.DocumentsSize.SizeInBytes;
+                            }
+                            return (totalCount, totalSize);
+                        }
+
+                        CollectionDetails col = db.DocumentsStorage.GetCollectionDetails(docsContext, collectionName);
+                        return (col.CountOfDocuments, col.DocumentsSize.SizeInBytes);
+                    };
+
+                    grade = IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(staticGrade, collections, stats: null, provider);
+                }
+            }
 
             await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -296,6 +296,8 @@ namespace Raven.Server.Documents.Indexes
         private bool _newComplexFieldsToReport = false;
         private record CachedStaticHeaviness(IndexHeavinessGrade Grade, IndexDefinitionBaseServerSide Definition);
         private record CachedFullHeaviness(IndexHeavinessGrade Grade, long TickCount);
+        // Full grade opens a read transaction to scan collection sizes; cache for 60 s to avoid
+        // overhead on frequent Studio polls. A slightly stale score is acceptable for a heuristic.
         private const long FullHeavinessCacheMs = 60_000;
         private volatile CachedStaticHeaviness _cachedHeaviness;
         private volatile CachedFullHeaviness _cachedFullHeaviness;
@@ -3278,12 +3280,13 @@ namespace Raven.Server.Documents.Indexes
 
             try
             {
-                IndexDefinition indexDefinition = GetIndexDefinition();
+                IndexDefinitionBaseServerSide currentDefinition = Definition;
+                IndexDefinition indexDefinition = currentDefinition.GetOrCreateIndexDefinitionInternal();
 
                 if (indexDefinition == null)
                     return null;
 
-                IndexHeavinessGrade staticGrade = GetOrComputeStaticHeavinessGrade(indexDefinition);
+                IndexHeavinessGrade staticGrade = GetOrComputeStaticHeavinessGrade(indexDefinition, currentDefinition);
 
                 IndexDefinitionHeavinessAnalyzer.CollectionDataProvider collectionDataProvider = null;
                 DocumentsOperationContext docsContext = null;
@@ -3326,7 +3329,7 @@ namespace Raven.Server.Documents.Indexes
                         };
                     }
 
-                    IndexHeavinessGrade result = IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(staticGrade, Collections, stats, collectionDataProvider);
+                    IndexHeavinessGrade result = IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(staticGrade, currentDefinition.Collections, stats, collectionDataProvider);
                     _cachedFullHeaviness = new CachedFullHeaviness(result, Environment.TickCount64);
                     return result;
                 }
@@ -3344,16 +3347,15 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        private IndexHeavinessGrade GetOrComputeStaticHeavinessGrade(IndexDefinition indexDefinition)
+        private IndexHeavinessGrade GetOrComputeStaticHeavinessGrade(IndexDefinition indexDefinition, IndexDefinitionBaseServerSide serverSideDefinition)
         {
-            IndexDefinitionBaseServerSide currentDefinition = Definition;
             CachedStaticHeaviness cached = _cachedHeaviness;
 
-            if (cached != null && ReferenceEquals(cached.Definition, currentDefinition))
+            if (cached != null && ReferenceEquals(cached.Definition, serverSideDefinition))
                 return cached.Grade;
 
-            IndexHeavinessGrade staticGrade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(indexDefinition, Collections);
-            _cachedHeaviness = new CachedStaticHeaviness(staticGrade, currentDefinition);
+            IndexHeavinessGrade staticGrade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(indexDefinition, serverSideDefinition.Collections);
+            _cachedHeaviness = new CachedStaticHeaviness(staticGrade, serverSideDefinition);
             return staticGrade;
         }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3326,8 +3326,11 @@ namespace Raven.Server.Documents.Indexes
                     contextRelease?.Dispose();
                 }
             }
-            catch
+            catch (Exception e)
             {
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Failed to compute heaviness grade for index '{Name}'.", e);
+
                 return null;
             }
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -294,6 +294,8 @@ namespace Raven.Server.Documents.Indexes
         
         private HashSet<string> _fieldsReportedAsComplex = new();
         private bool _newComplexFieldsToReport = false;
+        private IndexHeavinessGrade _cachedStaticHeavinessGrade;
+        private IndexDefinitionBaseServerSide _cachedHeavinessDefinition;
         public HashSet<IndexField> ComplexFieldsNotIndexedByCorax { get; private set; }
 
         protected Index(IndexType type, IndexSourceType sourceType, IndexDefinitionBaseServerSide definition, AbstractStaticIndexBase compiled)
@@ -3273,6 +3275,8 @@ namespace Raven.Server.Documents.Indexes
                 if (indexDefinition == null)
                     return null;
 
+                IndexHeavinessGrade staticGrade = GetOrComputeStaticHeavinessGrade(indexDefinition);
+
                 IndexDefinitionHeavinessAnalyzer.CollectionDataProvider collectionDataProvider = null;
                 DocumentsOperationContext docsContext = null;
                 IDisposable contextRelease = null;
@@ -3299,7 +3303,7 @@ namespace Raven.Server.Documents.Indexes
                         };
                     }
 
-                    return IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(indexDefinition, Collections, stats, collectionDataProvider);
+                    return IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(staticGrade, Collections, stats, collectionDataProvider);
                 }
                 finally
                 {
@@ -3310,6 +3314,19 @@ namespace Raven.Server.Documents.Indexes
             {
                 return null;
             }
+        }
+
+        private IndexHeavinessGrade GetOrComputeStaticHeavinessGrade(IndexDefinition indexDefinition)
+        {
+            IndexDefinitionBaseServerSide currentDefinition = Definition;
+
+            if (_cachedStaticHeavinessGrade != null && ReferenceEquals(_cachedHeavinessDefinition, currentDefinition))
+                return _cachedStaticHeavinessGrade;
+
+            IndexHeavinessGrade staticGrade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(indexDefinition, Collections);
+            _cachedStaticHeavinessGrade = staticGrade;
+            _cachedHeavinessDefinition = currentDefinition;
+            return staticGrade;
         }
 
         private IndexStats.MemoryStats GetMemoryStats()

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3249,6 +3249,8 @@ namespace Raven.Server.Documents.Indexes
                     if (calculateMemoryStats)
                         stats.Memory = GetMemoryStats();
 
+                    stats.HeavinessGrade = ComputeHeavinessGrade(stats, queryContext);
+
                     return stats;
                 }
             }
@@ -3260,6 +3262,54 @@ namespace Raven.Server.Documents.Indexes
             return GetReferencedCollections()?
                 .SelectMany(p => p.Value?.Select(z => z.Name))
                 .ToHashSet();
+        }
+
+        private IndexHeavinessGrade ComputeHeavinessGrade(IndexStats stats, QueryOperationContext queryContext)
+        {
+            try
+            {
+                IndexDefinition indexDefinition = GetIndexDefinition();
+
+                if (indexDefinition == null)
+                    return null;
+
+                IndexDefinitionHeavinessAnalyzer.CollectionDataProvider collectionDataProvider = null;
+                DocumentsOperationContext docsContext = null;
+                IDisposable contextRelease = null;
+
+                try
+                {
+                    if (queryContext?.Documents?.Transaction != null)
+                    {
+                        docsContext = queryContext.Documents;
+                    }
+                    else if (DocumentDatabase != null)
+                    {
+                        contextRelease = DocumentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out docsContext);
+                        docsContext.OpenReadTransaction();
+                    }
+
+                    if (docsContext != null)
+                    {
+                        DocumentsOperationContext capturedContext = docsContext;
+                        collectionDataProvider = collectionName =>
+                        {
+                            CollectionDetails details = DocumentDatabase.DocumentsStorage.GetCollectionDetails(capturedContext, collectionName);
+                            return (details.CountOfDocuments, details.DocumentsSize.SizeInBytes);
+                        };
+                    }
+
+                    return IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(indexDefinition, Collections, stats, collectionDataProvider);
+                }
+                finally
+                {
+                    contextRelease?.Dispose();
+                }
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         private IndexStats.MemoryStats GetMemoryStats()

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -294,8 +294,11 @@ namespace Raven.Server.Documents.Indexes
         
         private HashSet<string> _fieldsReportedAsComplex = new();
         private bool _newComplexFieldsToReport = false;
-        private IndexHeavinessGrade _cachedStaticHeavinessGrade;
-        private IndexDefinitionBaseServerSide _cachedHeavinessDefinition;
+        private record CachedStaticHeaviness(IndexHeavinessGrade Grade, IndexDefinitionBaseServerSide Definition);
+        private record CachedFullHeaviness(IndexHeavinessGrade Grade, long TickCount);
+        private const long FullHeavinessCacheMs = 60_000;
+        private volatile CachedStaticHeaviness _cachedHeaviness;
+        private volatile CachedFullHeaviness _cachedFullHeaviness;
         public HashSet<IndexField> ComplexFieldsNotIndexedByCorax { get; private set; }
 
         protected Index(IndexType type, IndexSourceType sourceType, IndexDefinitionBaseServerSide definition, AbstractStaticIndexBase compiled)
@@ -3269,6 +3272,10 @@ namespace Raven.Server.Documents.Indexes
 
         private IndexHeavinessGrade ComputeHeavinessGrade(IndexStats stats, QueryOperationContext queryContext)
         {
+            CachedFullHeaviness cachedFull = _cachedFullHeaviness;
+            if (cachedFull != null && Environment.TickCount64 - cachedFull.TickCount < FullHeavinessCacheMs)
+                return cachedFull.Grade;
+
             try
             {
                 IndexDefinition indexDefinition = GetIndexDefinition();
@@ -3319,7 +3326,9 @@ namespace Raven.Server.Documents.Indexes
                         };
                     }
 
-                    return IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(staticGrade, Collections, stats, collectionDataProvider);
+                    IndexHeavinessGrade result = IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(staticGrade, Collections, stats, collectionDataProvider);
+                    _cachedFullHeaviness = new CachedFullHeaviness(result, Environment.TickCount64);
+                    return result;
                 }
                 finally
                 {
@@ -3338,13 +3347,13 @@ namespace Raven.Server.Documents.Indexes
         private IndexHeavinessGrade GetOrComputeStaticHeavinessGrade(IndexDefinition indexDefinition)
         {
             IndexDefinitionBaseServerSide currentDefinition = Definition;
+            CachedStaticHeaviness cached = _cachedHeaviness;
 
-            if (_cachedStaticHeavinessGrade != null && ReferenceEquals(_cachedHeavinessDefinition, currentDefinition))
-                return _cachedStaticHeavinessGrade;
+            if (cached != null && ReferenceEquals(cached.Definition, currentDefinition))
+                return cached.Grade;
 
             IndexHeavinessGrade staticGrade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(indexDefinition, Collections);
-            _cachedStaticHeavinessGrade = staticGrade;
-            _cachedHeavinessDefinition = currentDefinition;
+            _cachedHeaviness = new CachedStaticHeaviness(staticGrade, currentDefinition);
             return staticGrade;
         }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3251,7 +3251,8 @@ namespace Raven.Server.Documents.Indexes
                     if (calculateMemoryStats)
                         stats.Memory = GetMemoryStats();
 
-                    stats.HeavinessGrade = ComputeHeavinessGrade(stats, queryContext);
+                    if (queryContext != null)
+                        stats.HeavinessGrade = ComputeHeavinessGrade(stats, queryContext);
 
                     return stats;
                 }
@@ -3298,6 +3299,21 @@ namespace Raven.Server.Documents.Indexes
                         DocumentsOperationContext capturedContext = docsContext;
                         collectionDataProvider = collectionName =>
                         {
+                            if (string.Equals(collectionName, Constants.Documents.Collections.AllDocumentsCollection, StringComparison.OrdinalIgnoreCase))
+                            {
+                                long totalCountOfDocuments = 0;
+                                long totalDocumentsSizeInBytes = 0;
+
+                                foreach (string name in DocumentDatabase.DocumentsStorage.GetCollectionsNames(capturedContext))
+                                {
+                                    CollectionDetails collectionDetails = DocumentDatabase.DocumentsStorage.GetCollectionDetails(capturedContext, name);
+                                    totalCountOfDocuments += collectionDetails.CountOfDocuments;
+                                    totalDocumentsSizeInBytes += collectionDetails.DocumentsSize.SizeInBytes;
+                                }
+
+                                return (totalCountOfDocuments, totalDocumentsSizeInBytes);
+                            }
+
                             CollectionDetails details = DocumentDatabase.DocumentsStorage.GetCollectionDetails(capturedContext, collectionName);
                             return (details.CountOfDocuments, details.DocumentsSize.SizeInBytes);
                         };

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Raven.Client;
@@ -66,6 +67,8 @@ namespace Raven.Server.Documents.Indexes
         private const int PenaltyExtraLetClause = 2;      // per extra beyond 3
         private const int PenaltyWhere = 1;
         private const int PenaltyRecurse = 10;
+
+        private const int PenaltyTooComplexToAnalyze = 20;
 
         // 1.4 Structural penalties
         private const int PenaltyOutputReduceToCollection = 10;
@@ -145,8 +148,25 @@ namespace Raven.Server.Documents.Indexes
             IndexStats stats,
             CollectionDataProvider collectionDataProvider)
         {
-            var staticPenalties = new List<IndexHeavinessPenalty>();
-            int staticScore = ComputeStaticScore(definition, collections, staticPenalties);
+            IndexHeavinessGrade staticGrade = ComputeStaticGrade(definition, collections);
+            return ComputeFullGrade(staticGrade, collections, stats, collectionDataProvider);
+        }
+
+        /// <summary>
+        /// Computes the full heaviness grade using a pre-computed static grade.
+        /// Avoids re-parsing map expressions when the static grade is cached.
+        /// </summary>
+        /// <param name="staticGrade">A previously computed static grade (from <see cref="ComputeStaticGrade"/>).</param>
+        /// <param name="collections">Collections indexed by this index (from Index.Collections).</param>
+        /// <param name="stats">Current runtime stats for the index, used for runtime penalties.</param>
+        /// <param name="collectionDataProvider">Delegate to retrieve per-collection document count and total size.</param>
+        public static IndexHeavinessGrade ComputeFullGrade(
+            IndexHeavinessGrade staticGrade,
+            IEnumerable<string> collections,
+            IndexStats stats,
+            CollectionDataProvider collectionDataProvider)
+        {
+            int staticScore = staticGrade.StaticScore;
 
             double dataScaleMultiplier = 1.0;
             if (collectionDataProvider != null)
@@ -163,10 +183,10 @@ namespace Raven.Server.Documents.Indexes
             {
                 StaticScore = staticScore,
                 FullScore = Math.Round(fullScore, 2),
-                StaticGradeLabel = GetStaticLabel(staticScore),
+                StaticGradeLabel = staticGrade.StaticGradeLabel,
                 FullGradeLabel = GetFullLabel(fullScore),
                 DataScaleMultiplier = Math.Round(dataScaleMultiplier, 2),
-                StaticPenalties = staticPenalties,
+                StaticPenalties = staticGrade.StaticPenalties,
                 RuntimePenalties = runtimePenalties
             };
         }
@@ -330,9 +350,13 @@ namespace Raven.Server.Documents.Indexes
                 if (visitor.HasRecurse)
                     score += AddPenalty(penalties, "Recurse (unbounded recursive traversal)", PenaltyRecurse);
             }
+            catch (InvalidDataException)
+            {
+                score += AddPenalty(penalties, "Map expression too complex to fully analyze (stack depth exceeded)", PenaltyTooComplexToAnalyze);
+            }
             catch
             {
-                // Ignore parse errors; we simply skip map analysis for that expression
+                // Ignore benign parse errors; we simply skip map analysis for that expression
             }
 
             return score;

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
@@ -1,0 +1,491 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Raven.Client;
+using Raven.Client.Documents.DataArchival;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Spatial;
+using Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters;
+
+namespace Raven.Server.Documents.Indexes
+{
+    /// <summary>
+    /// Computes the Index Heaviness Grade based on the index definition (static score)
+    /// and optionally data scale and runtime observations (full score).
+    ///
+    /// Static score — based purely on the IndexDefinition, server-independent.
+    /// Full score   — StaticScore × DataScaleMultiplier + RuntimePenalties.
+    ///
+    /// All penalty values are intentionally hardcoded constants that evolve through code changes.
+    /// </summary>
+    internal static class IndexDefinitionHeavinessAnalyzer
+    {
+        // ───────────────────────── Label thresholds ─────────────────────────
+        // Static
+        private const int StaticSimpleMax = 10;
+        private const int StaticModerateMax = 25;
+        private const int StaticComplexMax = 50;
+
+        // Full
+        private const double FullLightMax = 20;
+        private const double FullModerateMax = 80;
+        private const double FullHeavyMax = 200;
+        private const double FullVeryHeavyMax = 500;
+
+        // ─────────────────── Tier 1: Static penalty constants ───────────────
+
+        // 1.1 Index type base cost
+        private const int PenaltyMapReduce = 10;
+        private const int PenaltyJavaScript = 5;
+        private const int PenaltyExtraMap = 3;         // per extra map beyond 1
+        private const int PenaltyTimeSeriesSource = 3;
+        private const int PenaltyCountersSource = 2;
+
+        // 1.2 Field penalties
+        private const int PenaltyFieldBase = 1;
+        private const int PenaltyFieldStorage = 1;
+        private const int PenaltyFieldSearch = 2;
+        private const int PenaltyFieldCustomAnalyzer = 1;
+        private const int PenaltyFieldSuggestions = 3;
+        private const int PenaltyFieldTermVector = 1;
+        private const int PenaltyFieldTermVectorPositionsAndOffsets = 2;  // replaces +1
+        private const int PenaltyFieldSpatial = 4;
+        private const int PenaltyFieldSpatialQuadTree = 2;                // on top of spatial
+        private const int PenaltyFieldVector = 8;
+        private const int PenaltyFieldVectorHighDimensions = 4;           // on top of vector, if > 512
+        private const int HighFieldCountThreshold = 10;
+        private const int PenaltyHighFieldCountPerExtra = 2;
+
+        // 1.3 Map complexity penalties
+        private const int PenaltyLoadDocument = 15;
+        private const int PenaltyExtraLoadDocument = 5;  // per extra beyond 1
+        private const int PenaltyFanout = 8;
+        private const int PenaltyNestedFanout = 10;
+        private const int LetClauseThreshold = 3;
+        private const int PenaltyExtraLetClause = 2;      // per extra beyond 3
+        private const int PenaltyWhere = 1;
+        private const int PenaltyRecurse = 10;
+
+        // 1.4 Structural penalties
+        private const int PenaltyOutputReduceToCollection = 10;
+        private const int PenaltyPatternForOutputReduceReferences = 3;
+        private const int PenaltyAdditionalSourcesBase = 3;
+        private const int PenaltyAdditionalSourcesPerFile = 1;
+        private const int PenaltyAdditionalAssembliesBase = 5;
+        private const int PenaltyAdditionalAssembliesPerAssembly = 2;
+        private const int PenaltyAllDocsCollection = 15;
+        private const int PenaltyArchivedDataProcessing = 2;
+
+        // ─────────────────── Tier 2: Runtime penalty constants ──────────────
+        private const int PenaltyMaxOutputsHigh = 5;       // > 100
+        private const int PenaltyMaxOutputsVeryHigh = 10;  // > 1024 (on top)
+        private const int PenaltyReferenceLoadWarning = 10;
+        private const double ErrorRateThresholdHigh = 0.05;
+        private const double ErrorRateThresholdInvalid = 0.15;
+        private const int PenaltyErrorRateHigh = 5;
+        private const int PenaltyErrorRateInvalid = 10;
+
+        // ─────────────────── Collection size factors ────────────────────────
+        private static double GetCollectionSizeFactor(long count)
+        {
+            if (count < 1_000) return 0.5;
+            if (count < 10_000) return 1.0;
+            if (count < 100_000) return 2.0;
+            if (count < 1_000_000) return 4.0;
+            if (count < 10_000_000) return 8.0;
+            return 15.0;
+        }
+
+        // ─────────────────── Document size factors ──────────────────────────
+        private static double GetDocumentSizeFactor(long avgDocSizeBytes)
+        {
+            if (avgDocSizeBytes < 1_024) return 0.8;
+            if (avgDocSizeBytes < 10 * 1_024) return 1.0;
+            if (avgDocSizeBytes < 100 * 1_024) return 1.5;
+            if (avgDocSizeBytes < 1_024 * 1_024) return 2.5;
+            return 4.0;
+        }
+
+        /// <summary>
+        /// Computes the static-only heaviness grade from an index definition.
+        /// No server context required. Suitable for pre-flight analysis.
+        /// </summary>
+        /// <param name="definition">The index definition to analyze.</param>
+        /// <param name="collections">
+        /// Optional collection names indexed by this index. When null, the @all_docs structural penalty
+        /// will be skipped. Use <see cref="ExtractCollectionsFromMaps"/> to populate this from the definition maps.
+        /// </param>
+        public static IndexHeavinessGrade ComputeStaticGrade(IndexDefinition definition, IEnumerable<string> collections = null)
+        {
+            var staticPenalties = new List<IndexHeavinessPenalty>();
+            int staticScore = ComputeStaticScore(definition, collections, staticPenalties);
+
+            return new IndexHeavinessGrade
+            {
+                StaticScore = staticScore,
+                FullScore = staticScore,
+                StaticGradeLabel = GetStaticLabel(staticScore),
+                FullGradeLabel = GetFullLabel(staticScore),
+                DataScaleMultiplier = 1.0,
+                StaticPenalties = staticPenalties,
+                RuntimePenalties = new List<IndexHeavinessPenalty>()
+            };
+        }
+
+        /// <summary>
+        /// Computes the full heaviness grade including data scale modifiers and runtime observations.
+        /// </summary>
+        /// <param name="definition">The index definition.</param>
+        /// <param name="collections">Collections indexed by this index (from Index.Collections).</param>
+        /// <param name="stats">Current runtime stats for the index, used for runtime penalties.</param>
+        /// <param name="collectionDataProvider">Delegate to retrieve per-collection document count and total size.</param>
+        public static IndexHeavinessGrade ComputeFullGrade(
+            IndexDefinition definition,
+            IEnumerable<string> collections,
+            IndexStats stats,
+            CollectionDataProvider collectionDataProvider)
+        {
+            var staticPenalties = new List<IndexHeavinessPenalty>();
+            int staticScore = ComputeStaticScore(definition, collections, staticPenalties);
+
+            double dataScaleMultiplier = 1.0;
+            if (collectionDataProvider != null)
+                dataScaleMultiplier = ComputeDataScaleMultiplier(collections, collectionDataProvider);
+
+            var runtimePenalties = new List<IndexHeavinessPenalty>();
+            double runtimeScore = 0;
+            if (stats != null)
+                runtimeScore = ComputeRuntimePenalties(stats, runtimePenalties);
+
+            double fullScore = staticScore * dataScaleMultiplier + runtimeScore;
+
+            return new IndexHeavinessGrade
+            {
+                StaticScore = staticScore,
+                FullScore = Math.Round(fullScore, 2),
+                StaticGradeLabel = GetStaticLabel(staticScore),
+                FullGradeLabel = GetFullLabel(fullScore),
+                DataScaleMultiplier = Math.Round(dataScaleMultiplier, 2),
+                StaticPenalties = staticPenalties,
+                RuntimePenalties = runtimePenalties
+            };
+        }
+
+        private static int ComputeStaticScore(IndexDefinition definition, IEnumerable<string> collections, List<IndexHeavinessPenalty> penalties)
+        {
+            int score = 0;
+
+            // 1.1 Index type base cost
+            if (definition.Reduce != null)
+                score += AddPenalty(penalties, "MapReduce index (reduce phase)", PenaltyMapReduce);
+
+            bool isJavaScript = definition.Type.IsJavaScript();
+            if (isJavaScript)
+                score += AddPenalty(penalties, "JavaScript index (Jint interpreter overhead)", PenaltyJavaScript);
+
+            int mapCount = definition.Maps?.Count ?? 0;
+            if (mapCount > 1)
+            {
+                int extraMaps = mapCount - 1;
+                score += AddPenalty(penalties, $"Multi-map index ({extraMaps} extra map(s))", PenaltyExtraMap * extraMaps);
+            }
+
+            IndexSourceType sourceType = definition.SourceType;
+            if (sourceType == IndexSourceType.TimeSeries)
+                score += AddPenalty(penalties, "TimeSeries source type", PenaltyTimeSeriesSource);
+            else if (sourceType == IndexSourceType.Counters)
+                score += AddPenalty(penalties, "Counters source type", PenaltyCountersSource);
+
+            // 1.2 Field penalties
+            int fieldCount = 0;
+            if (definition.Fields != null)
+            {
+                foreach (var (fieldName, opts) in definition.Fields)
+                {
+                    if (opts == null)
+                        continue;
+
+                    if (fieldName == Constants.Documents.Indexing.Fields.AllFields)
+                        continue; // skip the special @all_fields entry
+
+                    fieldCount++;
+                    score += AddPenalty(penalties, $"Field '{fieldName}' (baseline)", PenaltyFieldBase);
+
+                    if (opts.Storage == FieldStorage.Yes)
+                        score += AddPenalty(penalties, $"Field '{fieldName}': Storage=Yes", PenaltyFieldStorage);
+
+                    if (opts.Indexing == FieldIndexing.Search)
+                        score += AddPenalty(penalties, $"Field '{fieldName}': Indexing=Search (full-text)", PenaltyFieldSearch);
+
+                    if (string.IsNullOrEmpty(opts.Analyzer) == false)
+                        score += AddPenalty(penalties, $"Field '{fieldName}': custom Analyzer", PenaltyFieldCustomAnalyzer);
+
+                    if (opts.Suggestions == true)
+                        score += AddPenalty(penalties, $"Field '{fieldName}': Suggestions=true (NGram)", PenaltyFieldSuggestions);
+
+                    if (opts.TermVector.HasValue && opts.TermVector.Value != FieldTermVector.No)
+                    {
+                        if (opts.TermVector.Value == FieldTermVector.WithPositionsAndOffsets)
+                            score += AddPenalty(penalties, $"Field '{fieldName}': TermVector=WithPositionsAndOffsets", PenaltyFieldTermVectorPositionsAndOffsets);
+                        else
+                            score += AddPenalty(penalties, $"Field '{fieldName}': TermVector={opts.TermVector.Value}", PenaltyFieldTermVector);
+                    }
+
+                    if (opts.Spatial != null)
+                    {
+                        score += AddPenalty(penalties, $"Field '{fieldName}': Spatial options (geospatial index)", PenaltyFieldSpatial);
+                        if (opts.Spatial.Strategy == SpatialSearchStrategy.QuadPrefixTree)
+                            score += AddPenalty(penalties, $"Field '{fieldName}': Spatial Strategy=QuadPrefixTree", PenaltyFieldSpatialQuadTree);
+                    }
+
+                    if (opts.Vector != null)
+                    {
+                        score += AddPenalty(penalties, $"Field '{fieldName}': Vector options (HNSW graph)", PenaltyFieldVector);
+                        if (opts.Vector.Dimensions > 512)
+                            score += AddPenalty(penalties, $"Field '{fieldName}': Vector Dimensions > 512", PenaltyFieldVectorHighDimensions);
+                    }
+                }
+
+                if (fieldCount > HighFieldCountThreshold)
+                {
+                    int extra = fieldCount - HighFieldCountThreshold;
+                    score += AddPenalty(penalties, $"High field count ({fieldCount} fields, {extra} beyond threshold of {HighFieldCountThreshold})", PenaltyHighFieldCountPerExtra * extra);
+                }
+            }
+
+            // 1.3 Map complexity (Roslyn AST analysis)
+            if (!isJavaScript)
+            {
+                foreach (string map in definition.Maps ?? new HashSet<string>())
+                    score += AnalyzeMapExpression(map, penalties);
+            }
+
+            // 1.4 Structural penalties
+            if (string.IsNullOrEmpty(definition.OutputReduceToCollection) == false)
+            {
+                score += AddPenalty(penalties, "OutputReduceToCollection (secondary write load)", PenaltyOutputReduceToCollection);
+                if (string.IsNullOrEmpty(definition.PatternForOutputReduceToCollectionReferences) == false)
+                    score += AddPenalty(penalties, "PatternForOutputReduceToCollectionReferences (extra reference documents)", PenaltyPatternForOutputReduceReferences);
+            }
+
+            int additionalSourcesCount = definition.AdditionalSources?.Count ?? 0;
+            if (additionalSourcesCount > 0)
+                score += AddPenalty(penalties, $"AdditionalSources ({additionalSourcesCount} file(s))", PenaltyAdditionalSourcesBase + PenaltyAdditionalSourcesPerFile * additionalSourcesCount);
+
+            int additionalAssembliesCount = definition.AdditionalAssemblies?.Count ?? 0;
+            if (additionalAssembliesCount > 0)
+                score += AddPenalty(penalties, $"AdditionalAssemblies ({additionalAssembliesCount} assembly/assemblies)", PenaltyAdditionalAssembliesBase + PenaltyAdditionalAssembliesPerAssembly * additionalAssembliesCount);
+
+            bool indexesAllDocs = collections?.Contains(Constants.Documents.Collections.AllDocumentsCollection, StringComparer.OrdinalIgnoreCase) == true;
+            if (indexesAllDocs)
+                score += AddPenalty(penalties, "@all_docs collection (indexes every document in the database)", PenaltyAllDocsCollection);
+
+            if (definition.ArchivedDataProcessingBehavior.HasValue &&
+                definition.ArchivedDataProcessingBehavior.Value != ArchivedDataProcessingBehavior.ExcludeArchived)
+                score += AddPenalty(penalties, $"ArchivedDataProcessingBehavior={definition.ArchivedDataProcessingBehavior.Value}", PenaltyArchivedDataProcessing);
+
+            return score;
+        }
+
+        private static int AnalyzeMapExpression(string mapExpression, List<IndexHeavinessPenalty> penalties)
+        {
+            if (string.IsNullOrWhiteSpace(mapExpression))
+                return 0;
+
+            int score = 0;
+
+            try
+            {
+                var tree = CSharpSyntaxTree.ParseText(mapExpression);
+                var root = tree.GetRoot();
+
+                var visitor = new IndexMapComplexityVisitor();
+                visitor.Visit(root);
+
+                if (visitor.LoadDocumentCount > 0)
+                {
+                    score += AddPenalty(penalties, "LoadDocument (cascading re-indexing)", PenaltyLoadDocument);
+                    if (visitor.LoadDocumentCount > 1)
+                    {
+                        int extraLoads = visitor.LoadDocumentCount - 1;
+                        score += AddPenalty(penalties, $"Multiple LoadDocument calls ({extraLoads} extra)", PenaltyExtraLoadDocument * extraLoads);
+                    }
+                }
+
+                if (visitor.HasFanout)
+                    score += AddPenalty(penalties, "Fanout (SelectMany / multiple from clauses)", PenaltyFanout);
+
+                if (visitor.HasNestedFanout)
+                    score += AddPenalty(penalties, "Nested fanout (cartesian product risk)", PenaltyNestedFanout);
+
+                if (visitor.LetClauseCount > LetClauseThreshold)
+                {
+                    int extra = visitor.LetClauseCount - LetClauseThreshold;
+                    score += AddPenalty(penalties, $"Many let clauses ({visitor.LetClauseCount} total, {extra} beyond threshold of {LetClauseThreshold})", PenaltyExtraLetClause * extra);
+                }
+
+                if (visitor.HasWhereClause)
+                    score += AddPenalty(penalties, "Where clause in map (per-document evaluation)", PenaltyWhere);
+
+                if (visitor.HasRecurse)
+                    score += AddPenalty(penalties, "Recurse (unbounded recursive traversal)", PenaltyRecurse);
+            }
+            catch
+            {
+                // Ignore parse errors; we simply skip map analysis for that expression
+            }
+
+            return score;
+        }
+
+        private static double ComputeDataScaleMultiplier(IEnumerable<string> collections, CollectionDataProvider provider)
+        {
+            if (provider == null)
+                return 1.0;
+
+            long totalDocs = 0;
+            long totalSizeBytes = 0;
+            int collectionCount = 0;
+
+            foreach (string collection in collections ?? Enumerable.Empty<string>())
+            {
+                (long count, long sizeBytes) = provider(collection);
+                totalDocs += count;
+                totalSizeBytes += sizeBytes;
+                collectionCount++;
+            }
+
+            if (collectionCount == 0)
+                return 1.0;
+
+            double sizeFactor = GetCollectionSizeFactor(totalDocs);
+            double avgDocSizeBytes = totalDocs > 0 ? (double)totalSizeBytes / totalDocs : 0;
+            double docSizeFactor = GetDocumentSizeFactor((long)avgDocSizeBytes);
+
+            return sizeFactor * docSizeFactor;
+        }
+
+        private static double ComputeRuntimePenalties(IndexStats stats, List<IndexHeavinessPenalty> penalties)
+        {
+            double score = 0;
+
+            if (stats.MaxNumberOfOutputsPerDocument > 1024)
+            {
+                score += AddPenalty(penalties, $"MaxNumberOfOutputsPerDocument={stats.MaxNumberOfOutputsPerDocument} (> 1024)", PenaltyMaxOutputsHigh + PenaltyMaxOutputsVeryHigh);
+            }
+            else if (stats.MaxNumberOfOutputsPerDocument > 100)
+            {
+                score += AddPenalty(penalties, $"MaxNumberOfOutputsPerDocument={stats.MaxNumberOfOutputsPerDocument} (> 100)", PenaltyMaxOutputsHigh);
+            }
+
+            long mapAttempts = (stats.MapAttempts + (stats.MapReferenceAttempts ?? 0));
+            long mapErrors = (stats.MapErrors + (stats.MapReferenceErrors ?? 0));
+            long reduceAttempts = stats.ReduceAttempts ?? 0;
+            long reduceErrors = stats.ReduceErrors ?? 0;
+            long totalAttempts = mapAttempts + reduceAttempts;
+            long totalErrors = mapErrors + reduceErrors;
+
+            if (totalAttempts > 0)
+            {
+                double errorRate = (double)totalErrors / totalAttempts;
+                if (errorRate > ErrorRateThresholdInvalid)
+                    score += AddPenalty(penalties, $"Error rate > {ErrorRateThresholdInvalid * 100:0}% (index likely invalid)", PenaltyErrorRateHigh + PenaltyErrorRateInvalid);
+                else if (errorRate > ErrorRateThresholdHigh)
+                    score += AddPenalty(penalties, $"Error rate > {ErrorRateThresholdHigh * 100:0}%", PenaltyErrorRateHigh);
+            }
+
+            return score;
+        }
+
+        private static int AddPenalty(List<IndexHeavinessPenalty> penalties, string reason, int score)
+        {
+            penalties.Add(new IndexHeavinessPenalty { Reason = reason, Score = score });
+            return score;
+        }
+
+        private static double AddPenalty(List<IndexHeavinessPenalty> penalties, string reason, double score)
+        {
+            penalties.Add(new IndexHeavinessPenalty { Reason = reason, Score = score });
+            return score;
+        }
+
+        private static string GetStaticLabel(int score)
+        {
+            if (score <= StaticSimpleMax) return "Simple";
+            if (score <= StaticModerateMax) return "Moderate";
+            if (score <= StaticComplexMax) return "Complex";
+            return "Very Complex";
+        }
+
+        private static string GetFullLabel(double score)
+        {
+            if (score <= FullLightMax) return "Light";
+            if (score <= FullModerateMax) return "Moderate";
+            if (score <= FullHeavyMax) return "Heavy";
+            if (score <= FullVeryHeavyMax) return "Very Heavy";
+            return "Extreme";
+        }
+
+        /// <summary>
+        /// Attempts to extract collection names from the map expressions of an IndexDefinition using Roslyn.
+        /// Returns null if parsing fails.
+        /// </summary>
+        internal static HashSet<string> ExtractCollectionsFromMaps(IndexDefinition definition)
+        {
+            if (definition.Maps == null || definition.Maps.Count == 0)
+                return null;
+
+            var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string map in definition.Maps)
+            {
+                if (string.IsNullOrWhiteSpace(map))
+                    continue;
+
+                try
+                {
+                    var tree = CSharpSyntaxTree.ParseText(map);
+                    var root = tree.GetRoot();
+
+                    // Try query syntax first, then method syntax
+                    var querySyntaxRetriever = CollectionNameRetriever.QuerySyntax;
+                    querySyntaxRetriever.Visit(root);
+
+                    if (querySyntaxRetriever.CollectionNames?.Length > 0)
+                    {
+                        foreach (string name in querySyntaxRetriever.CollectionNames)
+                            collections.Add(name);
+                        continue;
+                    }
+
+                    var methodSyntaxRetriever = CollectionNameRetriever.MethodSyntax;
+                    methodSyntaxRetriever.Visit(root);
+
+                    if (methodSyntaxRetriever.CollectionNames?.Length > 0)
+                    {
+                        foreach (string name in methodSyntaxRetriever.CollectionNames)
+                            collections.Add(name);
+                    }
+                    else
+                    {
+                        // No specific collection found means @all_docs
+                        collections.Add(Constants.Documents.Collections.AllDocumentsCollection);
+                    }
+                }
+                catch
+                {
+                    // Ignore parse errors
+                }
+            }
+
+            return collections.Count > 0 ? collections : null;
+        }
+
+        /// <summary>
+        /// Abstraction to retrieve per-collection document count and total size in bytes.
+        /// Separates the analyzer from DocumentsStorage to allow testing without a database.
+        /// </summary>
+        internal delegate (long Count, long TotalSizeBytes) CollectionDataProvider(string collectionName);
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
@@ -463,6 +463,9 @@ namespace Raven.Server.Documents.Indexes
             if (definition.Maps == null || definition.Maps.Count == 0)
                 return null;
 
+            if (definition.Type.IsJavaScript())
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { Constants.Documents.Collections.AllDocumentsCollection };
+
             var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (string map in definition.Maps)

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
@@ -137,6 +137,9 @@ namespace Raven.Server.Documents.Indexes
 
         /// <summary>
         /// Computes the full heaviness grade including data scale modifiers and runtime observations.
+        /// This convenience overload recomputes the static grade on every call (involves Roslyn parsing).
+        /// For repeated calls on the same index definition, prefer caching the static grade via
+        /// <see cref="ComputeStaticGrade"/> and using the <see cref="ComputeFullGrade(IndexHeavinessGrade, IEnumerable{string}, IndexStats, CollectionDataProvider)"/> overload.
         /// </summary>
         /// <param name="definition">The index definition.</param>
         /// <param name="collections">Collections indexed by this index (from Index.Collections).</param>

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
@@ -80,7 +80,6 @@ namespace Raven.Server.Documents.Indexes
         // ─────────────────── Tier 2: Runtime penalty constants ──────────────
         private const int PenaltyMaxOutputsHigh = 5;       // > 100
         private const int PenaltyMaxOutputsVeryHigh = 10;  // > 1024 (on top)
-        private const int PenaltyReferenceLoadWarning = 10;
         private const double ErrorRateThresholdHigh = 0.05;
         private const double ErrorRateThresholdInvalid = 0.15;
         private const int PenaltyErrorRateHigh = 5;
@@ -242,7 +241,7 @@ namespace Raven.Server.Documents.Indexes
                     if (opts.Vector != null)
                     {
                         score += AddPenalty(penalties, $"Field '{fieldName}': Vector options (HNSW graph)", PenaltyFieldVector);
-                        if (opts.Vector.Dimensions > 512)
+                        if (opts.Vector.Dimensions is > 512)
                             score += AddPenalty(penalties, $"Field '{fieldName}': Vector Dimensions > 512", PenaltyFieldVectorHighDimensions);
                     }
                 }
@@ -297,11 +296,11 @@ namespace Raven.Server.Documents.Indexes
 
             try
             {
-                var tree = CSharpSyntaxTree.ParseText(mapExpression);
-                var root = tree.GetRoot();
+                var normalizedMap = Static.IndexCompiler.NormalizeFunction(mapExpression);
+                var expression = SyntaxFactory.ParseExpression(normalizedMap);
 
                 var visitor = new IndexMapComplexityVisitor();
-                visitor.Visit(root);
+                visitor.Visit(expression);
 
                 if (visitor.LoadDocumentCount > 0)
                 {
@@ -445,12 +444,12 @@ namespace Raven.Server.Documents.Indexes
 
                 try
                 {
-                    var tree = CSharpSyntaxTree.ParseText(map);
-                    var root = tree.GetRoot();
+                    var normalizedMap = Static.IndexCompiler.NormalizeFunction(map);
+                    var expression = SyntaxFactory.ParseExpression(normalizedMap);
 
                     // Try query syntax first, then method syntax
                     var querySyntaxRetriever = CollectionNameRetriever.QuerySyntax;
-                    querySyntaxRetriever.Visit(root);
+                    querySyntaxRetriever.Visit(expression);
 
                     if (querySyntaxRetriever.CollectionNames?.Length > 0)
                     {
@@ -460,7 +459,7 @@ namespace Raven.Server.Documents.Indexes
                     }
 
                     var methodSyntaxRetriever = CollectionNameRetriever.MethodSyntax;
-                    methodSyntaxRetriever.Visit(root);
+                    methodSyntaxRetriever.Visit(expression);
 
                     if (methodSyntaxRetriever.CollectionNames?.Length > 0)
                     {

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
@@ -436,21 +436,21 @@ namespace Raven.Server.Documents.Indexes
             return score;
         }
 
-        private static string GetStaticLabel(int score)
+        private static IndexStaticGrade GetStaticLabel(int score)
         {
-            if (score <= StaticSimpleMax) return "Simple";
-            if (score <= StaticModerateMax) return "Moderate";
-            if (score <= StaticComplexMax) return "Complex";
-            return "Very Complex";
+            if (score <= StaticSimpleMax) return IndexStaticGrade.Simple;
+            if (score <= StaticModerateMax) return IndexStaticGrade.Moderate;
+            if (score <= StaticComplexMax) return IndexStaticGrade.Complex;
+            return IndexStaticGrade.VeryComplex;
         }
 
-        private static string GetFullLabel(double score)
+        private static IndexFullGrade GetFullLabel(double score)
         {
-            if (score <= FullLightMax) return "Light";
-            if (score <= FullModerateMax) return "Moderate";
-            if (score <= FullHeavyMax) return "Heavy";
-            if (score <= FullVeryHeavyMax) return "Very Heavy";
-            return "Extreme";
+            if (score <= FullLightMax) return IndexFullGrade.Lightweight;
+            if (score <= FullModerateMax) return IndexFullGrade.Moderate;
+            if (score <= FullHeavyMax) return IndexFullGrade.Heavy;
+            if (score <= FullVeryHeavyMax) return IndexFullGrade.VeryHeavy;
+            return IndexFullGrade.Extreme;
         }
 
         /// <summary>

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Acornima;
+using Acornima.Ast;
 using Microsoft.CodeAnalysis.CSharp;
 using Raven.Client;
 using Raven.Client.Documents.DataArchival;
@@ -464,7 +466,10 @@ namespace Raven.Server.Documents.Indexes
                 return null;
 
             if (definition.Type.IsJavaScript())
-                return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { Constants.Documents.Collections.AllDocumentsCollection };
+            {
+                HashSet<string> jsCollections = ExtractCollectionsFromJavaScriptMaps(definition.Maps);
+                return jsCollections?.Count > 0 ? jsCollections : null;
+            }
 
             var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -505,11 +510,56 @@ namespace Raven.Server.Documents.Indexes
                 }
                 catch
                 {
-                    // Ignore parse errors
+                    collections.Add(Constants.Documents.Collections.AllDocumentsCollection);
                 }
             }
 
             return collections.Count > 0 ? collections : null;
+        }
+
+        private static HashSet<string> ExtractCollectionsFromJavaScriptMaps(ISet<string> maps)
+        {
+            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var parser = new Parser(new ParserOptions { Tolerant = true });
+
+            foreach (string map in maps)
+            {
+                if (string.IsNullOrWhiteSpace(map))
+                    continue;
+
+                try
+                {
+                    Script script = parser.ParseScript(map);
+
+                    foreach (Statement stmt in script.Body)
+                    {
+                        if (stmt is not ExpressionStatement { Expression: CallExpression call })
+                            continue;
+
+                        if (call.Callee is not Identifier { Name: "map" } || call.Arguments.Count == 0)
+                            continue;
+
+                        if (call.Arguments[0] is Literal { Value: string col })
+                        {
+                            result.Add(col);
+                        }
+                        else if (call.Arguments[0] is ArrayExpression arr)
+                        {
+                            foreach (var element in arr.Elements)
+                            {
+                                if (element is Literal { Value: string elemCol })
+                                    result.Add(elemCol);
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    // Skip maps that cannot be parsed
+                }
+            }
+
+            return result;
         }
 
         /// <summary>

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionHeavinessAnalyzer.cs
@@ -297,7 +297,7 @@ namespace Raven.Server.Documents.Indexes
 
             int additionalAssembliesCount = definition.AdditionalAssemblies?.Count ?? 0;
             if (additionalAssembliesCount > 0)
-                score += AddPenalty(penalties, $"AdditionalAssemblies ({additionalAssembliesCount} assembly/assemblies)", PenaltyAdditionalAssembliesBase + PenaltyAdditionalAssembliesPerAssembly * additionalAssembliesCount);
+                score += AddPenalty(penalties, $"AdditionalAssemblies ({additionalAssembliesCount} {(additionalAssembliesCount == 1 ? "assembly" : "assemblies")})", PenaltyAdditionalAssembliesBase + PenaltyAdditionalAssembliesPerAssembly * additionalAssembliesCount);
 
             bool indexesAllDocs = collections?.Contains(Constants.Documents.Collections.AllDocumentsCollection, StringComparer.OrdinalIgnoreCase) == true;
             if (indexesAllDocs)
@@ -455,7 +455,8 @@ namespace Raven.Server.Documents.Indexes
 
         /// <summary>
         /// Attempts to extract collection names from the map expressions of an IndexDefinition using Roslyn.
-        /// Returns null if parsing fails.
+        /// Returns null if no collections could be extracted (all maps failed to parse or yielded no names).
+        /// Parse errors for individual maps are silently skipped; extraction continues with remaining maps.
         /// </summary>
         internal static HashSet<string> ExtractCollectionsFromMaps(IndexDefinition definition)
         {

--- a/src/Raven.Server/Documents/Indexes/IndexMapComplexityVisitor.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMapComplexityVisitor.cs
@@ -20,7 +20,6 @@ namespace Raven.Server.Documents.Indexes
         public bool HasWhereClause { get; private set; }
         public bool HasRecurse { get; private set; }
 
-        private int _fanoutDepth;
         private readonly HashSet<SyntaxNode> _visitedFanoutNodes = new();
 
         public override void VisitInvocationExpression(InvocationExpressionSyntax node)

--- a/src/Raven.Server/Documents/Indexes/IndexMapComplexityVisitor.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMapComplexityVisitor.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Raven.Server.Documents.Indexes
+{
+    /// <summary>
+    /// Roslyn syntax visitor that collects map complexity metrics from an index map function
+    /// for use in computing the index heaviness static score.
+    /// </summary>
+    internal sealed class IndexMapComplexityVisitor : CSharpSyntaxWalker
+    {
+        public int LoadDocumentCount { get; private set; }
+        public bool HasFanout { get; private set; }
+        public bool HasNestedFanout { get; private set; }
+        public int LetClauseCount { get; private set; }
+        public bool HasWhereClause { get; private set; }
+        public bool HasRecurse { get; private set; }
+
+        private int _fanoutDepth;
+        private readonly HashSet<SyntaxNode> _visitedFanoutNodes = new();
+
+        public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            AssertSufficientStack();
+
+            string methodName = null;
+
+            if (node.Expression is MemberAccessExpressionSyntax memberAccess)
+                methodName = memberAccess.Name.Identifier.ValueText;
+            else if (node.Expression is IdentifierNameSyntax identifier)
+                methodName = identifier.Identifier.ValueText;
+
+            switch (methodName)
+            {
+                case "LoadDocument":
+                    LoadDocumentCount++;
+                    break;
+
+                case "SelectMany":
+                    TrackFanout(node);
+                    break;
+
+                case "Where":
+                    HasWhereClause = true;
+                    break;
+
+                case "Recurse":
+                    HasRecurse = true;
+                    break;
+            }
+
+            base.VisitInvocationExpression(node);
+        }
+
+        public override void VisitQueryExpression(QueryExpressionSyntax node)
+        {
+            AssertSufficientStack();
+
+            // A query expression with multiple from clauses indicates fanout
+            int additionalFromCount = 0;
+            foreach (var clause in node.Body.Clauses)
+            {
+                if (clause is FromClauseSyntax)
+                    additionalFromCount++;
+            }
+
+            if (additionalFromCount > 0)
+            {
+                if (HasFanout)
+                    HasNestedFanout = true;
+                HasFanout = true;
+            }
+
+            base.VisitQueryExpression(node);
+        }
+
+        public override void VisitLetClause(LetClauseSyntax node)
+        {
+            AssertSufficientStack();
+            LetClauseCount++;
+            base.VisitLetClause(node);
+        }
+
+        public override void VisitWhereClause(WhereClauseSyntax node)
+        {
+            AssertSufficientStack();
+            HasWhereClause = true;
+            base.VisitWhereClause(node);
+        }
+
+        private void TrackFanout(SyntaxNode node)
+        {
+            if (_visitedFanoutNodes.Contains(node))
+                return;
+
+            _visitedFanoutNodes.Add(node);
+
+            if (HasFanout)
+                HasNestedFanout = true;
+
+            HasFanout = true;
+        }
+
+        private void AssertSufficientStack()
+        {
+            if (RuntimeHelpers.TryEnsureSufficientExecutionStack() == false)
+                throw new InvalidDataException("Index map expression is too complex to analyze.");
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/IndexMapComplexityVisitor.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMapComplexityVisitor.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -20,6 +21,11 @@ namespace Raven.Server.Documents.Indexes
         public bool HasWhereClause { get; private set; }
         public bool HasRecurse { get; private set; }
 
+        private const string MethodLoadDocument = "LoadDocument";
+        private const string MethodSelectMany = nameof(Enumerable.SelectMany);
+        private const string MethodWhere = nameof(Enumerable.Where);
+        private const string MethodRecurse = "Recurse";
+
         private readonly HashSet<SyntaxNode> _visitedFanoutNodes = new();
 
         public override void VisitInvocationExpression(InvocationExpressionSyntax node)
@@ -35,19 +41,19 @@ namespace Raven.Server.Documents.Indexes
 
             switch (methodName)
             {
-                case "LoadDocument":
+                case MethodLoadDocument:
                     LoadDocumentCount++;
                     break;
 
-                case "SelectMany":
+                case MethodSelectMany:
                     TrackFanout(node);
                     break;
 
-                case "Where":
+                case MethodWhere:
                     HasWhereClause = true;
                     break;
 
-                case "Recurse":
+                case MethodRecurse:
                     HasRecurse = true;
                     break;
             }

--- a/src/Raven.Server/Documents/Indexes/IndexMapComplexityVisitor.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMapComplexityVisitor.cs
@@ -69,7 +69,7 @@ namespace Raven.Server.Documents.Indexes
 
             if (additionalFromCount > 0)
             {
-                if (HasFanout)
+                if (HasFanout || additionalFromCount > 1)
                     HasNestedFanout = true;
                 HasFanout = true;
             }

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -983,7 +983,7 @@ namespace Raven.Server.Documents.Indexes.Static
             return $"{IndexNamePrefix}{Regex.Replace(name, @"[^\w\d]", "_")}";
         }
 
-        private static string NormalizeFunction(string function)
+        internal static string NormalizeFunction(string function)
         {
             return function?.Trim().TrimEnd(';');
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Indexes/ShardedIndexHandlerProcessorForAnalyzeHeaviness.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Indexes/ShardedIndexHandlerProcessorForAnalyzeHeaviness.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Json;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Indexes;
+
+internal sealed class ShardedIndexHandlerProcessorForAnalyzeHeaviness : AbstractDatabaseHandlerProcessor<ShardedDatabaseRequestHandler, TransactionOperationContext>
+{
+    public ShardedIndexHandlerProcessorForAnalyzeHeaviness([NotNull] ShardedDatabaseRequestHandler requestHandler)
+        : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
+        using (var json = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "index/definition"))
+        {
+            IndexDefinition indexDefinition = JsonDeserializationServer.IndexDefinition(json);
+
+            if (indexDefinition == null || indexDefinition.Maps.Count == 0)
+                throw new BadRequestException("Index definition must contain at least one map.");
+
+            HashSet<string> collections = IndexDefinitionHeavinessAnalyzer.ExtractCollectionsFromMaps(indexDefinition);
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(indexDefinition, collections);
+
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                DynamicJsonValue djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(grade);
+                writer.WriteObject(context.ReadObject(djv, "index/heaviness-grade"));
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIndexHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIndexHandler.cs
@@ -200,6 +200,13 @@ namespace Raven.Server.Documents.Sharding.Handlers
             using (var processor = new IndexHandlerProcessorForConvertAutoIndex<ShardedDatabaseRequestHandler, TransactionOperationContext>(this))
                 await processor.ExecuteAsync();
         }
+
+        [RavenShardedAction("/databases/*/indexes/heaviness/analyze", "POST")]
+        public async Task AnalyzeHeaviness()
+        {
+            using (var processor = new ShardedIndexHandlerProcessorForAnalyzeHeaviness(this))
+                await processor.ExecuteAsync();
+        }
     }
 }
 

--- a/test/FastTests/Server/Documents/Indexing/IndexHeavinessGradeTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/IndexHeavinessGradeTests.cs
@@ -1,0 +1,335 @@
+using System.Collections.Generic;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Spatial;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Server.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Server.Documents.Indexing
+{
+    public class IndexHeavinessGradeTests : NoDisposalNeeded
+    {
+        public IndexHeavinessGradeTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void SimpleMapIndex_HasLowStaticScore()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Orders/ByCompany",
+                Maps = { "from order in docs.Orders select new { order.Company }" },
+                Fields = new Dictionary<string, IndexFieldOptions>
+                {
+                    { "Company", new IndexFieldOptions { Indexing = FieldIndexing.Default } }
+                }
+            };
+
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition);
+
+            Assert.True(grade.StaticScore <= 10, $"Expected simple index to have static score <= 10 but got {grade.StaticScore}");
+            Assert.Equal("Simple", grade.StaticGradeLabel);
+            Assert.NotNull(grade.StaticPenalties);
+            Assert.True(grade.StaticPenalties.Count > 0);
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void MapReduceIndex_HasHigherStaticScore()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Orders/ByCompany/Count",
+                Maps = { "from order in docs.Orders select new { order.Company, Count = 1 }" },
+                Reduce = "from result in results group result by result.Company into g select new { Company = g.Key, Count = g.Sum(x => x.Count) }",
+                Fields = new Dictionary<string, IndexFieldOptions>
+                {
+                    { "Company", new IndexFieldOptions { Indexing = FieldIndexing.Default } },
+                    { "Count", new IndexFieldOptions { Indexing = FieldIndexing.Default } }
+                }
+            };
+
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition);
+
+            // MapReduce penalty = 10 + 2 fields = 12
+            Assert.True(grade.StaticScore >= 11, $"Expected map-reduce index to have static score >= 11 but got {grade.StaticScore}");
+            Assert.True(grade.StaticScore <= 25, $"Expected map-reduce index to have static score <= 25 but got {grade.StaticScore}");
+            Assert.Equal("Moderate", grade.StaticGradeLabel);
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void MultiMapIndex_HasExtraPenaltyPerMap()
+        {
+            IndexDefinition singleMapDef = new IndexDefinition
+            {
+                Name = "SingleMap",
+                Maps = { "from o in docs.Orders select new { o.Company }" }
+            };
+
+            IndexDefinition multiMapDef = new IndexDefinition
+            {
+                Name = "MultiMap",
+                Maps = {
+                    "from o in docs.Orders select new { o.Company }",
+                    "from p in docs.Products select new { Company = p.Supplier }"
+                }
+            };
+
+            IndexHeavinessGrade singleGrade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(singleMapDef);
+            IndexHeavinessGrade multiGrade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(multiMapDef);
+
+            Assert.True(multiGrade.StaticScore > singleGrade.StaticScore,
+                $"Multi-map should score higher than single-map. Single={singleGrade.StaticScore}, Multi={multiGrade.StaticScore}");
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void FullTextSearchField_AddsSearchPenalty()
+        {
+            IndexDefinition withoutSearch = new IndexDefinition
+            {
+                Name = "Without/Search",
+                Maps = { "from doc in docs.Products select new { doc.Name }" },
+                Fields = new Dictionary<string, IndexFieldOptions>
+                {
+                    { "Name", new IndexFieldOptions { Indexing = FieldIndexing.Default } }
+                }
+            };
+
+            IndexDefinition withSearch = new IndexDefinition
+            {
+                Name = "With/Search",
+                Maps = { "from doc in docs.Products select new { doc.Name }" },
+                Fields = new Dictionary<string, IndexFieldOptions>
+                {
+                    { "Name", new IndexFieldOptions { Indexing = FieldIndexing.Search } }
+                }
+            };
+
+            IndexHeavinessGrade gradeWithout = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(withoutSearch);
+            IndexHeavinessGrade gradeWith = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(withSearch);
+
+            Assert.True(gradeWith.StaticScore > gradeWithout.StaticScore,
+                $"Search field should increase score. Without={gradeWithout.StaticScore}, With={gradeWith.StaticScore}");
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void SpatialField_AddsHighPenalty()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Locations/Spatial",
+                Maps = { "from loc in docs.Locations select new { loc.Coordinates }" },
+                Fields = new Dictionary<string, IndexFieldOptions>
+                {
+                    { "Coordinates", new IndexFieldOptions { Spatial = new SpatialOptions() } }
+                }
+            };
+
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition);
+
+            // Spatial adds 4 points. Total field baseline (1) + spatial (4) = 5
+            Assert.True(grade.StaticScore >= 5, $"Spatial field should add >= 5 points, got {grade.StaticScore}");
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void VectorField_AddsHighestPenalty()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Products/Vector",
+                Maps = { "from p in docs.Products select new { p.Description }" },
+                Fields = new Dictionary<string, IndexFieldOptions>
+                {
+                    {
+                        "Description", new IndexFieldOptions
+                        {
+                            Vector = new VectorOptions { Dimensions = 768 }
+                        }
+                    }
+                }
+            };
+
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition);
+
+            // Vector (8) + Vector >512 dims (4) + field baseline (1) = 13
+            Assert.True(grade.StaticScore >= 13, $"High-dim vector field should add >= 13 points, got {grade.StaticScore}");
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void LoadDocument_AddsHighPenalty()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Orders/WithCompanyName",
+                Maps =
+                {
+                    "from order in docs.Orders let company = LoadDocument(order.Company, \"Companies\") select new { order.Id, CompanyName = company.Name }"
+                }
+            };
+
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition);
+
+            // LoadDocument penalty = 15
+            Assert.True(grade.StaticScore >= 15, $"LoadDocument should add at least 15 points, got {grade.StaticScore}");
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void OutputReduceToCollection_AddsStructuralPenalty()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Orders/DailyCount",
+                Maps = { "from order in docs.Orders select new { order.OrderedAt, Count = 1 }" },
+                Reduce = "from result in results group result by result.OrderedAt into g select new { OrderedAt = g.Key, Count = g.Sum(x => x.Count) }",
+                OutputReduceToCollection = "DailyOrderCounts"
+            };
+
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition);
+
+            // MapReduce (10) + OutputReduceToCollection (10) + fields...
+            Assert.True(grade.StaticScore >= 20, $"OutputReduceToCollection should increase score significantly, got {grade.StaticScore}");
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void DataScaleMultiplier_ScalesWithCollectionSize()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Products/ByName",
+                Maps = { "from p in docs.Products select new { p.Name }" },
+                Fields = new Dictionary<string, IndexFieldOptions>
+                {
+                    { "Name", new IndexFieldOptions { Indexing = FieldIndexing.Search } }
+                }
+            };
+
+            IndexHeavinessGrade gradeSmall = IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(
+                definition,
+                new[] { "Products" },
+                stats: null,
+                collectionDataProvider: _ => (500, 500 * 2048));  // 500 docs, 2KB each
+
+            IndexHeavinessGrade gradeLarge = IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(
+                definition,
+                new[] { "Products" },
+                stats: null,
+                collectionDataProvider: _ => (500_000, 500_000L * 5120));  // 500K docs, 5KB each
+
+            Assert.True(gradeLarge.FullScore > gradeSmall.FullScore,
+                $"Large collection should produce higher full score. Small={gradeSmall.FullScore}, Large={gradeLarge.FullScore}");
+            Assert.True(gradeLarge.DataScaleMultiplier > gradeSmall.DataScaleMultiplier,
+                $"Large collection should have higher data scale multiplier. Small={gradeSmall.DataScaleMultiplier}, Large={gradeLarge.DataScaleMultiplier}");
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void HighFieldCount_AddsExtraPenaltyBeyondThreshold()
+        {
+            // Create an index with 12 fields (above the threshold of 10)
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Everything/Index",
+                Maps = { "from doc in docs.Orders select new { doc.Company, doc.Employee, doc.ShipTo, doc.OrderedAt, doc.RequireAt, doc.ShippedAt, doc.ShipVia, doc.Freight, doc.ShipName, doc.ShipCity, doc.ShipRegion, doc.ShipCountry }" },
+                Fields = new Dictionary<string, IndexFieldOptions>()
+            };
+
+            foreach (string field in new[] { "Company", "Employee", "ShipTo", "OrderedAt", "RequireAt", "ShippedAt", "ShipVia", "Freight", "ShipName", "ShipCity", "ShipRegion", "ShipCountry" })
+                definition.Fields[field] = new IndexFieldOptions { Indexing = FieldIndexing.Default };
+
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition);
+
+            // 12 fields: 12 base + 2 extra beyond threshold of 10 = 14 from fields alone
+            bool hasHighFieldCountPenalty = grade.StaticPenalties.Exists(p => p.Reason.Contains("High field count"));
+            Assert.True(hasHighFieldCountPenalty, "Should have a high field count penalty for indexes with >10 fields");
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void ScoreLabels_AreCorrect()
+        {
+            void AssertLabel(IndexDefinition definition, IEnumerable<string> collections, string expectedStaticLabel)
+            {
+                IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition, collections);
+                Assert.Equal(expectedStaticLabel, grade.StaticGradeLabel);
+            }
+
+            // Simple: 0–10
+            AssertLabel(new IndexDefinition
+            {
+                Name = "Simple",
+                Maps = { "from doc in docs.Items select new { doc.Name }" },
+                Fields = new Dictionary<string, IndexFieldOptions> { { "Name", new IndexFieldOptions() } }
+            }, new[] { "Items" }, "Simple");
+
+            // Complex via LoadDocument (15 points — Moderate range)
+            AssertLabel(new IndexDefinition
+            {
+                Name = "Complex",
+                Maps = { "from order in docs.Orders let company = LoadDocument(order.Company, \"Companies\") select new { order.Id, CompanyName = company.Name }" }
+            }, new[] { "Orders" }, "Moderate");
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void StaticGrade_WithNullCollections_DoesNotThrow()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Test/Index",
+                Maps = { "from doc in docs.Orders select new { doc.Company }" }
+            };
+
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition, collections: null);
+            Assert.NotNull(grade);
+            Assert.True(grade.StaticScore >= 0);
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void RuntimePenalties_AddedForHighOutputCount()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Test/Fanout",
+                Maps = { "from doc in docs.Orders select new { doc.Company }" }
+            };
+
+            IndexStats stats = new IndexStats
+            {
+                MaxNumberOfOutputsPerDocument = 200
+            };
+
+            IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeFullGrade(definition, new[] { "Orders" }, stats, collectionDataProvider: null);
+
+            bool hasPenalty = grade.RuntimePenalties.Exists(p => p.Reason.Contains("MaxNumberOfOutputsPerDocument"));
+            Assert.True(hasPenalty, "Should have runtime penalty for high MaxNumberOfOutputsPerDocument");
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void ExtractCollectionsFromMaps_QuerySyntax()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Orders/ByCompany",
+                Maps = { "from order in docs.Orders select new { order.Company }" }
+            };
+
+            System.Collections.Generic.HashSet<string> collections = IndexDefinitionHeavinessAnalyzer.ExtractCollectionsFromMaps(definition);
+
+            Assert.NotNull(collections);
+            Assert.Contains("Orders", collections);
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void ExtractCollectionsFromMaps_MethodSyntax()
+        {
+            IndexDefinition definition = new IndexDefinition
+            {
+                Name = "Orders/ByCompany",
+                Maps = { "docs.Orders.Select(order => new { order.Company })" }
+            };
+
+            System.Collections.Generic.HashSet<string> collections = IndexDefinitionHeavinessAnalyzer.ExtractCollectionsFromMaps(definition);
+
+            Assert.NotNull(collections);
+            Assert.Contains("Orders", collections);
+        }
+    }
+}

--- a/test/FastTests/Server/Documents/Indexing/IndexHeavinessGradeTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/IndexHeavinessGradeTests.cs
@@ -30,7 +30,7 @@ namespace FastTests.Server.Documents.Indexing
             IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition);
 
             Assert.True(grade.StaticScore <= 10, $"Expected simple index to have static score <= 10 but got {grade.StaticScore}");
-            Assert.Equal("Simple", grade.StaticGradeLabel);
+            Assert.Equal(IndexStaticGrade.Simple, grade.StaticGradeLabel);
             Assert.NotNull(grade.StaticPenalties);
             Assert.True(grade.StaticPenalties.Count > 0);
         }
@@ -55,7 +55,7 @@ namespace FastTests.Server.Documents.Indexing
             // MapReduce penalty = 10 + 2 fields = 12
             Assert.True(grade.StaticScore >= 11, $"Expected map-reduce index to have static score >= 11 but got {grade.StaticScore}");
             Assert.True(grade.StaticScore <= 25, $"Expected map-reduce index to have static score <= 25 but got {grade.StaticScore}");
-            Assert.Equal("Moderate", grade.StaticGradeLabel);
+            Assert.Equal(IndexStaticGrade.Moderate, grade.StaticGradeLabel);
         }
 
         [RavenFact(RavenTestCategory.Indexes)]
@@ -246,7 +246,7 @@ namespace FastTests.Server.Documents.Indexing
         [RavenFact(RavenTestCategory.Indexes)]
         public void ScoreLabels_AreCorrect()
         {
-            void AssertLabel(IndexDefinition definition, IEnumerable<string> collections, string expectedStaticLabel)
+            void AssertLabel(IndexDefinition definition, IEnumerable<string> collections, IndexStaticGrade expectedStaticLabel)
             {
                 IndexHeavinessGrade grade = IndexDefinitionHeavinessAnalyzer.ComputeStaticGrade(definition, collections);
                 Assert.Equal(expectedStaticLabel, grade.StaticGradeLabel);
@@ -258,14 +258,14 @@ namespace FastTests.Server.Documents.Indexing
                 Name = "Simple",
                 Maps = { "from doc in docs.Items select new { doc.Name }" },
                 Fields = new Dictionary<string, IndexFieldOptions> { { "Name", new IndexFieldOptions() } }
-            }, new[] { "Items" }, "Simple");
+            }, new[] { "Items" }, IndexStaticGrade.Simple);
 
             // Complex via LoadDocument (15 points — Moderate range)
             AssertLabel(new IndexDefinition
             {
                 Name = "Complex",
                 Maps = { "from order in docs.Orders let company = LoadDocument(order.Company, \"Companies\") select new { order.Id, CompanyName = company.Name }" }
-            }, new[] { "Orders" }, "Moderate");
+            }, new[] { "Orders" }, IndexStaticGrade.Moderate);
         }
 
         [RavenFact(RavenTestCategory.Indexes)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22254

### Additional description

Adds an "index heaviness grade" concept that quantifies the expected resource impact of an index definition. The grade is computed in two modes:

- **Static grade** (`IndexStaticGrade`: Simple, Moderate, Complex, VeryComplex) — based solely on the index definition via Roslyn static analysis (map complexity, fanout detection, LoadDocument usage, reduce presence, etc.). Server-independent and comparable across environments.
- **Full grade** (`IndexFullGrade`: Lightweight, Moderate, Heavy, VeryHeavy, Extreme) — static score adjusted by a data-scale multiplier (collection document count + average document size) and runtime penalties (e.g. high `MaxNumberOfOutputsPerDocument`).

Key implementation details:
- `IndexDefinitionHeavinessAnalyzer` performs Roslyn-based static analysis and optional runtime/data-scale scoring.
- `IndexMapComplexityVisitor` walks map expression syntax trees to extract complexity signals.
- `HeavinessGrade` is attached to `IndexStats` and computed only when a `QueryOperationContext` is available (opt-in, avoids overhead on monitoring/SNMP polling paths).
- `@all_docs` indexes are handled by summing stats across all collections.
- A new `POST /databases/*/indexes/heaviness/analyze` endpoint exposes on-demand analysis.
- Grade labels use proper enums (`IndexStaticGrade`, `IndexFullGrade`) rather than strings.

### Type of change

- [x] New feature

### How risky is the change?

- [x] Low

### Backward compatibility

- [x] Non breaking change

### Is it platform specific issue?

- [x] No

### Documentation update

- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)

### Testing by RavenDB QA team

- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.