### PR TITLE
RavenDB-25832 SQL ETL on Postgres should not drop rows on per-row errors

### DIFF
--- a/src/Raven.Server/Config/Categories/EtlConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EtlConfiguration.cs
@@ -86,7 +86,7 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("ETL.ProcessHealthStatusImpairedThreshold", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public float ProcessHealthStatusImpairedThreshold { get; set; }
 
-        [Description("Max ratio of documents in a batch that can be excluded due to transaction-aborting errors. Beyond this threshold the batch fails.")]
+        [Description("Max ratio of inserts in a batch that can be excluded due to transaction-aborting errors. Beyond this threshold the batch fails. A small minimum number of retries is always allowed regardless of this ratio to handle tiny and medium batches.")]
         [DefaultValue(0.05f)]
         [ConfigurationEntry("ETL.SQL.MaxTransactionRetryRatio", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public float MaxTransactionRetryRatio { get; set; }

--- a/src/Raven.Server/Config/Categories/EtlConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EtlConfiguration.cs
@@ -86,6 +86,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("ETL.ProcessHealthStatusImpairedThreshold", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public float ProcessHealthStatusImpairedThreshold { get; set; }
 
+        [Description("Max ratio of documents in a batch that can be excluded due to transaction-aborting errors. Beyond this threshold the batch fails.")]
+        [DefaultValue(0.05f)]
+        [ConfigurationEntry("ETL.SQL.MaxTransactionRetryRatio", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public float MaxTransactionRetryRatio { get; set; }
+
         public override void Initialize(IConfigurationRoot settings, HashSet<string> settingsNames, IConfigurationRoot serverWideSettings, HashSet<string> serverWideSettingsNames, ResourceType type, string resourceName)
         {
             base.Initialize(settings, settingsNames, serverWideSettings, serverWideSettingsNames, type, resourceName);
@@ -107,6 +112,12 @@ namespace Raven.Server.Config.Categories
                 throw new InvalidOperationException(
                     $"The value of '{RavenConfiguration.GetKey(x => x.Etl.ProcessHealthStatusFailedThreshold)}' ({ProcessHealthStatusFailedThreshold}) must be greater than " +
                     $"the value of '{RavenConfiguration.GetKey(x => x.Etl.ProcessHealthStatusImpairedThreshold)}' ({ProcessHealthStatusImpairedThreshold}).");
+            }
+
+            if (MaxTransactionRetryRatio is < 0f or > 1f)
+            {
+                throw new InvalidOperationException(
+                    $"The value of '{RavenConfiguration.GetKey(x => x.Etl.MaxTransactionRetryRatio)}' ({MaxTransactionRetryRatio}) must be between 0 and 1.");
             }
         }
     }

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Util;
+using Raven.Server.Config;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common.Enumerators;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common.Metrics;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common.RelationalWriters;
@@ -83,30 +84,46 @@ public abstract class RelationalDatabaseEtlBase<TRelationalEtlConfiguration, TRe
 
     protected override int LoadInternal(IEnumerable<RelationalDatabaseTableWithRecords> records, DocumentsOperationContext context, EtlStatsScope scope)
     {
-        var count = 0;
+        var tables = records as IList<RelationalDatabaseTableWithRecords> ?? records.ToList();
 
-        using (var lazyWriter =
-               new DisposableLazy<RelationalDatabaseWriterBase<TRelationalConnectionString, TRelationalEtlConfiguration>>(
-                   GetRelationalDatabaseWriterInstance))
+        RetryableTransactionException lastRetryableFailure = null;
+
+        // each retry isolates at most one bad doc, so the meaningful cap is the batch size + 1;
+        // for larger batches use the configured ratio (higher failure rates suggest a systemic issue worth failing on)
+        var totalInserts = tables.Sum(x => x.Inserts.Count);
+        var maxRetries = Math.Min(totalInserts + 1, Math.Max(8, (int)Math.Ceiling(totalInserts * Database.Configuration.Etl.MaxTransactionRetryRatio)));
+
+        for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            foreach (var table in records)
+            using (var lazyWriter =
+                   new DisposableLazy<RelationalDatabaseWriterBase<TRelationalConnectionString, TRelationalEtlConfiguration>>(GetRelationalDatabaseWriterInstance))
             {
-                var writer = lazyWriter.Value;
+                try
+                {
+                    var count = 0;
+                    foreach (var table in tables)
+                    {
+                        var writer = lazyWriter.Value;
+                        var stats = writer.Write(table, null, CancellationToken);
+                        LogStats(stats, table);
+                        count += stats.DeletedRecordsCount + stats.InsertedRecordsCount;
+                    }
 
-                var stats = writer.Write(table, null, CancellationToken);
+                    if (lazyWriter.IsValueCreated)
+                        lazyWriter.Value.Commit();
 
-                LogStats(stats, table);
-
-                count += stats.DeletedRecordsCount + stats.InsertedRecordsCount;
-            }
-
-            if (lazyWriter.IsValueCreated)
-            {
-                lazyWriter.Value.Commit();
+                    return count;
+                }
+                catch (RetryableTransactionException e)
+                {
+                    lastRetryableFailure = e;
+                }
             }
         }
-
-        return count;
+        throw new InvalidOperationException(
+            $"Load aborted after {maxRetries} attempts: too many documents in this batch caused transaction-aborting errors. " +
+            $"See per document errors for the cause or raise '{RavenConfiguration.GetKey(x => x.Etl.MaxTransactionRetryRatio)}' to tolerate more.",
+            lastRetryableFailure);
     }
 
     protected abstract RelationalDatabaseWriterBase<TRelationalConnectionString, TRelationalEtlConfiguration> GetRelationalDatabaseWriterInstance();

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
@@ -121,8 +121,8 @@ public abstract class RelationalDatabaseEtlBase<TRelationalEtlConfiguration, TRe
             }
         }
         throw new InvalidOperationException(
-            $"Load aborted after {maxRetries} attempts: too many documents in this batch caused transaction-aborting errors. " +
-            $"See per document errors for the cause or raise '{RavenConfiguration.GetKey(x => x.Etl.MaxTransactionRetryRatio)}' to tolerate more.",
+            $"Load aborted after {maxRetries} attempts: too many inserts in this batch caused transaction-aborting errors. " +
+            $"See per item errors for the cause or raise '{RavenConfiguration.GetKey(x => x.Etl.MaxTransactionRetryRatio)}' to tolerate more.",
             lastRetryableFailure);
     }
 

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseItem.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseItem.cs
@@ -23,4 +23,6 @@ public sealed class RelationalDatabaseItem : ExtractedItem
     }
 
     public List<RelationalDatabaseColumn> Columns { get; set; }
