### PR TITLE
RavenDB-26665 Restrict recursive additional sources tests to Windows

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17867.cs
+++ b/test/SlowTests/Issues/RavenDB-17867.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Issues
         {
         }
 
-        [RavenFact(RavenTestCategory.Indexes)]
+        [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenPlatform.Windows)]
         public void Recursion_In_Additional_Sources_Should_Not_Crash_The_Server()
         {
             using (var store = GetDocumentStore())
@@ -65,7 +65,7 @@ public static class PeopleUtil
             }
         }
 
-        [RavenFact(RavenTestCategory.Indexes)]
+        [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenPlatform.Windows)]
         public void Recursion_In_Expression_Bodied_Additional_Sources_Should_Not_Crash_The_Server()
         {
             using (var store = GetDocumentStore())
@@ -112,7 +112,7 @@ public static class TreeUtil
             }
         }
 
-        [RavenFact(RavenTestCategory.Indexes)]
+        [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenPlatform.Windows)]
         public void Recursion_In_Local_Function_Additional_Sources_Should_Not_Crash_The_Server()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
On Linux RyuJIT's self-tail-call-to-loop optimization defeats EnsureSufficientExecutionStack so the recursion never throws; the PR remains a valid crash guard but the assertion on InsufficientExecutionStackException is platform-dependent.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26665

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
