### PR TITLE
RavenDB-26697 Fix CDC UI bugs and add warnings

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/hooks/useEditCdcSinkTaskSourceTableAutoFill.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/hooks/useEditCdcSinkTaskSourceTableAutoFill.ts
@@ -171,7 +171,7 @@ export function useEditCdcSinkTaskSourceTableAutoFill(path: AutoFillPath, mode: 
 
 function getEmbeddedPropertyName(
     selectedTable: CdcSinkSourceTable,
-    relation: { foreignKey: CdcSinkSourceForeignKey; type: "selectedToParent" | "parentToSelected" } | null
+    relation: { foreignKey: CdcSinkSourceForeignKey; type: "selectedToParent" | "parentToSelected" }
 ) {
     if (relation?.type === "parentToSelected") {
         return relation.foreignKey.Columns.map(propertyNameFromJoinColumn).join("And");

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/EditCdcSinkTaskWarningMessage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/EditCdcSinkTaskWarningMessage.tsx
@@ -1,0 +1,7 @@
+export default function EditCdcSinkTaskWarningMessage({ message }: { message: string }) {
+    return (
+        <div className="text-break" style={{ whiteSpace: "pre-line" }}>
+            {message}
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/EditCdcSinkTaskTablesExplorer.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/EditCdcSinkTaskTablesExplorer.tsx
@@ -2,7 +2,7 @@ import Button from "react-bootstrap/Button";
 import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
 import { Icon } from "components/common/Icon";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { EditCdcSinkTaskFormData } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation";
 import { FieldPath, UseFieldArrayReturn } from "react-hook-form";
 import { useAppDispatch, useAppSelector } from "components/store";
@@ -23,6 +23,7 @@ export default function EditCdcSinkTaskTablesExplorer({ tablesFieldArray }: Edit
     const dispatch = useAppDispatch();
     const isFieldMappingExpandedByDefault = useAppSelector(editCdcSinkTaskSelectors.isFieldMappingExpandedByDefault);
     const [filter, setFilter] = useState("");
+    const rootFieldIds = useMemo(() => tablesFieldArray.fields.map((field) => field.id), [tablesFieldArray.fields]);
 
     const handleAddRootTable = () => {
         tablesFieldArray.append({
@@ -125,7 +126,7 @@ export default function EditCdcSinkTaskTablesExplorer({ tablesFieldArray }: Edit
                 value={filter}
                 onChange={(e) => setFilter(e.target.value)}
             />
-            <EditCdcSinkTaskTableItems filter={filter} />
+            <EditCdcSinkTaskTableItems filter={filter} rootFieldIds={rootFieldIds} />
         </div>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskEmbeddedTableEditor.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskEmbeddedTableEditor.tsx
@@ -9,8 +9,13 @@ import {
 import RichAlert from "components/common/RichAlert";
 import { SelectOption } from "components/common/select/Select";
 import { useEditCdcSinkTaskSourceTableAutoFill } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/hooks/useEditCdcSinkTaskSourceTableAutoFill";
+import {
+    analyzeRootTables,
+    getEmbeddedTableWarningMessagesFromAnalysis,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings";
 import { EmbeddedTablePath } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes";
 import { EditCdcSinkTaskFormData } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation";
+import { useMemo } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import EditCdcSinkTaskAdvancedSettings from "./EditCdcSinkTaskAdvancedSettings";
 import EditCdcSinkTaskFieldMapping from "./EditCdcSinkTaskFieldMapping";
@@ -27,8 +32,7 @@ export default function EditCdcSinkTaskEmbeddedTableEditor({ path }: { path: Emb
     const patch = useWatch({ control, name: `${path}.patch` });
     const ignoreDeletes = useWatch({ control, name: `${path}.onDelete.ignoreDeletes` });
     const deletePatch = useWatch({ control, name: `${path}.onDelete.patch` });
-    const sourceTableSchema = useWatch({ control, name: `${path}.sourceTableSchema` });
-    const sourceTableName = useWatch({ control, name: `${path}.sourceTableName` });
+    const embeddedTable = useWatch({ control, name: path });
     const rootTables = useWatch({ control, name: "tables" });
     const { handleSourceTableChange, sourceSchemaOptions, sourceTableOptions } = useEditCdcSinkTaskSourceTableAutoFill(
         path,
@@ -36,20 +40,19 @@ export default function EditCdcSinkTaskEmbeddedTableEditor({ path }: { path: Emb
     );
 
     const hasAdvancedValues = Boolean(caseSensitiveKeys || patch || ignoreDeletes || deletePatch);
-    const hasRootTableConflict = rootTables?.some(
-        (table) =>
-            isSameSourceValue(table.sourceTableSchema, sourceTableSchema) &&
-            isSameSourceValue(table.sourceTableName, sourceTableName)
+    const rootTablesAnalysis = useMemo(() => analyzeRootTables(rootTables), [rootTables]);
+    const warningMessages = useMemo(
+        () => getEmbeddedTableWarningMessagesFromAnalysis(rootTablesAnalysis, embeddedTable),
+        [rootTablesAnalysis, embeddedTable]
     );
 
     return (
         <div>
-            {hasRootTableConflict && (
-                <RichAlert variant="warning" className="mb-3">
-                    This source table is already configured as a root table. CDC Sink can process a source table only
-                    once, so embedded updates may be routed to the root table instead.
+            {warningMessages.map((warning) => (
+                <RichAlert key={warning} variant="warning" className="mb-3">
+                    {warning}
                 </RichAlert>
-            )}
+            ))}
             <div className="grid mb-3">
                 <FormGroup className="g-col-6" marginClass="m-0">
                     <FormLabel>Source schema</FormLabel>
@@ -116,7 +119,3 @@ const relationTypeOptions: SelectOption<CdcSinkRelationType>[] = [
     { value: "Map", label: "Map" },
     { value: "Value", label: "Value" },
 ];
-
-function isSameSourceValue(left: string, right: string) {
-    return Boolean(left) && Boolean(right) && left.localeCompare(right, undefined, { sensitivity: "accent" }) === 0;
-}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskLinkedTableEditor.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskLinkedTableEditor.tsx
@@ -2,6 +2,7 @@ import { FormGroup, FormInput, FormLabel, FormSelectAutocomplete } from "compone
 import FormStringValueList from "components/common/formFields/FormStringValueList";
 import RichAlert from "components/common/RichAlert";
 import { useEditCdcSinkTaskSourceTableAutoFill } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/hooks/useEditCdcSinkTaskSourceTableAutoFill";
+import EditCdcSinkTaskWarningMessage from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/EditCdcSinkTaskWarningMessage";
 import {
     analyzeRootTables,
     getLinkedTableWarningMessagesFromAnalysis,
@@ -30,7 +31,7 @@ export default function EditCdcSinkTaskLinkedTableEditor({ path }: { path: Linke
         <div>
             {warningMessages.map((warning) => (
                 <RichAlert key={warning} variant="warning" className="mb-3">
-                    {warning}
+                    <EditCdcSinkTaskWarningMessage message={warning} />
                 </RichAlert>
             ))}
             <div className="grid mb-3">

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskLinkedTableEditor.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskLinkedTableEditor.tsx
@@ -1,19 +1,38 @@
 import { FormGroup, FormInput, FormLabel, FormSelectAutocomplete } from "components/common/Form";
 import FormStringValueList from "components/common/formFields/FormStringValueList";
+import RichAlert from "components/common/RichAlert";
 import { useEditCdcSinkTaskSourceTableAutoFill } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/hooks/useEditCdcSinkTaskSourceTableAutoFill";
+import {
+    analyzeRootTables,
+    getLinkedTableWarningMessagesFromAnalysis,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings";
 import { LinkedTablePath } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes";
 import { EditCdcSinkTaskFormData } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation";
-import { useFormContext } from "react-hook-form";
+import { useMemo } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 
 export default function EditCdcSinkTaskLinkedTableEditor({ path }: { path: LinkedTablePath }) {
     const { control } = useFormContext<EditCdcSinkTaskFormData>();
+    const linkedTable = useWatch({ control, name: path });
+    const rootTables = useWatch({ control, name: "tables" });
     const { handleSourceTableChange, sourceSchemaOptions, sourceTableOptions } = useEditCdcSinkTaskSourceTableAutoFill(
         path,
         "linked"
     );
 
+    const rootTablesAnalysis = useMemo(() => analyzeRootTables(rootTables), [rootTables]);
+    const warningMessages = useMemo(
+        () => getLinkedTableWarningMessagesFromAnalysis(rootTablesAnalysis, linkedTable),
+        [rootTablesAnalysis, linkedTable]
+    );
+
     return (
         <div>
+            {warningMessages.map((warning) => (
+                <RichAlert key={warning} variant="warning" className="mb-3">
+                    {warning}
+                </RichAlert>
+            ))}
             <div className="grid mb-3">
                 <FormGroup className="g-col-6" marginClass="m-0">
                     <FormLabel>Source schema</FormLabel>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskEmbeddedTableItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskEmbeddedTableItem.tsx
@@ -14,6 +14,7 @@ import Dropdown from "react-bootstrap/Dropdown";
 import { useFormContext } from "react-hook-form";
 import { FormErrorIcon } from "components/common/Form";
 import { editCdcSinkTaskConstants } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskConstants";
+import { EditCdcSinkTaskTableWarningIcon } from "./EditCdcSinkTaskTableWarningIcon";
 
 const { expandButtonWidthPx, nestedTableIndentPx } = editCdcSinkTaskConstants;
 
@@ -24,6 +25,7 @@ export function EditCdcSinkTaskEmbeddedTableItem({
     hasChildren,
     isExpanded,
     isRootDisabled,
+    warningMessages,
 }: ExplorerRowEmbeddedTable) {
     const dispatch = useAppDispatch();
     const tableActions = useEditCdcSinkTaskTableActions();
@@ -71,6 +73,7 @@ export function EditCdcSinkTaskEmbeddedTableItem({
                 </span>
                 <Icon icon="embed" margin="ms-1" className="font-size-14" />
                 <FormErrorIcon control={control} paths={[path]} iconClassName="font-size-14" />
+                <EditCdcSinkTaskTableWarningIcon messages={warningMessages} className="font-size-14" />
             </Button>
             <DropdownWithPortalMenu>
                 <Dropdown.Toggle

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskLinkedTableItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskLinkedTableItem.tsx
@@ -14,10 +14,17 @@ import Dropdown from "react-bootstrap/Dropdown";
 import { useFormContext } from "react-hook-form";
 import { FormErrorIcon } from "components/common/Form";
 import { editCdcSinkTaskConstants } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskConstants";
+import { EditCdcSinkTaskTableWarningIcon } from "./EditCdcSinkTaskTableWarningIcon";
 
 const { expandButtonWidthPx, nestedTableIndentPx } = editCdcSinkTaskConstants;
 
-export function EditCdcSinkTaskLinkedTableItem({ path, table, depth, isRootDisabled }: ExplorerRowLinkedTable) {
+export function EditCdcSinkTaskLinkedTableItem({
+    path,
+    table,
+    depth,
+    isRootDisabled,
+    warningMessages,
+}: ExplorerRowLinkedTable) {
     const dispatch = useAppDispatch();
     const tableActions = useEditCdcSinkTaskTableActions();
     const isActive = useAppSelector(editCdcSinkTaskSelectors.isActiveTable(path));
@@ -47,6 +54,7 @@ export function EditCdcSinkTaskLinkedTableItem({ path, table, depth, isRootDisab
                 </span>
                 <Icon icon="link" margin="ms-1" className="font-size-14" />
                 <FormErrorIcon control={control} paths={[path]} iconClassName="font-size-14" />
+                <EditCdcSinkTaskTableWarningIcon messages={warningMessages} className="font-size-14" />
             </Button>
             <DropdownWithPortalMenu>
                 <Dropdown.Toggle

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskRootTableItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskRootTableItem.tsx
@@ -14,10 +14,17 @@ import Dropdown from "react-bootstrap/Dropdown";
 import { useFormContext } from "react-hook-form";
 import { FormErrorIcon } from "components/common/Form";
 import { editCdcSinkTaskConstants } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskConstants";
+import { EditCdcSinkTaskTableWarningIcon } from "./EditCdcSinkTaskTableWarningIcon";
 
 const { expandButtonWidthPx } = editCdcSinkTaskConstants;
 
-export function EditCdcSinkTaskRootTableItem({ path, table, isExpanded, hasChildren }: ExplorerRowRootTable) {
+export function EditCdcSinkTaskRootTableItem({
+    path,
+    table,
+    isExpanded,
+    hasChildren,
+    warningMessages,
+}: ExplorerRowRootTable) {
     const dispatch = useAppDispatch();
     const tableActions = useEditCdcSinkTaskTableActions();
     const isActive = useAppSelector(editCdcSinkTaskSelectors.isActiveTable(path));
@@ -64,6 +71,7 @@ export function EditCdcSinkTaskRootTableItem({ path, table, isExpanded, hasChild
                     {label}
                 </span>
                 <FormErrorIcon control={control} paths={[path]} iconClassName="font-size-14" />
+                <EditCdcSinkTaskTableWarningIcon messages={warningMessages} className="font-size-14" />
             </Button>
             <DropdownWithPortalMenu>
                 <Dropdown.Toggle

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableItems.spec.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableItems.spec.ts
@@ -1,0 +1,236 @@
+import {
+    ExplorerRowRootTable,
+    FormEmbeddedTable,
+    FormRootTable,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes";
+import { buildExplorerRows } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableItems";
+
+describe("buildExplorerRows", () => {
+    it("keeps distinct root paths when the same table name exists in multiple schemas", () => {
+        const rows = buildExplorerRows({
+            allTables: [
+                createRootTable({ sourceTableSchema: "dbo", sourceTableName: "orders", collectionName: "Orders" }),
+                createRootTable({
+                    sourceTableSchema: "sales",
+                    sourceTableName: "orders",
+                    collectionName: "SalesOrders",
+                }),
+            ],
+            expandedTables: {},
+            filter: "",
+            rootFieldIds: ["root-1", "root-2"],
+        });
+
+        const rootRows = getRootRows(rows);
+
+        expect(rootRows.map((row) => row.path)).toEqual(["tables.0", "tables.1"]);
+        expect(rootRows.map((row) => row.rowKey)).toEqual(["root:root-1", "root:root-2"]);
+    });
+
+    it("keeps the surviving root row key stable after removing an earlier root row", () => {
+        const tables = [
+            createRootTable({ sourceTableSchema: "dbo", sourceTableName: "orders", collectionName: "Orders" }),
+            createRootTable({ sourceTableSchema: "sales", sourceTableName: "orders", collectionName: "SalesOrders" }),
+        ];
+
+        const beforeRows = getRootRows(
+            buildExplorerRows({
+                allTables: tables,
+                expandedTables: {},
+                filter: "",
+                rootFieldIds: ["root-1", "root-2"],
+            })
+        );
+
+        const afterRows = getRootRows(
+            buildExplorerRows({
+                allTables: tables.slice(1),
+                expandedTables: {},
+                filter: "",
+                rootFieldIds: ["root-2"],
+            })
+        );
+
+        expect(beforeRows[1].rowKey).toBe("root:root-2");
+        expect(afterRows[0].path).toBe("tables.0");
+        expect(afterRows[0].rowKey).toBe(beforeRows[1].rowKey);
+    });
+
+    it("adds linked-table warnings to explorer rows", () => {
+        const rows = buildExplorerRows({
+            allTables: [
+                createRootTable({
+                    linkedTables: [
+                        {
+                            sourceTableName: "companies",
+                            sourceTableSchema: "dbo",
+                            linkedCollectionName: "Companies",
+                            propertyName: "Company",
+                            joinColumns: [{ value: "CompanyId" }],
+                        },
+                    ],
+                }),
+            ],
+            expandedTables: {
+                "tables.0": true,
+            },
+            filter: "",
+            rootFieldIds: ["root-1"],
+        });
+
+        const rootRow = getRootRows(rows)[0];
+        const linkedRow = rows.find((row) => row.type === "linked");
+
+        expect(rootRow.warningMessages).toEqual([expect.stringContaining('"Companies" collection')]);
+        expect(linkedRow?.warningMessages).toEqual([expect.stringContaining('"Companies" collection')]);
+    });
+
+    it("adds linked-table warnings to collapsed root explorer rows", () => {
+        const rows = buildExplorerRows({
+            allTables: [
+                createRootTable({
+                    linkedTables: [
+                        {
+                            sourceTableName: "media",
+                            sourceTableSchema: "public",
+                            linkedCollectionName: "Media",
+                            propertyName: "Media",
+                            joinColumns: [{ value: "MediaId" }],
+                        },
+                    ],
+                }),
+            ],
+            expandedTables: {},
+            filter: "",
+            rootFieldIds: ["root-1"],
+        });
+
+        expect(rows.some((row) => row.type === "linked")).toBe(false);
+        expect(getRootRows(rows)[0].warningMessages).toEqual([
+            expect.stringContaining('"public.media" is also configured as a root table'),
+        ]);
+    });
+
+    it("adds embedded-table warnings to explorer rows", () => {
+        const rows = buildExplorerRows({
+            allTables: [
+                createRootTable({
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "companies",
+                    collectionName: "Companies",
+                }),
+                createRootTable({
+                    embeddedTables: [
+                        createEmbeddedTable({
+                            propertyName: "Company",
+                            sourceTableName: "companies",
+                            sourceTableSchema: "dbo",
+                        }),
+                    ],
+                }),
+            ],
+            expandedTables: {
+                "tables.1": true,
+            },
+            filter: "",
+            rootFieldIds: ["root-1", "root-2"],
+        });
+
+        const embeddedRow = rows.find((row) => row.type === "embedded");
+
+        expect(getRootRows(rows)[1].warningMessages).toEqual([
+            expect.stringContaining("already configured as a root table"),
+        ]);
+        expect(embeddedRow?.warningMessages).toEqual([expect.stringContaining("already configured as a root table")]);
+    });
+
+    it("adds descendant warnings to collapsed embedded explorer rows", () => {
+        const rows = buildExplorerRows({
+            allTables: [
+                createRootTable({
+                    embeddedTables: [
+                        createEmbeddedTable({
+                            linkedTables: [
+                                {
+                                    sourceTableName: "media",
+                                    sourceTableSchema: "public",
+                                    linkedCollectionName: "Media",
+                                    propertyName: "Media",
+                                    joinColumns: [{ value: "MediaId" }],
+                                },
+                            ],
+                        }),
+                    ],
+                }),
+            ],
+            expandedTables: {
+                "tables.0": true,
+            },
+            filter: "",
+            rootFieldIds: ["root-1"],
+        });
+
+        const embeddedRow = rows.find((row) => row.type === "embedded");
+
+        expect(rows.some((row) => row.type === "linked")).toBe(false);
+        expect(embeddedRow?.warningMessages).toEqual([
+            expect.stringContaining('"public.media" is also configured as a root table'),
+        ]);
+    });
+});
+
+function getRootRows(rows: ReturnType<typeof buildExplorerRows>) {
+    return rows.filter((row): row is ExplorerRowRootTable => row.type === "root");
+}
+
+function createRootTable(overrides: Partial<FormRootTable>): FormRootTable {
+    return {
+        collectionName: "Orders",
+        columns: [
+            {
+                column: "Id",
+                name: "Id",
+                type: "Default",
+            },
+        ],
+        disabled: false,
+        embeddedTables: [],
+        linkedTables: [],
+        onDelete: {
+            ignoreDeletes: false,
+            patch: "",
+        },
+        patch: "",
+        primaryKeyColumns: [{ value: "Id" }],
+        sourceTableName: "orders",
+        sourceTableSchema: "dbo",
+        ...overrides,
+    };
+}
+
+function createEmbeddedTable(overrides: Partial<FormRootTable["embeddedTables"][number]>): FormEmbeddedTable {
+    return {
+        caseSensitiveKeys: false,
+        columns: [
+            {
+                column: "Id",
+                name: "Id",
+                type: "Default",
+            },
+        ],
+        embeddedTables: [],
+        joinColumns: [{ value: "CompanyId" }],
+        linkedTables: [],
+        onDelete: {
+            ignoreDeletes: false,
+            patch: "",
+        },
+        patch: "",
+        primaryKeyColumns: [{ value: "Id" }],
+        propertyName: "Company",
+        sourceTableName: "companies",
+        sourceTableSchema: "dbo",
+        type: "Array",
+        ...overrides,
+    };
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableItems.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableItems.tsx
@@ -7,6 +7,7 @@ import {
     ExplorerRow,
     FormEmbeddedTable,
     FormRootTable,
+    getRootTablePath,
 } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes";
 import { EditCdcSinkTaskFormData } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation";
 import _ from "lodash";
@@ -17,6 +18,13 @@ import { EditCdcSinkTaskLinkedTableItem } from "./EditCdcSinkTaskLinkedTableItem
 import { EditCdcSinkTaskEmbeddedTableItem } from "./EditCdcSinkTaskEmbeddedTableItem";
 import assertUnreachable from "components/utils/assertUnreachable";
 import { editCdcSinkTaskConstants } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskConstants";
+import {
+    analyzeRootTables,
+    getEmbeddedTableWarningMessagesFromAnalysis,
+    getLinkedTableWarningMessagesFromAnalysis,
+    getRootTableWarningMessagesFromAnalysis,
+    RootTablesAnalysis,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings";
 
 const { explorerRowHeightPx } = editCdcSinkTaskConstants;
 
@@ -24,65 +32,43 @@ type ExpandedTables = Partial<Record<FieldPath<EditCdcSinkTaskFormData>, boolean
 
 interface EditCdcSinkTaskTableItemsProps {
     filter: string;
+    rootFieldIds: string[];
 }
 
-export function EditCdcSinkTaskTableItems({ filter }: EditCdcSinkTaskTableItemsProps) {
+interface BuildExplorerRowsArgs {
+    allTables: FormRootTable[];
+    expandedTables: ExpandedTables;
+    filter: string;
+    rootFieldIds: string[];
+}
+
+interface IndexedRootTable {
+    index: number;
+    table: FormRootTable;
+}
+
+export function EditCdcSinkTaskTableItems({ filter, rootFieldIds }: EditCdcSinkTaskTableItemsProps) {
     const parentRef = useRef<HTMLDivElement>(null);
     const expandedTables = useAppSelector((state) => state.editCdcSinkTask.expandedTables);
     const { control } = useFormContext<EditCdcSinkTaskFormData>();
     const allTables = useWatch({ control, name: "tables" }) ?? [];
 
-    const filteredTables = useMemo(() => {
-        const normalizedFilter = filter.trim().toLowerCase();
-
-        const filteredGroupedTables = Object.entries(
-            _.groupBy(allTables, (table) => table?.sourceTableSchema || "public")
-        )
-            .map(([schema, rootTables]) => ({
-                schema,
-                tables: normalizedFilter
-                    ? rootTables.filter((table) =>
-                          (table?.sourceTableName ?? "").toLowerCase().includes(normalizedFilter)
-                      )
-                    : rootTables,
-            }))
-            .filter((group) => group.tables.length > 0);
-
-        return filteredGroupedTables.flatMap(({ schema, tables }) => {
-            const rows: ExplorerRow[] = [{ type: "schema", path: `schema:${schema}`, label: schema }];
-
-            tables.forEach((table, idx) => {
-                const rootPath = `tables.${idx}` as const;
-                const isExpanded = Boolean(expandedTables[rootPath]);
-                rows.push({
-                    type: "root",
-                    path: rootPath,
-                    table,
-                    hasChildren: hasChildren(table),
-                    isExpanded,
-                });
-
-                if (expandedTables[rootPath]) {
-                    addChildRows({
-                        rows,
-                        parentPath: rootPath,
-                        table,
-                        isRootDisabled: Boolean(table?.disabled),
-                        depth: 1,
-                        expandedTables,
-                    });
-                }
-            });
-
-            return rows;
-        });
-    }, [filter, expandedTables, allTables]);
+    const filteredTables = useMemo(
+        () =>
+            buildExplorerRows({
+                allTables,
+                expandedTables,
+                filter,
+                rootFieldIds,
+            }),
+        [filter, expandedTables, allTables, rootFieldIds]
+    );
 
     const virtualizer = useVirtualizer({
         count: filteredTables.length,
         getScrollElement: () => parentRef.current,
         estimateSize: () => explorerRowHeightPx,
-        getItemKey: (index) => filteredTables[index].path,
+        getItemKey: (index) => filteredTables[index].rowKey,
         overscan: 4,
     });
     const virtualRows = virtualizer.getVirtualItems();
@@ -131,6 +117,72 @@ export function EditCdcSinkTaskTableItems({ filter }: EditCdcSinkTaskTableItemsP
     );
 }
 
+export function buildExplorerRows({ allTables, expandedTables, filter, rootFieldIds }: BuildExplorerRowsArgs) {
+    const normalizedFilter = filter.trim().toLowerCase();
+    const rootTablesAnalysis = analyzeRootTables(allTables);
+
+    const indexedTables: IndexedRootTable[] = allTables.map((table, index) => ({
+        table,
+        index,
+    }));
+
+    const filteredGroupedTables = Object.entries(
+        _.groupBy(indexedTables, ({ table }) => table?.sourceTableSchema || "public")
+    )
+        .map(([schema, rootTables]) => ({
+            schema,
+            tables: normalizedFilter
+                ? rootTables.filter(({ table }) =>
+                      (table?.sourceTableName ?? "").toLowerCase().includes(normalizedFilter)
+                  )
+                : rootTables,
+        }))
+        .filter((group) => group.tables.length > 0);
+
+    return filteredGroupedTables.flatMap(({ schema, tables }) => {
+        const rows: ExplorerRow[] = [
+            {
+                type: "schema",
+                path: `schema:${schema}`,
+                rowKey: `schema:${schema}`,
+                label: schema,
+            },
+        ];
+
+        tables.forEach(({ table, index }) => {
+            const rootPath = getRootTablePath(index);
+            const rootRowKey = getRootRowKey(rootFieldIds, index, rootPath);
+            const isExpanded = Boolean(expandedTables[rootPath]);
+            const warningMessages = getRootTableWarningMessagesFromAnalysis(rootTablesAnalysis, table);
+
+            rows.push({
+                type: "root",
+                path: rootPath,
+                rowKey: rootRowKey,
+                warningMessages,
+                table,
+                hasChildren: hasChildren(table),
+                isExpanded,
+            });
+
+            if (isExpanded) {
+                addChildRows({
+                    rows,
+                    parentPath: rootPath,
+                    rowKeyPrefix: rootRowKey,
+                    table,
+                    isRootDisabled: Boolean(table?.disabled),
+                    depth: 1,
+                    expandedTables,
+                    rootTablesAnalysis,
+                });
+            }
+        });
+
+        return rows;
+    });
+}
+
 function ExplorerRowItem({ row }: { row: ExplorerRow }) {
     const rowType = row.type;
     switch (rowType) {
@@ -172,18 +224,32 @@ function getActiveSchemaLabel(rows: ExplorerRow[], scrollOffset: number): string
 interface AddChildRowsArgs {
     rows: ExplorerRow[];
     parentPath: string;
+    rowKeyPrefix: string;
     table: FormRootTable | FormEmbeddedTable;
     isRootDisabled: boolean;
     depth: number;
     expandedTables: ExpandedTables;
+    rootTablesAnalysis: RootTablesAnalysis;
 }
 
-function addChildRows({ rows, parentPath, table, isRootDisabled, depth, expandedTables }: AddChildRowsArgs) {
+function addChildRows({
+    rows,
+    parentPath,
+    rowKeyPrefix,
+    table,
+    isRootDisabled,
+    depth,
+    expandedTables,
+    rootTablesAnalysis,
+}: AddChildRowsArgs) {
     table?.linkedTables?.forEach((linkedTable, idx) => {
         const path = castToLinkedTablePath(`${parentPath}.linkedTables.${idx}`);
+        const warningMessages = getLinkedTableWarningMessagesFromAnalysis(rootTablesAnalysis, linkedTable);
         rows.push({
             type: "linked",
             path,
+            rowKey: `${rowKeyPrefix}:linked:${idx}`,
+            warningMessages,
             table: linkedTable,
             isRootDisabled,
             depth,
@@ -192,10 +258,14 @@ function addChildRows({ rows, parentPath, table, isRootDisabled, depth, expanded
 
     table?.embeddedTables?.forEach((embeddedTable, idx) => {
         const path = castToEmbeddedTablePath(`${parentPath}.embeddedTables.${idx}`);
+        const rowKey = `${rowKeyPrefix}:embedded:${idx}`;
         const isExpanded = Boolean(expandedTables[path]);
+        const warningMessages = getEmbeddedTableWarningMessagesFromAnalysis(rootTablesAnalysis, embeddedTable);
         rows.push({
             type: "embedded",
             path,
+            rowKey,
+            warningMessages,
             table: embeddedTable,
             isRootDisabled,
             depth,
@@ -207,10 +277,12 @@ function addChildRows({ rows, parentPath, table, isRootDisabled, depth, expanded
             addChildRows({
                 rows,
                 parentPath: path,
+                rowKeyPrefix: rowKey,
                 table: embeddedTable,
                 isRootDisabled,
                 depth: depth + 1,
                 expandedTables,
+                rootTablesAnalysis,
             });
         }
     });
@@ -218,4 +290,8 @@ function addChildRows({ rows, parentPath, table, isRootDisabled, depth, expanded
 
 function hasChildren(table: FormRootTable | FormEmbeddedTable) {
     return Boolean(table?.linkedTables?.length || table?.embeddedTables?.length);
+}
+
+function getRootRowKey(rootFieldIds: string[], index: number, rootPath: ReturnType<typeof getRootTablePath>) {
+    return `root:${rootFieldIds[index] ?? rootPath}`;
 }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableWarningIcon.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableWarningIcon.tsx
@@ -1,0 +1,31 @@
+import { Icon } from "components/common/Icon";
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+
+interface EditCdcSinkTaskTableWarningIconProps {
+    messages?: string[];
+    className?: string;
+}
+
+export function EditCdcSinkTaskTableWarningIcon({ messages, className }: EditCdcSinkTaskTableWarningIconProps) {
+    if (!messages?.length) {
+        return null;
+    }
+
+    return (
+        <PopoverWithHoverWrapper
+            message={
+                messages.length === 1 ? (
+                    messages[0]
+                ) : (
+                    <ul className="mb-0 ps-3">
+                        {messages.map((message) => (
+                            <li key={message}>{message}</li>
+                        ))}
+                    </ul>
+                )
+            }
+        >
+            <Icon icon="warning" color="warning" margin="ms-1" className={className} />
+        </PopoverWithHoverWrapper>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableWarningIcon.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableWarningIcon.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "components/common/Icon";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import EditCdcSinkTaskWarningMessage from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/EditCdcSinkTaskWarningMessage";
 
 interface EditCdcSinkTaskTableWarningIconProps {
     messages?: string[];
@@ -15,11 +16,13 @@ export function EditCdcSinkTaskTableWarningIcon({ messages, className }: EditCdc
         <PopoverWithHoverWrapper
             message={
                 messages.length === 1 ? (
-                    messages[0]
+                    <EditCdcSinkTaskWarningMessage message={messages[0]} />
                 ) : (
                     <ul className="mb-0 ps-3">
                         {messages.map((message) => (
-                            <li key={message}>{message}</li>
+                            <li key={message}>
+                                <EditCdcSinkTaskWarningMessage message={message} />
+                            </li>
                         ))}
                     </ul>
                 )

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/store/editCdcSinkTaskSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/store/editCdcSinkTaskSlice.ts
@@ -26,7 +26,7 @@ export type CdcActiveTable =
 
 interface EditCdcSinkTaskState {
     selectedConnectionString: SqlConnectionString;
-    sourceSchema: CdcSinkSourceSchema | null;
+    sourceSchema: CdcSinkSourceSchema;
     activeTable?: CdcActiveTable;
     expandedTables: Partial<Record<FieldPath<EditCdcSinkTaskFormData>, boolean>>;
     isFieldMappingExpandedByDefault: boolean;
@@ -71,7 +71,7 @@ export const editCdcSinkTaskSlice = createSlice({
             state.selectedConnectionString = action.payload;
             state.sourceSchema = null;
         },
-        sourceSchemaSet: (state, action: PayloadAction<CdcSinkSourceSchema | null>) => {
+        sourceSchemaSet: (state, action: PayloadAction<CdcSinkSourceSchema>) => {
             state.sourceSchema = action.payload;
         },
         activeTableSet: (state, action: PayloadAction<CdcActiveTable>) => {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils.ts
@@ -51,7 +51,7 @@ export function getSourceTableOptionLabel(table: CdcSinkSourceTable) {
 }
 
 export function getSourceTableOptions(
-    schema: CdcSinkSourceSchema | null,
+    schema: CdcSinkSourceSchema,
     sourceTableSchema: string,
     excludedTable?: { sourceTableSchema: string; sourceTableName: string }
 ): CdcSinkSourceTableOption[] {
@@ -73,7 +73,7 @@ export function getSourceTableOptions(
         }));
 }
 
-export function getSourceSchemaOptions(schema: CdcSinkSourceSchema | null): SelectOption<string>[] {
+export function getSourceSchemaOptions(schema: CdcSinkSourceSchema): SelectOption<string>[] {
     const schemas = new Set((schema?.Tables ?? []).filter(isTableSupported).map((table) => table.SourceTableSchema));
 
     return Array.from(schemas)
@@ -84,11 +84,7 @@ export function getSourceSchemaOptions(schema: CdcSinkSourceSchema | null): Sele
         }));
 }
 
-export function findSourceTable(
-    schema: CdcSinkSourceSchema | null,
-    sourceTableSchema: string,
-    sourceTableName: string
-) {
+export function findSourceTable(schema: CdcSinkSourceSchema, sourceTableSchema: string, sourceTableName: string) {
     return (schema?.Tables ?? []).find(
         (table) => table.SourceTableSchema === sourceTableSchema && table.SourceTableName === sourceTableName
     );

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.spec.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.spec.ts
@@ -1,0 +1,223 @@
+import {
+    FormEmbeddedTable,
+    FormRootTable,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes";
+import {
+    analyzeRootTables,
+    getDuplicateRootTableErrors,
+    getEmbeddedTableWarningMessagesFromAnalysis,
+    getEmbeddedRootTableConflictWarning,
+    getMissingRelatedCollectionWarning,
+    getRootTableWarningMessagesFromAnalysis,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings";
+
+describe("CDC Sink table warnings", () => {
+    it("returns duplicate errors for each repeated root source table", () => {
+        const duplicateErrors = getDuplicateRootTableErrors([
+            createRootTable({ sourceTableSchema: "dbo", sourceTableName: "orders", collectionName: "Orders" }),
+            createRootTable({ sourceTableSchema: "DBO", sourceTableName: "Orders", collectionName: "Cars" }),
+            createRootTable({ sourceTableSchema: "dbo", sourceTableName: "companies", collectionName: "Companies" }),
+        ]);
+
+        expect(duplicateErrors).toEqual([
+            expect.objectContaining({ index: 0, message: expect.stringContaining('"dbo.orders"') }),
+            expect.objectContaining({ index: 1, message: expect.stringContaining('"DBO.Orders"') }),
+        ]);
+    });
+
+    it("returns an embedded warning when the source table is already configured as a root table", () => {
+        const warning = getEmbeddedRootTableConflictWarning(
+            [
+                createRootTable({
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "companies",
+                    collectionName: "Companies",
+                }),
+            ],
+            {
+                sourceTableName: "companies",
+                sourceTableSchema: "dbo",
+            }
+        );
+
+        expect(warning).toContain("already configured as a root table");
+    });
+
+    it("returns null when a matching root table creates the linked collection", () => {
+        const warning = getMissingRelatedCollectionWarning(
+            [
+                createRootTable({
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "companies",
+                    collectionName: "companies",
+                }),
+            ],
+            {
+                linkedCollectionName: "Companies",
+                propertyName: "Company",
+                sourceTableName: "companies",
+                sourceTableSchema: "dbo",
+            }
+        );
+
+        expect(warning).toBeNull();
+    });
+
+    it("returns a warning when no root table creates the linked collection", () => {
+        const warning = getMissingRelatedCollectionWarning(
+            [
+                createRootTable({
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "companies",
+                    collectionName: "Businesses",
+                }),
+            ],
+            {
+                linkedCollectionName: "Companies",
+                propertyName: "Company",
+                sourceTableName: "companies",
+                sourceTableSchema: "dbo",
+            }
+        );
+
+        expect(warning).toBe(`No root table is configured for the related "Companies" collection.
+The Company property will contain related document IDs that reference documents in the "Companies" collection,
+but those documents will not be created unless "dbo.companies" is also configured as a root table.`);
+    });
+
+    it("returns root-level warnings from the whole table tree", () => {
+        const rootTable = createRootTable({
+            embeddedTables: [
+                {
+                    caseSensitiveKeys: false,
+                    columns: [
+                        {
+                            column: "Id",
+                            name: "Id",
+                            type: "Default",
+                        },
+                    ],
+                    embeddedTables: [],
+                    joinColumns: [{ value: "CompanyId" }],
+                    linkedTables: [
+                        {
+                            sourceTableName: "media",
+                            sourceTableSchema: "public",
+                            linkedCollectionName: "Media",
+                            propertyName: "Media",
+                            joinColumns: [{ value: "MediaId" }],
+                        },
+                    ],
+                    onDelete: {
+                        ignoreDeletes: false,
+                        patch: "",
+                    },
+                    patch: "",
+                    primaryKeyColumns: [{ value: "Id" }],
+                    propertyName: "Company",
+                    sourceTableName: "companies",
+                    sourceTableSchema: "dbo",
+                    type: "Array",
+                },
+            ],
+        });
+        const conflictingRootTable = createRootTable({
+            sourceTableSchema: "dbo",
+            sourceTableName: "companies",
+            collectionName: "Companies",
+        });
+
+        const warnings = getRootTableWarningMessagesFromAnalysis(
+            analyzeRootTables([rootTable, conflictingRootTable]),
+            rootTable
+        );
+
+        expect(warnings).toEqual([
+            expect.stringContaining("already configured as a root table"),
+            `No root table is configured for the related "Media" collection.
+The Media property will contain related document IDs that reference documents in the "Media" collection,
+but those documents will not be created unless "public.media" is also configured as a root table.`,
+        ]);
+    });
+
+    it("returns embedded-level warnings for the embedded table and its descendants", () => {
+        const rootTable = createRootTable({
+            sourceTableSchema: "dbo",
+            sourceTableName: "companies",
+            collectionName: "Companies",
+        });
+        const embeddedTable = createEmbeddedTable({
+            linkedTables: [
+                {
+                    sourceTableName: "media",
+                    sourceTableSchema: "public",
+                    linkedCollectionName: "Media",
+                    propertyName: "Media",
+                    joinColumns: [{ value: "MediaId" }],
+                },
+            ],
+            propertyName: "Company",
+            sourceTableName: "companies",
+            sourceTableSchema: "dbo",
+        });
+
+        const warnings = getEmbeddedTableWarningMessagesFromAnalysis(analyzeRootTables([rootTable]), embeddedTable);
+
+        expect(warnings).toEqual([
+            expect.stringContaining("already configured as a root table"),
+            expect.stringContaining('"public.media" is also configured as a root table'),
+        ]);
+    });
+});
+
+function createRootTable(overrides: Partial<FormRootTable>): FormRootTable {
+    return {
+        collectionName: "Orders",
+        columns: [
+            {
+                column: "Id",
+                name: "Id",
+                type: "Default",
+            },
+        ],
+        disabled: false,
+        embeddedTables: [],
+        linkedTables: [],
+        onDelete: {
+            ignoreDeletes: false,
+            patch: "",
+        },
+        patch: "",
+        primaryKeyColumns: [{ value: "Id" }],
+        sourceTableName: "orders",
+        sourceTableSchema: "dbo",
+        ...overrides,
+    };
+}
+
+function createEmbeddedTable(overrides: Partial<FormRootTable["embeddedTables"][number]>): FormEmbeddedTable {
+    return {
+        caseSensitiveKeys: false,
+        columns: [
+            {
+                column: "Id",
+                name: "Id",
+                type: "Default",
+            },
+        ],
+        embeddedTables: [],
+        joinColumns: [{ value: "CompanyId" }],
+        linkedTables: [],
+        onDelete: {
+            ignoreDeletes: false,
+            patch: "",
+        },
+        patch: "",
+        primaryKeyColumns: [{ value: "Id" }],
+        propertyName: "Company",
+        sourceTableName: "companies",
+        sourceTableSchema: "dbo",
+        type: "Array",
+        ...overrides,
+    };
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.spec.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.spec.ts
@@ -81,8 +81,8 @@ describe("CDC Sink table warnings", () => {
         );
 
         expect(warning).toBe(`No root table is configured for the related "Companies" collection.
-The Company property will contain related document IDs that reference documents in the "Companies" collection,
-but those documents will not be created unless "dbo.companies" is also configured as a root table.`);
+The Company property will contain related document IDs that reference documents in the "Companies" collection.
+However, those documents will not be created unless "dbo.companies" is also configured as a root table.`);
     });
 
     it("returns root-level warnings from the whole table tree", () => {
@@ -135,8 +135,8 @@ but those documents will not be created unless "dbo.companies" is also configure
         expect(warnings).toEqual([
             expect.stringContaining("already configured as a root table"),
             `No root table is configured for the related "Media" collection.
-The Media property will contain related document IDs that reference documents in the "Media" collection,
-but those documents will not be created unless "public.media" is also configured as a root table.`,
+The Media property will contain related document IDs that reference documents in the "Media" collection.
+However, those documents will not be created unless "public.media" is also configured as a root table.`,
         ]);
     });
 

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.ts
@@ -159,8 +159,8 @@ export function getMissingRelatedCollectionWarningFromAnalysis(
     }
 
     return `No root table is configured for the related "${linkedCollectionName}" collection.
-The ${propertyName} property will contain related document IDs that reference documents in the "${linkedCollectionName}" collection,
-but those documents will not be created unless "${sourceTableSchema}.${sourceTableName}" is also configured as a root table.`;
+The ${propertyName} property will contain related document IDs that reference documents in the "${linkedCollectionName}" collection.
+However, those documents will not be created unless "${sourceTableSchema}.${sourceTableName}" is also configured as a root table.`;
 }
 
 export function analyzeRootTables(rootTables: ReadonlyArray<RootTableAnalysisInput>): RootTablesAnalysis {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.ts
@@ -1,0 +1,272 @@
+import {
+    FormEmbeddedTable,
+    FormLinkedTable,
+    FormRootTable,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes";
+
+export interface RootTablesAnalysis {
+    sourceCountByKey: Map<string, number>;
+    collectionNameKeysBySourceKey: Map<string, Set<string>>;
+}
+
+interface SourceTableContext {
+    sourceTableName?: string;
+    sourceTableSchema?: string;
+}
+
+interface LinkedTableWarningContext {
+    linkedCollectionName?: string;
+    propertyName?: string;
+    sourceTableName?: string;
+    sourceTableSchema?: string;
+}
+
+interface DuplicateRootTableError {
+    index: number;
+    message: string;
+}
+
+type RootTableAnalysisInput = SourceTableContext & {
+    collectionName?: string;
+};
+
+interface TableWarningContext {
+    analysis: RootTablesAnalysis;
+}
+
+type TableWarningProvider<TTable> = (table: TTable, context: TableWarningContext) => string | null;
+
+// Add new row warning rules here. They are collected for the row itself and bubbled up to parent/root rows.
+const rootTableWarningProviders: TableWarningProvider<FormRootTable>[] = [];
+const embeddedTableWarningProviders: TableWarningProvider<FormEmbeddedTable>[] = [
+    (table, context) => getEmbeddedRootTableConflictWarningFromAnalysis(context.analysis, table),
+];
+const linkedTableWarningProviders: TableWarningProvider<FormLinkedTable>[] = [
+    (table, context) => getMissingRelatedCollectionWarningFromAnalysis(context.analysis, table),
+];
+
+export function getDuplicateRootTableErrors(
+    rootTables: ReadonlyArray<RootTableAnalysisInput>
+): DuplicateRootTableError[] {
+    const analysis = analyzeRootTables(rootTables);
+
+    return (rootTables ?? []).flatMap((rootTable, index) => {
+        const sourceTableLabel = getSourceTableLabel(rootTable);
+
+        if (!sourceTableLabel) {
+            return [];
+        }
+
+        const sourceKey = getSourceTableKey(rootTable.sourceTableSchema, rootTable.sourceTableName);
+        const duplicateCount = analysis.sourceCountByKey.get(sourceKey) ?? 0;
+
+        if (duplicateCount < 2) {
+            return [];
+        }
+
+        return [
+            {
+                index,
+                message: `Source table ${sourceTableLabel} is already configured as another root table. CDC Sink can process a source table only once.`,
+            },
+        ];
+    });
+}
+
+export function getEmbeddedRootTableConflictWarning(rootTables: FormRootTable[], embeddedTable: SourceTableContext) {
+    return getEmbeddedRootTableConflictWarningFromAnalysis(analyzeRootTables(rootTables), embeddedTable);
+}
+
+export function getMissingRelatedCollectionWarning(
+    rootTables: FormRootTable[],
+    linkedTable: LinkedTableWarningContext
+) {
+    return getMissingRelatedCollectionWarningFromAnalysis(analyzeRootTables(rootTables), linkedTable);
+}
+
+export function getRootTableWarningMessagesFromAnalysis(analysis: RootTablesAnalysis, table?: FormRootTable) {
+    if (!table) {
+        return [];
+    }
+
+    const warnings = new Set<string>();
+    collectRootTableWarningMessages(analysis, table, warnings);
+
+    return Array.from(warnings);
+}
+
+export function getEmbeddedTableWarningMessagesFromAnalysis(analysis: RootTablesAnalysis, table?: FormEmbeddedTable) {
+    if (!table) {
+        return [];
+    }
+
+    const warnings = new Set<string>();
+    collectEmbeddedTableWarningMessages(analysis, table, warnings);
+
+    return Array.from(warnings);
+}
+
+export function getLinkedTableWarningMessagesFromAnalysis(analysis: RootTablesAnalysis, table?: FormLinkedTable) {
+    if (!table) {
+        return [];
+    }
+
+    const warnings = new Set<string>();
+    collectLinkedTableWarningMessages(analysis, table, warnings);
+
+    return Array.from(warnings);
+}
+
+export function getEmbeddedRootTableConflictWarningFromAnalysis(
+    analysis: RootTablesAnalysis,
+    embeddedTable: SourceTableContext
+) {
+    const sourceTableLabel = getSourceTableLabel(embeddedTable);
+
+    if (!sourceTableLabel) {
+        return null;
+    }
+
+    const sourceKey = getSourceTableKey(embeddedTable.sourceTableSchema, embeddedTable.sourceTableName);
+
+    if (!analysis.sourceCountByKey.has(sourceKey)) {
+        return null;
+    }
+
+    return "This source table is already configured as a root table. CDC Sink can process a source table only once, so embedded updates may be routed to the root table instead.";
+}
+
+export function getMissingRelatedCollectionWarningFromAnalysis(
+    analysis: RootTablesAnalysis,
+    linkedTable: LinkedTableWarningContext
+) {
+    const linkedCollectionName = linkedTable.linkedCollectionName?.trim();
+    const propertyName = linkedTable.propertyName?.trim();
+    const sourceTableName = linkedTable.sourceTableName?.trim();
+    const sourceTableSchema = linkedTable.sourceTableSchema?.trim();
+
+    if (!linkedCollectionName || !sourceTableName || !sourceTableSchema || !propertyName) {
+        return null;
+    }
+
+    const sourceKey = getSourceTableKey(sourceTableSchema, sourceTableName);
+    const collectionNameKey = normalizeValue(linkedCollectionName);
+    const collectionNameKeys = analysis.collectionNameKeysBySourceKey.get(sourceKey);
+    const hasMatchingRootTable = collectionNameKeys?.has(collectionNameKey);
+
+    if (hasMatchingRootTable) {
+        return null;
+    }
+
+    return `No root table is configured for the related "${linkedCollectionName}" collection.
+The ${propertyName} property will contain related document IDs that reference documents in the "${linkedCollectionName}" collection,
+but those documents will not be created unless "${sourceTableSchema}.${sourceTableName}" is also configured as a root table.`;
+}
+
+export function analyzeRootTables(rootTables: ReadonlyArray<RootTableAnalysisInput>): RootTablesAnalysis {
+    const sourceCountByKey = new Map<string, number>();
+    const collectionNameKeysBySourceKey = new Map<string, Set<string>>();
+
+    (rootTables ?? []).forEach((rootTable) => {
+        const sourceKey = getSourceTableKey(rootTable.sourceTableSchema, rootTable.sourceTableName);
+
+        if (!sourceKey) {
+            return;
+        }
+
+        sourceCountByKey.set(sourceKey, (sourceCountByKey.get(sourceKey) ?? 0) + 1);
+
+        const collectionNameKey = normalizeValue(rootTable.collectionName);
+        if (!collectionNameKey) {
+            return;
+        }
+
+        if (!collectionNameKeysBySourceKey.has(sourceKey)) {
+            collectionNameKeysBySourceKey.set(sourceKey, new Set<string>());
+        }
+
+        collectionNameKeysBySourceKey.get(sourceKey).add(collectionNameKey);
+    });
+
+    return {
+        sourceCountByKey,
+        collectionNameKeysBySourceKey,
+    };
+}
+
+function getSourceTableKey(sourceTableSchema: string, sourceTableName: string) {
+    const normalizedSchema = normalizeValue(sourceTableSchema);
+    const normalizedTableName = normalizeValue(sourceTableName);
+
+    if (!normalizedSchema || !normalizedTableName) {
+        return null;
+    }
+
+    return `${normalizedSchema}::${normalizedTableName}`;
+}
+
+function getSourceTableLabel(table: SourceTableContext) {
+    const sourceTableSchema = table.sourceTableSchema?.trim();
+    const sourceTableName = table.sourceTableName?.trim();
+
+    if (!sourceTableSchema || !sourceTableName) {
+        return null;
+    }
+
+    return `"${sourceTableSchema}.${sourceTableName}"`;
+}
+
+function normalizeValue(value?: string) {
+    return value?.trim().toLowerCase() ?? "";
+}
+
+function collectRootTableWarningMessages(analysis: RootTablesAnalysis, table: FormRootTable, warnings: Set<string>) {
+    addWarningsFromProviders(warnings, rootTableWarningProviders, table, { analysis });
+    collectChildTableWarningMessages(analysis, table, warnings);
+}
+
+function collectEmbeddedTableWarningMessages(
+    analysis: RootTablesAnalysis,
+    table: FormEmbeddedTable,
+    warnings: Set<string>
+) {
+    addWarningsFromProviders(warnings, embeddedTableWarningProviders, table, { analysis });
+    collectChildTableWarningMessages(analysis, table, warnings);
+}
+
+function collectLinkedTableWarningMessages(
+    analysis: RootTablesAnalysis,
+    table: FormLinkedTable,
+    warnings: Set<string>
+) {
+    addWarningsFromProviders(warnings, linkedTableWarningProviders, table, { analysis });
+}
+
+function collectChildTableWarningMessages(
+    analysis: RootTablesAnalysis,
+    table: FormRootTable | FormEmbeddedTable,
+    warnings: Set<string>
+) {
+    table?.linkedTables?.forEach((linkedTable) => {
+        collectLinkedTableWarningMessages(analysis, linkedTable, warnings);
+    });
+
+    table?.embeddedTables?.forEach((embeddedTable) => {
+        collectEmbeddedTableWarningMessages(analysis, embeddedTable, warnings);
+    });
+}
+
+function addWarningsFromProviders<TTable>(
+    warnings: Set<string>,
+    providers: ReadonlyArray<TableWarningProvider<TTable>>,
+    table: TTable,
+    context: TableWarningContext
+) {
+    providers.forEach((provider) => {
+        const warning = provider(table, context);
+
+        if (warning) {
+            warnings.add(warning);
+        }
+    });
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes.ts
@@ -37,12 +37,15 @@ export type FormLinkedTable = FormRootTable["linkedTables"][number];
 interface ExplorerRowSchema {
     type: "schema";
     path: string;
+    rowKey: string;
     label: string;
 }
 
 export interface ExplorerRowRootTable {
     type: "root";
     path: RootTablePath;
+    rowKey: string;
+    warningMessages?: string[];
     table: FormRootTable;
     hasChildren: boolean;
     isExpanded: boolean;
@@ -51,6 +54,8 @@ export interface ExplorerRowRootTable {
 export interface ExplorerRowLinkedTable {
     type: "linked";
     path: LinkedTablePath;
+    rowKey: string;
+    warningMessages?: string[];
     table: FormLinkedTable;
     isRootDisabled: boolean;
     depth: number;
@@ -59,6 +64,8 @@ export interface ExplorerRowLinkedTable {
 export interface ExplorerRowEmbeddedTable {
     type: "embedded";
     path: EmbeddedTablePath;
+    rowKey: string;
+    warningMessages?: string[];
     table: FormEmbeddedTable;
     hasChildren: boolean;
     isExpanded: boolean;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation.spec.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation.spec.ts
@@ -1,0 +1,79 @@
+import {
+    EditCdcSinkTaskFormData,
+    editCdcSinkTaskSchema,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation";
+
+describe("editCdcSinkTaskSchema", () => {
+    it("rejects duplicate root source table configurations", async () => {
+        const formData = createFormData({
+            tables: [
+                createRootTable({
+                    collectionName: "Orders",
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "orders",
+                }),
+                createRootTable({
+                    collectionName: "Cars",
+                    sourceTableSchema: "DBO",
+                    sourceTableName: "Orders",
+                }),
+            ],
+        });
+
+        await expect(editCdcSinkTaskSchema.validate(formData, { abortEarly: false })).rejects.toMatchObject({
+            inner: expect.arrayContaining([
+                expect.objectContaining({
+                    path: "tables.0.sourceTableName",
+                    message: expect.stringContaining('"dbo.orders"'),
+                }),
+                expect.objectContaining({
+                    path: "tables.1.sourceTableName",
+                    message: expect.stringContaining('"DBO.Orders"'),
+                }),
+            ]),
+        });
+    });
+});
+
+function createFormData(overrides: Partial<EditCdcSinkTaskFormData>): EditCdcSinkTaskFormData {
+    return {
+        name: "Task",
+        state: "Enabled",
+        isSetResponsibleNode: false,
+        responsibleNode: "",
+        isPinResponsibleNode: false,
+        connectionStringName: "sql-name",
+        skipInitialLoad: false,
+        postgresPublicationName: "",
+        postgresSlotName: "",
+        tables: [createRootTable()],
+        ...overrides,
+    };
+}
+
+function createRootTable(
+    overrides: Partial<EditCdcSinkTaskFormData["tables"][number]> = {}
+): EditCdcSinkTaskFormData["tables"][number] {
+    return {
+        collectionName: "Orders",
+        columns: [
+            {
+                column: "Id",
+                name: "Id",
+                type: "Default",
+            },
+        ],
+        disabled: false,
+        embeddedTables: [],
+        linkedTables: [],
+        onDelete: {
+            ignoreDeletes: false,
+            patch: "",
+        },
+        patch: "",
+        primaryKeyColumns: [{ value: "Id" }],
+        sourceTableName: "orders",
+        sourceTableSchema: "dbo",
+        ...overrides,
+    };
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation.ts
@@ -1,5 +1,6 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import { RecursiveRequired } from "components/utils/common";
+import { getDuplicateRootTableErrors } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings";
 import { Resolver } from "react-hook-form/dist/types/resolvers";
 import * as yup from "yup";
 
@@ -105,7 +106,7 @@ const cdcSinkTableSchema = yup.object({
     sourceTableSchema: yup.string().nullable().required(),
 });
 
-const editCdcSinkTaskSchema = yup.object({
+export const editCdcSinkTaskSchema = yup.object({
     name: yup.string().nullable().required(),
     state: yup.string<CdcTaskState>().required(),
     isSetResponsibleNode: yup.boolean(),
@@ -127,7 +128,23 @@ const editCdcSinkTaskSchema = yup.object({
         .min(1, "At least one table is required")
         .test("unique-collection-names", "Collection names must be unique", (items) =>
             hasUniqueValues(items, (item) => item.collectionName)
-        ),
+        )
+        .test("unique-root-source-tables", function (items) {
+            const duplicateErrors = getDuplicateRootTableErrors(items);
+
+            if (duplicateErrors.length === 0) {
+                return true;
+            }
+
+            return new yup.ValidationError(
+                duplicateErrors.map(({ index, message }) =>
+                    this.createError({
+                        path: `tables.${index}.sourceTableName`,
+                        message,
+                    })
+                )
+            );
+        }),
 });
 
 export type EditCdcSinkTaskFormData = RecursiveRequired<yup.InferType<typeof editCdcSinkTaskSchema>>;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26697/CDC-Sink-some-fixes

### Additional description

This PR fixes several CDC Sink Studio configuration issues. It stabilizes configured-table row identity so tables with the same name in different schemas can be edited and removed independently, and it prevents stale action popups after row deletion. It also blocks duplicate root source-table configurations, adds warnings for linked and embedded mappings that reference data the task will not actually create, and surfaces those warnings directly in the Configured Tables explorer with a lightweight row-level indicator.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
