### PR TITLE
RavenDB-26109: AI Connection Strings Test problem

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
@@ -102,7 +102,7 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
                     case AiModelType.Chat:
                         using (var client = ChatCompletionClient.CreateChatCompletionClient( ServerStore.ContextPool, aiConnectionString))
                         {
-                            var schema = ChatCompletionClient.GetSchemaFromSampleObject("{}");
+                            var schema = ChatCompletionClient.GetSchemaFromSampleObject("{\"answer\":\"the answer to the user's prompt\"}");
                             await client.TestCompleteAsync("Reply with exact word only: raven", "hi", schema, HttpContext.RequestAborted);
                         }
 

--- a/test/SlowTests/Server/Documents/AI/AiConnectionTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiConnectionTests.cs
@@ -116,7 +116,7 @@ namespace SlowTests.Server.Documents.AI
         {
         }
 
-        private class TestAiConnectionStringOperation : IMaintenanceOperation<NodeConnectionTestResult>
+        internal class TestAiConnectionStringOperation : IMaintenanceOperation<NodeConnectionTestResult>
         {
             private readonly AiConnectionString _connectionString;
 

--- a/test/SlowTests/Server/Documents/AI/RavenDB-26109.cs
+++ b/test/SlowTests/Server/Documents/AI/RavenDB-26109.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.AI;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI
+{
+    public class RavenDB_26109 : RavenTestBase
+    {
+        public RavenDB_26109(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.AzureOpenAI | RavenAiIntegration.Google, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task TestConnectionEndpoint_ShouldSucceed(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+
+            var result = await store.Maintenance.SendAsync(new AiConnectionTests.TestAiConnectionStringOperation(configuration.Connection));
+
+            Assert.True(result.Error == null, result.Error);
+            Assert.True(result.Success);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26109/AI-Connection-Strings-Open-AI-GPT-4o-Test-problem

### Additional description

older models like gpt-4 for its versions fails frequently with empty schema

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