+
+    public bool SkipOnTxRetry { get; set; }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
@@ -42,6 +42,8 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
     private readonly List<Func<DbParameter, string, bool>> _stringParserList;
     private const int LongStatementWarnThresholdInMs = 3000;
 
+    protected virtual bool ShouldAbortAndRetryTransaction(Exception e) => false;
+
     protected RelationalDatabaseWriterBase(DocumentDatabase database, EtlConfiguration<TRelationalConnectionString> configuration, string taskName,
         RelationalDatabaseEtlMetricsCountersManager sqlMetrics, EtlProcessStatistics statistics, bool shouldConnectToTarget = true)
     {
@@ -152,6 +154,9 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
         var sp = new Stopwatch();
         foreach (var itemToReplicate in toInsert)
         {
+            if (itemToReplicate.SkipOnTxRetry)
+                continue;
+
             sp.Restart();
 
             using (var cmd = GetInsertCommand(tableName, pkName, itemToReplicate))
@@ -173,11 +178,22 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
                         {
                             Logger.Info(
                                 $"Failed to replicate changes to relational database for: {_etlName} " +
-                                $"(doc: {itemToReplicate.DocumentId}), will continue trying. {Environment.NewLine}{cmd.CommandText}", e);
+                                $"(doc: {itemToReplicate.DocumentId}), the document will be skipped and ETL will continue. {Environment.NewLine}{cmd.CommandText}", e);
                         }
 
                         var errorMessage = $"Insert statement:{Environment.NewLine}{cmd.CommandText}{Environment.NewLine}. Error:{Environment.NewLine}{e}";
                         _statistics.RecordItemLoadError(errorMessage, itemToReplicate.DocumentId);
+
+                        if (ShouldAbortAndRetryTransaction(e))
+                        {
+                            // an error that caused the whole transaction to be in invalid state so next inserts will also fail, and the only way to
+                            // recover from it is to retry the transaction, so we throw a special exception that will be handled by the caller
+                            // the problematic document that caused the problem will be excluded from the retried transaction to avoid hitting the same error again
+
+                            itemToReplicate.SkipOnTxRetry = true;
+
+                            throw new RetryableTransactionException(e);
+                        }
                     }
                 }
                 finally

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RetryableTransactionException.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RetryableTransactionException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common.RelationalWriters;
+
+public sealed class RetryableTransactionException : Exception
+{
+    public RetryableTransactionException(Exception innerException)
+        : base(innerException?.Message, innerException)
+    {
+    }
+}

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/SQL/RelationalWriters/SqlDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/SQL/RelationalWriters/SqlDatabaseWriter.cs
@@ -51,6 +51,20 @@ internal sealed class SqlDatabaseWriter: RelationalDatabaseWriterBase<SqlConnect
 
     public override bool ParametrizeDeletes { get; }
 
