### PR TITLE
RavenDB-26677 Handle nagative subscription IDs in ongoing tasks

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
@@ -354,8 +354,6 @@ public abstract class AbstractSubscriptionStorage<TState> : AbstractSubscription
     {
         if (state == null)
             throw new ArgumentNullException(nameof(state));
-        if (subscriptionId <= 0)
-            throw new ArgumentOutOfRangeException(nameof(subscriptionId));
 
         var tag = GetSubscriptionResponsibleNode(context, state);
         OngoingTaskConnectionStatus connectionStatus = OngoingTaskConnectionStatus.NotActive;

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -798,8 +798,8 @@ namespace Raven.Server.ServerWide
                             $"Cannot set typed value of type {type} for database {database}, because it does not exist");
                     }
 
-                    var id = updateCommand.FindFreeId(context, index);
-                    updateCommand.Execute(context, items, id, record: null, _parent.CurrentState, out _);
+                    updateCommand.SubscriptionId = updateCommand.FindFreeId(context, index);
+                    updateCommand.Execute(context, items, index, record: null, _parent.CurrentState, out _);
 
                     if (databases.Add(database))
                     {

--- a/test/SlowTests/Client/Subscriptions/RavenDB_26677.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_26677.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Documents.Subscriptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.Subscriptions
+{
+    public class RavenDB_26677 : RavenTestBase
+    {
+        public RavenDB_26677(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions | RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
+        public async Task OngoingTasksEndpointMustNotFailAfterImportingSubscriptionsWithNonPositiveIds()
+        {
+            const int subscriptionCount = 50;
+
+            var file = GetTempFileName();
+
+            using (var source = GetDocumentStore())
+            {
+                for (int i = 0; i < subscriptionCount; i++)
+                {
+                    await source.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                    {
+                        Name = $"Sub_{i:D3}",
+                        Query = "from Users"
+                    });
+                }
+
+                var export = await source.Smuggler.ExportAsync(
+                    new DatabaseSmugglerExportOptions { OperateOnTypes = DatabaseItemType.Subscriptions },
+                    file);
+                await export.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+            }
+
+            using (var targetServer = GetNewServer())
+            using (var target = GetDocumentStore(new Options { Server = targetServer }))
+            {
+                var import = await target.Smuggler.ImportAsync(
+                    new DatabaseSmugglerImportOptions { OperateOnTypes = DatabaseItemType.Subscriptions },
+                    file);
+                await import.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                var subscriptions = await target.Subscriptions.GetSubscriptionsAsync(0, int.MaxValue);
+                Assert.Equal(subscriptionCount, subscriptions.Count);
+                Assert.Contains(subscriptions, x => x.SubscriptionId <= 0);
+
+                var ongoingTasks = await Databases.GetOngoingTasks(target.Database, targetServer);
+                Assert.Equal(subscriptionCount, ongoingTasks.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26677

### Additional description

Drop the read-side subscriptionId <= 0 validation so databases can enumerate ongoing tasks.

Set the generated subscription ID on each imported subscription command before execution, while keeping the Raft index as the command apply index.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
