### PR TITLE
RavenDB-26648, RavenDB-26691 - Guard HTTP client cache cleanup during test teardown

### DIFF
--- a/test/Tests.Infrastructure/ParallelTestBase.cs
+++ b/test/Tests.Infrastructure/ParallelTestBase.cs
@@ -25,6 +25,7 @@ public class ParallelTestBase : LinuxRaceConditionWorkAround, IAsyncLifetime
     private const string XunitConfigurationFile = "xunit.runner.json";
 
     private static readonly SemaphoreSlim ConcurrentTestsSemaphore;
+    private static readonly int MaxNumberOfConcurrentTests;
     private readonly MultipleUseFlag _concurrentTestsSemaphoreTaken = new();
 
     static ParallelTestBase()
@@ -54,6 +55,7 @@ public class ParallelTestBase : LinuxRaceConditionWorkAround, IAsyncLifetime
         }
 
         Console.WriteLine("Max number of concurrent tests is: " + maxNumberOfConcurrentTests);
+        MaxNumberOfConcurrentTests = maxNumberOfConcurrentTests;
         ConcurrentTestsSemaphore = new SemaphoreSlim(maxNumberOfConcurrentTests, maxNumberOfConcurrentTests);
 
         if (bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_WRITE_RUNNING_TESTS_TO_FILE"), out var writeToFile))
@@ -101,6 +103,38 @@ public class ParallelTestBase : LinuxRaceConditionWorkAround, IAsyncLifetime
         }
 
         return Task.CompletedTask;
+    }
+
+    protected bool TryExecuteWhenNoOtherTestsAreRunning(Action action)
+    {
+        if (action == null)
+            throw new ArgumentNullException(nameof(action));
+
+        if (_concurrentTestsSemaphoreTaken.IsRaised() == false)
+            return false;
+
+        var acquired = 0;
+        try
+        {
+            for (var i = 1; i < MaxNumberOfConcurrentTests; i++)
+            {
+                if (ConcurrentTestsSemaphore.Wait(0) == false)
+                    return false;
+
+                acquired++;
+            }
+
+            action();
+            return true;
+        }
+        finally
+        {
+            while (acquired > 0)
+            {
+                ConcurrentTestsSemaphore.Release();
+                acquired--;
+            }
+        }
     }
 
     public override void Dispose()

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -730,66 +730,70 @@ namespace FastTests
         {
             GC.SuppressFinalize(this);
 
-            base.Dispose();
-
             var exceptionAggregator = new ExceptionAggregator("Could not dispose test");
-
-            var testOutcomeAnalyzer = new TestOutcomeAnalyzer(Context);
-            var shouldSaveDebugPackage = testOutcomeAnalyzer.ShouldSaveDebugPackage();
-
-            exceptionAggregator.Execute(() =>
+            try
             {
-                if (_globalServer?.ServerStore.Observer?.Suspended == true)
-                    throw new InvalidOperationException("The observer is suspended for the global server!");
-            });
-
-            Dispose(exceptionAggregator);
-
-            DownloadAndSaveDebugPackage(shouldSaveDebugPackage, _globalServer, exceptionAggregator, Context);
-
-            if (_localServer != null && _localServer != _globalServer)
-            {
-                DownloadAndSaveDebugPackage(shouldSaveDebugPackage, _localServer, exceptionAggregator, Context);
+                var testOutcomeAnalyzer = new TestOutcomeAnalyzer(Context);
+                var shouldSaveDebugPackage = testOutcomeAnalyzer.ShouldSaveDebugPackage();
 
                 exceptionAggregator.Execute(() =>
                 {
-                    DisposeServer(_localServer, _disposeTimeout);
-                    _localServer = null;
+                    if (_globalServer?.ServerStore.Observer?.Suspended == true)
+                        throw new InvalidOperationException("The observer is suspended for the global server!");
                 });
-            }
 
-            for (int i = 0; i < ServersForDisposal.Count; i++)
-            {
-                var serverForDisposal = ServersForDisposal[i];
+                Dispose(exceptionAggregator);
 
-                if (i == 0)
-                    DownloadAndSaveDebugPackage(shouldSaveDebugPackage, serverForDisposal, exceptionAggregator, Context);
+                DownloadAndSaveDebugPackage(shouldSaveDebugPackage, _globalServer, exceptionAggregator, Context);
 
-                exceptionAggregator.Execute(() => DisposeServer(serverForDisposal, _disposeTimeout));
-            }
+                if (_localServer != null && _localServer != _globalServer)
+                {
+                    DownloadAndSaveDebugPackage(shouldSaveDebugPackage, _localServer, exceptionAggregator, Context);
+
+                    exceptionAggregator.Execute(() =>
+                    {
+                        DisposeServer(_localServer, _disposeTimeout);
+                        _localServer = null;
+                    });
+                }
+
+                for (int i = 0; i < ServersForDisposal.Count; i++)
+                {
+                    var serverForDisposal = ServersForDisposal[i];
+
+                    if (i == 0)
+                        DownloadAndSaveDebugPackage(shouldSaveDebugPackage, serverForDisposal, exceptionAggregator, Context);
+
+                    exceptionAggregator.Execute(() => DisposeServer(serverForDisposal, _disposeTimeout));
+                }
 
 #if DEBUG2
-            var properties = TcpExtensions.GetIPGlobalPropertiesSafely();
-            var connections = properties.GetActiveTcpConnectionsSafely() ?? Array.Empty<TcpConnectionInformation>();
+                var properties = TcpExtensions.GetIPGlobalPropertiesSafely();
+                var connections = properties.GetActiveTcpConnectionsSafely() ?? Array.Empty<TcpConnectionInformation>();
 
-            var sb = new StringBuilder($"TCP Connections '{Context.UniqueTestName}' ({connections.Length}): {Environment.NewLine}");
-            var groupedConnections = connections.GroupBy(x => x.State).Select(x => new { State = x.Key, Count = x.Count() }).OrderByDescending(x => x.Count);
-            foreach (var group in groupedConnections)
-            {
-                if (group.Count == 0)
-                    continue;
+                var sb = new StringBuilder($"TCP Connections '{Context.UniqueTestName}' ({connections.Length}): {Environment.NewLine}");
+                var groupedConnections = connections.GroupBy(x => x.State).Select(x => new { State = x.Key, Count = x.Count() }).OrderByDescending(x => x.Count);
+                foreach (var group in groupedConnections)
+                {
+                    if (group.Count == 0)
+                        continue;
 
-                sb.AppendLine($"- {group.State} - {group.Count}");
-            }
+                    sb.AppendLine($"- {group.State} - {group.Count}");
+                }
 
-            Output.WriteLine(sb.ToString());
+                Output.WriteLine(sb.ToString());
 #endif
 
-            ServersForDisposal = null;
+                ServersForDisposal = null;
 
-            RavenTestHelper.DeletePaths(_localPathsToDelete, exceptionAggregator);
+                RavenTestHelper.DeletePaths(_localPathsToDelete, exceptionAggregator);
 
-            exceptionAggregator.Execute(() => DefaultRavenHttpClientFactory.Instance.Clear());
+                exceptionAggregator.Execute(() => TryExecuteWhenNoOtherTestsAreRunning(() => DefaultRavenHttpClientFactory.Instance.Clear()));
+            }
+            finally
+            {
+                base.Dispose();
+            }
 
             exceptionAggregator.ThrowIfNeeded();
         }

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -789,6 +789,8 @@ namespace FastTests
 
             RavenTestHelper.DeletePaths(_localPathsToDelete, exceptionAggregator);
 
