### PR TITLE
RavenDB-26672 Added handling of GenAi tasks in AbstractRestoreBackupTask.DisableOngoingTasksIfNeeded()

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -476,6 +476,14 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 }
             }
 
+            if (databaseRecord.GenAis != null)
+            {
+                foreach (var task in databaseRecord.GenAis)
+                {
+                    task.Disabled = true;
+                }
+            }
+
             if (databaseRecord.PeriodicBackups != null)
             {
                 foreach (var task in databaseRecord.PeriodicBackups)

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -1770,6 +1770,27 @@ namespace SlowTests.Smuggler
                 await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(aiConnectionString));
                 await store.Maintenance.SendAsync(new AddEmbeddingsGenerationOperation(embeddingsGenerationConfiguration));
 
+                var genAiConnectionString = new AiConnectionString
+                {
+                    Name = "genai-connection",
+                    ModelType = AiModelType.Chat,
+                    OpenAiSettings = new OpenAiSettings { ApiKey = "fake-key", Model = "test" }
+                };
+                genAiConnectionString.Identifier = genAiConnectionString.GenerateIdentifier();
+                var genAiConfiguration = new GenAiConfiguration
+                {
+                    Name = "gen-ai-test",
+                    ConnectionStringName = genAiConnectionString.Identifier,
+                    Collection = "Users",
+                    Prompt = "Process users",
+                    SampleObject = "{\"Result\":\"test\"}",
+                    UpdateScript = "this.Result = $output.Result",
+                    GenAiTransformation = new GenAiTransformation { Script = "ai.genContext({ Name: this.Name });" }
+                };
+                genAiConfiguration.Identifier = genAiConfiguration.GenerateIdentifier();
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(genAiConnectionString));
+                await store.Maintenance.SendAsync(new AddGenAiOperation(genAiConfiguration));
+
                 // pull replication sink
                 var sink = new PullReplicationAsSink { HubName = "aa", ConnectionString = connectionString, ConnectionStringName = connectionString.Name };
                 await store.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(sink));
@@ -1838,6 +1859,12 @@ namespace SlowTests.Smuggler
                             tasksCount++;
                         }
 
+                        foreach (var task in databaseRecord.GenAis)
+                        {
+                            Assert.Equal(disableOngoingTasks, task.Disabled);
+                            tasksCount++;
+                        }
+
                         foreach (var task in databaseRecord.PeriodicBackups)
                         {
                             Assert.Equal(disableOngoingTasks, task.Disabled);
@@ -1862,7 +1889,7 @@ namespace SlowTests.Smuggler
                             tasksCount++;
                         }
 
-                        Assert.Equal(10, tasksCount);
+                        Assert.Equal(11, tasksCount);
                     }
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26672/AbstractRestoreBackupTask.DisableOngoingTasksIfNeeded-doesnt-disable-GenAi-tasks

### Additional description

`DisableOngoingTasks` in `RestoreBackupConfiguration` should disable GenAi task

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
