### PR TITLE
RavenDB-26663 Skip hard-link warning when destination exists as separate inode

### DIFF
--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -741,17 +741,23 @@ namespace Voron.Impl.Journal
                     continue;
 
                 var rc = Pal.rvn_ensure_hard_link_non_durable(_journalPager.FileName, dest, out var errorCode);
-                if (rc == PalFlags.FailCodes.Success) 
+                if (rc == PalFlags.FailCodes.Success)
                     continue;
-                
-                // error handling here is complex, because we need to account for users manually removing / copying / moving the 
-                // branch directory directly. That may break the existing links, but we cannot assume much about this. So we'll 
+
+                // error handling here is complex, because we need to account for users manually removing / copying / moving the
+                // branch directory directly. That may break the existing links, but we cannot assume much about this. So we'll
                 // be optimistic about it and move on. This code is only meant to apply if we had a machine level failures and need
                 // to re-wire the hard links that may have been dropped because it is too expensive to make them durable at the
                 // link creation time
-                if (_log.IsWarnEnabled is false) 
+
+                // Destination exists as a separate inode: source folder was copied without preserving hard links.
+                // The destination already holds valid branch journal content; skip silently to avoid spamming on every recovery.
+                if (File.Exists(dest))
                     continue;
-                    
+
+                if (_log.IsWarnEnabled is false)
+                    continue;
+
                 var msg = PalHelper.CreateErrorMessage(rc, errorCode, $"Failed to ensure hard link from '{_journalPager.FileName}' to: '{dest}', this can be because of manual manipulation of the storage environment directories.", out _);
                 _log.Warn(msg);
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26663

### Additional description

When a storage folder is copied without preserving hard links (e.g. 'cp -r' instead of 'cp -al'), replaying the LinkedJournalsRecord during recovery would fail with EEXIST and emit a "Failed to ensure hard link" warning for every entry on every recovery. The destination already holds valid branch journal content, so skip silently in that case and keep the warning only for the genuine "destination missing" recovery path.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
