### PR TITLE
RavenDB-26653  Enumerate @SharedJournals + de-dup hard-linked journals

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -616,7 +616,8 @@ namespace Raven.Server.Documents
         {
             StorageEnvironmentWithType.StorageEnvironmentType.Documents,
             StorageEnvironmentWithType.StorageEnvironmentType.Configuration,
-            StorageEnvironmentWithType.StorageEnvironmentType.Index
+            StorageEnvironmentWithType.StorageEnvironmentType.Index,
+            StorageEnvironmentWithType.StorageEnvironmentType.SharedJournals
         };
 
         private static readonly List<StorageEnvironmentWithType.StorageEnvironmentType> DefaultStorageEnvironmentTypesForBackup = new()
@@ -1492,6 +1493,14 @@ namespace Raven.Server.Documents
                                         LastIndexQueryTime = index.GetLastQueryingTime()
                                     };
                         }
+                        break;
+
+                    case StorageEnvironmentWithType.StorageEnvironmentType.SharedJournals:
+                        var sharedJournalsEnv = IndexStore?.SharedJournals?.Env;
+                        if (sharedJournalsEnv != null)
+                            yield return
+                                new StorageEnvironmentWithType(Config.Categories.IndexingConfiguration.SharedJournalsStorageName,
+                                    StorageEnvironmentWithType.StorageEnvironmentType.SharedJournals, sharedJournalsEnv);
                         break;
                 }
             }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1999,8 +1999,9 @@ namespace Raven.Server.Documents
                     continue;
 
                 var sizeOnDisk = environment.Environment.GenerateSizeReport(includeTempBuffers: true);
-                physicalInBytes += sizeOnDisk.DataFilePhysicalSizeInBytes + sizeOnDisk.JournalsInBytes;
-                allocatedInBytes += sizeOnDisk.DataFileAllocatedSizeInBytes + sizeOnDisk.JournalsInBytes;
+                var uniqueJournalsInBytes = sizeOnDisk.JournalsInBytes - sizeOnDisk.HardLinkedJournalsInBytes;
+                physicalInBytes += sizeOnDisk.DataFilePhysicalSizeInBytes + uniqueJournalsInBytes;
+                allocatedInBytes += sizeOnDisk.DataFileAllocatedSizeInBytes + uniqueJournalsInBytes;
                 tempBuffersInBytes += sizeOnDisk.TempBuffersInBytes;
             }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetReport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetReport.cs
@@ -52,7 +52,14 @@ namespace Raven.Server.Documents.Handlers.Processors.Debugging
                         writer.WriteComma();
                         
                         writer.WritePropertyName("SharedJournals");
