### PR TITLE
RavenDB-26670 Gate the Snowflake row of RavenDB_19967.TombstoneCleaningAfterEtlLoaderDisabled

### DIFF
--- a/test/SlowTests.Issues/Issues/RavenDB-19967.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-19967.cs
@@ -305,7 +305,10 @@ namespace SlowTests.Issues
         [InlineData(EtlType.Olap)]
         [InlineData(EtlType.ElasticSearch)]
         [InlineData(EtlType.Queue)]
-        [InlineData(EtlType.Snowflake)]
+        [InlineData(EtlType.Snowflake,
+            Skip = "Snowflake is not configured in this environment",
+            SkipType = typeof(SnowflakeHelper),
+            SkipUnless = nameof(SnowflakeHelper.IsAvailable))]
         [InlineData(EtlType.EmbeddingsGeneration)]
         //[InlineData(EtlType.GenAi)] not relevant since GenAi doesn't handle deletions
         public async Task TombstoneCleaningAfterEtlLoaderDisabled(EtlType etlType)

--- a/test/Tests.Infrastructure/SnowflakeHelper.cs
+++ b/test/Tests.Infrastructure/SnowflakeHelper.cs
@@ -4,6 +4,13 @@ namespace Tests.Infrastructure;
 
 public static class SnowflakeHelper
 {
+    /// <summary>
+    /// Returns true when Snowflake-dependent tests can run in the current environment.
+    /// Intended for use with xUnit v3 <c>SkipUnless</c>, e.g.
+    /// <c>[InlineData(..., SkipType = typeof(SnowflakeHelper), SkipUnless = nameof(IsAvailable))]</c>.
+    /// </summary>
+    public static bool IsAvailable => ShouldSkip(out _) == false;
+
     internal static bool ShouldSkip(out string skipMessage)
     {
         if (RavenTestHelper.EnvironmentVariables.SkipIntegrationTests)


### PR DESCRIPTION
Closes RavenDB-26670. Without RAVEN_SNOWFLAKE_CONNECTION_STRING the Snowflake InlineData row threw InvalidOperationException from SnowflakeConnectionString.Instance.VerifiedConnectionString.Value instead of skipping.

Added SnowflakeHelper.IsAvailable (delegates to existing ShouldSkip) and switched the InlineData to xunit.v3's SkipType/SkipUnless. The other six EtlTypes still run; only the Snowflake row is skipped.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26670

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
