### PR TITLE
RavenDB-26251 Stream JSON buffer to output via CopyToAsync in FlushAsync

### DIFF
--- a/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
@@ -122,7 +122,7 @@ namespace Raven.Server.Documents.Includes
         public async ValueTask WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, CancellationToken token)
         {
             var first = true;
-            ValueTask<int> maybeFlush;
+            ValueTask<long> maybeFlush;
             if (IdByRevisionsByDateTimeResults != null)
             {
                 foreach ((string id, var dateTimeToDictionary) in IdByRevisionsByDateTimeResults)

--- a/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
+++ b/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
@@ -179,7 +179,7 @@ namespace Raven.Server.Utils
             _inner.WritePropertyName(prop);
         }
 
-        public ValueTask<int> MaybeFlushAsync(CancellationToken token = default)
+        public ValueTask<long> MaybeFlushAsync(CancellationToken token = default)
         {
             return _inner.MaybeFlushAsync(token);
         }

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IO;
 
 namespace Sparrow.Json
 {
@@ -11,8 +12,8 @@ namespace Sparrow.Json
         private readonly Stream _outputStream;
         private readonly CancellationToken _cancellationToken;
         
-        // PERF: Cache the MemoryStream reference to avoid repeated casting
-        private readonly MemoryStream _innerStream;
+        // PERF: Cache the RecyclableMemoryStream reference to avoid repeated casting
+        private readonly RecyclableMemoryStream _innerStream;
         private readonly bool _continueOnCapturedContext;
 
         internal static readonly AsyncLocal<bool> CaptureContextOnAwait = new();
@@ -21,11 +22,11 @@ namespace Sparrow.Json
         {
             _outputStream = stream ?? throw new ArgumentNullException(nameof(stream));
             _cancellationToken = cancellationToken;
-            _innerStream = _stream as MemoryStream; // Cache the cast since we know it's always MemoryStream
+            _innerStream = _stream as RecyclableMemoryStream; // Cache the cast since we know it's always RecyclableMemoryStream
             _continueOnCapturedContext = CaptureContextOnAwait.Value;
 
             if (_innerStream == null)
-                throw new ArgumentException($"Expected stream to be MemoryStream, but got {(_stream?.GetType() == null ? "null" : _stream.ToString())}.");
+                throw new ArgumentException($"Expected stream to be RecyclableMemoryStream, but got {(_stream?.GetType() == null ? "null" : _stream.ToString())}.");
         }
 
         public async ValueTask WriteStreamAsync(Stream stream, CancellationToken token = default)
@@ -51,42 +52,40 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueTask<int> MaybeFlushAsync(CancellationToken token = default)
         {
-            // PERF: Use cached MemoryStream reference
+            // PERF: Use cached RecyclableMemoryStream reference
             if (_innerStream.Length * 2 <= _innerStream.Capacity)
                 return new ValueTask<int>(0);
 
-            FlushInternal(); // this is OK, because inner stream is a MemoryStream
+            FlushInternal(); // this is OK, because inner stream is a RecyclableMemoryStream
             return FlushAsync(token);
         }
 
         public ValueTask<int> FlushAsync(CancellationToken token = default)
         {
-            // PERF: Use cached MemoryStream reference
             FlushInternal();
-            _innerStream.TryGetBuffer(out var bytes);
-            var bytesCount = bytes.Count;
+            var bytesCount = (int)_innerStream.Length;
             if (bytesCount == 0)
                 return new ValueTask<int>(0);
-            
-            var writeTask = _outputStream.WriteAsync(bytes.Array, bytes.Offset, bytesCount, token);
-            if (writeTask.IsCompleted)
+
+            _innerStream.Position = 0;
+            // bufferSize is required by the netstandard2.0 overload but is unused by RecyclableMemoryStream.CopyToAsync, which writes each internal block directly.
+            var copyTask = _innerStream.CopyToAsync(_outputStream, bufferSize: 4096, token);
+            if (copyTask.IsCompleted)
             {
                 // PERF: Fast synchronous path - avoid async state machine overhead
-                // This happens when _outputStream is MemoryStream, FileStream with sync completion, etc.
-                writeTask.GetAwaiter().GetResult();
+                copyTask.GetAwaiter().GetResult();
                 _innerStream.SetLength(0);
                 return new ValueTask<int>(bytesCount);
             }
-            
-            // Slow asynchronous path for network streams, slow disk I/O, etc.
-            return FlushAsyncSlow(writeTask, _innerStream, bytesCount);
-        }
-        
-        private async ValueTask<int> FlushAsyncSlow(Task writeTask, MemoryStream innerStream, int bytesCount)
-        {
-            await writeTask.ConfigureAwait(_continueOnCapturedContext);
 
-            innerStream.SetLength(0);
+            return FlushAsyncSlow(copyTask, bytesCount);
+        }
+
+        private async ValueTask<int> FlushAsyncSlow(Task copyTask, int bytesCount)
+        {
+            await copyTask.ConfigureAwait(_continueOnCapturedContext);
+
+            _innerStream.SetLength(0);
             return bytesCount;
         }
 

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -50,22 +50,22 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ValueTask<int> MaybeFlushAsync(CancellationToken token = default)
+        public ValueTask<long> MaybeFlushAsync(CancellationToken token = default)
         {
             // PERF: Use cached RecyclableMemoryStream reference
             if (_innerStream.Length * 2 <= _innerStream.Capacity)
-                return new ValueTask<int>(0);
+                return new ValueTask<long>(0);
 
             FlushInternal(); // this is OK, because inner stream is a RecyclableMemoryStream
             return FlushAsync(token);
         }
 
-        public ValueTask<int> FlushAsync(CancellationToken token = default)
+        public ValueTask<long> FlushAsync(CancellationToken token = default)
         {
             FlushInternal();
-            var bytesCount = (int)_innerStream.Length;
+            var bytesCount = _innerStream.Length;
             if (bytesCount == 0)
-                return new ValueTask<int>(0);
+                return new ValueTask<long>(0);
 
             _innerStream.Position = 0;
             // bufferSize is required by the netstandard2.0 overload but is unused by RecyclableMemoryStream.CopyToAsync, which writes each internal block directly.
@@ -75,13 +75,13 @@ namespace Sparrow.Json
                 // PERF: Fast synchronous path - avoid async state machine overhead
                 copyTask.GetAwaiter().GetResult();
                 _innerStream.SetLength(0);
-                return new ValueTask<int>(bytesCount);
+                return new ValueTask<long>(bytesCount);
             }
 
             return FlushAsyncSlow(copyTask, bytesCount);
         }
 
-        private async ValueTask<int> FlushAsyncSlow(Task copyTask, int bytesCount)
+        private async ValueTask<long> FlushAsyncSlow(Task copyTask, long bytesCount)
         {
             await copyTask.ConfigureAwait(_continueOnCapturedContext);
 
@@ -121,7 +121,7 @@ namespace Sparrow.Json
             return DisposeAsyncSlow(flushTask);
         }
 
-        private async ValueTask DisposeAsyncSlow(ValueTask<int> flushTask)
+        private async ValueTask DisposeAsyncSlow(ValueTask<long> flushTask)
         {
             var bytesWritten = await flushTask.ConfigureAwait(_continueOnCapturedContext);
             if (bytesWritten > 0)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26251

### Additional description

We had an optimization where flushing the inner stream to the output used TryGetBuffer to get the underlying array and pass it directly to WriteAsync. 
This made sense for MemoryStream, it has a real internal array and TryGetBuffer just returns it.

The inner stream was later replaced with RecyclableMemoryStream, which implements the MemoryStream interface and also exposes TryGetBuffer. 
The difference is that instead of returning an existing buffer, it has to switch the stream from block-based storage to a single contiguous buffer. 
Once in that mode, all subsequent writes go to that buffer. 
When it reaches capacity it is reallocated and all existing data is copied.

The bug was hidden when LargeBufferMultiple was at its default of 1 MB, large enough that most responses never triggered a reallocation. 
When LargeBufferMultiple was changed to 64 KB, even moderate responses exceed it quickly, and a large write can trigger the reallocation repeatedly. 
Each reallocation copies all previously written data, making the total work O(n²).

The regression requires TryGetBuffer to be called while the stream holds more than one block (~32 KB). 
That call is what switches the stream to large-buffer mode and affects all subsequent writes.

#### Fix

Replace TryGetBuffer + WriteAsync with Position = 0; CopyToAsync. RecyclableMemoryStream.CopyToAsync writes block-by-block to the output without coalescing, so large-buffer mode is never triggered.

Verification

#### Benchmark

Used the original MemoryStream implementation as the baseline.

  | Method                                   | Mean        | Error     | StdDev    | Median      | Ratio | RatioSD |
  |----------------------------------------- |------------:|----------:|----------:|------------:|------:|--------:|
  | SmallFlushes_10x8KB_PlainStream          |    37.87 us |  0.318 us |  0.282 us |    37.85 us |  1.00 |    0.01 |
  | SmallFlushes_10x8KB_TryGetBuffer         |    38.78 us |  0.363 us |  0.321 us |    38.78 us |  1.02 |    0.01 |
  | SmallFlushes_10x8KB_CopyToAsync          |    38.04 us |  0.311 us |  0.276 us |    38.01 us |  1.00 |    0.01 |
  | LargeResponse_40KB_then_1MB_PlainStream  |   729.18 us |  7.256 us |  6.059 us |   727.88 us | 19.26 |    0.21 |
  | LargeResponse_40KB_then_1MB_TryGetBuffer | 1,231.67 us | 23.656 us | 24.293 us | 1,223.66 us | 32.53 |    0.67 |
  | LargeResponse_40KB_then_1MB_CopyToAsync  |   791.79 us |  7.976 us |  7.461 us |   790.29 us | 20.91 |    0.24 |
  | MediumFlushes_10x40KB_PlainStream        |   188.43 us |  1.623 us |  1.518 us |   188.29 us |  4.98 |    0.05 |
  | MediumFlushes_10x40KB_TryGetBuffer       |   189.25 us |  1.388 us |  1.159 us |   188.92 us |  5.00 |    0.05 |
  | MediumFlushes_10x40KB_CopyToAsync        |   191.82 us |  2.696 us |  6.461 us |   189.61 us |  5.07 |    0.17 |
  | SingleLargeFlush_1MB_PlainStream         |   702.68 us |  8.311 us |  7.368 us |   699.81 us | 18.56 |    0.23 |
  | SingleLargeFlush_1MB_TryGetBuffer        |   846.50 us | 16.395 us | 20.735 us |   836.86 us | 22.35 |    0.56 |
  | SingleLargeFlush_1MB_CopyToAsync         |   759.63 us |  5.444 us |  5.092 us |   757.73 us | 20.06 |    0.19 |

LargeResponse_40KB_then_1MB shows the regression clearly: flushing 40 KB first (two blocks, which triggers large-buffer mode at 64 KB) and then writing 1 MB makes TryGetBuffer 68% slower than the baseline. CopyToAsync matches the baseline.

#### dotTrace

Compared TryGetBuffer vs CopyToAsync on the 40 KB + 1 MB scenario, collected with Sampling mode.

The TryGetBuffer profile shows 13% of total time in `System.Buffer._Memmove`, the repeated reallocation copies. 
After the fix, it is near zero.

[dotTrace.txt](https://github.com/user-attachments/files/28340075/dotTrace.txt)

### Type of change
- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