+            exceptionAggregator.Execute(() => DefaultRavenHttpClientFactory.Instance.Clear());
+
             exceptionAggregator.ThrowIfNeeded();
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26648
https://issues.hibernatingrhinos.com/issue/RavenDB-26691

### Additional description

This PR makes the test infrastructure clear the process-wide `DefaultRavenHttpClientFactory` cache during test teardown, but only when the current test is the only running test in the process.

The failing CIDI scenario involved two filtered replication tests running serially in the same x86 VSTest process, with short-lived test servers and certificates. The predecessor test passed and disposed its test environment, but it could leave HTTP clients, handlers, and connection state behind in the process-wide RavenDB client cache. The following test could then reuse HTTP client state created for the previous short-lived test environment.

The observed failure shape was not a certificate/keyset, TLS, or authorization failure. The target test reached the replication wait, replication was not established, and the test eventually failed in `EnsureReplicating` with `Assert.NotNull`.

This is test-lifecycle state bleeding between tests in one process. The production HTTP client cache behavior is unchanged.

How the fix works:
- `TestBase.Dispose()` clears `DefaultRavenHttpClientFactory.Instance` after local test paths are cleaned up and before accumulated teardown exceptions are thrown.
- The clear is guarded by `TryExecuteWhenNoOtherTestsAreRunning()` in `ParallelTestBase`.
- The guard uses the existing `ConcurrentTestsSemaphore`: the current test already owns one slot, and the guard tries to acquire all remaining slots with `Wait(0)`.
- If another test is running, the clear is skipped.
- If no other test is running, the cache is cleared and the extra semaphore slots are released immediately.

In the CIDI repro configuration, `Max number of concurrent tests is: 1`, so teardown clears the cache after each test. In parallel test runs, the cleanup is best-effort and only runs when it is safe to do so.

Safety notes:
- No production HTTP client cache key or lifetime behavior is changed.
- The change is limited to test infrastructure.
- `DefaultRavenHttpClientFactory.Clear()` removes entries from the process-wide cache; it does not dispose `HttpClient` instances that were already handed out to running code.
- Tests should not depend on process-wide HTTP client reuse across test boundaries. This change removes that hidden coupling for serial runs and avoids clearing while other tests are active.

Evidence from Eagle-5:
- Baseline, no fix: `5/6` CIDI-like reproductions under the recovered CIDI-like conditions, requiring at least 5 reproductions within 10 attempts.
- With this change: `10/10` runs passed under the same conditions.
- Baseline `target-alone` control passed.
- Baseline hub predecessor controls passed.
- Fixed `target-alone` and hub predecessor controls passed.
- The runs used Windows PowerShell ISE 5.1, x86 VSTest 17.11.1, xUnit VSTest Adapter 2.8.2 on .NET 8.0.27, serial execution, `parallel test collections = off`, and `Max number of concurrent tests is: 1`.
- The failing baseline runs had no `Keyset does not exist`, no `0x80090016`, no `0x8009030D`, no `Certificate with private key is required`, and no `AuthorizationException`.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing

Validation:
- `dotnet build RavenDB.sln` succeeded locally.
- Existing CIDI repro scenario on Eagle-5: baseline `5/6` CIDI-like reproductions, fixed `10/10` pass.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required`
- [x] No UI work is needed