### PR TITLE
RavenDB-26665 - skip recursion tests on 32 bits

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17867.cs
+++ b/test/SlowTests/Issues/RavenDB-17867.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Issues
         {
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenPlatform.Windows)]
+        [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenPlatform.Windows, RavenArchitecture.AllX64)]
         public void Recursion_In_Additional_Sources_Should_Not_Crash_The_Server()
         {
             using (var store = GetDocumentStore())
@@ -65,7 +65,7 @@ public static class PeopleUtil
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenPlatform.Windows)]
+        [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenPlatform.Windows, RavenArchitecture.AllX64)]
         public void Recursion_In_Expression_Bodied_Additional_Sources_Should_Not_Crash_The_Server()
         {
             using (var store = GetDocumentStore())

--- a/test/SlowTests/Issues/RavenDB-17867.cs
+++ b/test/SlowTests/Issues/RavenDB-17867.cs
@@ -112,7 +112,7 @@ public static class TreeUtil
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenPlatform.Windows)]
+        [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenPlatform.Windows, RavenArchitecture.AllX64)]
         public void Recursion_In_Local_Function_Additional_Sources_Should_Not_Crash_The_Server()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26665

### Additional description

skip recursion tests on 32 bits

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
