### PR TITLE
RavenDB-26654 Do not initialize @SharedJournals when Indexing.StorageDisableSharedJournals is true

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -839,6 +839,8 @@ namespace Raven.Server.Documents.Indexes
         {
             if (_sharedJournals != null)
                 return Task.CompletedTask;
+            if (_documentDatabase.Configuration.Indexing.DisableSharedJournals)
+                return Task.CompletedTask;
             return Task.Run(() =>
             {
                 _sharedJournals ??= new SharedIndexJournals(_documentDatabase);
@@ -851,7 +853,8 @@ namespace Raven.Server.Documents.Indexes
                 throw new InvalidOperationException($"{nameof(IndexStore)} was already initialized.");
 
             InitializePath(_documentDatabase.Configuration.Indexing.StoragePath);
-            InitializePath(_documentDatabase.Configuration.Indexing.SharedJournalsPath);
+            if (_documentDatabase.Configuration.Indexing.DisableSharedJournals == false)
+                InitializePath(_documentDatabase.Configuration.Indexing.SharedJournalsPath);
 
             _initialized = true;
 

--- a/test/SlowTests.Issues/Issues/RavenDB-26654.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26654.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26654 : RavenTestBase
+{
+    public RavenDB_26654(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task DisableSharedJournals_true_must_not_create_dedicated_env()
+    {
+        using var store = GetDocumentStore(new Options
+        {
+            RunInMemory = false,
+            ModifyDatabaseRecord = r =>
+                r.Settings[RavenConfiguration.GetKey(c => c.Indexing.DisableSharedJournals)] = "true"
+        });
+
+        await new Users_ByName().ExecuteAsync(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = "Joe" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+        Assert.Null(database.IndexStore.SharedJournals);
+
+        string sharedJournalsPath = database.Configuration.Indexing.SharedJournalsPath.FullPath;
+        Assert.False(Directory.Exists(sharedJournalsPath),
+            $"@SharedJournals directory must not exist when DisableSharedJournals=true, but found: {sharedJournalsPath}");
+    }
+
+    private class Users_ByName : AbstractIndexCreationTask<User>
+    {
+        public Users_ByName()
+        {
+            Map = users => from u in users select new { u.Name };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26654

### Additional description



### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