-                        writer.WriteString(env.Environment.Options.RootJournal is null ? "Root" : "Branch");
+                        string sharedJournalsRole;
+                        if (env.Type == StorageEnvironmentWithType.StorageEnvironmentType.SharedJournals)
+                            sharedJournalsRole = "Root";
+                        else if (env.Environment.Options.RootJournal != null)
+                            sharedJournalsRole = "Branch";
+                        else
+                            sharedJournalsRole = "None";
+                        writer.WriteString(sharedJournalsRole);
                         writer.WriteComma();
 
                         var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(GetReport(env));

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3877,7 +3877,7 @@ namespace Raven.Server.ServerWide
 
             if (diskSpaceResult.DriveName == driveInfo?.JournalPath.DriveName)
             {
-                usage.UsedSpace += sizeOnDisk.JournalsInBytes;
+                usage.UsedSpace += sizeOnDisk.JournalsInBytes - sizeOnDisk.HardLinkedJournalsInBytes;
             }
             else
             {

--- a/src/Raven.Studio/typescript/models/database/status/storageReportItem.ts
+++ b/src/Raven.Studio/typescript/models/database/status/storageReportItem.ts
@@ -24,6 +24,8 @@ class storageReportItem {
     isGrouped: boolean;
     
     recyclableJournal = false;
+    hardLinkedJournal = false;
+    physicalSizeHint?: string;
 
     constructor(name: string, type: string, showType: boolean, size: number, internalChildren: storageReportItem[] = null, isGrouped = false) {
         this.name = name;

--- a/src/Raven.Studio/typescript/models/database/status/storageReportItem.ts
+++ b/src/Raven.Studio/typescript/models/database/status/storageReportItem.ts
@@ -24,7 +24,6 @@ class storageReportItem {
     isGrouped: boolean;
     
     recyclableJournal = false;
-    hardLinkedJournal = false;
     physicalSizeHint?: string;
 
     constructor(name: string, type: string, showType: boolean, size: number, internalChildren: storageReportItem[] = null, isGrouped = false) {

--- a/src/Raven.Studio/typescript/viewmodels/database/status/ioStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/ioStats.ts
@@ -18,7 +18,7 @@ class ioStats extends shardViewModelBase {
 
         this.graph = new ioStatsGraph(
             () => `database-${detailedDatabaseName}`,
-            ["Documents", "Index", "Configuration"],
+            ["Documents", "Index", "Configuration", "SharedJournals"],
             true,
             (onUpdate, cutOff) => new dbLiveIOStatsWebSocketClient(this.db, this.location, onUpdate, cutOff));
     }

--- a/src/Raven.Studio/typescript/viewmodels/database/status/storageReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/storageReport.ts
@@ -158,8 +158,10 @@ class storageReport extends shardViewModelBase {
             dataFile.size + journals.size + tempFiles.size,
             [dataFile, journals, tempFiles]);
 
-        if (dataFile.physicalSize != null) {
-            item.physicalSize = dataFile.physicalSize + journals.size + tempFiles.size;
+        if (dataFile.physicalSize != null || journals.physicalSize != null) {
+            item.physicalSize = (dataFile.physicalSize ?? dataFile.size)
+                + (journals.physicalSize ?? journals.size)
+                + tempFiles.size;
         }
 
         return item;
@@ -175,6 +177,9 @@ class storageReport extends shardViewModelBase {
         const storageItem = new storageReportItem("Datafile", "data", false, dataFile.AllocatedSpaceInBytes);
         storageItem.lazyLoadChildren = true;
         storageItem.physicalSize = dataFile.PhysicalSpaceInBytes;
+        if (dataFile.PhysicalSpaceInBytes < dataFile.AllocatedSpaceInBytes) {
+            storageItem.physicalSizeHint = "Unused pages returned to OS via sparse regions.";
+        }
 
         return storageItem;
     }
@@ -324,16 +329,33 @@ class storageReport extends shardViewModelBase {
     private mapJournals(report: Voron.Debugging.StorageReport): storageReportItem {
         const journals = report.Journals;
 
-        const mappedJournals = journals.map(journal => 
-            new storageReportItem(
+        const mappedJournals = journals.map(journal => {
+            const item = new storageReportItem(
                 "Journal #" + journal.Number,
                 "journal",
                 false,
                 journal.AllocatedSpaceInBytes,
                 []
-            ));
+            );
+            item.hardLinkedJournal = journal.IsHardLink;
+            if (journal.IsHardLink === false) {
+                item.physicalSize = journal.AllocatedSpaceInBytes;
+            } else {
+                item.physicalSize = 0;
+                item.physicalSizeHint = "Hard link to a journal owned by @SharedJournals env.";
+            }
+            return item;
+        });
 
-        return new storageReportItem("Journals", "journals", false, mappedJournals.reduce((p, c) => p + c.size, 0), mappedJournals);
+        const allocatedSum = mappedJournals.reduce((p, c) => p + c.size, 0);
+        const onDiskSum = mappedJournals.reduce((p, c) => p + (c.physicalSize ?? c.size), 0);
+
+        const journalsItem = new storageReportItem("Journals", "journals", false, allocatedSum, mappedJournals);
+        journalsItem.physicalSize = onDiskSum;
+        if (mappedJournals.some(j => j.hardLinkedJournal)) {
+            journalsItem.physicalSizeHint = "Hard-linked journals are counted once at @SharedJournals root.";
+        }
+        return journalsItem;
     }
     
     private mapTempFiles(report: Voron.Debugging.StorageReport): storageReportItem {

--- a/src/Raven.Studio/typescript/viewmodels/database/status/storageReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/storageReport.ts
@@ -337,7 +337,6 @@ class storageReport extends shardViewModelBase {
                 journal.AllocatedSpaceInBytes,
                 []
             );
-            item.hardLinkedJournal = journal.IsHardLink;
             if (journal.IsHardLink === false) {
                 item.physicalSize = journal.AllocatedSpaceInBytes;
             } else {
@@ -352,7 +351,7 @@ class storageReport extends shardViewModelBase {
 
         const journalsItem = new storageReportItem("Journals", "journals", false, allocatedSum, mappedJournals);
         journalsItem.physicalSize = onDiskSum;
-        if (mappedJournals.some(j => j.hardLinkedJournal)) {
+        if (journals.some(j => j.IsHardLink)) {
             journalsItem.physicalSizeHint = "Hard-linked journals are counted once at @SharedJournals root.";
         }
         return journalsItem;

--- a/src/Raven.Studio/typescript/viewmodels/manage/storageReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/storageReport.ts
@@ -255,7 +255,6 @@ class storageReport extends viewModelBase {
                 journal.AllocatedSpaceInBytes,
                 []
             );
-            item.hardLinkedJournal = journal.IsHardLink;
             if (journal.IsHardLink === false) {
                 item.physicalSize = journal.AllocatedSpaceInBytes;
             } else {
@@ -270,7 +269,7 @@ class storageReport extends viewModelBase {
 
         const journalsItem = new storageReportItem("Journals", "journals", false, allocatedSum, mappedJournals);
         journalsItem.physicalSize = onDiskSum;
-        if (mappedJournals.some(j => j.hardLinkedJournal)) {
+        if (journals.some(j => j.IsHardLink)) {
             journalsItem.physicalSizeHint = "Hard-linked journals are counted once at @SharedJournals root.";
         }
         return journalsItem;

--- a/src/Raven.Studio/typescript/viewmodels/manage/storageReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/storageReport.ts
@@ -132,8 +132,10 @@ class storageReport extends viewModelBase {
             dataFile.size + journals.size + tempFiles.size,
             [dataFile, journals, tempFiles]);
 
-        if (dataFile.physicalSize != null) {
-            item.physicalSize = dataFile.physicalSize + journals.size + tempFiles.size;
+        if (dataFile.physicalSize != null || journals.physicalSize != null) {
+            item.physicalSize = (dataFile.physicalSize ?? dataFile.size)
+                + (journals.physicalSize ?? journals.size)
+                + tempFiles.size;
         }
 
         return item;
@@ -144,6 +146,9 @@ class storageReport extends viewModelBase {
 
         const d = new storageReportItem("Datafile", "data", false, dataFile.AllocatedSpaceInBytes);
         d.physicalSize = dataFile.PhysicalSpaceInBytes;
+        if (dataFile.PhysicalSpaceInBytes < dataFile.AllocatedSpaceInBytes) {
+            d.physicalSizeHint = "Unused pages returned to OS via sparse regions.";
+        }
 
         const tables = this.mapTables(report.Tables);
         const trees = this.mapTrees(report.Trees, "Trees");
@@ -242,16 +247,33 @@ class storageReport extends viewModelBase {
     private mapJournals(report: Voron.Debugging.DetailedStorageReport): storageReportItem {
         const journals = report.Journals.Journals;
 
-        const mappedJournals = journals.map(journal => 
-            new storageReportItem(
+        const mappedJournals = journals.map(journal => {
+            const item = new storageReportItem(
                 "Journal #" + journal.Number,
                 "journal",
                 false,
                 journal.AllocatedSpaceInBytes,
                 []
-            ));
+            );
+            item.hardLinkedJournal = journal.IsHardLink;
+            if (journal.IsHardLink === false) {
+                item.physicalSize = journal.AllocatedSpaceInBytes;
+            } else {
+                item.physicalSize = 0;
+                item.physicalSizeHint = "Hard link to a journal owned by @SharedJournals env.";
+            }
+            return item;
+        });
 
-        return new storageReportItem("Journals", "journals", false, mappedJournals.reduce((p, c) => p + c.size, 0), mappedJournals);
+        const allocatedSum = mappedJournals.reduce((p, c) => p + c.size, 0);
+        const onDiskSum = mappedJournals.reduce((p, c) => p + (c.physicalSize ?? c.size), 0);
+
+        const journalsItem = new storageReportItem("Journals", "journals", false, allocatedSum, mappedJournals);
+        journalsItem.physicalSize = onDiskSum;
+        if (mappedJournals.some(j => j.hardLinkedJournal)) {
+            journalsItem.physicalSizeHint = "Hard-linked journals are counted once at @SharedJournals root.";
+        }
+        return journalsItem;
     }
     
     private mapTempFiles(report: Voron.Debugging.DetailedStorageReport): storageReportItem {

--- a/src/Raven.Studio/wwwroot/App/views/database/status/storageReport.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/storageReport.html
@@ -58,7 +58,10 @@
                 <td data-bind="visible: $root.showTempFiles, text: $root.dataSizeFormatted($data)"></td>
                 <td data-bind="visible: $root.showTempFiles, text: $root.tempSizeFormatted($data)"></td>
                 <td data-bind="html: formatSize(false)"></td>
-                <td data-bind="visible: $root.showOnDiskColumn, text: $root.onDiskSizeFormatted($data)"></td>
+                <td data-bind="visible: $root.showOnDiskColumn">
+                    <span data-bind="text: $root.onDiskSizeFormatted($data)"></span>
+                    <span data-bind="visible: physicalSizeHint"><small data-toggle="tooltip" data-bind="attr: { title: physicalSizeHint }"><i class="icon-info text-info"></i></small></span>
+                </td>
                 <td data-bind="text: formatPercentage($parent.node().size)"></td>
             </tr>
         </tbody>

--- a/src/Raven.Studio/wwwroot/App/views/manage/storageReport.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/storageReport.html
@@ -40,7 +40,10 @@
                 <td data-bind="visible: $root.showPagesColumn(), text: pageCount ? pageCount.toLocaleString() : 0"></td>
                 <td data-bind="visible: $root.showEntriesColumn(), text: numberOfEntries ? numberOfEntries.toLocaleString() : 0"></td>
                 <td data-bind="html: formatSize(false)"></td>
-                <td data-bind="visible: $root.showOnDiskColumn, text: $root.onDiskSizeFormatted($data)"></td>
+                <td data-bind="visible: $root.showOnDiskColumn">
+                    <span data-bind="text: $root.onDiskSizeFormatted($data)"></span>
+                    <span data-bind="visible: physicalSizeHint"><small data-toggle="tooltip" data-bind="attr: { title: physicalSizeHint }"><i class="icon-info text-info"></i></small></span>
+                </td>
                 <td data-bind="text: formatPercentage($parent.node().size)"></td>
             </tr>
         </tbody>

--- a/src/Raven.Studio/wwwroot/Content/css/pages/storage-report.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/storage-report.less
@@ -15,6 +15,7 @@
 @chart-trees-color: @color-1-1;
 @chart-tree-color: @color-1;
 @chart-configuration-color: @color-5-3;
+@chart-sharedjournals-color: @color-4-3;
 @chart-free-color: @gray-darker;
 
 
@@ -145,6 +146,20 @@
                 fill: lighten(@chart-configuration-color, 5%);
                 &.grouped {
                     fill: darken(@chart-configuration-color, 10%);
+                }
+            }
+        }
+
+        &.sharedjournals {
+            fill: @chart-sharedjournals-color;
+            &.grouped {
+                fill: darken(@chart-sharedjournals-color, 7%);
+            }
+
+            &:hover {
+                fill: lighten(@chart-sharedjournals-color, 5%);
+                &.grouped {
+                    fill: darken(@chart-sharedjournals-color, 10%);
                 }
             }
         }
@@ -438,6 +453,14 @@
 
                 &:hover {
                     background-color: lighten(@chart-configuration-color,5%);
+                }
+            }
+
+            &.sharedjournals {
+                background-color: @chart-sharedjournals-color;
+
+                &:hover {
+                    background-color: lighten(@chart-sharedjournals-color,5%);
                 }
             }
 

--- a/src/Voron/Debugging/DetailedStorageReport.cs
+++ b/src/Voron/Debugging/DetailedStorageReport.cs
@@ -14,6 +14,7 @@ namespace Voron.Debugging
         public long DataFilePhysicalSizeInBytes { get; set; }
         public long DataFileAllocatedSizeInBytes { get; set; }
         public long JournalsInBytes { get; set; }
+        public long HardLinkedJournalsInBytes { get; set; }
         public long TempBuffersInBytes { get; set; }
     }
 
@@ -86,6 +87,7 @@ namespace Voron.Debugging
         public long Available4Kbs { get; set; }
         public long LastTransaction { get; set; }
         public bool Flushed { get; set; }
+        public bool IsHardLink { get; set; }
     }
 
     public sealed class TempBufferReport

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -305,6 +305,7 @@ namespace Voron.Debugging
                     AllocatedSpaceInBytes = (long)journalWriter.NumberOfAllocated4Kb * 4 * Constants.Size.Kilobyte,
                     Available4Kbs = journal.GetAvailable4Kbs(_tx.CurrentStateRecord),
                     LastTransaction = journal.LastTransactionId,
+                    IsHardLink = journal.IsHardLinked,
                 };
             });
             var flushedJournalReports = flushedJournals.Select(journal =>
@@ -321,6 +322,7 @@ namespace Voron.Debugging
                     AllocatedSpaceInBytes = (long)journalWriter.NumberOfAllocated4Kb * 4 * Constants.Size.Kilobyte,
                     Available4Kbs = journal.GetAvailable4Kbs(_tx.CurrentStateRecord),
                     LastTransaction = journal.LastTransactionId,
+                    IsHardLink = journal.IsHardLinked,
                 };
             });
             return journalReports.Concat(flushedJournalReports).Where(x => x != null).ToList();

--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -19,7 +19,9 @@ namespace Voron.Impl.Journal
         private List<TransactionHeader> _transactionHeaders = new();
 
         public FrozenSet<Guid> RecoveredJournalIds = recoveredJournalIds;
-        
+
+        public bool IsHardLinked { get; init; }
+
         public override string ToString()
         {
             return $"Number: {Number}";

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -407,7 +407,10 @@ namespace Voron.Impl.Journal
                             ? _env.Options.CreateReadOnlyJournalWriter(journalNumber, journalPagerState.TotalAllocatedSize)
                             : _env.Options.CreateJournalWriter(journalNumber, journalPagerState.TotalAllocatedSize);
 
-                        var jrnlFile = new JournalFile(_env, jrnlWriter, journalNumber, journalReader.RecoveredJournalIds.ToFrozenSet());
+                        var jrnlFile = new JournalFile(_env, jrnlWriter, journalNumber, journalReader.RecoveredJournalIds.ToFrozenSet())
+                        {
+                            IsHardLinked = isHardLinked
+                        };
                         jrnlFile.DoneWriting = new SingleUseFlag();
 
                         if (isHardLinked)
@@ -2109,7 +2112,10 @@ namespace Voron.Impl.Journal
             JournalFile AddJournal(long index)
             {
                 var journalWriter = _env.Options.CreateJournalWriterForBranchEnvironment(index, existingJournalFileName, journalFile);
-                var journal = new JournalFile(_env, journalWriter, index, FrozenSet<Guid>.Empty);
+                var journal = new JournalFile(_env, journalWriter, index, FrozenSet<Guid>.Empty)
+                {
+                    IsHardLinked = true
+                };
                 journal.NewlyCreatedFile = true;
                 journal.DoneWriting = journalFile.DoneWriting;
                 journal.AddRef();

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -2093,7 +2093,7 @@ namespace Voron.Impl.Journal
                 if (_env.Options.IsLinked(_journalIndex, journalFile.JournalWriter.FileName.FullPath, out existingJournalFileName))
                 {
                     // The file is already linked, so we can reuse the file link
-                    matchingJournal = AddJournal(_journalIndex);
+                    matchingJournal = AddJournal(_journalIndex, isHardLinked: true);
                     return matchingJournal;
                 }
             }
@@ -2101,20 +2101,20 @@ namespace Voron.Impl.Journal
             long journalIndex = _journalIndex + 1;
 
             _env.Options.LinkFiles(journalIndex,journalFile.JournalWriter.FileName.FullPath, out existingJournalFileName);
-            matchingJournal = AddJournal(journalIndex);
+            matchingJournal = AddJournal(journalIndex, isHardLinked: true);
 
-            // we modify the in memory state _after_ we created the file, because we have to make sure that 
-            // we have created it successfully first. 
+            // we modify the in memory state _after_ we created the file, because we have to make sure that
+            // we have created it successfully first.
             _journalIndex++;
-            
+
             return matchingJournal;
 
-            JournalFile AddJournal(long index)
+            JournalFile AddJournal(long index, bool isHardLinked)
             {
                 var journalWriter = _env.Options.CreateJournalWriterForBranchEnvironment(index, existingJournalFileName, journalFile);
                 var journal = new JournalFile(_env, journalWriter, index, FrozenSet<Guid>.Empty)
                 {
-                    IsHardLinked = true
+                    IsHardLinked = isHardLinked
                 };
                 journal.NewlyCreatedFile = true;
                 journal.DoneWriting = journalFile.DoneWriting;

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -920,11 +920,14 @@ namespace Voron
         {
             long journalsSize = 0;
             long hardLinkedJournalsSize = 0;
+            // A root's own journals may show IsHardLinked=true (branches link to them) -
+            // those bytes belong here, not to a branch, so don't subtract on the root side.
+            bool envHostsBranches = Journal.BranchJournalMerger != null;
             foreach (var journal in Journal.Files)
             {
                 var size = (long)journal.JournalWriter.NumberOfAllocated4Kb * 4 * Constants.Size.Kilobyte;
                 journalsSize += size;
-                if (journal.IsHardLinked)
+                if (journal.IsHardLinked && envHostsBranches == false)
                     hardLinkedJournalsSize += size;
             }
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1893,7 +1893,8 @@ namespace Voron
             Documents,
             Index,
             Configuration,
-            System
+            System,
+            SharedJournals
         }
     }
 }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -919,9 +919,13 @@ namespace Voron
         public SizeReport GenerateSizeReport(bool includeTempBuffers)
         {
             long journalsSize = 0;
+            long hardLinkedJournalsSize = 0;
             foreach (var journal in Journal.Files)
             {
-                journalsSize += (long)journal.JournalWriter.NumberOfAllocated4Kb * 4 * Constants.Size.Kilobyte;
+                var size = (long)journal.JournalWriter.NumberOfAllocated4Kb * 4 * Constants.Size.Kilobyte;
+                journalsSize += size;
+                if (journal.IsHardLinked)
+                    hardLinkedJournalsSize += size;
             }
 
             long tempBuffers = 0;
@@ -949,6 +953,7 @@ namespace Voron
                 DataFilePhysicalSizeInBytes = _currentStateRecord.DataPagerState.TotalPhysicalSpace,
                 DataFileAllocatedSizeInBytes = _currentStateRecord.DataPagerState.TotalAllocatedSize,
                 JournalsInBytes = journalsSize,
+                HardLinkedJournalsInBytes = hardLinkedJournalsSize,
                 TempBuffersInBytes = tempBuffers,
             };
         }

--- a/test/SlowTests.Issues/Issues/RavenDB-26653.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26653.cs
@@ -110,6 +110,88 @@ public class RavenDB_26653 : RavenTestBase
         Assert.DoesNotContain(envs, x => x.Type == StorageEnvironmentWithType.StorageEnvironmentType.SharedJournals);
     }
 
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task Branch_index_env_journals_must_be_marked_as_hard_links_and_excluded_from_aggregated_size()
+    {
+        using var store = GetDocumentStore(new Options
+        {
+            RunInMemory = false
+        });
+
+        await new Users_ByName().ExecuteAsync(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 100; i++)
+                await session.StoreAsync(new User { Name = "user-" + i });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        Assert.NotNull(database.IndexStore.SharedJournals);
+
+        var rootEnv = database.IndexStore.SharedJournals.Env;
+        Assert.All(rootEnv.Journal.Files, j => Assert.False(j.IsHardLinked,
+            $"@SharedJournals root must not have hard-linked journals; journal #{j.Number} reported IsHardLinked=true"));
+
+        var rootReport = rootEnv.GenerateSizeReport(includeTempBuffers: false);
+        Assert.Equal(0, rootReport.HardLinkedJournalsInBytes);
+        Assert.True(rootReport.JournalsInBytes > 0, "expected root env to have non-empty journals");
+
+        var indexes = database.IndexStore.GetIndexes().ToList();
+        Assert.NotEmpty(indexes);
+
+        long branchHardLinkedTotal = 0;
+        long branchJournalsTotal = 0;
+        foreach (var index in indexes)
+        {
+            var branchEnv = index._indexStorage.Environment();
+
+            Assert.All(branchEnv.Journal.Files, j => Assert.True(j.IsHardLinked,
+                $"index '{index.Name}' branch env journal #{j.Number} must be hard-linked while shared journals enabled"));
+
+            var branchReport = branchEnv.GenerateSizeReport(includeTempBuffers: false);
+            Assert.Equal(branchReport.JournalsInBytes, branchReport.HardLinkedJournalsInBytes);
+            branchJournalsTotal += branchReport.JournalsInBytes;
+            branchHardLinkedTotal += branchReport.HardLinkedJournalsInBytes;
+        }
+
+        Assert.True(branchHardLinkedTotal > 0, "expected branch envs to have hard-linked journals");
+        Assert.Equal(branchJournalsTotal, branchHardLinkedTotal);
+
+        var totalsAfterDedup = database.GetSizeOnDisk();
+
+        long expectedJournalsContribution = rootReport.JournalsInBytes;
+        long branchDataFiles = indexes.Sum(i => i._indexStorage.Environment().GenerateSizeReport(includeTempBuffers: false).DataFilePhysicalSizeInBytes);
+        long docsAndConfigDataFiles = 0;
+        long docsAndConfigJournals = 0;
+        foreach (var env in database.GetAllStoragesEnvironment(new List<StorageEnvironmentWithType.StorageEnvironmentType>
+                 {
+                     StorageEnvironmentWithType.StorageEnvironmentType.Documents,
+                     StorageEnvironmentWithType.StorageEnvironmentType.Configuration
+                 }))
+        {
+            var r = env.Environment.GenerateSizeReport(includeTempBuffers: false);
+            docsAndConfigDataFiles += r.DataFilePhysicalSizeInBytes;
+            docsAndConfigJournals += r.JournalsInBytes - r.HardLinkedJournalsInBytes;
+        }
+
+        var expectedPhysical = rootReport.DataFilePhysicalSizeInBytes
+                               + expectedJournalsContribution
+                               + branchDataFiles
+                               + docsAndConfigDataFiles
+                               + docsAndConfigJournals;
+
+        Assert.Equal(expectedPhysical, totalsAfterDedup.Physical.SizeInBytes);
+
+        long naiveJournalsSum = rootReport.JournalsInBytes + branchJournalsTotal + docsAndConfigJournals;
+        long dedupedJournalsSum = rootReport.JournalsInBytes + docsAndConfigJournals;
+        Assert.True(dedupedJournalsSum < naiveJournalsSum,
+            $"de-duped journals total ({dedupedJournalsSum}) should be smaller than the naive sum ({naiveJournalsSum})");
+    }
+
     private class Users_ByName : AbstractIndexCreationTask<User>
     {
         public Users_ByName()

--- a/test/SlowTests.Issues/Issues/RavenDB-26653.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26653.cs
@@ -196,6 +196,128 @@ public class RavenDB_26653 : RavenTestBase
             $"de-duped journals total ({dedupedJournalsSum}) should be smaller than the naive sum ({naiveJournalsSum})");
     }
 
+    [RavenFact(RavenTestCategory.Voron)]
+    public void Root_env_must_not_subtract_its_own_journal_bytes_after_reopen_with_stale_branch_link()
+    {
+        // After a root env that hosts branches is disposed and reopened, branch dirs still
+        // hold hard links to its journal inodes - so the root's own journals show
+        // IsHardLinked=true. GenerateSizeReport must not subtract those bytes on the root
+        // side, or the root under-reports disk usage on every reopen.
+        string rootPath = NewDataPath(suffix: "root");
+        Raven.Server.Utils.IOExtensions.DeleteDirectory(rootPath);
+        string branchPath = NewDataPath(suffix: "branch");
+        Raven.Server.Utils.IOExtensions.DeleteDirectory(branchPath);
+
+        // Phase 1: open root + one branch, commit through branch to materialize the hard link.
+        {
+            using var rootOptions = StorageEnvironmentOptions.ForPathForTests(rootPath);
+            rootOptions.ManualFlushing = true;
+            rootOptions.ManualSyncing = true;
+
+            using var root = new StorageEnvironment(rootOptions);
+            using var _scope = root.Journal.SharedJournalsScope();
+
+            var mre = new System.Threading.ManualResetEventSlim(false);
+            root.Journal.BranchJournalMerger = new FastTests.Voron.SharedJournal.SharedJournalTests.MyJournalMerger(mre);
+
+            var task = System.Threading.Tasks.Task.Run(() =>
+            {
+                using var branch = FastTests.Voron.SharedJournal.SharedJournalTests.CreateBranchEnv(branchPath, root);
+                using var btx = branch.WriteTransaction();
+                btx.CreateTree("branchTree").Add("k", "v");
+                btx.Commit();
+            });
+            task.ContinueWith(_ => mre.Set());
+            FastTests.Voron.SharedJournal.SharedJournalTests.WaitForTaskAndExecuteBranchTransactions(task, mre, root);
+
+            // ManualFlushing means the journal stays on disk - do NOT flush to data file here.
+        }
+
+        // Phase 2: branch dir still holds its hard link; reopen root alone and inspect.
+        {
+            using var rootOptions = StorageEnvironmentOptions.ForPathForTests(rootPath);
+            rootOptions.ManualFlushing = true;
+            rootOptions.ManualSyncing = true;
+
+            using var root = new StorageEnvironment(rootOptions);
+            // Re-enter shared-journals mode (server-side orchestrator does this via SharedIndexJournals).
+            // Dedup reads BranchJournalMerger to know this env is the canonical owner.
+            using var _scope = root.Journal.SharedJournalsScope();
+            var mre = new System.Threading.ManualResetEventSlim(false);
+            root.Journal.BranchJournalMerger = new FastTests.Voron.SharedJournal.SharedJournalTests.MyJournalMerger(mre);
+
+            Assert.NotEmpty(root.Journal.Files);
+
+            // Branch dir still holds its link, so IsHardLinked honestly reports true.
+            Assert.All(root.Journal.Files, j => Assert.True(j.IsHardLinked,
+                $"Root's journal #{j.Number} should reflect OS-level nlinks > 1 (the branch link survives)"));
+
+            // But these bytes belong to the root - dedup must not subtract.
+            var sizeReport = root.GenerateSizeReport(includeTempBuffers: false);
+            Assert.True(sizeReport.JournalsInBytes > 0, "root must report non-empty journals after reopen");
+            Assert.Equal(0, sizeReport.HardLinkedJournalsInBytes);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void FallenBack_branch_must_still_subtract_its_old_hard_linked_journals()
+    {
+        // When a branch can no longer create hard links (e.g. OS hard-link limit reached)
+        // it clears its RootJournal and switches to unshared mode. Its existing JournalFile
+        // entries remain IsHardLinked=true (the root still holds those bytes); only new
+        // local journals are IsHardLinked=false.
+        //
+        // The dedup math must still subtract those old hard-linked entries even though
+        // the env's RootJournal is now null and the env no longer hosts branches.
+        string rootPath = NewDataPath(suffix: "root");
+        Raven.Server.Utils.IOExtensions.DeleteDirectory(rootPath);
+        string branchPath = NewDataPath(suffix: "branch");
+        Raven.Server.Utils.IOExtensions.DeleteDirectory(branchPath);
+
+        using var rootOptions = StorageEnvironmentOptions.ForPathForTests(rootPath);
+        rootOptions.ManualFlushing = true;
+        rootOptions.ManualSyncing = true;
+
+        using var root = new StorageEnvironment(rootOptions);
+        using var _scope = root.Journal.SharedJournalsScope();
+
+        var mre = new System.Threading.ManualResetEventSlim(false);
+        root.Journal.BranchJournalMerger = new FastTests.Voron.SharedJournal.SharedJournalTests.MyJournalMerger(mre);
+
+        StorageEnvironment branch = null;
+        try
+        {
+            var task = System.Threading.Tasks.Task.Run(() =>
+            {
+                branch = FastTests.Voron.SharedJournal.SharedJournalTests.CreateBranchEnv(branchPath, root);
+                using var btx = branch.WriteTransaction();
+                btx.CreateTree("branchTree").Add("k", "v");
+                btx.Commit();
+            });
+            task.ContinueWith(_ => mre.Set());
+            FastTests.Voron.SharedJournal.SharedJournalTests.WaitForTaskAndExecuteBranchTransactions(task, mre, root);
+
+            Assert.NotNull(branch);
+            // Simulate the fallback: branch loses its RootJournal but the existing journal
+            // entries (created via the branch-link path) keep IsHardLinked=true.
+            branch.Options.RootJournal = null;
+
+            Assert.NotEmpty(branch.Journal.Files);
+            Assert.All(branch.Journal.Files, j => Assert.True(j.IsHardLinked,
+                $"Pre-fallback branch journal #{j.Number} must remain IsHardLinked - root still owns the inode"));
+
+            var sizeReport = branch.GenerateSizeReport(includeTempBuffers: false);
+            Assert.True(sizeReport.JournalsInBytes > 0);
+            // Root still owns these bytes; the fallen-back branch's size report must
+            // subtract them so the cluster-wide sum doesn't double-count.
+            Assert.Equal(sizeReport.JournalsInBytes, sizeReport.HardLinkedJournalsInBytes);
+        }
+        finally
+        {
+            branch?.Dispose();
+        }
+    }
+
     private class Users_ByName : AbstractIndexCreationTask<User>
     {
         public Users_ByName()

--- a/test/SlowTests.Issues/Issues/RavenDB-26653.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26653.cs
@@ -140,22 +140,27 @@ public class RavenDB_26653 : RavenTestBase
         Assert.Equal(0, rootReport.HardLinkedJournalsInBytes);
         Assert.True(rootReport.JournalsInBytes > 0, "expected root env to have non-empty journals");
 
-        var indexes = database.IndexStore.GetIndexes().ToList();
-        Assert.NotEmpty(indexes);
+        var indexEnvs = database.GetAllStoragesEnvironment(new List<StorageEnvironmentWithType.StorageEnvironmentType>
+        {
+            StorageEnvironmentWithType.StorageEnvironmentType.Index
+        }).ToList();
+        Assert.NotEmpty(indexEnvs);
 
         long branchHardLinkedTotal = 0;
         long branchJournalsTotal = 0;
-        foreach (var index in indexes)
+        long branchDataFiles = 0;
+        foreach (var indexEnv in indexEnvs)
         {
-            var branchEnv = index._indexStorage.Environment();
+            var branchEnv = indexEnv.Environment;
 
             Assert.All(branchEnv.Journal.Files, j => Assert.True(j.IsHardLinked,
-                $"index '{index.Name}' branch env journal #{j.Number} must be hard-linked while shared journals enabled"));
+                $"index '{indexEnv.Name}' branch env journal #{j.Number} must be hard-linked while shared journals enabled"));
 
             var branchReport = branchEnv.GenerateSizeReport(includeTempBuffers: false);
             Assert.Equal(branchReport.JournalsInBytes, branchReport.HardLinkedJournalsInBytes);
             branchJournalsTotal += branchReport.JournalsInBytes;
             branchHardLinkedTotal += branchReport.HardLinkedJournalsInBytes;
+            branchDataFiles += branchReport.DataFilePhysicalSizeInBytes;
         }
 
         Assert.True(branchHardLinkedTotal > 0, "expected branch envs to have hard-linked journals");
@@ -164,7 +169,6 @@ public class RavenDB_26653 : RavenTestBase
         var totalsAfterDedup = database.GetSizeOnDisk();
 
         long expectedJournalsContribution = rootReport.JournalsInBytes;
-        long branchDataFiles = indexes.Sum(i => i._indexStorage.Environment().GenerateSizeReport(includeTempBuffers: false).DataFilePhysicalSizeInBytes);
         long docsAndConfigDataFiles = 0;
         long docsAndConfigJournals = 0;
         foreach (var env in database.GetAllStoragesEnvironment(new List<StorageEnvironmentWithType.StorageEnvironmentType>

--- a/test/SlowTests.Issues/Issues/RavenDB-26653.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26653.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26653 : RavenTestBase
+{
+    public RavenDB_26653(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task GetAllStoragesEnvironment_must_include_SharedJournals_env()
+    {
+        using var store = GetDocumentStore(new Options
+        {
+            RunInMemory = false
+        });
+
+        await new Users_ByName().ExecuteAsync(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = "Joe" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+        Assert.NotNull(database.IndexStore.SharedJournals);
+
+        var envs = database.GetAllStoragesEnvironment().ToList();
+
+        var sharedJournals = envs.Where(x => x.Type == StorageEnvironmentWithType.StorageEnvironmentType.SharedJournals).ToList();
+        Assert.Single(sharedJournals);
+
+        var entry = sharedJournals[0];
+        Assert.Equal(Raven.Server.Config.Categories.IndexingConfiguration.SharedJournalsStorageName, entry.Name);
+        Assert.Same(database.IndexStore.SharedJournals.Env, entry.Environment);
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task GetAllStoragesEnvironment_must_not_include_SharedJournals_env_when_disabled()
+    {
+        using var store = GetDocumentStore(new Options
+        {
+            RunInMemory = false,
+            ModifyDatabaseRecord = r =>
+                r.Settings[RavenConfiguration.GetKey(c => c.Indexing.DisableSharedJournals)] = "true"
+        });
+
+        await new Users_ByName().ExecuteAsync(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = "Joe" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+        Assert.Null(database.IndexStore.SharedJournals);
+
+        var envs = database.GetAllStoragesEnvironment().ToList();
+        Assert.DoesNotContain(envs, x => x.Type == StorageEnvironmentWithType.StorageEnvironmentType.SharedJournals);
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task Backup_type_list_must_not_include_SharedJournals_env()
+    {
+        using var store = GetDocumentStore(new Options
+        {
+            RunInMemory = false
+        });
+
+        await new Users_ByName().ExecuteAsync(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = "Joe" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+        Assert.NotNull(database.IndexStore.SharedJournals);
+
+        var backupTypes = new List<StorageEnvironmentWithType.StorageEnvironmentType>
+        {
+            StorageEnvironmentWithType.StorageEnvironmentType.Index,
+            StorageEnvironmentWithType.StorageEnvironmentType.Documents,
+            StorageEnvironmentWithType.StorageEnvironmentType.Configuration,
+        };
+
+        var envs = database.GetAllStoragesEnvironment(backupTypes).ToList();
+        Assert.DoesNotContain(envs, x => x.Type == StorageEnvironmentWithType.StorageEnvironmentType.SharedJournals);
+    }
+
+    private class Users_ByName : AbstractIndexCreationTask<User>
+    {
+        public Users_ByName()
+        {
+            Map = users => from u in users select new { u.Name };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26653

### Additional description

**Enumeration:**
- New `StorageEnvironmentType.SharedJournals` and a switch case yielding `IndexStore.SharedJournals?.Env`. Added to `DefaultStorageEnvironmentTypes`; intentionally NOT added to `DefaultStorageEnvironmentTypesForBackup` so snapshot backup remains unchanged (merged journals are already covered via hard-link mirroring into per-index backup folders).
- `/debug/storage/report` label is now three-state Root/Branch/None: the @SharedJournals env reports `Root`, branches with `RootJournal != null` report `Branch`, everything else reports `None`.

**Hard-link tracking + de-dup:**
- `JournalFile.IsHardLinked` (`init`-only bool) captured at creation. Set from existing `isHardLinked` boolean in recovery path; set to `true` in branch-env journal creation (the path that calls `LinkFiles`). No runtime syscalls.
- `SizeReport.HardLinkedJournalsInBytes` and `JournalReport.IsHardLink` surface the flag.
- `DocumentDatabase.GetSizeOnDisk` and `ServerStore.GetMountPointUsageDetailsFor` subtract `HardLinkedJournalsInBytes` so shared journal bytes are counted once at the @SharedJournals root, not once per branch.
- Per-env reports (`Index.CalculateIndexStorageSize`, single-env storage report queries) keep the existing "bytes visible from this path" semantics that match `du` / Explorer.

**Studio:**
- Added `"SharedJournals"` to the IO Stats tracksOrder whitelist (without it, the env's I/O was silently dropped from the live graph).
- Storage report "On Disk" column now reflects sparse-region savings AND hard-link de-dup. An `(i)` icon appears next to the "On Disk" value with a one-line tooltip explaining the cause - either sparse regions or hard-linked journals.
- Dashboard widget ("Data on disk", "Total") already routes through `GetSizeOnDisk`, so it automatically gets the de-duped number.

### Screenshots

<img width="2183" height="238" alt="image" src="https://github.com/user-attachments/assets/570dd8ae-29c7-4cec-b117-7ac354d94dc7" />


<img width="1286" height="202" alt="image" src="https://github.com/user-attachments/assets/b3123360-1fa2-4e0f-b4dd-e0edf0e2e210" />


<img width="1261" height="175" alt="image" src="https://github.com/user-attachments/assets/12714b77-7fe8-4443-a6e1-a7a720bf82db" />

<img width="1293" height="391" alt="image" src="https://github.com/user-attachments/assets/433ecb2c-c08c-4b45-a9bc-b7f669c764fd" />


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
