### PR TITLE
RavenDB-26683: added info to flaky tests

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24847.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24847.cs
@@ -1,15 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Exceptions.Documents.Attachments;
+using Raven.Server.Documents.Handlers.AI.Agents;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -40,7 +44,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             await store.AI.CreateAgentAsync(agent, new OutputSchema());
 
-            var chat = store.AI.Conversation(agent.Identifier, "chats/", new AiConversationCreationOptions());
+            var chat = store.AI.Conversation(agent.Identifier, "chats/", new AiConversationCreationOptions(), debug: true);
             chat.SetUserPrompt("what are inside the images I sent you? what are their colors?");
 
             AiAnswer<OutputSchema> result;
@@ -56,12 +60,17 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 result = await chat.RunAsync<OutputSchema>(CancellationToken.None);
             }
 
-            Assert.Equal(AiConversationResult.Done, result?.Status);
-            Assert.NotNull(result?.Answer);
-            Assert.Contains("banana", result.Answer.Answer, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("star", result.Answer.Answer, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("heart", result.Answer.Answer, StringComparison.OrdinalIgnoreCase);
-            
+            Assert.Equal(AiConversationResult.Done, result.Status);
+            Assert.NotNull(result.Answer);
+            Assert.NotNull(result.Answer.Answer);
+
+            var traces = await LoadDebugTracesAsync(store, chat.Id);
+            Assert.True(result.Answer.Answer.Contains("banana", StringComparison.OrdinalIgnoreCase),
+                BuildAssertMessage("banana", result.Answer.Answer, traces));
+            Assert.True(result.Answer.Answer.Contains("star", StringComparison.OrdinalIgnoreCase),
+                BuildAssertMessage("star", result.Answer.Answer, traces));
+            Assert.True(result.Answer.Answer.Contains("heart", StringComparison.OrdinalIgnoreCase),
+                BuildAssertMessage("heart", result.Answer.Answer, traces));
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
@@ -259,7 +268,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             await store.AI.CreateAgentAsync(agent, new OutputSchema());
 
-            var chat = store.AI.Conversation(agent.Identifier, "chats/", new AiConversationCreationOptions());
+            var chat = store.AI.Conversation(agent.Identifier, "chats/", new AiConversationCreationOptions(), debug: true);
 
             chat.AddUserPrompt(new[] { "Please describe it.", "can you give tags related to it?" });
 
@@ -279,7 +288,11 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             Assert.Equal(AiConversationResult.Done, result2.Status);
             Assert.NotNull(result2.Answer);
-            Assert.Contains("banana", result2.Answer.Answer, StringComparison.OrdinalIgnoreCase);
+            Assert.NotNull(result2.Answer.Answer);
+
+            var traces = await LoadDebugTracesAsync(store, chat.Id);
+            Assert.True(result2.Answer.Answer.Contains("banana", StringComparison.OrdinalIgnoreCase),
+                BuildAssertMessage("banana", result2.Answer.Answer, traces));
         }
 
         private static Stream GetEmbeddedImgStream(string name)
@@ -292,6 +305,36 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 throw new FileNotFoundException($"Embedded resource not found: {resourceName}");
 
             return stream;
+        }
+
+        internal static async Task<string> LoadDebugTracesAsync(IDocumentStore store, string conversationId)
+        {
+            using var session = store.OpenAsyncSession();
+            var traces = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>(
+                $"{conversationId}/{AiDebugTrace.TraceSegment}/")).ToList();
+
+            if (traces.Count == 0)
+                return "(no debug traces persisted)";
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < traces.Count; i++)
+            {
+                sb.AppendLine($"--- Trace #{i + 1} ---");
+                sb.AppendLine($"RequestBody: {traces[i].RequestBody}");
+                sb.AppendLine($"Response: {traces[i].Response}");
+            }
+            return sb.ToString();
+        }
+
+        internal static string BuildAssertMessage(string expected, string actual, string traces)
+        {
+            return $"Expected substring '{expected}' in answer.\nActual answer: {actual}\nDebug traces:\n{traces}";
+        }
+
+        internal class DebugTraceDoc
+        {
+            public string RequestBody { get; set; }
+            public object Response { get; set; }
         }
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26426.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26426.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             await store.AI.CreateAgentAsync(agent, new AiAgentBasics.OutputSchema());
 
-            var chat = store.AI.Conversation(agent.Identifier, "chats/", new AiConversationCreationOptions());
+            var chat = store.AI.Conversation(agent.Identifier, "chats/", new AiConversationCreationOptions(), debug: true);
 
             // First turn: send the image and ask what fruit it is
             AiAnswer<AiAgentBasics.OutputSchema> result1;
@@ -47,7 +47,11 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             Assert.Equal(AiConversationResult.Done, result1.Status);
             Assert.NotNull(result1.Answer);
-            Assert.Contains("banana", result1.Answer.Answer, StringComparison.OrdinalIgnoreCase);
+            Assert.NotNull(result1.Answer.Answer);
+
+            var tracesAfterTurn1 = await RavenDB_24847.LoadDebugTracesAsync(store, chat.Id);
+            Assert.True(result1.Answer.Answer.Contains("banana", StringComparison.OrdinalIgnoreCase),
+                RavenDB_24847.BuildAssertMessage("banana", result1.Answer.Answer, tracesAfterTurn1));
 
             // Second turn: re-send the same image via a fresh stream and ask a follow-up question
             AiAnswer<AiAgentBasics.OutputSchema> result2;
@@ -60,7 +64,11 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             Assert.Equal(AiConversationResult.Done, result2.Status);
             Assert.NotNull(result2.Answer);
-            Assert.Contains("yellow", result2.Answer.Answer, StringComparison.OrdinalIgnoreCase);
+            Assert.NotNull(result2.Answer.Answer);
+
+            var tracesAfterTurn2 = await RavenDB_24847.LoadDebugTracesAsync(store, chat.Id);
+            Assert.True(result2.Answer.Answer.Contains("yellow", StringComparison.OrdinalIgnoreCase),
+                RavenDB_24847.BuildAssertMessage("yellow", result2.Answer.Answer, tracesAfterTurn2));
         }
 
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26685/SlowTests.Server.Documents.AI.AiAgent.RavenDB26426.CanSendSameImageTwiceInSeparateTurnsoptions-DatabaseMode-Single-config
https://issues.hibernatingrhinos.com/issue/RavenDB-26684/SlowTests.Server.Documents.AI.AiAgent.RavenDB24847.CanAnalyzeImagesoptions-DatabaseMode-Single-config-OpenAiAiIntegrationTask
https://issues.hibernatingrhinos.com/issue/RavenDB-26683/SlowTests.Server.Documents.AI.AiAgent.RavenDB24847.MultipartUserPromptArrayWithAttachmentsoptions-DatabaseMode-Single-config


### Additional description

added debug conversation info on the tests

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
