### PR TITLE
RavenDB-21192 Removed persisting ETL process error in SQL ETL test script run

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
@@ -150,33 +150,18 @@ public abstract class RelationalDatabaseEtlBase<TRelationalEtlConfiguration, TRe
 
         if (performRolledBackTransaction)
         {
-            try
+            using (var writer = GetRelationalDatabaseWriterInstance())
             {
-                using (var writer = GetRelationalDatabaseWriterInstance())
+                foreach (var records in toWrite)
                 {
-                    foreach (var records in toWrite)
-                    {
-                        var commands = new List<DbCommand>();
+                    var commands = new List<DbCommand>();
 
-                        writer.Write(records, commands, CancellationToken);
+                    writer.Write(records, commands, CancellationToken);
 
-                        summaries.Add(TableQuerySummary.GenerateSummaryFromCommands(records.TableName, commands));
-                    }
-
-                    writer.Rollback();
+                    summaries.Add(TableQuerySummary.GenerateSummaryFromCommands(records.TableName, commands));
                 }
-            }
-            catch (Exception e)
-            {
-                Database.TaskErrorsStorage.StoreProcessError(TaskCategory, new TaskProcessError
-                {
-                    CreatedAt = SystemTime.UtcNow,
-                    TaskName = Name,
-                    AffectedDocumentsCount = 0,
-                    Step = TaskErrorStep.Load,
-                    Error = e.ToString()
-                });
-                Statistics.RecordProcessLoadError(count: 0);
+
+                writer.Rollback();
             }
         }
         else

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
@@ -150,18 +150,25 @@ public abstract class RelationalDatabaseEtlBase<TRelationalEtlConfiguration, TRe
 
         if (performRolledBackTransaction)
         {
-            using (var writer = GetRelationalDatabaseWriterInstance())
+            try
             {
-                foreach (var records in toWrite)
+                using (var writer = GetRelationalDatabaseWriterInstance())
                 {
-                    var commands = new List<DbCommand>();
+                    foreach (var records in toWrite)
+                    {
+                        var commands = new List<DbCommand>();
 
-                    writer.Write(records, commands, CancellationToken);
+                        writer.Write(records, commands, CancellationToken);
 
-                    summaries.Add(TableQuerySummary.GenerateSummaryFromCommands(records.TableName, commands));
+                        summaries.Add(TableQuerySummary.GenerateSummaryFromCommands(records.TableName, commands));
+                    }
+
+                    writer.Rollback();
                 }
-
-                writer.Rollback();
+            }
+            catch
+            {
+                Statistics.RecordProcessLoadError(count: 0);
             }
         }
         else

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
@@ -147,6 +147,7 @@ public abstract class RelationalDatabaseEtlBase<TRelationalEtlConfiguration, TRe
     public RelationalDatabaseEtlTestScriptResult RunTest(DocumentsOperationContext context, IEnumerable<RelationalDatabaseTableWithRecords> toWrite, bool performRolledBackTransaction)
     {
         var summaries = new List<TableQuerySummary>();
+        TaskProcessError processError = null;
 
         if (performRolledBackTransaction)
         {
@@ -166,8 +167,16 @@ public abstract class RelationalDatabaseEtlBase<TRelationalEtlConfiguration, TRe
                     writer.Rollback();
                 }
             }
-            catch
+            catch (Exception e)
             {
+                processError = new TaskProcessError
+                {
+                    CreatedAt = SystemTime.UtcNow,
+                    TaskName = Name,
+                    AffectedDocumentsCount = 0,
+                    Step = TaskErrorStep.Unknown,
+                    Error = e.ToString()
+                };
                 Statistics.RecordProcessLoadError(count: 0);
             }
         }
@@ -183,7 +192,7 @@ public abstract class RelationalDatabaseEtlBase<TRelationalEtlConfiguration, TRe
                 summaries.Add(new TableQuerySummary { TableName = records.TableName, Commands = commands });
             }
         }
-        
+
         var itemErrors = Statistics.ReadInMemoryItemErrors();
 
         return new RelationalDatabaseEtlTestScriptResult
