### PR TITLE
RavenDB-24513 Fixed logging when SharedJournals feature is turned off

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -26,6 +26,7 @@ using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
+using Raven.Server.Config;
 using Raven.Server.Config.Categories;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
@@ -614,20 +615,27 @@ namespace Raven.Server.Documents.Indexes
 
         private static void AttemptToLinkDatabaseAndIndexJournals(string name, StorageEnvironmentOptions indexOptions, DocumentDatabase documentDatabase)
         {
-            if (documentDatabase.Configuration.Indexing.DisableSharedJournals is false &&
-                indexOptions.CanJournalsBeLinkedWith(documentDatabase.DocumentsStorage.Environment.Options))
+            var logger = RavenLogManager.Instance.GetLoggerForIndex(typeof(Index), documentDatabase.Name, name);
+
+            if (documentDatabase.Configuration.Indexing.DisableSharedJournals)
             {
-                // here we enable the root / branch model for this index
-                documentDatabase.IndexStore.RegisterSharedJournals(indexOptions);
+                if (logger.IsInfoEnabled)
+                    logger.Info($"Shared journals disabled by '{RavenConfiguration.GetKey(c => c.Indexing.DisableSharedJournals)}' for index '{name}'.");
                 return;
             }
 
-            var logger = RavenLogManager.Instance.GetLoggerForIndex(typeof(Index), documentDatabase.Name, name);
-            if (logger.IsWarnEnabled)
+            if (indexOptions.CanJournalsBeLinkedWith(documentDatabase.DocumentsStorage.Environment.Options) == false)
             {
-                logger.Warn($"Unable to create hard links between '{documentDatabase.DocumentsStorage.Environment.Options.JournalPath}' and '{indexOptions.JournalPath}'." +
-                            $"Shared journals mode is disabled for this index: {name}");
+                if (logger.IsWarnEnabled)
+                {
+                    logger.Warn($"Unable to create hard links between '{documentDatabase.DocumentsStorage.Environment.Options.JournalPath}' and '{indexOptions.JournalPath}'. " +
+                                $"Shared journals mode is disabled for this index: {name}.");
+                }
+                return;
             }
+
+            // here we enable the root / branch model for this index
+            documentDatabase.IndexStore.RegisterSharedJournals(indexOptions);
         }
 
         public IndexType Type { get; }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24513

### Additional description

Split `AttemptToLinkDatabaseAndIndexJournals` log so `DisableSharedJournals` path logs "disabled by config" instead of falsely claiming a hard-link failure

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