+    protected override bool ShouldAbortAndRetryTransaction(Exception e)
+    {
+        if (_providerType != SqlProvider.Npgsql)
+            return false;
+
+        if (e is not Npgsql.PostgresException pe)
+            return false;
+
+        const string dataExceptionErrorPrefix = "22";
+        const string integrityConstraintViolationPrefix = "23";
+        
+        return pe.SqlState.StartsWith(dataExceptionErrorPrefix) || pe.SqlState.StartsWith(integrityConstraintViolationPrefix);
+    }
+
     protected override string GetConnectionString(EtlConfiguration<SqlConnectionString> configuration)
     {
         return configuration.Connection.ConnectionString;

--- a/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_25832.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_25832.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Threading.Tasks;
+using Npgsql;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Server.Documents.ETL;
+using Raven.Server.SqlMigration;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.ETL.SQL;
+
+public class RavenDB_25832 : SqlAwareTestBase
+{
+    public RavenDB_25832(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class TwoColumnItem
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
+
+    private const string SingleTableScript = @"
+loadToItems({
+    Name: this.Name
+});";
+
+    private const string TwoTableScript = @"
+loadToItems_a({
+    Name: this.Name
+});
+loadToItems_b({
+    Value: this.Value
+});";
+
+    [RavenFact(RavenTestCategory.Etl, Requires = RavenServiceRequirement.NpgSql)]
+    public async Task PostgresSqlEtl_RowConstraintViolation_OtherRowsStillLoad()
+    {
+        using (var store = GetDocumentStore())
+        using (WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out _, dataSet: null, includeData: false))
+        {
+            CreateSingleTableSchema(connectionString);
+
+            var etlDone = await SetUpEtl(store, "Items", new[] { "items" }, SingleTableScript, connectionString);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Item { Name = "A" }, "items/1");
+                await session.StoreAsync(new Item { Name = null }, "items/2");
+                await session.StoreAsync(new Item { Name = "C" }, "items/3");
+                await session.StoreAsync(new Item { Name = "D" }, "items/4");
+                await session.SaveChangesAsync();
+            }
+
+            var stats = await etlDone.WaitForCompletion();
+
+            Assert.Equal(3, stats.LoadSuccesses);
+            Assert.Equal(1, stats.LoadErrors);
+            AssertRowCount(connectionString, "items", expected: 3);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Etl, Requires = RavenServiceRequirement.NpgSql)]
+    public async Task PostgresSqlEtl_MultipleFailingRows_OtherRowsStillLoad()
+    {
+        using (var store = GetDocumentStore())
+        using (WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out _, dataSet: null, includeData: false))
+        {
+            CreateSingleTableSchema(connectionString);
+
+            var etlDone = await SetUpEtl(store, "Items", new[] { "items" }, SingleTableScript, connectionString);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Item { Name = "A" }, "items/1");
+                await session.StoreAsync(new Item { Name = null }, "items/2");
+                await session.StoreAsync(new Item { Name = "C" }, "items/3");
+                await session.StoreAsync(new Item { Name = null }, "items/4");
+                await session.StoreAsync(new Item { Name = "E" }, "items/5");
+                await session.StoreAsync(new Item { Name = null }, "items/6");
+                await session.StoreAsync(new Item { Name = "G" }, "items/7");
+                await session.SaveChangesAsync();
+            }
+
+            var stats = await etlDone.WaitForCompletion();
+
+            Assert.Equal(4, stats.LoadSuccesses);
+            Assert.Equal(3, stats.LoadErrors);
+            AssertRowCount(connectionString, "items", expected: 4);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Etl, Requires = RavenServiceRequirement.NpgSql)]
+    public async Task PostgresSqlEtl_AllDocsInBatchFail_NextGoodDocStillLands()
+    {
+        using (var store = GetDocumentStore())
+        using (WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out _, dataSet: null, includeData: false))
+        {
+            CreateSingleTableSchema(connectionString);
+
+            var etlDone = await SetUpEtl(store, "Items", new[] { "items" }, SingleTableScript, connectionString);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Item { Name = null }, "items/1");
+                await session.StoreAsync(new Item { Name = null }, "items/2");
+                await session.StoreAsync(new Item { Name = null }, "items/3");
+                await session.StoreAsync(new Item { Name = null }, "items/4");
+                await session.StoreAsync(new Item { Name = "OK" }, "items/5");
+                await session.SaveChangesAsync();
+            }
+
+            var stats = await etlDone.WaitForCompletion();
+
+            // every bad doc must be marked-and-skipped without poisoning the good one; ETL must not get stuck
+            Assert.Equal(1, stats.LoadSuccesses);
+            Assert.Equal(4, stats.LoadErrors);
+            AssertRowCount(connectionString, "items", expected: 1);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Etl, Requires = RavenServiceRequirement.NpgSql)]
+    public async Task PostgresSqlEtl_DocFailingInOneTable_StillLandsInOtherTables()
+    {
+        using (var store = GetDocumentStore())
+        using (WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out _, dataSet: null, includeData: false))
+        {
+            CreateTwoTableSchema(connectionString);
+
+            var etlDone = await SetUpEtl(store, "TwoColumnItems", new[] { "items_a", "items_b" }, TwoTableScript, connectionString,
+                collection: "TwoColumnItems");
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new TwoColumnItem { Name = "A1", Value = "B1" }, "items/1");
+                await session.StoreAsync(new TwoColumnItem { Name = "A2", Value = null }, "items/2");
+                await session.StoreAsync(new TwoColumnItem { Name = "A3", Value = "B3" }, "items/3");
+                await session.StoreAsync(new TwoColumnItem { Name = "A4", Value = "B4" }, "items/4");
+                await session.SaveChangesAsync();
+            }
+
+            var stats = await etlDone.WaitForCompletion();
+
+            // items/2 fails only on items_b (NOT NULL Value violation) - it still loads into items_a where its Name is valid
+            Assert.Equal(7, stats.LoadSuccesses);
+            Assert.Equal(1, stats.LoadErrors);
+            AssertRowCount(connectionString, "items_a", expected: 4);
+            AssertRowCount(connectionString, "items_b", expected: 3);
+        }
+    }
+
+    private async Task<EtlCompletion> SetUpEtl(IDocumentStore store, string transformationName, string[] tableNames, string script,
+        string connectionString, string collection = "Items")
+    {
+        var configurationName = transformationName + "_" + Guid.NewGuid();
+        var connectionStringName = $"{transformationName}_{store.Database}";
+
+        store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+        {
+            Name = connectionStringName,
+            FactoryName = "Npgsql",
+            ConnectionString = connectionString
+        }));
+
+        var configuration = new SqlEtlConfiguration
+        {
+            Name = configurationName,
+            ConnectionStringName = connectionStringName,
+            Transforms =
+            {
+                new Transformation
+                {
+                    Name = transformationName,
+                    Collections = { collection },
+                    Script = script
+                }
+            }
+        };
+        foreach (var tableName in tableNames)
+            configuration.SqlTables.Add(new SqlEtlTable { TableName = tableName, DocumentIdColumn = "Id" });
+
+        store.Maintenance.Send(new AddEtlOperation<SqlConnectionString>(configuration));
+
+        var database = await GetDatabase(store.Database);
+        var completion = new EtlCompletion(configurationName, transformationName);
+        database.EtlLoader.BatchCompleted += completion.OnBatchCompleted;
+        return completion;
+    }
+
+    private sealed class EtlCompletion
+    {
+        private readonly string _configurationName;
+        private readonly string _transformationName;
+        private readonly AsyncManualResetEvent _done = new();
+        private long _loadSuccesses;
+        private long _loadErrors;
+
+        public EtlCompletion(string configurationName, string transformationName)
+        {
+            _configurationName = configurationName;
+            _transformationName = transformationName;
+        }
+
+        public void OnBatchCompleted((string ConfigurationName, string TransformationName, EtlProcessStatistics Statistics) e)
+        {
+            if (e.ConfigurationName != _configurationName || e.TransformationName != _transformationName)
+                return;
+
+            if (e.Statistics.LoadSuccesses == 0)
+                return;
+
+            _loadSuccesses = e.Statistics.LoadSuccesses;
+            _loadErrors = e.Statistics.LoadErrors;
+            _done.Set();
+        }
+
+        public async Task<(long LoadSuccesses, long LoadErrors)> WaitForCompletion()
+        {
+            Assert.True(await _done.WaitAsync(TimeSpan.FromMinutes(1)),
+                $"ETL batch did not complete in time. LoadSuccesses={_loadSuccesses}, LoadErrors={_loadErrors}");
+            return (_loadSuccesses, _loadErrors);
+        }
+    }
+
+    private static void CreateSingleTableSchema(string connectionString)
+    {
+        ExecuteSql(connectionString, @"
+DROP TABLE IF EXISTS items;
+
+CREATE TABLE items
+(
+    ""Id"" text NOT NULL PRIMARY KEY,
+    ""Name"" text NOT NULL
+);");
+    }
+
+    private static void CreateTwoTableSchema(string connectionString)
+    {
+        ExecuteSql(connectionString, @"
+DROP TABLE IF EXISTS items_a;
+DROP TABLE IF EXISTS items_b;
+
+CREATE TABLE items_a
+(
+    ""Id"" text NOT NULL PRIMARY KEY,
+    ""Name"" text
+);
+
+CREATE TABLE items_b
+(
+    ""Id"" text NOT NULL PRIMARY KEY,
+    ""Value"" text NOT NULL
+);");
+    }
+
+    private static void ExecuteSql(string connectionString, string sql)
+    {
+        using (var con = new NpgsqlConnection(connectionString))
+        {
+            con.Open();
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandText = sql;
+                cmd.ExecuteNonQuery();
+            }
+        }
+    }
+
+    private static void AssertRowCount(string connectionString, string tableName, long expected)
+    {
+        using (var con = new NpgsqlConnection(connectionString))
+        {
+            con.Open();
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandText = $"SELECT COUNT(*) FROM {tableName}";
+                Assert.Equal(expected, cmd.ExecuteScalar());
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25832

### Additional description

On Postgres a row-level error aborts the whole transaction, so every row queued after the first failure was silently dropped. The writer now signals provider-recognized row errors as retryable, marks the failing document to be skipped, rolls back, and the loader replays the batch in a fresh transaction.

Retries are bounded by batch size, with a percentage cap for large batches. The retry decision is provider-specific (Postgres: SqlState classes 22 and 23); other providers keep their original behavior.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