@@ -191,7 +200,8 @@ public abstract class RelationalDatabaseEtlBase<TRelationalEtlConfiguration, TRe
             TransformationErrors = itemErrors.Where(x => x.Step == TaskErrorStep.Transformation).ToList(),
             ItemLoadErrors = itemErrors.Where(x => x.Step == TaskErrorStep.Load).ToList(),
             SlowSqlWarnings = Statistics.LastSlowSqlWarningsInCurrentBatch.Statements.ToList(),
-            Summary = summaries
+            Summary = summaries,
+            ProcessError = processError
         };
     }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
@@ -283,10 +283,10 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
                             Logger.Info($"Failure to replicate deletions to relational database for: {_etlName}, " +
                                         "will continue trying." + Environment.NewLine + cmd.CommandText, e);
 
-                        var errorMessage = $"Delete statement:{Environment.NewLine}{cmd.CommandText}{Environment.NewLine}Error:{Environment.NewLine}{e}";
-                        
                         if (Configuration.TestMode == false)
                         {
+                            var errorMessage = $"Delete statement:{Environment.NewLine}{cmd.CommandText}{Environment.NewLine}Error:{Environment.NewLine}{e}";
+
                             Database.TaskErrorsStorage.StoreProcessError(TaskCategory.Etl, new TaskProcessError
                             {
                                 CreatedAt = SystemTime.UtcNow,

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
@@ -284,14 +284,19 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
                                         "will continue trying." + Environment.NewLine + cmd.CommandText, e);
 
                         var errorMessage = $"Delete statement:{Environment.NewLine}{cmd.CommandText}{Environment.NewLine}Error:{Environment.NewLine}{e}";
-                        Database.TaskErrorsStorage.StoreProcessError(TaskCategory.Etl, new TaskProcessError
+                        
+                        if (Configuration.TestMode == false)
                         {
-                            CreatedAt = SystemTime.UtcNow,
-                            TaskName = _taskName,
-                            AffectedDocumentsCount = countOfDeletes,
-                            Step = TaskErrorStep.Load,
-                            Error = errorMessage
-                        });
+                            Database.TaskErrorsStorage.StoreProcessError(TaskCategory.Etl, new TaskProcessError
+                            {
+                                CreatedAt = SystemTime.UtcNow,
+                                TaskName = _taskName,
+                                AffectedDocumentsCount = countOfDeletes,
+                                Step = TaskErrorStep.Load,
+                                Error = errorMessage
+                            });
+                        }
+
                         _statistics.RecordProcessLoadError(countOfDeletes);
                     }
                 }

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/Test/RelationalDatabaseEtlTestScriptResult.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/Test/RelationalDatabaseEtlTestScriptResult.cs
@@ -8,7 +8,9 @@ public sealed class RelationalDatabaseEtlTestScriptResult : TestEtlScriptResult
 {
     public List<TableQuerySummary> Summary { get; set; }
 
-    public List<TaskItemError> ItemLoadErrors{ get; set; }
+    public List<TaskItemError> ItemLoadErrors { get; set; }
 
     public List<SlowSqlStatementInfo> SlowSqlWarnings { get; set; }
+    
+    public TaskProcessError ProcessError { get; set; }
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editSnowflakeEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editSnowflakeEtlTask.ts
@@ -61,12 +61,14 @@ class snowflakeTaskTestMode {
     transformationErrors = ko.observableArray<Raven.Server.Documents.ETL.TaskItemError>([]);
     loadErrors = ko.observableArray<Raven.Server.Documents.ETL.TaskItemError>([]);
     slowSqlWarnings = ko.observableArray<Raven.Server.NotificationCenter.Notifications.Details.SlowSqlStatementInfo>([]);
-    
+    processError = ko.observable<Raven.Server.Documents.ETL.TaskProcessError>(null);
+
     warningsCount = ko.pureComputed(() => {
         const transformationCount = this.transformationErrors().length;
         const loadErrorCount = this.loadErrors().length;
         const slowSqlCount = this.slowSqlWarnings().length;
-        return transformationCount + loadErrorCount + slowSqlCount;
+        const processErrorCount = this.processError() ? 1 : 0;
+        return transformationCount + loadErrorCount + slowSqlCount + processErrorCount;
     });
     
     constructor(db: database, validateParent: () => boolean, 
@@ -157,9 +159,10 @@ class snowflakeTaskTestMode {
                     this.testResults(testResult.Summary.flatMap(x => x.Commands));
                     this.debugOutput(testResult.DebugOutput);
                     this.loadErrors(testResult.ItemLoadErrors);
-                    this.slowSqlWarnings(testResult.SlowSqlWarnings); 
+                    this.slowSqlWarnings(testResult.SlowSqlWarnings);
                     this.transformationErrors(testResult.TransformationErrors);
-                    
+                    this.processError(testResult.ProcessError);
+
                     if (this.warningsCount()) {
                         $('.test-container a[href="#warnings"]').tab('show');
                     } else {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editSqlEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editSqlEtlTask.ts
@@ -61,12 +61,14 @@ class sqlTaskTestMode {
     transformationErrors = ko.observableArray<Raven.Server.Documents.ETL.TaskItemError>([]);
     loadErrors = ko.observableArray<Raven.Server.Documents.ETL.TaskItemError>([]);
     slowSqlWarnings = ko.observableArray<Raven.Server.NotificationCenter.Notifications.Details.SlowSqlStatementInfo>([]);
-    
+    processError = ko.observable<Raven.Server.Documents.ETL.TaskProcessError>(null);
+
     warningsCount = ko.pureComputed(() => {
         const transformationCount = this.transformationErrors().length;
         const loadErrorCount = this.loadErrors().length;
         const slowSqlCount = this.slowSqlWarnings().length;
-        return transformationCount + loadErrorCount + slowSqlCount;
+        const processErrorCount = this.processError() ? 1 : 0;
+        return transformationCount + loadErrorCount + slowSqlCount + processErrorCount;
     });
     
     constructor(db: database, validateParent: () => boolean, 
@@ -157,9 +159,10 @@ class sqlTaskTestMode {
                     this.testResults(testResult.Summary.flatMap(x => x.Commands));
                     this.debugOutput(testResult.DebugOutput);
                     this.loadErrors(testResult.ItemLoadErrors);
-                    this.slowSqlWarnings(testResult.SlowSqlWarnings); 
+                    this.slowSqlWarnings(testResult.SlowSqlWarnings);
                     this.transformationErrors(testResult.TransformationErrors);
-                    
+                    this.processError(testResult.ProcessError);
+
                     if (this.warningsCount()) {
                         $('.test-container a[href="#warnings"]').tab('show');
                     } else {

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSnowflakeEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSnowflakeEtlTask.html
@@ -437,6 +437,10 @@ Option unchecked: <Br />No execution will take place, only generate the SQL stat
                         <pre class="margin-left margin-bottom margin-bottom-sm" data-bind="text: Error"></pre>
                     </div>
                 </div>
+                <div class="process-error" data-bind="if: processError()">
+                    <h3>Process Error:</h3>
+                    <pre class="margin-left margin-bottom margin-bottom-sm" data-bind="text: processError().Error"></pre>
+                </div>
                 <div class="load-errors" data-bind="visible: loadErrors().length">
                     <h3>Load Errors:</h3>
                     <div data-bind="foreach: loadErrors">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
@@ -475,6 +475,10 @@ Option unchecked: <Br />No execution will take place, only generate the SQL stat
                         <pre class="margin-left margin-bottom margin-bottom-sm" data-bind="text: Error"></pre>
                     </div>
                 </div>
+                <div class="process-error" data-bind="if: processError()">
+                    <h3>Process Error:</h3>
+                    <pre class="margin-left margin-bottom margin-bottom-sm" data-bind="text: processError().Error"></pre>
+                </div>
                 <div class="load-errors" data-bind="visible: loadErrors().length">
                     <h3>Load Errors:</h3>
                     <div data-bind="foreach: loadErrors">

--- a/test/SlowTests.Issues/Issues/RavenDB-21192.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21192.cs
@@ -1246,7 +1246,7 @@ public class RavenDB_21192 : RavenTestBase
     }
     
     [RavenFact(RavenTestCategory.Etl)]
-    public void TestScriptErrorsShouldNotBePersisted()
+    public void RavenEtlTestScriptErrorsShouldNotBePersisted()
     {
         using (var store = GetDocumentStore())
         {
@@ -1289,6 +1289,9 @@ public class RavenDB_21192 : RavenTestBase
 
                 var itemErrors = database.TaskErrorsStorage.ReadAllItemErrors(TaskCategory.Etl);
                 Assert.Empty(itemErrors);
+
+                var processErrors = database.TaskErrorsStorage.ReadAllProcessErrors(TaskCategory.Etl);
+                Assert.Empty(processErrors);
             }
         }
     }
@@ -1413,6 +1416,11 @@ public class RavenDB_21192 : RavenTestBase
                 
                 var testResult = (RelationalDatabaseEtlTestScriptResult)SqlEtl.TestScript(testScript, database, database.ServerStore, context);
                 Assert.NotNull(testResult);
+
+                Assert.NotNull(testResult.ProcessError);
+                Assert.False(string.IsNullOrEmpty(testResult.ProcessError.Error),
+                    $"Expected {nameof(testResult.ProcessError)}.{nameof(testResult.ProcessError.Error)} to contain the underlying exception text.");
+                Assert.Empty(testResult.ItemLoadErrors);
 
                 var itemErrors = database.TaskErrorsStorage.ReadAllItemErrors(TaskCategory.Etl);
                 Assert.Empty(itemErrors);

--- a/test/SlowTests.Issues/Issues/RavenDB-21192.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21192.cs
@@ -14,6 +14,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Http;
 using Raven.Client.ServerWide.Operations;
@@ -22,9 +23,11 @@ using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Commands.Studio;
 using Raven.Server.Documents.ETL;
-using Raven.Server.Documents.ETL.Handlers.Processors;
 using Raven.Server.Documents.ETL.Providers.Raven;
 using Raven.Server.Documents.ETL.Providers.Raven.Test;
+using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common;
+using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common.Test;
+using Raven.Server.Documents.ETL.Providers.RelationalDatabase.SQL;
 using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
@@ -1283,13 +1286,142 @@ public class RavenDB_21192 : RavenTestBase
                 
                 var result = (RavenEtlTestScriptResult)testResult;
                 Assert.Single(result.TransformationErrors);
-                
+
                 var itemErrors = database.TaskErrorsStorage.ReadAllItemErrors(TaskCategory.Etl);
                 Assert.Empty(itemErrors);
             }
         }
     }
-    
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public void SqlEtlTestScriptErrorsShouldNotBePersisted()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var user = new User { Id = "users/1", Name = "Joe Doe" };
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(user);
+                session.SaveChanges();
+            }
+
+            var database = GetDatabase(store.Database).GetAwaiter().GetResult();
+
+            const string connectionStringName = "simulate";
+            
+            store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+            {
+                Name = connectionStringName,
+                ConnectionString = "Server=tcp:not-a-real-server,1433;Database=fake;User Id=u;Password=p;",
+                FactoryName = "Microsoft.Data.SqlClient"
+            }));
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var testResult = SqlEtl.TestScript(
+                    new TestRelationalDatabaseEtlScript<SqlConnectionString, SqlEtlConfiguration>
+                    {
+                        DocumentId = user.Id,
+                        PerformRolledBackTransaction = false,
+                        Configuration = new SqlEtlConfiguration
+                        {
+                            Name = connectionStringName,
+                            ConnectionStringName = connectionStringName,
+                            SqlTables =
+                            {
+                                new SqlEtlTable { TableName = "Users", DocumentIdColumn = "Id", InsertOnlyMode = false }
+                            },
+                            Transforms =
+                            {
+                                new Transformation
+                                {
+                                    Collections = { "Users" },
+                                    Name = "Users",
+                                    Script =
+                                        """
+                                        throw new Error("dummy error");
+                                        loadToUsers({ Id: id(this), Name: this.Name });
+                                        """
+                                }
+                            }
+                        }
+                    }, database, database.ServerStore, context);
+
+                var result = (RelationalDatabaseEtlTestScriptResult)testResult;
+                Assert.Single(result.TransformationErrors);
+                Assert.Empty(result.ItemLoadErrors);
+
+                var itemErrors = database.TaskErrorsStorage.ReadAllItemErrors(TaskCategory.Etl);
+                Assert.Empty(itemErrors);
+
+                var processErrors = database.TaskErrorsStorage.ReadAllProcessErrors(TaskCategory.Etl);
+                Assert.Empty(processErrors);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public void SqlEtlTestScriptLoadFailures_ShouldNotPersistErrors()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var user = new User { Id = "users/1", Name = "Joe Doe" };
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(user);
+                session.SaveChanges();
+            }
+
+            var database = GetDatabase(store.Database).GetAwaiter().GetResult();
+
+            const string connectionStringName = "simulate";
+            
+            store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+            {
+                Name = connectionStringName,
+                ConnectionString = "Server=tcp:127.0.0.1,1;Database=fake;User Id=u;Password=p;Connect Timeout=1;TrustServerCertificate=true",
+                FactoryName = "Microsoft.Data.SqlClient"
+            }));
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var testScript = new TestRelationalDatabaseEtlScript<SqlConnectionString, SqlEtlConfiguration>
+                {
+                    DocumentId = user.Id,
+                    PerformRolledBackTransaction = true,
+                    Configuration = new SqlEtlConfiguration
+                    {
+                        Name = connectionStringName,
+                        ConnectionStringName = connectionStringName,
+                        SqlTables =
+                        {
+                            new SqlEtlTable { TableName = "Users", DocumentIdColumn = "Id", InsertOnlyMode = false }
+                        },
+                        Transforms =
+                        {
+                            new Transformation
+                            {
+                                Collections = { "Users" },
+                                Name = "Users",
+                                Script = "loadToUsers({ Id: id(this), Name: this.Name });"
+                            }
+                        }
+                    }
+                };
+                
+                Assert.ThrowsAny<Exception>(() => SqlEtl.TestScript(testScript, database, database.ServerStore, context));
+
+                var itemErrors = database.TaskErrorsStorage.ReadAllItemErrors(TaskCategory.Etl);
+                Assert.Empty(itemErrors);
+
+                var processErrors = database.TaskErrorsStorage.ReadAllProcessErrors(TaskCategory.Etl);
+                Assert.Empty(processErrors);
+            }
+        }
+    }
+
     [RavenFact(RavenTestCategory.Monitoring | RavenTestCategory.Etl)]
     public async Task CanGetEtlErrorsSnmpMetrics_V2C()
     {

--- a/test/SlowTests.Issues/Issues/RavenDB-21192.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21192.cs
@@ -1411,7 +1411,8 @@ public class RavenDB_21192 : RavenTestBase
                     }
                 };
                 
-                Assert.ThrowsAny<Exception>(() => SqlEtl.TestScript(testScript, database, database.ServerStore, context));
+                var testResult = (RelationalDatabaseEtlTestScriptResult)SqlEtl.TestScript(testScript, database, database.ServerStore, context);
+                Assert.NotNull(testResult);
 
                 var itemErrors = database.TaskErrorsStorage.ReadAllItemErrors(TaskCategory.Etl);
                 Assert.Empty(itemErrors);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21192/Redesign-ETL-error-handling

### Additional description

We don't want to persist test run errors. In-memory errors list is already returned in script run result.

<img width="2146" height="1096" alt="Screenshot 2026-05-27 114214" src="https://github.com/user-attachments/assets/5262e27b-bb75-4e61-ba3c-827664a173a5" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
