### PR TITLE
RavenDB-26285 Support non-seekable streams in Tree.AddStream

### DIFF
--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -94,8 +94,11 @@ namespace Voron.Data.BTrees
                 _tag = tag;
             }
 
-            public void Write(Stream stream)
+            public void Write(Stream stream, byte* preReadBuffer = null, int preReadBytes = 0)
             {
+                Debug.Assert(preReadBytes == 0 || (preReadBuffer != null && stream != Stream.Null),
+                    "preReadBytes > 0 implies a real stream and a captured buffer pointer from the inline probe");
+
                 AllocateNextPage();
 
                 ((StreamPageHeader*)_currentPage.Pointer)->StreamPageFlags |= StreamPageFlags.First;
@@ -103,46 +106,54 @@ namespace Voron.Data.BTrees
                 var buffer = stream != Stream.Null ? _parent.Llt.Transaction.StreamBuffer : StreamBufferAllocator.Buffer.Null;
                 var localBuffer = buffer.AsSpan();
 
+                if (preReadBytes > 0)
                 {
-                    while (true)
-                    {
-                        var read = stream.Read(localBuffer);
-                        if (read == 0)
-                            break;
+                    WriteFromBuffer(preReadBuffer, preReadBytes);
+                }
 
-                        var toWrite = 0L;
-                        while (true)
-                        {
-                            toWrite += WriteBufferToPage(buffer.Pointer + toWrite, read - toWrite);
-                            if (toWrite == read)
-                                break;
+                while (true)
+                {
+                    var read = stream.Read(localBuffer);
+                    if (read == 0)
+                        break;
 
-                            // run out of room, need to allocate more
-                            RecordChunkPage(_currentPage.PageNumber, (int)(_writePos - _currentPage.DataPointer));
-                            AllocateNextPage();
-                        }
-                    }
+                    WriteFromBuffer(buffer.Pointer, read);
+                }
 
-                    var chunkSize = (int)(_writePos - _currentPage.DataPointer);
+                var chunkSize = (int)(_writePos - _currentPage.DataPointer);
+                RecordChunkPage(_currentPage.PageNumber, chunkSize);
+
+                var remaining = _writePosEnd - _writePos;
+                var infoSize = StreamInfo.SizeOf;
+
+                if (_tag != null)
+                    infoSize += _tag.Value.Size;
+
+                if (remaining < infoSize)
+                {
+                    _numberOfPagesPerChunk = 1;
+                    AllocateNextPage();
+                    chunkSize = 0;
                     RecordChunkPage(_currentPage.PageNumber, chunkSize);
+                }
 
-                    var remaining = _writePosEnd - _writePos;
-                    var infoSize = StreamInfo.SizeOf;
+                RecordStreamInfo();
 
-                    if (_tag != null)
-                        infoSize += _tag.Value.Size;
+                _parent._tx.LowLevelTransaction.ShrinkOverflowPage(_currentPage.PageNumber, chunkSize + infoSize, _parent.State);
+            }
 
-                    if (remaining < infoSize)
-                    {
-                        _numberOfPagesPerChunk = 1;
-                        AllocateNextPage();
-                        chunkSize = 0;
-                        RecordChunkPage(_currentPage.PageNumber, chunkSize);
-                    }
+            private void WriteFromBuffer(byte* pBuffer, int size)
+            {
+                var toWrite = 0L;
+                while (true)
+                {
+                    toWrite += WriteBufferToPage(pBuffer + toWrite, size - toWrite);
+                    if (toWrite == size)
+                        break;
 
-                    RecordStreamInfo();
-
-                    _parent._tx.LowLevelTransaction.ShrinkOverflowPage(_currentPage.PageNumber, chunkSize + infoSize, _parent.State);
+                    // run out of room, need to allocate more
+                    RecordChunkPage(_currentPage.PageNumber, (int)(_writePos - _currentPage.DataPointer));
+                    AllocateNextPage();
                 }
             }
 
