### PR TITLE
RavenDB-26681 fix RecreateDatabase creating Voron files for non-existent database

### DIFF
--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -348,7 +348,7 @@ namespace Raven.Server.Web.System
                 return;
 
             var databaseConfiguration = DatabasesLandlord.CreateDatabaseConfiguration(ServerStore, databaseName, settings);
-            if (databaseConfiguration.Core.RunInMemory)
+            if (databaseConfiguration.Core.RunInMemory || Directory.Exists(databaseConfiguration.Core.DataDirectory.FullPath) == false)
                 return;
 
             var addToInitLog = new Action<LogMode, string>((logMode, txt) =>

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -32,6 +32,8 @@ namespace SlowTests.Issues
             var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(3, watcherCluster: true);
             var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
+            var nonLeaderTags = nodes.Where(n => n != leader).Select(n => n.ServerStore.NodeTag).ToList();
+
             var options = new Options
             {
                 Server = leader,
@@ -40,7 +42,12 @@ namespace SlowTests.Issues
                 AdminCertificate = certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = _ => databaseName,
                 Encrypted = true,
-                RunInMemory = false
+                RunInMemory = false,
+                ModifyDatabaseRecord = r => r.Topology = new DatabaseTopology
+                {
+                    Members = nonLeaderTags,
+                    ReplicationFactor = 2
+                }
             };
             using (var store = GetDocumentStore(options))
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26681

### Additional description
RecreateDatabase is called during PUT /admin/databases when the database doesn't exist in the cluster. 
Its purpose is to open the existing Voron store, if exist, and recover index definitions from it.

It was missing a check for whether the data directory actually exists. 
That caused the function to create a new data directory instead of reusing the existing one.

The fix adds a Directory.Exists guard before opening the store. 
If the directory isn't there, skip the recreation because there's nothing to recover.

### Type of change
- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
