### PR TITLE
RavenDB-25951 Ensure both ETL tasks generate embeddings and validate their existence before completing the test.

### DIFF
--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorFromExternalDocumentTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorFromExternalDocumentTests.cs
@@ -410,12 +410,18 @@ public class LoadVectorFromExternalDocumentTests(ITestOutputHelper output) : Emb
         }
 
         Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+
+        // etlStatus.WaitAsync is signaled on the first batch with LoadSuccesses > 0, so it only guarantees that ONE of
+        // the two ETL tasks (localaitask, querydtotask) has produced an embedding. Wait until both new embeddings exist.
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifierForDto, aiConnectionStringIdentifierForDto, "Name", ["sdklfjklsadjkl;assdjaskll"], dtoId);
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifierForQueriesDto, aiConnectionStringIdentifierForQueriesDto, "Name", ["dsafadfae"], queryDtoId);
+
         await Indexes.WaitForIndexingAsync(store);
         using (var session = store.OpenSession())
         {
             var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
             Assert.Equal(0, nullElements);
-            
+
             nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector2 == null);
             Assert.Equal(0, nullElements);
 
@@ -425,7 +431,7 @@ public class LoadVectorFromExternalDocumentTests(ITestOutputHelper output) : Emb
                 .ToList();
 
             Assert.Empty(byVector);
-            
+
             byVector = session.Query<QueryDto, TIndex>()
                 .VectorSearch(f => f.WithField(s => s.Vector2),
                     v => v.ByText("car"), minimumSimilarity: 0.75f)
@@ -433,10 +439,6 @@ public class LoadVectorFromExternalDocumentTests(ITestOutputHelper output) : Emb
 
             Assert.Empty(byVector);
         }
-
-        AssertEmbeddingsForPath(store, aiIntegrationIdentifierForDto, aiConnectionStringIdentifierForDto, "Name", ["sdklfjklsadjkl;assdjaskll"], dtoId);
-        
-        AssertEmbeddingsForPath(store, aiIntegrationIdentifierForQueriesDto, aiConnectionStringIdentifierForQueriesDto, "Name", ["dsafadfae"], queryDtoId);
     }
 
     private class IndexByName : AbstractIndexCreationTask<QueryDto>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25951
### Additional description

 Ensure both ETL tasks generate embeddings and validate their existence before completing the test.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