@@ -230,24 +241,25 @@ namespace Voron.Data.BTrees
 
         public void AddStream(Slice key, Stream stream, Slice? tag = null, int? initialNumberOfPagesPerChunk = null)
         {
-            Debug.Assert(stream.CanSeek, "Stream must be seekable, we need it to simplify reseting position when stream is too large for inline storage");
-            
             if ((State.Header.Flags & TreeFlags.Streams) != TreeFlags.Streams)
             {
                 ref var state = ref State.Modify();
                 state.Flags |= TreeFlags.Streams;
             }
 
-            if (TryAddInlineStream(key, stream, tag))
+            if (TryAddInlineStream(key, stream, tag, out var preReadBytes, out var preReadBuffer))
                 return;
 
             var writer = new StreamToPageWriter();
             writer.Init(this, key, tag, initialNumberOfPagesPerChunk);
-            writer.Write(stream);
+            writer.Write(stream, preReadBuffer, preReadBytes);
         }
 
-        private bool TryAddInlineStream(Slice key, Stream stream, Slice? tag)
+        private bool TryAddInlineStream(Slice key, Stream stream, Slice? tag, out int preReadBytes, out byte* preReadBuffer)
         {
+            preReadBytes = 0;
+            preReadBuffer = null;
+
             var tagSize = tag?.Size ?? 0;
             // maxInlineSize calculates space available for the value (header + tag + data).
             // Key.Size is not subtracted because DirectAdd(key, len, ...) only accounts for value length.
@@ -270,8 +282,9 @@ namespace Voron.Data.BTrees
 
             if (totalRead > maxInlineSize)
             {
-                // Stream is too large for inline storage, reset and fall back
-                stream.Position = 0;
+                // Stream is too large for inline storage, hand the buffer pointer + count off so the chunked writer can drain them
+                preReadBytes = totalRead;
+                preReadBuffer = buffer.Pointer;
                 return false;
             }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_26285.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26285.cs
@@ -522,6 +522,86 @@ namespace SlowTests.Issues
                 Assert.Equal(tinyData, fullData);
             }
         }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(64)]          // fits inline
+        [InlineData(2048)]        // fits inline (boundary-ish)
+        [InlineData(8 * 1024)]    // exceeds inline, falls back to chunked - this is the embeddings regression path
+        [InlineData(128 * 1024)]  // far exceeds inline, multiple chunks
+        public void CanAddStream_WithNonSeekableStream(int size)
+        {
+            // Regression: embeddings generator passes a CanSeek=false stream; AddStream
+            // used to assert seekability because the inline-probe fallback reset Position.
+            var data = new byte[size];
+            new Random(size).NextBytes(data);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream("stream/1", new NonSeekableStream(data));
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                using var stream = tree.ReadStream("stream/1");
+                Assert.NotNull(stream);
+                Assert.Equal(size, stream.Length);
+
+                var readBack = new byte[size];
+                var totalRead = 0;
+                while (totalRead < size)
+                {
+                    var read = stream.Read(readBack, totalRead, size - totalRead);
+                    if (read == 0)
+                        break;
+                    totalRead += read;
+                }
+
+                Assert.Equal(size, totalRead);
+                Assert.Equal(data, readBack);
+            }
+        }
+
+        private sealed class NonSeekableStream : Stream
+        {
+            private readonly byte[] _data;
+            private int _position;
+
+            public NonSeekableStream(byte[] data)
+            {
+                _data = data;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => _data.Length;
+
+            public override long Position
+            {
+                get => _position;
+                set => throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                var remaining = _data.Length - _position;
+                if (remaining <= 0)
+                    return 0;
+
+                var toRead = Math.Min(count, remaining);
+                Buffer.BlockCopy(_data, _position, buffer, offset, toRead);
+                _position += toRead;
+                return toRead;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override void Flush() { }
+        }
     }
 
     public unsafe class RavenDB_26285_Encrypted : StorageTest


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26285

### Additional description

Inline-probe fallback reset `stream.Position`, requiring `CanSeek`; embeddings pass `ReadOnlyMemoryStream<byte>` (`CanSeek=false`) and tripped the assert. `TryAddInlineStream` now hands the pre-read buffer pointer + byte count to `StreamToPageWriter.Write`, which drains them before continuing to read.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
