### PR TITLE
RavenDB-26694 fix null crash when backup type changes during an active backup

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -487,10 +487,10 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
             catch (Exception e) when (e.ExtractSingleInnerException() is OperationCanceledException oce)
             {
-                if (_periodicBackups.TryGetValue(periodicBackup.BackupStatus.TaskId, out PeriodicBackup inMemoryBackupStatus))
+                if (_periodicBackups.TryGetValue(periodicBackup.Configuration.TaskId, out PeriodicBackup inMemoryBackupStatus))
                 {
-                    runningBackupStatus.DelayUntil = inMemoryBackupStatus.BackupStatus.DelayUntil;
-                    runningBackupStatus.OriginalBackupTime = inMemoryBackupStatus.BackupStatus.OriginalBackupTime;
+                    runningBackupStatus.DelayUntil = inMemoryBackupStatus.BackupStatus?.DelayUntil;
+                    runningBackupStatus.OriginalBackupTime = inMemoryBackupStatus.BackupStatus?.OriginalBackupTime;
                 }
 
                 if (_logger.IsOperationsEnabled)

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -4365,6 +4365,53 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
         
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task BackupTypeChange_WhenBackupRunningAndCanceled_ShouldNotCrashServer()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    await session.StoreAsync(new User(), "users/" + i);
+                }
+
+                await session.SaveChangesAsync();
+            }
+            
+            var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 0 1 1 *");
+            var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+            var taskId = result.TaskId;
+
+            Backup.WaitForResponsibleNodeUpdate(Server.ServerStore, store.Database, taskId);
+
+            var database = await GetDocumentDatabaseInstanceFor(store);
+            var runner = database.PeriodicBackupRunner;
+
+            var holdTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            runner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = holdTcs;
+
+            await store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: true, taskId));
+
+            Assert.True(WaitForValue(() => runner.OnGoingBackup(taskId) != null, true),
+                "Backup did not start within the expected time");
+
+            config.TaskId = taskId;
+            config.BackupType = BackupType.Snapshot;
+            config.Disabled = true;
+            await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+            holdTcs.SetResult(null);
+
+            Assert.True(WaitForValue(() => runner.OnGoingBackup(taskId) == null, true, timeout: 30_000),
+                "Backup did not finish within the expected time");
+
+            var dbRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            Assert.NotNull(dbRecord);
+        }
+        
         private static IDisposable ReadOnly(string path)
         {
             var files = Directory.GetFiles(path);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26694

### Additional description
When a periodic backup is running and its configuration is updated mid-flight with a backup type change (e.g. Full/Incremental → Snapshot), UpdateConfigurations deliberately sets existingBackupState.BackupStatus = null to clear stale
  status before scheduling a fresh full backup.
  
  Concurrently, the running backup can receive an OperationCanceledException through several paths:
  - The task is disabled in a config update → DisableFutureBackups() cancels the token
  - A timer fires while the task is no longer active on the current node (reassigned to another node or missing responsible node) → DisableFutureBackups() cancels the token
  - The database shuts down → the runner's cancellation token is canceled

  When both happen at the same time — BackupStatus is null and the backup receives an OperationCanceledException — the catch block tried to read periodicBackup.BackupStatus.TaskId, resulting in a NullReferenceException that crashed the
  server.

  Two fixes in PeriodicBackupRunner.RunBackupThread:
  1. Use periodicBackup.Configuration.TaskId instead of periodicBackup.BackupStatus.TaskId — Configuration is always populated; BackupStatus can be null after a type change.
  2. Add null-conditional operators when copying DelayUntil and OriginalBackupTime from the in-memory entry, since that entry's BackupStatus can equally be null.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
