### PR TITLE
RavenDB-26405 HNSW vector search: combined optimization series

### DIFF
--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -306,7 +306,7 @@ public partial class IndexWriter
 
             var vectorWriter = field.GetVectorIndexer(_parent._transaction.LowLevelTransaction, value.Length, random);
             var vectorHash = vectorWriter.Register((long)_entryId, value);
-            
+
             //We're storing the vector hash for removal purposes
             RegisterTerm(field, vectorHash.ToSpan(), StoredFieldType.Raw);
         }

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -85,6 +85,23 @@ namespace Corax.Indexing
         private PostingList _largePostingListSet;
         public int? MaximumConcurrentBatchesForHnswAcceleration;
 
+        /// <summary>
+        /// Per-field set of node ids whose container record was rewritten by the just-finished
+        /// vector commit. Populated as each <see cref="Hnsw.Registration.Commit"/> completes and
+        /// drained by the post-commit hook via <see cref="DrainDirtyVectorSets"/>; the registration
+        /// itself is cleared on field reset, so this dictionary is the only surviving handle to
+        /// the dirty set after <see cref="ResetWriter"/> runs.
+        /// </summary>
+        private Dictionary<Slice, HashSet<long>> _dirtyVectorSets;
+
+        /// <summary>
+        /// Per-field set of node ids that the just-finished commit rewrote in the underlying
+        /// HNSW container. Read by <c>CoraxIndexPersistence.RecreateSearcher</c> to apply
+        /// incremental updates to the long-lived <c>HnswIndexCache</c>; null when no vector
+        /// field saw any modification.
+        /// </summary>
+        public Dictionary<Slice, HashSet<long>> DirtyVectorSets => _dirtyVectorSets;
+
         private long _compactTreeDictionaryId = Constants.IndexSearcher.InvalidId;
         private EntriesToTermsTracker _entriesToTermsTracker;
 
@@ -1094,6 +1111,15 @@ namespace Corax.Indexing
                     if (MaximumConcurrentBatchesForHnswAcceleration != null)
                         indexedField.VectorIndexer.MaxConcurrentBatches = MaximumConcurrentBatchesForHnswAcceleration.Value;
                     indexedField.VectorIndexer.Commit(token);
+
+                    // Snapshot DirtyNodeIds before ResetWriter clears the field's VectorIndexer.
+                    // The post-commit hook (CoraxIndexPersistence.RecreateSearcher) consumes this
+                    // to apply incremental updates against the long-lived HnswIndexCache.
+                    if (indexedField.VectorIndexer.DirtyNodeIds.Count > 0)
+                    {
+                        _dirtyVectorSets ??= new Dictionary<Slice, HashSet<long>>(SliceComparer.Instance);
+                        _dirtyVectorSets[indexedField.Name] = indexedField.VectorIndexer.DirtyNodeIds;
+                    }
                 }
 
                 if (indexedField.Textual.Count == 0)

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -35,6 +35,8 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     private Dictionary<string, Slice> _dynamicFieldNameMapping;
 
     private readonly IndexFieldsMapping _fieldMapping;
+    private Dictionary<Slice, Hnsw.SearchState> _vectorSearchStateCache;
+    private Dictionary<Slice, HnswIndexCache> _vectorNodeCaches;
     private HashSet<long> _nullTermsMarkers;
     private HashSet<long> _nonExistingTermsMarkers;
     private long[] _vectorFieldsMarkers;
@@ -480,8 +482,50 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     }
 
     
+    /// <summary>
+    /// Returns a shared SearchState for the given vector field, creating one if needed.
+    /// The SearchState is cached per field name and disposed when the IndexSearcher is disposed.
+    /// This lets multiple vector search operations against the same field share loaded
+    /// node topology and vector pointers. The distance cache is keyed by the query vector
+    /// (see <see cref="Hnsw.SearchState.OnQueryVector"/>): sub-searches with distinct vectors
+    /// see independent caches, while same-vector re-entry (e.g. eF re-expansion in filtered
+    /// search) keeps its cached distances.
+    /// </summary>
+    internal Hnsw.SearchState GetOrCreateVectorSearchState(Slice fieldName)
+    {
+        _vectorSearchStateCache ??= new(SliceComparer.Instance);
+        ref var state = ref CollectionsMarshal.GetValueRefOrAddDefault(_vectorSearchStateCache, fieldName, out bool exists);
+        if (exists == false)
+        {
+            // Look for a shared HnswIndexCache for this field
+            HnswIndexCache nodeCache = null;
+            _vectorNodeCaches?.TryGetValue(fieldName, out nodeCache);
+            state = new Hnsw.SearchState(_transaction.LowLevelTransaction, fieldName, nodeCache);
+        }
+        return state;
+    }
+
+    /// <summary>
+    /// Attach a per-field dictionary of HNSW node caches to this IndexSearcher. Each
+    /// SearchState created by <see cref="GetOrCreateVectorSearchState"/> looks up its field's
+    /// cache here and uses it for node lookups instead of reading them through Voron.
+    /// The dictionary is read by query code only and must not be mutated while the
+    /// IndexSearcher is alive.
+    /// </summary>
+    public void AttachVectorNodeCaches(Dictionary<Slice, HnswIndexCache> caches)
+    {
+        _vectorNodeCaches = caches;
+    }
+
     public void Dispose()
     {
+        if (_vectorSearchStateCache != null)
+        {
+            foreach (var kvp in _vectorSearchStateCache)
+                kvp.Value.Dispose();
+            _vectorSearchStateCache = null;
+        }
+
         if (_ownsTransaction)
             _transaction?.Dispose();
 

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
 using Corax.Utils;
@@ -35,8 +34,9 @@ public struct MultiVectorSearchMatch : IQueryMatch
     private GrowableBuffer<long, Constant<long>> _matches;
     private GrowableBuffer<float, Constant<float>> _distances;
 
-    // Voron VectorSearch Retriever
-    private Hnsw.VectorSearchRetriever[] _vectorsRetrievers;
+    // Reference to the first sub-query's retriever, kept so Score can call its distance-to-score
+    // conversion methods after all retrievers have been disposed.
+    private Hnsw.VectorSearchRetriever _firstRetriever;
     private ContextBoundNativeList<long> _nodesIdsToScan;
     private bool _vectorRetrieverInitialized;
 
@@ -106,25 +106,11 @@ public struct MultiVectorSearchMatch : IQueryMatch
             }
         }
 
-        _vectorsRetrievers = new Hnsw.VectorSearchRetriever[_vectorsToSearch.Length];
-        var llt = _indexSearcher.Transaction.LowLevelTransaction;
-        var allEmpty = true;
-        for (int i = 0; i < _vectorsRetrievers.Length; ++i)
-        {
-            var vector = _vectorsToSearch[i].GetEmbeddingMemory();
-            _vectorsRetrievers[i] = (_isExact) switch
-            {
+        // Obtain the IndexSearcher-scoped SearchState for this field; sub-queries below reuse it
+        // so loaded node data (edges, vectors) is shared across them.
+        var sharedSearchState = _indexSearcher.GetOrCreateVectorSearchState(_metadata.FieldName);
 
-                _ when _scanningQuery => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, false, _nodesIdsToScan),
-                true => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null, null),
-                false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt,  _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults!.Value, _random)), 
-                false => Hnsw.ApproximateNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
-            };
-
-            allEmpty &= _vectorsRetrievers[i].IsEmpty;
-        }
-
-        _isEmpty = allEmpty || (_filterQuery != null && _filterResults!.Value.Count == 0);
+        _isEmpty = sharedSearchState.IsEmpty || (_filterQuery != null && _filterResults!.Value.Count == 0);
     }
 
     public int Fill(Span<long> matches)
@@ -155,12 +141,33 @@ public struct MultiVectorSearchMatch : IQueryMatch
         _resultsPersisted = true;
         if (_isEmpty)
             return;
-        
+
+        // Construct and fully consume each retriever before moving to the next; the shared
+        // SearchState has a single pair of priority queues (_candidatesQ, _nearestEdgesQ) that
+        // cannot be interleaved across retrievers.
+        var sharedSearchState = _indexSearcher.GetOrCreateVectorSearchState(_metadata.FieldName);
+
         _matches.Init(_indexSearcher.Allocator, 128);
         _distances.Init(_indexSearcher.Allocator, 128);
-        for (var i = 0; i < _vectorsRetrievers.Length; ++i)
+        for (var i = 0; i < _vectorsToSearch.Length; ++i)
         {
-            ref var vectorSearcher = ref _vectorsRetrievers[i];
+            // Invariant: when a new retriever starts, the shared priority queues on SearchState
+            // must be empty. Violating this causes the new traversal to read leftover entries
+            // from the previous sub-query.
+            sharedSearchState.AssertSharedQueuesClean();
+
+            var vector = _vectorsToSearch[i].GetEmbeddingMemory();
+            var vectorSearcher = (_isExact) switch
+            {
+                _ when _scanningQuery => Hnsw.ExactNearest(sharedSearchState, _numberOfCandidates, vector, _minimumMatch, false, _nodesIdsToScan),
+                true => Hnsw.ExactNearest(sharedSearchState, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null, null),
+                false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(sharedSearchState, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults!.Value, _random)),
+                false => Hnsw.ApproximateNearest(sharedSearchState, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
+            };
+
+            if (i == 0)
+                _firstRetriever = vectorSearcher;
+
             int currentRead = 0;
             do
             {
@@ -168,9 +175,8 @@ public struct MultiVectorSearchMatch : IQueryMatch
                 var distanceBuffer = _distances.GetSpace();
                 Debug.Assert(matchBuffer.Length == distanceBuffer.Length, "matchBuffer.Length == distanceBuffer.Length");
 
-
                 currentRead = vectorSearcher.Fill(matchBuffer, distanceBuffer, _filterResults);
-                
+
                 _matches.AddUsage(currentRead);
                 _distances.AddUsage(currentRead);
                 Count += currentRead;
@@ -234,13 +240,13 @@ public struct MultiVectorSearchMatch : IQueryMatch
                     continue;
 
                 var distance = _distances.Results[pos];
-                scores[i] += boostFactor * _vectorsRetrievers[0].DistanceToScore(distance);
+                scores[i] += boostFactor * _firstRetriever.DistanceToScore(distance);
             }
         }
         else
         {
             _distances.Results[..scores.Length].CopyTo(scores);
-            _vectorsRetrievers[0].DistancesToScores(scores);
+            _firstRetriever.DistancesToScores(scores);
             for (int i = 0; i < scores.Length; ++i)
                 scores[i] *= boostFactor;
         }
@@ -268,7 +274,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
             parameters: new Dictionary<string, string>()
             {
                 { Constants.QueryInspectionNode.FieldName, _metadata.FieldName.ToString() },                
-                { nameof(Hnsw.SimilarityMethod), _vectorsRetrievers.FirstOrDefault().SimilarityMethod?.ToString() ?? "Query not initialized." },
+                { nameof(Hnsw.SimilarityMethod), _firstRetriever.SimilarityMethod?.ToString() ?? "Query not initialized." },
                 { "IsExact", _isExact.ToString() },
                 { "IsScanning", _scanningQuery.ToString() },
                 { "Minimum match", _minimumMatch.ToString(CultureInfo.InvariantCulture) },

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -132,12 +132,13 @@ public struct VectorSearchMatch : IQueryMatch
         }
         
         
+        var searchState = _indexSearcher.GetOrCreateVectorSearchState(fieldName);
         _vectorSearchRetriever = _isExact switch
         {
-            _ when _scanningQuery => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, hasFilterMatch: false, nodesIdsToScan),
-            true => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
-            false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults!.Value, _random)), 
-                _ => Hnsw.ApproximateNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
+            _ when _scanningQuery => Hnsw.ExactNearest(searchState, _numberOfCandidates, vector, _minimumMatch, hasFilterMatch: false, nodesIdsToScan),
+            true => Hnsw.ExactNearest(searchState, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
+            false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(searchState, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults!.Value, _random)),
+                _ => Hnsw.ApproximateNearest(searchState, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
         };
         
 

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -133,6 +133,7 @@ public struct VectorSearchMatch : IQueryMatch
         
         
         var searchState = _indexSearcher.GetOrCreateVectorSearchState(fieldName);
+
         _vectorSearchRetriever = _isExact switch
         {
             _ when _scanningQuery => Hnsw.ExactNearest(searchState, _numberOfCandidates, vector, _minimumMatch, hasFilterMatch: false, nodesIdsToScan),

--- a/src/Corax/Utils/VectorValue.cs
+++ b/src/Corax/Utils/VectorValue.cs
@@ -41,7 +41,7 @@ public struct VectorValue : IDisposable
     }
 
     public void OverrideLength(int len) => _length = len;
-    
+
     public void Dispose()
     {
         _memoryScope?.Dispose();

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -666,6 +666,15 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Corax.VectorSearch.VectorSearchScanningThreshold", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public int CoraxVectorSearchScanningThreshold { get; set; }
 
+        [Description("The maximum amount of memory for the HNSW vector search node cache per index. " +
+                     "This cache pre-loads upper-level graph nodes to accelerate vector queries. " +
+                     "Changing this value does not require re-indexing.")]
+        [DefaultValue(10)]
+        [SizeUnit(SizeUnit.Megabytes)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
+        [ConfigurationEntry("Indexing.Corax.VectorSearch.CacheSizeInMb", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public Size CoraxVectorSearchCacheSize { get; set; }
+
         [Description("Use default search analyzer for dynamic fields if not set explicitly.")]
         [DefaultValue(false)]
         [IndexUpdateType(IndexUpdateType.Refresh)]

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -37,6 +37,7 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
     private StorageEnvironment _environment;
     private Action<LowLevelTransaction> _newTransactionCreatedHandler;
     internal IndexWriter ActiveWriter;
+    internal Dictionary<Slice, HashSet<long>> PendingDirtyVectorSets;
 
     public CoraxIndexPersistence(Index index, IIndexReadOperationFactory indexReadOperationFactory) : base(index, indexReadOperationFactory)
     {
@@ -227,33 +228,57 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     internal override void RecreateSearcher(Transaction asOfTx)
     {
-        var writer = ActiveWriter;
-        if (writer == null || _hnswCaches == null)
+        var dirty = PendingDirtyVectorSets;
+        PendingDirtyVectorSets = null;
+        if (dirty == null)
             return;
 
-        if (GetMaxNodesForVectorCache() <= 0)
+        var maxNodes = GetMaxNodesForVectorCache();
+        if (maxNodes <= 0)
         {
             // Cache disabled at runtime (CacheSizeInMb set to 0): stop publishing the caches and drop
             // our references so new read transactions resolve from disk and a later re-enable rebuilds
             // from scratch rather than serving entries that missed the commits made while disabled.
             // In-flight readers keep their captured snapshot; the dropped instances release their native
             // memory via finalization once those transactions complete.
-            Volatile.Write(ref _currentCache, null);
-            Volatile.Write(ref _hnswCaches, null);
+            if (_hnswCaches != null)
+            {
+                Volatile.Write(ref _currentCache, null);
+                Volatile.Write(ref _hnswCaches, null);
+            }
             return;
         }
-
-        var dirty = writer.DirtyVectorSets;
-        if (dirty == null)
-            return;
 
         var llt = asOfTx.LowLevelTransaction;
+        Dictionary<Slice, HnswIndexCache> freshlyAdded = null;
         foreach (var kv in dirty)
         {
-            if (_hnswCaches.TryGetValue(kv.Key, out var cache) == false)
+            if (_hnswCaches != null && _hnswCaches.TryGetValue(kv.Key, out var cache))
+            {
+                cache.ApplyCommit(llt, kv.Key, kv.Value);
                 continue;
-            cache.ApplyCommit(llt, kv.Key, kv.Value);
+            }
+
+            var fresh = HnswIndexCache.WarmFromScratch(llt, kv.Key, maxNodes);
+            if (fresh is null)
+                continue;
+            (freshlyAdded ??= new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance))[kv.Key] = fresh;
         }
+
+        if (freshlyAdded is null)
+            return;
+
+        // Copy-on-write: in-flight readers that captured the previous _hnswCaches reference
+        // keep observing it unchanged; new transactions pick up the replacement via the
+        // NewTransactionCreated subscription. Single-writer here (post-commit hook is serial).
+        var grown = _hnswCaches is null
+            ? new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance)
+            : new Dictionary<Slice, HnswIndexCache>(_hnswCaches, SliceComparer.Instance);
+        foreach (var kv in freshlyAdded)
+            grown[kv.Key] = kv.Value;
+
+        Volatile.Write(ref _hnswCaches, grown);
+        Volatile.Write(ref _currentCache, new IndexTransactionCache { VectorNodeCaches = grown });
     }
 
     private void WarmInitialCaches(Transaction tx)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -22,6 +22,7 @@ using Voron.Data.CompactTrees;
 using Voron.Data.Graphs;
 using Voron.Impl;
 using Constants = Raven.Client.Constants;
+using IndexWriter = Corax.Indexing.IndexWriter;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax;
 
@@ -31,9 +32,11 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
     private readonly RavenLogger _logger;
     private readonly CoraxDocumentConverterBase _converter;
 
+    private Dictionary<Slice, HnswIndexCache> _hnswCaches;
     private IndexTransactionCache _currentCache;
     private StorageEnvironment _environment;
     private Action<LowLevelTransaction> _newTransactionCreatedHandler;
+    internal IndexWriter ActiveWriter;
 
     public CoraxIndexPersistence(Index index, IIndexReadOperationFactory indexReadOperationFactory) : base(index, indexReadOperationFactory)
     {
@@ -122,6 +125,12 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
             _environment = null;
         }
         _converter?.Dispose();
+        if (_hnswCaches != null)
+        {
+            foreach (var kv in _hnswCaches)
+                kv.Value.Dispose();
+            _hnswCaches = null;
+        }
     }
 
     public override bool RequireOnBeforeExecuteIndexing()
@@ -199,7 +208,8 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
     public override void Initialize(StorageEnvironment environment)
     {
         using (var roTx = environment.ReadTransaction())
-            _currentCache = BuildVectorCacheSnapshot(roTx);
+            WarmInitialCaches(roTx);
+        _currentCache = BuildSnapshotWrapper();
 
         _environment = environment;
         _newTransactionCreatedHandler = tx => tx.ImmutableExternalState = Volatile.Read(ref _currentCache);
@@ -208,41 +218,55 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     public override void PublishIndexCacheToNewTransactions(IndexTransactionCache transactionCache)
     {
-        // Corax builds and publishes its cache in RecreateSearcher rather than here.
-        // BuildStreamCacheAfterTx returns null, so this method is always invoked with null.
     }
 
     internal override IndexTransactionCache BuildStreamCacheAfterTx(Transaction tx)
     {
-        // The actual vector cache build runs in RecreateSearcher, which is invoked from the
-        // post-commit hook — only after the commit is durable.
         return null;
     }
 
     internal override void RecreateSearcher(Transaction asOfTx)
     {
-        // Invoked from AfterCommitWhenNewTransactionsPrevented: at this point the commit is
-        // durable and no new read transaction can be created until this method returns. Building
-        // and assigning _currentCache here guarantees that the published cache reflects a state
-        // that is already visible on disk, and that every read transaction created afterwards
-        // captures it atomically via the NewTransactionCreated subscription in Initialize.
-        var newCache = BuildVectorCacheSnapshot(asOfTx);
-        if (newCache != null)
-            _currentCache = newCache;
+        var writer = ActiveWriter;
+        if (writer == null || _hnswCaches == null)
+            return;
+
+        if (GetMaxNodesForVectorCache() <= 0)
+        {
+            // Cache disabled at runtime (CacheSizeInMb set to 0): stop publishing the caches and drop
+            // our references so new read transactions resolve from disk and a later re-enable rebuilds
+            // from scratch rather than serving entries that missed the commits made while disabled.
+            // In-flight readers keep their captured snapshot; the dropped instances release their native
+            // memory via finalization once those transactions complete.
+            Volatile.Write(ref _currentCache, null);
+            Volatile.Write(ref _hnswCaches, null);
+            return;
+        }
+
+        var dirty = writer.DirtyVectorSets;
+        if (dirty == null)
+            return;
+
+        var llt = asOfTx.LowLevelTransaction;
+        foreach (var kv in dirty)
+        {
+            if (_hnswCaches.TryGetValue(kv.Key, out var cache) == false)
+                continue;
+            cache.ApplyCommit(llt, kv.Key, kv.Value);
+        }
     }
 
-    private IndexTransactionCache BuildVectorCacheSnapshot(Transaction tx)
+    private void WarmInitialCaches(Transaction tx)
     {
         var mapping = _converter?.GetKnownFieldsForQuerying();
         if (mapping is null)
-            return null;
+            return;
 
         var maxNodes = GetMaxNodesForVectorCache();
         if (maxNodes <= 0)
-            return null;
+            return;
 
         var llt = tx.LowLevelTransaction;
-        Dictionary<Slice, HnswIndexCache> vectorCaches = null;
         foreach (var field in mapping)
         {
             if (field.VectorOptions is null)
@@ -250,16 +274,21 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
             var cache = HnswIndexCache.WarmFromScratch(llt, field.FieldName, maxNodes);
             if (cache is null)
                 continue;
-            vectorCaches ??= new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance);
+            _hnswCaches ??= new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance);
             // FieldName is allocated against _converter's persistent scope; _converter is
-            // disposed only when this CoraxIndexPersistence is disposed, which outlives any cache
-            // reachable from _currentCache or an open read tx's ImmutableExternalState.
+            // disposed only when this CoraxIndexPersistence is disposed, which outlives any
+            // open read tx's ImmutableExternalState reference.
             Debug.Assert(field.FieldName.HasValue && field.FieldName.Size > 0,
                 "Vector field name must be allocated and non-empty for cache keying");
-            vectorCaches[field.FieldName] = cache;
+            _hnswCaches[field.FieldName] = cache;
         }
+    }
 
-        return vectorCaches is null ? null : new IndexTransactionCache { VectorNodeCaches = vectorCaches };
+    private IndexTransactionCache BuildSnapshotWrapper()
+    {
+        return _hnswCaches is null
+            ? null
+            : new IndexTransactionCache { VectorNodeCaches = _hnswCaches };
     }
 
     internal override void RecreateSuggestionsSearchers(Transaction asOfTx)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Corax;
@@ -11,11 +13,13 @@ using Raven.Server.Indexing;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server.Logging;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Graphs;
 using Voron.Impl;
 using Constants = Raven.Client.Constants;
 
@@ -26,10 +30,22 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
     private const bool DisableDictionaryTraining = false; // [DEBUG ONLY]: disable training.
     private readonly RavenLogger _logger;
     private readonly CoraxDocumentConverterBase _converter;
+
+    private IndexTransactionCache _currentCache;
+    private StorageEnvironment _environment;
+    private Action<LowLevelTransaction> _newTransactionCreatedHandler;
+
     public CoraxIndexPersistence(Index index, IIndexReadOperationFactory indexReadOperationFactory) : base(index, indexReadOperationFactory)
     {
         _logger = RavenLogManager.Instance.GetLoggerForIndex<CoraxIndexPersistence>(index);
         _converter = CreateConverter(index);
+    }
+
+    private int GetMaxNodesForVectorCache()
+    {
+        var cacheSizeBytes = _index.Configuration.CoraxVectorSearchCacheSize.GetValue(SizeUnit.Bytes);
+        var bytesPerNode = HnswIndexCache.EstimateBytesPerNode(_index.Configuration.CoraxVectorDefaultNumberOfEdges);
+        return (int)Math.Min(cacheSizeBytes / bytesPerNode, int.MaxValue);
     }
 
     private CoraxDocumentConverterBase CreateConverter(Index index)
@@ -99,6 +115,12 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     public override void Dispose()
     {
+        if (_environment != null && _newTransactionCreatedHandler != null)
+        {
+            _environment.NewTransactionCreated -= _newTransactionCreatedHandler;
+            _newTransactionCreatedHandler = null;
+            _environment = null;
+        }
         _converter?.Dispose();
     }
 
@@ -176,23 +198,68 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     public override void Initialize(StorageEnvironment environment)
     {
+        using (var roTx = environment.ReadTransaction())
+            _currentCache = BuildVectorCacheSnapshot(roTx);
+
+        _environment = environment;
+        _newTransactionCreatedHandler = tx => tx.ImmutableExternalState = Volatile.Read(ref _currentCache);
+        environment.NewTransactionCreated += _newTransactionCreatedHandler;
     }
-    
+
     public override void PublishIndexCacheToNewTransactions(IndexTransactionCache transactionCache)
     {
-        //lucene method
+        // Corax builds and publishes its cache in RecreateSearcher rather than here.
+        // BuildStreamCacheAfterTx returns null, so this method is always invoked with null.
     }
 
     internal override IndexTransactionCache BuildStreamCacheAfterTx(Transaction tx)
     {
-        //lucene method
-
+        // The actual vector cache build runs in RecreateSearcher, which is invoked from the
+        // post-commit hook — only after the commit is durable.
         return null;
     }
 
     internal override void RecreateSearcher(Transaction asOfTx)
     {
-        //lucene method
+        // Invoked from AfterCommitWhenNewTransactionsPrevented: at this point the commit is
+        // durable and no new read transaction can be created until this method returns. Building
+        // and assigning _currentCache here guarantees that the published cache reflects a state
+        // that is already visible on disk, and that every read transaction created afterwards
+        // captures it atomically via the NewTransactionCreated subscription in Initialize.
+        var newCache = BuildVectorCacheSnapshot(asOfTx);
+        if (newCache != null)
+            _currentCache = newCache;
+    }
+
+    private IndexTransactionCache BuildVectorCacheSnapshot(Transaction tx)
+    {
+        var mapping = _converter?.GetKnownFieldsForQuerying();
+        if (mapping is null)
+            return null;
+
+        var maxNodes = GetMaxNodesForVectorCache();
+        if (maxNodes <= 0)
+            return null;
+
+        var llt = tx.LowLevelTransaction;
+        Dictionary<Slice, HnswIndexCache> vectorCaches = null;
+        foreach (var field in mapping)
+        {
+            if (field.VectorOptions is null)
+                continue;
+            var cache = HnswIndexCache.WarmFromScratch(llt, field.FieldName, maxNodes);
+            if (cache is null)
+                continue;
+            vectorCaches ??= new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance);
+            // FieldName is allocated against _converter's persistent scope; _converter is
+            // disposed only when this CoraxIndexPersistence is disposed, which outlives any cache
+            // reachable from _currentCache or an open read tx's ImmutableExternalState.
+            Debug.Assert(field.FieldName.HasValue && field.FieldName.Size > 0,
+                "Vector field name must be allocated and non-empty for cache keying");
+            vectorCaches[field.FieldName] = cache;
+        }
+
+        return vectorCaches is null ? null : new IndexTransactionCache { VectorNodeCaches = vectorCaches };
     }
 
     internal override void RecreateSuggestionsSearchers(Transaction asOfTx)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -26,6 +26,7 @@ using Raven.Server.Documents.Queries.Highlightings;
 using Raven.Server.Documents.Queries.MoreLikeThis.Corax;
 using Raven.Server.Documents.Queries.Results;
 using Raven.Server.Documents.Queries.Timings;
+using Raven.Server.Indexing;
 using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -108,7 +109,17 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             {
                 MaxMemoizationSizeInBytes = index.Configuration.MaxMemoizationSize.GetValue(SizeUnit.Bytes),
             };
-            
+
+            // Pick up the per-field HNSW vector node caches that CoraxIndexPersistence attached
+            // to this transaction's ImmutableExternalState at creation time. The transaction
+            // holds the only reference the IndexSearcher needs; once the transaction disposes
+            // and no other transaction is still keeping the cache alive, GC reclaims it.
+            if (readTransaction.LowLevelTransaction.ImmutableExternalState is IndexTransactionCache txCache
+                && txCache.VectorNodeCaches is { Count: > 0 } vectorCaches)
+            {
+                IndexSearcher.AttachVectorNodeCaches(vectorCaches);
+            }
+
             if (index is {_forTestingPurposes: {CoraxConfiguration: not null}})
                 IndexSearcher.SetTestingConfiguration(index._forTestingPurposes.CoraxConfiguration);
             

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 {
     public class CoraxIndexWriteOperation : IndexWriteOperationBase
     {
-        
+
         public const int MaximumPersistedCapacityOfCoraxWriter = 512;
         private readonly IndexWriter _indexWriter;
         private readonly CoraxDocumentConverterBase _converter;
@@ -32,10 +32,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         private IndexFieldsMapping _dynamicFields;
         private readonly CurrentIndexingScope _indexingScope;
         private readonly ByteStringContext _allocator;
+        private readonly CoraxIndexPersistence _persistence;
 
         public CoraxIndexWriteOperation(Index index, Transaction writeTransaction, CoraxDocumentConverterBase converter, RavenLogger logger) : base(index, logger)
         {
             _converter = converter;
+            _persistence = index.IndexPersistence as CoraxIndexPersistence;
             var knownFields = _converter.GetKnownFieldsForWriter();
             _indexingScope = CurrentIndexingScope.Current;
             if (_indexingScope != null)
@@ -82,11 +84,25 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         
         public override void Commit(IndexingStatsScope stats, CancellationToken token)
         {
-            if (_indexWriter != null)
+            if (_indexWriter == null)
+                return;
+
+            using (var commitStats = stats.For(IndexingOperation.Corax.Commit))
             {
-                using (var commitStats = stats.For(IndexingOperation.Corax.Commit))
+                // Publish the writer to the persistence so RecreateSearcher (which fires from
+                // the LLT post-commit hook inside _indexWriter.Commit) can read DirtyVectorSets
+                // and mutate the long-lived HnswIndexCache instances. Cleared in finally so the
+                // back-reference never leaks beyond a single commit even if the commit throws.
+                if (_persistence != null)
+                    _persistence.ActiveWriter = _indexWriter;
+                try
                 {
                     _indexWriter.Commit(new CoraxIndexingStats(commitStats), token);
+                }
+                finally
+                {
+                    if (_persistence != null)
+                        _persistence.ActiveWriter = null;
                 }
             }
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -89,15 +89,17 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
             using (var commitStats = stats.For(IndexingOperation.Corax.Commit))
             {
-                // Publish the writer to the persistence so RecreateSearcher (which fires from
-                // the LLT post-commit hook inside _indexWriter.Commit) can read DirtyVectorSets
-                // and mutate the long-lived HnswIndexCache instances. Cleared in finally so the
-                // back-reference never leaks beyond a single commit even if the commit throws.
                 if (_persistence != null)
                     _persistence.ActiveWriter = _indexWriter;
                 try
                 {
                     _indexWriter.Commit(new CoraxIndexingStats(commitStats), token);
+
+                    // RecreateSearcher fires later from the outer storage tx's commit hook,
+                    // by which time the writer reference is gone. Snapshot the dirty sets now
+                    // so the post-commit cache update has the data it needs.
+                    if (_persistence != null)
+                        _persistence.PendingDirtyVectorSets = _indexWriter.DirtyVectorSets;
                 }
                 finally
                 {

--- a/src/Raven.Server/Indexing/IndexTransactionCache.cs
+++ b/src/Raven.Server/Indexing/IndexTransactionCache.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using Voron;
 using Voron.Data.BTrees;
+using Voron.Data.Graphs;
 
 namespace Raven.Server.Indexing
 {
@@ -32,5 +34,16 @@ namespace Raven.Server.Indexing
 
         public Dictionary<string, DirectoryFiles> DirectoriesByName = new Dictionary<string, DirectoryFiles>(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, CollectionEtags> Collections = new Dictionary<string, CollectionEtags>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Per-field HNSW vector caches keyed by field name. Populated by Corax indexes only
+        /// (null or empty for Lucene indexes and for Corax indexes without vector fields).
+        /// Attached to a transaction via
+        /// <see cref="Voron.Impl.LowLevelTransaction.ImmutableExternalState"/>, so a read tx
+        /// observes the same cache instance that was current at the moment its transaction was
+        /// created. Each cache instance is long-lived (one per index field) and survives across
+        /// commits; the dictionary only changes when a vector field is added or removed.
+        /// </summary>
+        public Dictionary<Slice, HnswIndexCache> VectorNodeCaches;
     }
 }

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -46,6 +46,7 @@ class configurationItem {
         "Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb",
         "Indexing.Corax.Static.ComplexFieldIndexingBehavior",
         "Indexing.Corax.UnmanagedAllocationsBatchSizeLimitInMb",
+        "Indexing.Corax.VectorSearch.CacheSizeInMb",
         "Indexing.Corax.VectorSearch.DefaultMinimumSimilarity",
         "Indexing.Corax.VectorSearch.DefaultNumberOfEdges",
         "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForIndexing",

--- a/src/Sparrow.Server/Tensors/Functions.cs
+++ b/src/Sparrow.Server/Tensors/Functions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Net;
 using System.Numerics;
 using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
@@ -27,6 +26,39 @@ namespace Sparrow.Server.Tensors
             where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
         {
             return TResult.One - CosineSimilarity<T, TResult>(a, b);
+        }
+
+        /// <summary>
+        /// Returns Σ aᵢ·bᵢ for two equal-length f32 spans. On AVX2+FMA / AVX-512 the work is
+        /// issued as multiple independent FMA chains using <see cref="Arithmetics.MultiplyAddEstimate(Vector512{float}, Vector512{float}, Vector512{float})"/>.
+        /// On AArch64/NEON the NEON-shaped kernel is used. On 32-bit hosts or for inputs shorter
+        /// than one Vector512 the call is forwarded to <see cref="TensorPrimitives.Dot(ReadOnlySpan{float}, ReadOnlySpan{float})"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float DotProduct(ReadOnlySpan<float> a, ReadOnlySpan<float> b)
+        {
+            Debug.Assert(a.Length == b.Length, "a.Length == b.Length");
+
+            if (PlatformDetails.Is32Bits || a.Length < Vector512<float>.Count)
+                return TensorPrimitives.Dot(a, b);
+
+            if (AdvInstructionSet.IsAcceleratedVector256)
+            {
+                return (float)Vectorized512.DotProductInternalX64(
+                    ref MemoryMarshal.GetReference(a),
+                    ref MemoryMarshal.GetReference(b),
+                    (nuint)a.Length);
+            }
+
+            if (AdvInstructionSet.Arm.IsSupported)
+            {
+                return (float)Vectorized512.DotProductInternalNeon(
+                    ref MemoryMarshal.GetReference(a),
+                    ref MemoryMarshal.GetReference(b),
+                    (nuint)a.Length);
+            }
+
+            return TensorPrimitives.Dot(a, b);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -407,6 +439,121 @@ namespace Sparrow.Server.Tensors
                 double b2Reciprocal = rsqrts.ToScalar(); // lane 0
                 double a2Reciprocal = Sse2.UnpackHigh(rsqrts, rsqrts).ToScalar(); // lane 1
                 return  ab * a2Reciprocal * b2Reciprocal;
+            }
+
+            /// <summary>
+            /// Σ aᵢ·bᵢ for an f32 span on x64 with AVX2+FMA or AVX-512. Two Vector512 accumulators
+            /// are updated per loop iteration; on AVX2-only hardware the JIT lowers each Vector512
+            /// FMA to a pair of Vector256 FMAs, yielding 4 independent ymm FMA chains that saturate
+            /// the FMA issue ports. The two-accumulator shape keeps total ymm pressure at 4, inside
+            /// the 16-register budget. The trailing partial vector is masked via
+            /// <see cref="MoveMaskTable"/> so no scalar tail loop is required.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static double DotProductInternalX64(ref float aRef, ref float bRef, nuint size)
+            {
+                Vector512<float> ab0 = Vector512<float>.Zero;
+                Vector512<float> ab1 = Vector512<float>.Zero;
+
+                nuint step = (nuint)Vector512<float>.Count;
+                nuint oneVectorFromEnd = size - step;
+                nuint twoFromEnd = size >= 2 * step ? size - 2 * step : 0;
+                nuint i = 0;
+
+            Loop2:
+                // Two independent FMA chains per iteration. Enter only when the span is wide
+                // enough to load both vectors; the single-vector body below drains the rest.
+                if (size >= 2 * step && i <= twoFromEnd)
+                {
+                    var a0 = Vector512.LoadUnsafe(ref aRef, i);
+                    var b0 = Vector512.LoadUnsafe(ref bRef, i);
+                    var a1 = Vector512.LoadUnsafe(ref aRef, i + step);
+                    var b1 = Vector512.LoadUnsafe(ref bRef, i + step);
+
+                    ab0 = Arithmetics.MultiplyAddEstimate(a0, b0, ab0);
+                    ab1 = Arithmetics.MultiplyAddEstimate(a1, b1, ab1);
+
+                    i += 2 * step;
+                    goto Loop2;
+                }
+
+                if (i <= oneVectorFromEnd)
+                {
+                    var aV = Vector512.LoadUnsafe(ref aRef, i);
+                    var bV = Vector512.LoadUnsafe(ref bRef, i);
+                    ab0 = Arithmetics.MultiplyAddEstimate(aV, bV, ab0);
+                    i += step;
+                }
+
+                if (i != size)
+                {
+                    nuint offset = size - i;
+                    Debug.Assert((int)offset * sizeof(float) + Vector512<byte>.Count <= MoveMaskTable.Length);
+
+                    var mask = Vector512.LoadUnsafe<float>(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, float>(MoveMaskTable)), offset);
+
+                    var aTail = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef, oneVectorFromEnd), mask);
+                    var bTail = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef, oneVectorFromEnd), mask);
+                    ab0 = Arithmetics.MultiplyAddEstimate(aTail, bTail, ab0);
+                }
+
+                return (double)Vector512.Sum(ab0 + ab1);
+            }
+
+            /// <summary>
+            /// Σ aᵢ·bᵢ for an f32 span on AArch64/NEON. Two Vector512 accumulators are updated per
+            /// loop iteration; the JIT lowers each Vector512 op onto four 128-bit NEON vectors,
+            /// yielding independent FMA chains. Tail bytes are masked via <see cref="MoveMaskTable"/>.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static double DotProductInternalNeon(ref float aRef, ref float bRef, nuint size)
+            {
+                Vector512<float> ab0 = Vector512<float>.Zero;
+                Vector512<float> ab1 = Vector512<float>.Zero;
+
+                nuint step = (nuint)Vector512<float>.Count;
+                nuint oneVectorFromEnd = size - step;
+                nuint twoFromEnd = size >= 2 * step ? size - 2 * step : 0;
+                nuint i = 0;
+
+            Loop2:
+                // Two independent FMA chains per iteration. Enter only when the span is wide
+                // enough to load both vectors; the single-vector body below drains the rest.
+                if (size >= 2 * step && i <= twoFromEnd)
+                {
+                    var a0 = Vector512.LoadUnsafe(ref aRef, i);
+                    var b0 = Vector512.LoadUnsafe(ref bRef, i);
+                    var a1 = Vector512.LoadUnsafe(ref aRef, i + step);
+                    var b1 = Vector512.LoadUnsafe(ref bRef, i + step);
+
+                    ab0 = Arithmetics.MultiplyAddEstimate(a0, b0, ab0);
+                    ab1 = Arithmetics.MultiplyAddEstimate(a1, b1, ab1);
+
+                    i += 2 * step;
+                    goto Loop2;
+                }
+
+                if (i <= oneVectorFromEnd)
+                {
+                    var aV = Vector512.LoadUnsafe(ref aRef, i);
+                    var bV = Vector512.LoadUnsafe(ref bRef, i);
+                    ab0 = Arithmetics.MultiplyAddEstimate(aV, bV, ab0);
+                    i += step;
+                }
+
+                if (i != size)
+                {
+                    nuint offset = size - i;
+                    var mask = Vector512.LoadUnsafe<float>(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, float>(MoveMaskTable)), offset);
+
+                    var aTail = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef, oneVectorFromEnd), mask);
+                    var bTail = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef, oneVectorFromEnd), mask);
+                    ab0 = Arithmetics.MultiplyAddEstimate(aTail, bTail, ab0);
+                }
+
+                return (double)Vector512.Sum(ab0 + ab1);
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Sparrow/PortableIntrinsics.cs
+++ b/src/Sparrow/PortableIntrinsics.cs
@@ -1,0 +1,72 @@
+using System.Runtime.CompilerServices;
+
+#if NET7_0_OR_GREATER
+using System.Runtime.Intrinsics.X86;
+#endif
+#if NET9_0_OR_GREATER
+using System.Runtime.Intrinsics.Arm;
+#endif
+
+namespace Sparrow
+{
+    internal static class PortableIntrinsics
+    {
+        /// <summary>
+        /// JIT-time constant: true when software prefetch is available on this platform.
+        /// Use to guard scan-ahead or range-walk logic that is only worthwhile when
+        /// we can actually issue prefetch instructions.
+        /// </summary>
+        public static bool CanPrefetch
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+#if NET9_0_OR_GREATER
+                if (Sve.IsSupported)
+                    return true;
+#endif
+#if NET7_0_OR_GREATER
+                if (Sse.IsSupported)
+                    return true;
+#endif
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Prefetch a single cache line for temporal read (L1).
+        /// x86: SSE PREFETCHT0.  ARM SVE: PRFM PLDL1KEEP.  Otherwise: no-op.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void PrefetchRead(void* address)
+        {
+#if NET7_0_OR_GREATER
+            if (Sse.IsSupported)
+            {
+                Sse.Prefetch0(address);
+                return;
+            }
+#endif
+#if NET9_0_OR_GREATER
+            if (Sve.IsSupported)
+            {
+                Sve.Prefetch8Bit(Sve.CreateTrueMaskByte(), address, SvePrefetchType.LoadL1Temporal);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Prefetch a contiguous memory range for temporal read at 512-byte intervals.
+        /// The stride primes the hardware sequential prefetcher across page boundaries.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void PrefetchRange(byte* address, int length)
+        {
+            if (CanPrefetch == false)
+                return;
+
+            for (byte* p = address, end = address + length; p < end; p += 512)
+                PrefetchRead(p);
+        }
+    }
+}

--- a/src/Sparrow/Sparrow.csproj
+++ b/src/Sparrow/Sparrow.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);SYSLIB5003</NoWarn> <!-- ARM SVE intrinsics are experimental in .NET 10 -->
     <AssemblyName>Sparrow</AssemblyName>
     <PackageId>Sparrow</PackageId>
     <CodeAnalysisRuleSet>..\..\RavenDB.Client.ruleset</CodeAnalysisRuleSet>

--- a/src/Voron/Constants.cs
+++ b/src/Voron/Constants.cs
@@ -102,11 +102,18 @@ namespace Voron.Global
                 public const long VectorContainerInternalIndexer = 1;
             }
 
-            internal static class HnswVersion
+            public static class HnswVersion
             {
                 public const ushort InitialVersion = 7_000;
-                
-                public const ushort CurrentVersion = InitialVersion;
+
+                // Singles vectors store a trailing float L2 norm alongside the payload,
+                // mirroring the (sbyte[dims] + float magnitude) layout already used by Int8.
+                // The kernel reads the cached norm instead of recomputing Σ x_i² on every
+                // distance call. Indexes created before this version keep the legacy
+                // float[dims] layout and are served by the norm-recomputing kernel.
+                public const ushort SinglesWithL2Norm = 7_001;
+
+                public const ushort CurrentVersion = SinglesWithL2Norm;
             }
         }
         

--- a/src/Voron/Data/Graphs/Hnsw.Constants.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Constants.cs
@@ -8,7 +8,7 @@ public partial class Hnsw
 
     internal static readonly Slice VectorContainerStorageSlice;
     internal static readonly Slice VectorsContainerIdSlice;
-    private static readonly Slice NodeIdToLocationSlice;
+    internal static readonly Slice NodeIdToLocationSlice;
     public static readonly Slice NodesByVectorIdSlice;
     public static readonly Slice VectorsIdByHashSlice;
     internal static readonly Slice HnswGlobalConfigSlice;

--- a/src/Voron/Data/Graphs/Hnsw.Debug.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Debug.cs
@@ -158,8 +158,7 @@ table, th, td {
             var edges = new ContextBoundNativeList<int>(llt.Allocator, 16);
             searchState.SearchNearestAcrossLevels(vector, -1, searchState.Options.MaxLevel,  ref path);
             using var search = searchState.NearestSearch(path[0], new Memory<byte>(vector.ToArray()), 0, 8, edges, SearchState.NearestEdgesFlags.StartingPointAsEdge, false);
-            using var it = search.Search().GetEnumerator();
-            it.MoveNext();
+            search.MoveNextBatch();
             search.TryGetCurrentCandidates(out edges);
             
             

--- a/src/Voron/Data/Graphs/Hnsw.EmptySearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.EmptySearcher.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Voron.Util;
 
 namespace Voron.Data.Graphs;
@@ -14,10 +13,7 @@ public partial class Hnsw
             {
             }
 
-            public IEnumerable<bool> Search()
-            {
-                yield break;
-            }
+            public bool MoveNextBatch() => false;
 
             public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates)
             {

--- a/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
@@ -44,6 +44,12 @@ public partial class Hnsw
 
             public IEnumerable<bool> Search()
             {
+                // Reset the visited set for this traversal and record the query vector so the
+                // per-node QueryDistance cache is either reused (same vector) or invalidated
+                // (different vector) — OnQueryVector decides based on Memory identity.
+                ++_searchState._visitsCounter;
+                _searchState.OnQueryVector(_vector);
+
                 _pq = new PriorityQueue<long, float>();
                 Span<byte> vector = _vector.Span;
                 IEnumerable<long> toScan = _nodesToScan.HasValue ? _nodesToScan.Value.Iterate() : AllNodes();

--- a/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
@@ -20,6 +20,7 @@ public partial class Hnsw
             private readonly ContextBoundNativeList<long>? _nodesToScan;
             private PriorityQueue<long, float> _pq;
             private long _vectorReadCounter = 0;
+            private bool _initialized;
             
             public ExactSearcher(SearchState searchState, Memory<byte> vector, bool hasFilterMatch, int numberOfCandidates, ContextBoundNativeList<long>? nodesToScan)
             {
@@ -42,7 +43,31 @@ public partial class Hnsw
                 _candidates.Dispose();
             }
 
-            public IEnumerable<bool> Search()
+            public bool MoveNextBatch()
+            {
+                if (_initialized == false)
+                {
+                    Initialize();
+                    _initialized = true;
+                }
+
+                if (_pq.Count == 0)
+                {
+                    _candidates.Count = 0;
+                    return false;
+                }
+
+                _candidates.Count = 0;
+                while (_candidates.Count < NumberOfCandidates && _pq.TryDequeue(out var nodeId, out _))
+                {
+                    _candidates.AddByRefUnsafe() = _searchState.GetNodeIndexById(nodeId);
+                }
+
+                _candidates.Inner.Reverse();
+                return true;
+            }
+
+            private void Initialize()
             {
                 // Reset the visited set for this traversal and record the query vector so the
                 // per-node QueryDistance cache is either reused (same vector) or invalidated
@@ -51,45 +76,32 @@ public partial class Hnsw
                 _searchState.OnQueryVector(_vector);
 
                 _pq = new PriorityQueue<long, float>();
-                Span<byte> vector = _vector.Span;
-                IEnumerable<long> toScan = _nodesToScan.HasValue ? _nodesToScan.Value.Iterate() : AllNodes();
-                foreach (long nodeId in toScan)
+                if (_nodesToScan.HasValue)
                 {
-                    CandidatesProcessed++;
-                    var nodeIndex = _searchState.GetNodeIndexById(nodeId);
-                    if ((_searchState.GetNodeByIndex(nodeIndex).PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone)
-                        continue; // no entries, can skip
-
-                    var distance = _searchState.QueryDistance(_vector.Span, nodeIndex, ref _vectorReadCounter);
-                    if (_pq.Count < NumberOfCandidates || _hasFilterMatch)
-                    {
-                        _pq.Enqueue(nodeId, -distance);
-                    }
-                    else
-                    {
-                        _pq.EnqueueDequeue(nodeId, -distance);
-                    }
+                    foreach (long nodeId in _nodesToScan.Value.Iterate())
+                        ScanNode(nodeId);
                 }
-
-                while (_pq.Count > 0)
+                else
                 {
-                    _candidates.Count = 0;
-                    while (_candidates.Count < NumberOfCandidates && _pq.TryDequeue(out var nodeId, out _))
-                    {
-                        _candidates.AddByRefUnsafe() = _searchState.GetNodeIndexById(nodeId);
-                    }
-
-                    _candidates.Inner.Reverse();
-                    yield return true;
+                    long count = _searchState.Options.CountOfVectors;
+                    for (long nodeId = 1; nodeId <= count; nodeId++)
+                        ScanNode(nodeId);
                 }
+            }
 
-                _candidates.Count = 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private void ScanNode(long nodeId)
+            {
+                CandidatesProcessed++;
+                var nodeIndex = _searchState.GetNodeIndexById(nodeId);
+                if ((_searchState.GetNodeByIndex(nodeIndex).PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone)
+                    return;
 
-                IEnumerable<long> AllNodes()
-                {
-                    for (long nodeId = 1; nodeId <= _searchState.Options.CountOfVectors; nodeId++)
-                        yield return nodeId;
-                }
+                var distance = _searchState.QueryDistance(_vector.Span, nodeIndex, ref _vectorReadCounter);
+                if (_pq.Count < NumberOfCandidates || _hasFilterMatch)
+                    _pq.Enqueue(nodeId, -distance);
+                else
+                    _pq.EnqueueDequeue(nodeId, -distance);
             }
 
             public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates)

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -31,6 +31,14 @@ public unsafe partial class Hnsw
             private long _vectorReadCounter = 0;
             private readonly int _startingPointIndex;
             private ContextBoundNativeList<int> _startingPointIndexes;
+
+            // Traversal state carried across MoveNextBatch calls so the caller can consume
+            // one batch at a time. _needsRestart triggers a fresh InitState; _isDone short-circuits
+            // further work once the outer traversal has finished.
+            private float _lowerBound;
+            private int _visitedCounter;
+            private bool _needsRestart = true;
+            private bool _isDone;
             
             public long CandidatesProcessed { get => _vectorReadCounter; }
             public int NumberOfCandidates { get; init; }
@@ -146,53 +154,57 @@ public unsafe partial class Hnsw
                 }
             }
 
-            public IEnumerable<bool> Search()
+            public bool MoveNextBatch()
             {
-                Start:
+                if (_isDone)
+                    return false;
+
                 var candidatesQ = _searchState._candidatesQ;
                 var nearestEdgesQ = _searchState._nearestEdgesQ;
-                var allocator = _searchState.Llt.Allocator;
 
-                Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
-                Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
-                InitState(out float lowerBound, out int visitedCounter);
+                if (_needsRestart)
+                {
+                    Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
+                    Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
+                    InitState(out _lowerBound, out _visitedCounter);
+                    _needsRestart = false;
+                }
 
                 while (candidatesQ.TryDequeue(out var cur, out var curDistance))
                 {
-                    if (-curDistance < lowerBound &&
+                    if (-curDistance < _lowerBound &&
                         nearestEdgesQ.Count == _internalNumberOfCandidates)
                     {
                         ProcessResults();
-                        // Drain candidatesQ before yielding. Non-filtered queries consume only
-                        // the first batch and never resume the iterator, so without this clear
-                        // the shared SearchState carries far-from-the-old-vector candidates into
-                        // the next query, polluting its priority queue and forcing the search to
-                        // expand 25-30% more nodes than a fresh state would.
+                        // Drain candidatesQ before yielding. Non-filtered queries consume only the
+                        // first batch and never resume; without this clear, a shared SearchState
+                        // (e.g. MultiVectorSearch sub-queries) carries far-from-the-old-vector
+                        // candidates into the next query and pollutes its priority queue. It also
+                        // satisfies InitState's empty-queue precondition on the restart path.
                         candidatesQ.Clear();
-                        yield return true;
-                        // If we need to fetch more, we'll start the query again with a higher NumberOfCandidates.
-                        // The SearchState keeps its state, so traversal through already visited nodes is I/O-free
-                        // because we keep distances in memory from the previous run.
-                        // This method can be greedy enough to traverse the entire graph, so it's the caller's
-                        // responsibility to enforce a stop condition.
-                        goto Start;
+                        // Yield the current batch. Subsequent MoveNextBatch calls re-enter via InitState;
+                        // revisits are I/O-free because per-node distances remain cached in SearchState.
+                        // The caller is responsible for enforcing a stop condition: otherwise the search
+                        // may traverse the entire graph.
+                        _needsRestart = true;
+                        return true;
                     }
 
-                    _searchState.GetNodeByIndex(cur).Visited = visitedCounter;
+                    _searchState.GetNodeByIndex(cur).Visited = _visitedCounter;
                     _searchState.ResolveEdgeIndexes(cur, _level, ref _nodeIds, ref _indexes);
 
                     for (int i = 0; i < _indexes.Count; i++)
                     {
                         var nextIndex = _indexes[i];
                         ref var next = ref _searchState.GetNodeByIndex(nextIndex);
-                        if (next.Visited == visitedCounter)
+                        if (next.Visited == _visitedCounter)
                             continue; // already checked
-                        next.Visited = visitedCounter;
+                        next.Visited = _visitedCounter;
 
                         // Prefetch the next unvisited neighbor's vector data to overlap
                         // cache-miss latency with the current distance computation.
                         // SimilarityCalc is ~65% of query time, ~80% of which is data loading.
-                        PrefetchNextNeighborVector(i + 1, visitedCounter);
+                        PrefetchNextNeighborVector(i + 1, _visitedCounter);
 
                         var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone
                                         || (_hasFilterMatch && _alreadyReturnedEdges.Contains(nextIndex));
@@ -207,7 +219,7 @@ public unsafe partial class Hnsw
                                 nearestEdgesQ.Enqueue(nextIndex, nextDist);
                             }
                         }
-                        else if (lowerBound < nextDist)
+                        else if (_lowerBound < nextDist)
                         {
                             candidatesQ.Enqueue(nextIndex, -nextDist);
 
@@ -222,14 +234,15 @@ public unsafe partial class Hnsw
                         }
 
                         Debug.Assert(candidatesQ.Count > 0);
-                        nearestEdgesQ.TryPeek(out _, out lowerBound);
+                        nearestEdgesQ.TryPeek(out _, out _lowerBound);
                     }
                 }
 
                 // Nothing more to visit. Move the current results into the candidates list and finish.
                 ProcessResults();
                 candidatesQ.Clear();
-                yield return _candidates.Count > 0;
+                _isDone = true;
+                return _candidates.Count > 0;
             }
 
             public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates)
@@ -242,6 +255,9 @@ public unsafe partial class Hnsw
             {
                 Reset();
                 _internalNumberOfCandidates += GetPrefetchExtendSize(_internalNumberOfCandidates);
+                // The next MoveNextBatch call will InitState from the starting points again.
+                _needsRestart = true;
+                _isDone = false;
             }
 
             // Reset the NearestSearcher state; however, it does not clear the data already stored inside SearchState.

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -193,23 +193,27 @@ public unsafe partial class Hnsw
                     _searchState.GetNodeByIndex(cur).Visited = _visitedCounter;
                     _searchState.ResolveEdgeIndexes(cur, _level, ref _nodeIds, ref _indexes);
 
-                    for (int i = 0; i < _indexes.Count; i++)
+                    // Pin loop locals: NativeList field reads through `this` force the JIT to
+                    // reload the storage pointer on every candidate.
+                    int indexesCount = _indexes.Count;
+                    int* indexesPtr = _indexes.RawItems;
+                    int visitedCounter = _visitedCounter;
+                    for (int i = 0; i < indexesCount; i++)
                     {
-                        var nextIndex = _indexes[i];
+                        var nextIndex = indexesPtr[i];
                         ref var next = ref _searchState.GetNodeByIndex(nextIndex);
-                        if (next.Visited == _visitedCounter)
+                        if (next.Visited == visitedCounter)
                             continue; // already checked
-                        next.Visited = _visitedCounter;
+                        next.Visited = visitedCounter;
 
                         // Prefetch the next unvisited neighbor's vector data to overlap
                         // cache-miss latency with the current distance computation.
-                        // SimilarityCalc is ~65% of query time, ~80% of which is data loading.
-                        PrefetchNextNeighborVector(i + 1, _visitedCounter);
+                        PrefetchNextNeighborVector(indexesPtr, indexesCount, i + 1, visitedCounter);
 
                         var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone
                                         || (_hasFilterMatch && _alreadyReturnedEdges.Contains(nextIndex));
 
-                        float nextDist = -_searchState.QueryDistance(_vector.Span, nextIndex, ref _vectorReadCounter);
+                        float nextDist = -_searchState.QueryDistance(_vector.Span, ref next, ref _vectorReadCounter);
                         if (nearestEdgesQ.Count < _internalNumberOfCandidates)
                         {
                             candidatesQ.Enqueue(nextIndex, -nextDist);
@@ -312,14 +316,14 @@ public unsafe partial class Hnsw
             /// On platforms without software prefetch the JIT eliminates this entirely.
             /// </summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private void PrefetchNextNeighborVector(int startFrom, int visitedCounter)
+            private void PrefetchNextNeighborVector(int* indexesPtr, int indexesCount, int startFrom, int visitedCounter)
             {
                 if (PortableIntrinsics.CanPrefetch == false)
                     return;
 
-                for (int j = startFrom; j < _indexes.Count; j++)
+                for (int j = startFrom; j < indexesCount; j++)
                 {
-                    var idx = _indexes[j];
+                    var idx = indexesPtr[j];
                     ref var node = ref _searchState.GetNodeByIndex(idx);
                     if (node.Visited == visitedCounter)
                         continue;

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Sparrow;
 using Voron.Global;
 using Voron.Util;
 
 namespace Voron.Data.Graphs;
 
-public partial class Hnsw
+public unsafe partial class Hnsw
 {
     public partial class SearchState
     {
@@ -192,6 +194,11 @@ public partial class Hnsw
                             continue; // already checked
                         next.Visited = visitedCounter;
 
+                        // Prefetch the next unvisited neighbor's vector data to overlap
+                        // cache-miss latency with the current distance computation.
+                        // SimilarityCalc is ~65% of query time, ~80% of which is data loading.
+                        PrefetchNextNeighborVector(i + 1, visitedCounter);
+
                         var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone
                                         || (_hasFilterMatch && _alreadyReturnedEdges.Contains(nextIndex));
 
@@ -285,6 +292,33 @@ public partial class Hnsw
                 };
                 
                 return _vectorReadCounter < max;
+            }
+
+            /// <summary>
+            /// Finds the next unvisited neighbor starting from <paramref name="startFrom"/> and
+            /// issues software prefetch instructions for its vector data. This overlaps the
+            /// cache-miss latency (~500ns for 6KB from L3) with the current distance computation (~633ns).
+            /// On platforms without software prefetch the JIT eliminates this entirely.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private void PrefetchNextNeighborVector(int startFrom, int visitedCounter)
+            {
+                if (PortableIntrinsics.CanPrefetch == false)
+                    return;
+
+                for (int j = startFrom; j < _indexes.Count; j++)
+                {
+                    var idx = _indexes[j];
+                    ref var node = ref _searchState.GetNodeByIndex(idx);
+                    if (node.Visited == visitedCounter)
+                        continue;
+
+                    if (node.TryGetVectorAddress(out byte* address, out int length) == false)
+                        return; // vector not loaded yet, skip prefetch
+
+                    PortableIntrinsics.PrefetchRange(address, length);
+                    return;
+                }
             }
 
             private static int GetPrefetchExtendSize(int numberOfCandidates) => numberOfCandidates switch

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -96,6 +96,7 @@ public partial class Hnsw
 
                 lowerBound = float.MaxValue;
                 visitedCounter = ++_searchState._visitsCounter;
+                _searchState.OnQueryVector(_vector);
 
                 foreach (var nodeIdx in _startingPointIndexes)
                 {
@@ -122,8 +123,9 @@ public partial class Hnsw
                 Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
                 Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
 
-                lowerBound = -_searchState.QueryDistance(_vector.Span, _startingPointIndex, ref _vectorReadCounter);
                 visitedCounter = ++_searchState._visitsCounter;
+                _searchState.OnQueryVector(_vector);
+                lowerBound = -_searchState.QueryDistance(_vector.Span, _startingPointIndex, ref _vectorReadCounter);
                 {
                     ref var startingPoint = ref _searchState.GetNodeByIndex(_startingPointIndex);
                     startingPoint.Visited = visitedCounter;
@@ -159,6 +161,12 @@ public partial class Hnsw
                         nearestEdgesQ.Count == _internalNumberOfCandidates)
                     {
                         ProcessResults();
+                        // Drain candidatesQ before yielding. Non-filtered queries consume only
+                        // the first batch and never resume the iterator, so without this clear
+                        // the shared SearchState carries far-from-the-old-vector candidates into
+                        // the next query, polluting its priority queue and forcing the search to
+                        // expand 25-30% more nodes than a fresh state would.
+                        candidatesQ.Clear();
                         yield return true;
                         // If we need to fetch more, we'll start the query again with a higher NumberOfCandidates.
                         // The SearchState keeps its state, so traversal through already visited nodes is I/O-free
@@ -236,17 +244,13 @@ public partial class Hnsw
 
             // Reset the NearestSearcher state; however, it does not clear the data already stored inside SearchState.
             // This is important because it allows us to reduce I/O pressure during over-fetching and when restarting the query.
+            // Node.Visited uses version-based invalidation keyed on SearchState._visitsCounter
+            // (incremented in InitState), and Node.QueryDistanceVersion uses a separate version
+            // keyed on the query vector, so neither needs a per-node reset here.
             private void Reset()
             {
                 _searchState._candidatesQ.Clear();
                 _searchState._nearestEdgesQ.Clear();
-
-                for (int nodeIdx = 0; nodeIdx < _searchState._nodes.Count; nodeIdx++)
-                {
-                    _searchState._nodes[nodeIdx].Visited = 0;
-                }
-
-                _searchState._visitsCounter = 0;
                 _candidates.Clear();
                 _nodeIds.Clear();
                 _indexes.Clear();

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -178,13 +178,8 @@ public unsafe partial class Hnsw
                         goto Start;
                     }
 
-                    ref var candidate = ref _searchState.GetNodeByIndex(cur);
-                    candidate.Visited = visitedCounter;
-
-                    ref var edges = ref candidate.EdgesPerLevel[_level];
-
-                    _nodeIds.ResetAndCopyFrom(allocator, edges.ToSpan());
-                    _searchState.LoadNodeIndexes(ref _nodeIds, ref _indexes);
+                    _searchState.GetNodeByIndex(cur).Visited = visitedCounter;
+                    _searchState.ResolveEdgeIndexes(cur, _level, ref _nodeIds, ref _indexes);
 
                     for (int i = 0; i < _indexes.Count; i++)
                     {

--- a/src/Voron/Data/Graphs/Hnsw.Node.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Node.cs
@@ -37,6 +37,25 @@ public partial class Hnsw
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ReadOnlySpan<long> EdgesAtLevel(int level) => EdgesPerLevel[level].ToSpan();
 
+        /// <summary>
+        /// Returns the vector's memory address and length without triggering I/O.
+        /// Returns false if the vector hasn't been loaded yet.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetVectorAddress(out byte* address, out int length)
+        {
+            if (_vectorSpan.Length > 0)
+            {
+                address = _vectorSpan.Address;
+                length = _vectorSpan.Length;
+                return true;
+            }
+
+            address = null;
+            length = 0;
+            return false;
+        }
+
         public long GetVectorContainerId()
         {
             if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)

--- a/src/Voron/Data/Graphs/Hnsw.Node.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Node.cs
@@ -15,27 +15,59 @@ public partial class Hnsw
     public unsafe struct Node
     {
         internal const long VectorIdMask = ~0xFFF;
+
+        // Hot fields read by the search inner loop are colocated at the start of the struct so a
+        // single cache line covers PostingListId (tombstone check), _vectorSpan (kernel input),
+        // Visited (RW per candidate), and the QueryDistance memo. VectorId / NodeId follow to keep
+        // line 0 saturated; the resolve-only fields (EdgesPerLevel / EdgesIndexesPerLevel /
+        // Cached*) land on line 1.
         public long PostingListId;
-        public long VectorId;
-        public long NodeId;
-        public NativeList<NativeList<long>> EdgesPerLevel;
-        public NativeList<NativeList<int>> EdgesIndexesPerLevel;
         internal UnmanagedSpan _vectorSpan;
         public int Visited;
+        public int QueryDistanceVersion;
         // Cached distance between this node and the current query vector. Valid only when
         // QueryDistanceVersion == SearchState._queryVectorVersion. SearchState bumps that
         // version whenever the query vector changes (see OnQueryVector), which in turn
         // invalidates this entry without touching the node.
         public float QueryDistanceValue;
-        public int QueryDistanceVersion;
+        public long VectorId;
+        public long NodeId;
+
+        public NativeList<NativeList<long>> EdgesPerLevel;
+        public NativeList<NativeList<int>> EdgesIndexesPerLevel;
+
+        // When non-null, this node's edge data lives in the HnswIndexCache buffer rather than in
+        // EdgesPerLevel. Set during search-side LoadNodeIndexes when the node hits the cache and
+        // the alternative copy was elided. Indexing-side code paths never set this pointer and
+        // continue to read/write EdgesPerLevel as before.
+        internal HnswIndexCache.CachedNodeHeader* CachedHeader;
+        internal int* CachedOffsets;
+        internal long* CachedEdges;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal int GetLevelCount() => CachedHeader != null ? CachedHeader->LevelCount : EdgesPerLevel.Count;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal int EdgeCountAtLevel(int level)
+        {
+            if (CachedHeader != null)
+                return CachedOffsets[level + 1] - CachedOffsets[level];
+            return EdgesPerLevel[level].Count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal ReadOnlySpan<long> EdgesAtLevel(int level)
+        {
+            if (CachedHeader != null)
+            {
+                int start = CachedOffsets[level];
+                int end = CachedOffsets[level + 1];
+                return new ReadOnlySpan<long>(CachedEdges + start, end - start);
+            }
+            return EdgesPerLevel[level].ToSpan();
+        }
 
         public bool VectorLoaded => _vectorSpan.Length > 0;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal int GetLevelCount() => EdgesPerLevel.Count;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ReadOnlySpan<long> EdgesAtLevel(int level) => EdgesPerLevel[level].ToSpan();
 
         /// <summary>
         /// Returns the vector's memory address and length without triggering I/O.

--- a/src/Voron/Data/Graphs/Hnsw.Node.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Node.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Sparrow;
 using Sparrow.Compression;
 using Sparrow.Server.Utils;
@@ -19,11 +20,22 @@ public partial class Hnsw
         public long NodeId;
         public NativeList<NativeList<long>> EdgesPerLevel;
         public NativeList<NativeList<int>> EdgesIndexesPerLevel;
-        private UnmanagedSpan _vectorSpan;
+        internal UnmanagedSpan _vectorSpan;
         public int Visited;
-        public float? QueryDistance;
+        // Cached distance between this node and the current query vector. Valid only when
+        // QueryDistanceVersion == SearchState._queryVectorVersion. SearchState bumps that
+        // version whenever the query vector changes (see OnQueryVector), which in turn
+        // invalidates this entry without touching the node.
+        public float QueryDistanceValue;
+        public int QueryDistanceVersion;
 
         public bool VectorLoaded => _vectorSpan.Length > 0;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal int GetLevelCount() => EdgesPerLevel.Count;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal ReadOnlySpan<long> EdgesAtLevel(int level) => EdgesPerLevel[level].ToSpan();
 
         public long GetVectorContainerId()
         {
@@ -102,7 +114,7 @@ public partial class Hnsw
             return GetVectorUnmanagedSpan(state).ToSpan();
         }
 
-        internal void SetVector(SearchState searchState, UnmanagedSpan span)
+        internal void SetVector(in Options options, UnmanagedSpan span)
         {
             if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
             {
@@ -111,8 +123,8 @@ public partial class Hnsw
             }
 
             var count = (byte)(VectorId >> 1);
-            var offset = count * searchState.Options.VectorSizeBytes;
-            _vectorSpan = new UnmanagedSpan(span.Address + offset, searchState.Options.VectorSizeBytes);
+            var offset = count * options.VectorSizeBytes;
+            _vectorSpan = new UnmanagedSpan(span.Address + offset, options.VectorSizeBytes);
         }
     }
 }

--- a/src/Voron/Data/Graphs/Hnsw.NormalizedLayout.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NormalizedLayout.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Numerics.Tensors;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Sparrow.Server;
+
+namespace Voron.Data.Graphs;
+
+public partial class Hnsw
+{
+    /// <summary>
+    /// Shared storage layout for HNSW tensors that carry a scalar magnitude: <c>T[dims]</c>
+    /// followed by a trailing <c>float</c>. Used by <see cref="SimilarityMethod.CosineSimilaritySingles"/>
+    /// (unit vector + L2 norm, starting at <see cref="Global.Constants.Graphs.HnswVersion.SinglesWithL2Norm"/>)
+    /// and <see cref="SimilarityMethod.CosineSimilarityI8"/> (int8-quantized vector + quantization
+    /// scale). Hamming/Binary does not use this layout.
+    /// </summary>
+    public const int MagnitudeSizeInBytes = sizeof(float);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int TensorSizeBytes<T>(int dimensions) where T : unmanaged
+        => dimensions * Unsafe.SizeOf<T>() + MagnitudeSizeInBytes;
+
+    /// <summary>
+    /// Writes <paramref name="vector"/> followed by <paramref name="magnitude"/> into
+    /// <paramref name="destination"/>. The destination must be sized exactly
+    /// <see cref="TensorSizeBytes{T}"/>.
+    /// </summary>
+    public static void WriteTensor<T>(ReadOnlySpan<T> vector, float magnitude, Span<byte> destination) where T : unmanaged
+    {
+        int expected = TensorSizeBytes<T>(vector.Length);
+        if (destination.Length != expected)
+            throw new ArgumentException($"Destination must be {expected} bytes, got {destination.Length}.", nameof(destination));
+
+        var vecBytes = MemoryMarshal.AsBytes(vector);
+        vecBytes.CopyTo(destination);
+        Unsafe.WriteUnaligned(ref destination[vecBytes.Length], magnitude);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float ReadTensorMagnitude(ReadOnlySpan<byte> atRest)
+        => Unsafe.ReadUnaligned<float>(
+            ref MemoryMarshal.GetReference(atRest[^MagnitudeSizeInBytes..]));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlySpan<T> ReadTensorVector<T>(ReadOnlySpan<byte> atRest) where T : unmanaged
+        => MemoryMarshal.Cast<byte, T>(atRest[..^MagnitudeSizeInBytes]);
+
+    /// <summary>
+    /// True when vectors for <paramref name="options"/> must be pre-normalized into the storage
+    /// layout before being handed to HNSW. Only the f32 cosine path needs this; Int8 and Hamming
+    /// keep their original shapes.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool VectorNormalizationRequired(in Options options) =>
+        options.SimilarityMethod == SimilarityMethod.CosineSimilaritySingles
+        && options.Version >= Global.Constants.Graphs.HnswVersion.SinglesWithL2Norm;
+
+    /// <summary>
+    /// Allocates a scope-owned buffer, normalizes <paramref name="vector"/> into it, and
+    /// rebinds <paramref name="vector"/> to the new buffer. Returns <c>false</c> without
+    /// allocating when no normalization is needed (similarity method that does not consume
+    /// the normalized layout, on-disk version that predates it, or input already in storage
+    /// form). Throws when the input is not a raw
+    /// float[dims] payload of the expected dimensionality.
+    /// </summary>
+    internal static bool TryNormalizeQueryVector(in Options options, ByteStringContext allocator, ref Memory<byte> vector,
+        out ByteStringContext<ByteStringMemoryCache>.InternalScope scope)
+    {
+        scope = default;
+        if (VectorNormalizationRequired(options) == false)
+            return false;
+        if (vector.Length == options.VectorSizeBytes)
+            return false;
+
+        var floats = MemoryMarshal.Cast<byte, float>(vector.Span);
+        var expected = TensorSizeBytes<float>(floats.Length);
+        if (expected != options.VectorSizeBytes)
+            throw new ArgumentException($"Query vector has {vector.Length} bytes which does not match the expected normalized size ({options.VectorSizeBytes}) for this index.");
+
+        scope = AllocateNormalizedQueryVector(allocator, floats, expected, out vector);
+        return true;
+    }
+
+    private static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope AllocateNormalizedQueryVector(
+        ByteStringContext allocator, ReadOnlySpan<float> floats, int expected, out Memory<byte> vector)
+    {
+        var scope = allocator.Allocate(expected, out ByteString buf);
+        WriteNormalizedTensor(floats, buf.ToSpan());
+        vector = new NormalizedQueryMemoryManager(buf.Ptr, expected).Memory;
+        return scope;
+    }
+
+    private sealed unsafe class NormalizedQueryMemoryManager : System.Buffers.MemoryManager<byte>
+    {
+        private readonly byte* _ptr;
+        private readonly int _length;
+
+        public NormalizedQueryMemoryManager(byte* ptr, int length)
+        {
+            _ptr = ptr;
+            _length = length;
+        }
+
+        public override Span<byte> GetSpan() => new(_ptr, _length);
+        public override System.Buffers.MemoryHandle Pin(int elementIndex = 0) => new(_ptr + elementIndex);
+        public override void Unpin() { }
+        protected override void Dispose(bool disposing) { }
+    }
+
+    /// <summary>
+    /// Normalizes <paramref name="raw"/> in place into <paramref name="destination"/>
+    /// (unit floats + trailing L2 norm). Returns the original L2 norm; zero-norm input
+    /// is preserved verbatim with magnitude 0 and the distance kernel must branch on it.
+    /// </summary>
+    public static float WriteNormalizedTensor(ReadOnlySpan<float> raw, Span<byte> destination)
+    {
+        int expected = TensorSizeBytes<float>(raw.Length);
+        if (destination.Length != expected)
+            throw new ArgumentException($"Destination must be {expected} bytes, got {destination.Length}.", nameof(destination));
+
+        var unit = MemoryMarshal.Cast<byte, float>(destination[..(raw.Length * sizeof(float))]);
+
+        float sumSq = TensorPrimitives.SumOfSquares(raw);
+        float magnitude = MathF.Sqrt(sumSq);
+        if (magnitude > 0f)
+            TensorPrimitives.Divide(raw, magnitude, unit);
+        else
+            raw.CopyTo(unit); // zero vector: preserve zeros; kernel must branch on magnitude == 0
+
+        Unsafe.WriteUnaligned(
+            ref destination[raw.Length * sizeof(float)],
+            magnitude);
+
+        return magnitude;
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -49,7 +49,7 @@ public partial class Hnsw
         // Both operands are unit vectors here, so cosine distance collapses to 1 - a·b.
         var aUnit = ReadTensorVector<float>(a);
         var bUnit = ReadTensorVector<float>(b);
-        return 1f - TensorPrimitives.Dot(aUnit, bUnit);
+        return 1f - Sparrow.Server.Tensors.Functions.DotProduct(aUnit, bUnit);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -26,17 +26,41 @@ public partial class Hnsw
         return Functions.CosineDistance(aSingles, bSingles);
     }
 
+    /// <summary>
+    /// Distance kernel for the <c>SinglesWithL2Norm</c> on-disk layout: both operands
+    /// are pre-normalized unit vectors with the original L2 norm stored in the trailing
+    /// <see cref="MagnitudeSizeInBytes"/> bytes of the buffer. For unit-norm inputs
+    /// <c>cosDistance(a,b) = 1 - a·b</c>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static float CosineDistanceSinglesNormalized(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    {
+        Debug.Assert(a.Length == b.Length, "a.Length == b.Length");
+
+        // Degenerate inputs: both zero-norm -> NaN (undefined direction on both sides);
+        // exactly one zero-norm -> similarity 0 (distance 1).
+        var aNorm = ReadTensorMagnitude(a);
+        var bNorm = ReadTensorMagnitude(b);
+        if (aNorm == 0f && bNorm == 0f)
+            return float.NaN;
+        if (aNorm == 0f || bNorm == 0f)
+            return 1f;
+
+        // Both operands are unit vectors here, so cosine distance collapses to 1 - a·b.
+        var aUnit = ReadTensorVector<float>(a);
+        var bUnit = ReadTensorVector<float>(b);
+        return 1f - TensorPrimitives.Dot(aUnit, bUnit);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static float CosineDistanceI8(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
         Debug.Assert(a.Length == b.Length, "a.Length == b.Length");
-        var vectorLength = a.Length - sizeof(float);
 
-        var aRef = MemoryMarshal.Cast<byte, sbyte>(a[..vectorLength]);
-        var bRef = MemoryMarshal.Cast<byte, sbyte>(b[..vectorLength]);
-
-        var aMag = Unsafe.ReadUnaligned<float>(ref MemoryMarshal.GetReference(a[vectorLength..]));
-        var bMag = Unsafe.ReadUnaligned<float>(ref MemoryMarshal.GetReference(b[vectorLength..]));
+        var aRef = ReadTensorVector<sbyte>(a);
+        var bRef = ReadTensorVector<sbyte>(b);
+        var aMag = ReadTensorMagnitude(a);
+        var bMag = ReadTensorMagnitude(b);
 
         return Functions.CosineDistance(aRef, aMag, bRef, bMag);
     }

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -42,7 +42,7 @@ public partial class Hnsw
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static float HammingDistance(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    internal static float HammingDistance(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
         return Functions.HammingBitDistance(a, b);
     }

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -31,6 +31,10 @@ public partial class Hnsw
         private readonly IHnswSearcher _vectorsSearcher;
         private readonly Memory<byte> _vector;
         private IEnumerator<bool> _resultsEnumerator;
+        // When the searchState-based entry points allocate a normalized copy of the query
+        // vector they hand the scope here so Dispose releases it alongside the retriever's
+        // other per-query state.
+        private Sparrow.Server.ByteStringContext<Sparrow.Server.ByteStringMemoryCache>.InternalScope? _queryVectorScope;
 
         public SimilarityMethod? SimilarityMethod => _searchState?.Options.SimilarityMethod;
         
@@ -45,12 +49,13 @@ public partial class Hnsw
         public long CandidatesProcessed => _vectorsSearcher?.CandidatesProcessed ?? 0;
         
         public VectorSearchRetriever(SearchState searchState, IHnswSearcher vectorsSearcher, Memory<byte> vector, float minimumSimilarity,
-            bool ownsSearchState = true)
+            bool ownsSearchState = true, Sparrow.Server.ByteStringContext<Sparrow.Server.ByteStringMemoryCache>.InternalScope? queryVectorScope = null)
         {
             _searchState = searchState;
             _ownsSearchState = ownsSearchState;
             _vectorsSearcher = vectorsSearcher;
             _vector = vector;
+            _queryVectorScope = queryVectorScope;
             _postingListResults = new(_searchState.Llt.Allocator);
             _pforDecoder = new(searchState.Llt.Allocator);
             _maximumDistance = searchState.MinimumSimilarityToDistance(minimumSimilarity);
@@ -314,6 +319,7 @@ public partial class Hnsw
             _pforDecoder.Dispose();
             _resultsEnumerator?.Dispose();
             _vectorsSearcher?.Dispose();
+            _queryVectorScope?.Dispose();
             if (_ownsSearchState)
                 _searchState.Dispose();
         }

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Sparrow;
-using Sparrow.Server;
 using Sparrow.Server.Collections;
 using Voron.Data.Containers;
 using Voron.Data.PostingLists;
@@ -30,7 +28,6 @@ public partial class Hnsw
         private bool _foundCandidateInCurrentSmallPostingList;
         private readonly IHnswSearcher _vectorsSearcher;
         private readonly Memory<byte> _vector;
-        private IEnumerator<bool> _resultsEnumerator;
         // When the searchState-based entry points allocate a normalized copy of the query
         // vector they hand the scope here so Dispose releases it alongside the retriever's
         // other per-query state.
@@ -59,8 +56,7 @@ public partial class Hnsw
             _postingListResults = new(_searchState.Llt.Allocator);
             _pforDecoder = new(searchState.Llt.Allocator);
             _maximumDistance = searchState.MinimumSimilarityToDistance(minimumSimilarity);
-            _resultsEnumerator = _vectorsSearcher.Search().GetEnumerator();
-            _resultsEnumerator.MoveNext(); //read first batch
+            _vectorsSearcher.MoveNextBatch(); // prime the first batch
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -184,13 +180,10 @@ public partial class Hnsw
                     {
                         break;
                     }
-                    
-                    if (_resultsEnumerator.MoveNext() == false)
-                    {
-                        _resultsEnumerator = _vectorsSearcher.Search().GetEnumerator();    
-                        _resultsEnumerator.MoveNext();
-                    }
-                    
+
+                    // Pull the next batch into _vectorsSearcher. An empty batch is valid — TryGetCurrentCandidates below handles it.
+                    _vectorsSearcher.MoveNextBatch();
+
                     // If we fetch more than once, we've no guarantee that the whole set of results are sorted by distances.
                     // We could explore not previously seen nodes that are closer to the query vector than the ones we've already seen.
                     IsSortedByDistance = false;
@@ -317,7 +310,6 @@ public partial class Hnsw
         {
             _postingListResults.Dispose();
             _pforDecoder.Dispose();
-            _resultsEnumerator?.Dispose();
             _vectorsSearcher?.Dispose();
             _queryVectorScope?.Dispose();
             if (_ownsSearchState)

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -20,6 +20,7 @@ public partial class Hnsw
     {
         private int _returnedCandidates;
         private readonly SearchState _searchState;
+        private readonly bool _ownsSearchState;
         private int _currentNode, _currentMatchesIndex;
         private ContextBoundNativeList<long> _postingListResults;
         private FastPForDecoder _pforDecoder;
@@ -43,9 +44,11 @@ public partial class Hnsw
 
         public long CandidatesProcessed => _vectorsSearcher?.CandidatesProcessed ?? 0;
         
-        public VectorSearchRetriever(SearchState searchState, IHnswSearcher vectorsSearcher, Memory<byte> vector, float minimumSimilarity)
+        public VectorSearchRetriever(SearchState searchState, IHnswSearcher vectorsSearcher, Memory<byte> vector, float minimumSimilarity,
+            bool ownsSearchState = true)
         {
             _searchState = searchState;
+            _ownsSearchState = ownsSearchState;
             _vectorsSearcher = vectorsSearcher;
             _vector = vector;
             _postingListResults = new(_searchState.Llt.Allocator);
@@ -311,7 +314,8 @@ public partial class Hnsw
             _pforDecoder.Dispose();
             _resultsEnumerator?.Dispose();
             _vectorsSearcher?.Dispose();
-            _searchState.Dispose();
+            if (_ownsSearchState)
+                _searchState.Dispose();
         }
     }
 }

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -136,6 +136,9 @@ public unsafe partial class Hnsw
         public readonly delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> SimilarityCalc;
         public readonly bool IsEmpty;
         private readonly HnswIndexCache _nodeCache;
+        // Fixed at construction. Lookups gate the shared cache on this so a reader at
+        // storage tx R never observes an entry stamped by a later commit.
+        private readonly long _readerTxId;
         private ByteStringContext<ByteStringMemoryCache>.InternalScope? _queryNormalizationScope;
 
         public Span<Node> Nodes => _nodes.ToSpan();
@@ -175,6 +178,7 @@ public unsafe partial class Hnsw
         {
             Llt = llt;
             _nodeCache = nodeCache;
+            _readerTxId = llt.Id;
             _tree = llt.Transaction.ReadTree(name);
 
             if (_tree is null || _tree.TryGetLookupFor(NodeIdToLocationSlice, out _nodeIdToLocations) == false)
@@ -183,18 +187,18 @@ public unsafe partial class Hnsw
                 return;
             }
 
-            if (_nodeCache != null)
-            {
-                // Use options and similarity calc from the cache (already resolved)
-                Options = _nodeCache.Options;
-                SimilarityCalc = _nodeCache.SimilarityCalc;
-            }
-            else
-            {
-                var options = _tree.DirectRead(OptionsSlice);
-                Options = Unsafe.Read<Options>(options);
-                SimilarityCalc = GetDistanceKernel(Options);
-            }
+            // Options must come from disk: CountOfVectors (and the derived MaxLevel) advances
+            // with every commit, while the cache snapshot is frozen at warm-up time. Using the
+            // cached value would route the search from a level the entry point never reached.
+            var optionsPtr = _tree.DirectRead(OptionsSlice);
+            Options = Unsafe.Read<Options>(optionsPtr);
+            SimilarityCalc = _nodeCache != null ? _nodeCache.SimilarityCalc : GetDistanceKernel(Options);
+
+            // Lazy lookup only: LoadNodeIndexes / GetNodeIndexById probe the shared cache
+            // on demand. Eagerly materializing the entire cache into a per-query SearchState
+            // dominated query wall (~49% in dotnet-trace) because the prepop work isn't
+            // amortized — each Corax query builds its own IndexSearcher and SearchState.
+            // Call PrepopulateFromNodeCache() explicitly for long-lived/batch SearchStates only.
         }
 
         public float MinimumSimilarityToDistance(float minimumSimilarity)
@@ -269,6 +273,68 @@ public unsafe partial class Hnsw
             return nodeIndex;
         }
 
+        /// <summary>
+        /// Materialize one local Node per cache entry up front so every dictionary probe in the
+        /// search hot path takes the cached fast path. Vector spans are resolved through the
+        /// shared LLT here, eliminating the per-candidate Container.Get walk; edge ids are
+        /// pre-translated to local node indexes for each level. Suitable for batch and long-lived
+        /// SearchStates only — per-query SearchStates would pay the prepop cost without
+        /// amortizing it across queries.
+        /// </summary>
+        public void PrepopulateFromNodeCache()
+        {
+            if (_nodeCache is null)
+                return;
+
+            // Pass 1: allocate a local Node and copy cache pointers.
+            _nodeCache.ForEachNode(_readerTxId, (nodeId, view) =>
+            {
+                int idx = AllocateNodeIndex(nodeId);
+                CopyNodeFromCache(in view, ref _nodes[idx]);
+                _nodeIdToIdx[nodeId] = idx;
+            });
+
+            // Pass 2: resolve vector spans so QueryDistance miss path skips Container.Get.
+            var self = this;
+            for (int i = 0; i < _nodes.Count; i++)
+            {
+                ref var node = ref _nodes[i];
+                if (node.VectorLoaded)
+                    continue;
+                var span = NodeReader.ReadVector(node.VectorId, in self);
+                node.SetVector(in Options, span);
+            }
+
+            // Pass 3: pre-translate edges per level into EdgesIndexesPerLevel so ResolveEdgeIndexes
+            // takes its fast path on first visit.
+            var translation = new NativeList<int>();
+            for (int i = 0; i < _nodes.Count; i++)
+            {
+                ref var node = ref _nodes[i];
+                int levels = node.GetLevelCount();
+                node.EdgesIndexesPerLevel.SetCapacity(Llt.Allocator, levels);
+                for (int lvl = 0; lvl < levels; lvl++)
+                {
+                    var edges = node.EdgesAtLevel(lvl);
+                    translation.ResetAndEnsureCapacity(Llt.Allocator, edges.Length);
+                    for (int e = 0; e < edges.Length; e++)
+                    {
+                        if (_nodeIdToIdx.TryGetValue(edges[e], out var idx) == false)
+                        {
+                            // Edge target not in cache: leave EdgesIndexesPerLevel[lvl] empty so
+                            // ResolveEdgeIndexes falls through to the slow path on first visit.
+                            translation.Clear();
+                            break;
+                        }
+                        translation.AddUnsafe(idx);
+                    }
+                    if (translation.Count == edges.Length)
+                        node.EdgesIndexesPerLevel[lvl].ResetAndCopyFrom(Llt.Allocator, translation.ToSpan());
+                }
+            }
+            translation.Dispose(Llt.Allocator);
+        }
+
         public bool TryGetLocationForNode(long nodeId, out long locationId) =>
             _nodeIdToLocations.TryGetValue(nodeId, out locationId);
 
@@ -303,19 +369,15 @@ public unsafe partial class Hnsw
             local.NodeId = cached.Header->NodeId;
             local.PostingListId = cached.Header->PostingListId;
             local.VectorId = cached.Header->VectorId;
-            // local._vectorSpan and per-query scratch (Visited, QueryDistance*) stay at default.
+            // Per-query scratch (Visited, QueryDistance*) stays at default; vector span is
+            // resolved on first use.
 
-            int levelCount = cached.Header->LevelCount;
-            local.EdgesPerLevel.EnsureCapacityFor(Llt.Allocator, levelCount);
-            for (int lvl = 0; lvl < levelCount; lvl++)
-            {
-                var src = cached.EdgesAtLevel(lvl);
-                var dst = new NativeList<long>();
-                dst.EnsureCapacityFor(Llt.Allocator, src.Length);
-                for (int e = 0; e < src.Length; e++)
-                    dst.AddUnsafe(src[e]);
-                local.EdgesPerLevel.AddUnsafe(dst);
-            }
+            // Bind the cache-resident topology into the Node so EdgesAtLevel / EdgeCountAtLevel
+            // read directly from the cache buffer. EdgesPerLevel is left empty: indexing-side
+            // code paths never traverse a Node loaded through this method.
+            local.CachedHeader = cached.Header;
+            local.CachedOffsets = cached.Offsets;
+            local.CachedEdges = cached.Edges;
         }
 
         /// <summary>
@@ -332,8 +394,9 @@ public unsafe partial class Hnsw
             // Fast path: the resolved indexes for this level are already cached on the node.
             // The slow path (miss) is in a NoInlining helper so only this copy is inlined into
             // callers inside the search loop.
+            int edgeCount = node.EdgeCountAtLevel(level);
             if (node.EdgesIndexesPerLevel.Count > level &&
-                node.EdgesIndexesPerLevel[level].Count == node.EdgesPerLevel[level].Count)
+                node.EdgesIndexesPerLevel[level].Count == edgeCount)
             {
                 indexes.ResetAndCopyFrom(Llt.Allocator, node.EdgesIndexesPerLevel[level].ToSpan());
                 return;
@@ -346,7 +409,7 @@ public unsafe partial class Hnsw
         private void ResolveEdgeIndexesSlow(int nodeIndex, int level, ref NativeList<long> nodeIds, ref NativeList<int> indexes)
         {
             ref var node = ref GetNodeByIndex(nodeIndex);
-            nodeIds.ResetAndCopyFrom(Llt.Allocator, node.EdgesPerLevel[level].ToSpan());
+            nodeIds.ResetAndCopyFrom(Llt.Allocator, node.EdgesAtLevel(level));
             LoadNodeIndexes(ref nodeIds, ref indexes);
 
             node = ref GetNodeByIndex(nodeIndex);
@@ -372,7 +435,7 @@ public unsafe partial class Hnsw
                 }
 
                 // Check the shared HnswIndexCache before going to disk
-                if (_nodeCache != null && _nodeCache.TryGetNode(nodeIds[i], out var cached))
+                if (_nodeCache != null && _nodeCache.TryGetNode(nodeIds[i], _readerTxId, out var cached))
                 {
                     var localIdx = AllocateNodeIndex(nodeIds[i]);
                     CopyNodeFromCache(in cached, ref _nodes[localIdx]);
@@ -416,10 +479,12 @@ public unsafe partial class Hnsw
             if (exists)
                 return nodeIdx;
 
-            // Check the shared HnswIndexCache for a pre-loaded copy.
-            // Deep-copy edge lists into the local allocator (NativeLists can't cross allocator boundaries).
-            // Vector data is read on demand through this transaction; the cache itself doesn't pin pages.
-            if (_nodeCache != null && _nodeCache.TryGetNode(nodeId, out var cached))
+            // The shared HnswIndexCache is optimistic — a stale entry would have to be tolerated
+            // by every consumer, which the entry point cannot do: its cached LevelCount sets
+            // maxLevel for the entire descent. Reading it from disk costs one extra container
+            // fetch per query but keeps the search routed correctly when the graph has grown
+            // past the warm-up snapshot.
+            if (nodeId != EntryPointId && _nodeCache != null && _nodeCache.TryGetNode(nodeId, _readerTxId, out var cached))
             {
                 nodeIdx = AllocateNodeIndex(nodeId);
                 CopyNodeFromCache(in cached, ref GetNodeByIndex(nodeIdx));
@@ -474,6 +539,17 @@ public unsafe partial class Hnsw
             // — loading the stored vector and running SimilarityCalc — lives in a NoInlining helper so
             // its register footprint does not leak into the search loop.
             ref var to = ref GetNodeByIndex(toIdx);
+            if (to.QueryDistanceVersion == _queryVectorVersion)
+                return to.QueryDistanceValue;
+
+            return QueryDistanceMiss(vector, ref to, ref vectorReadCounter);
+        }
+
+        // Same fast/slow split as the index-taking overload. Callers in the search inner loop
+        // already hold a ref to the Node so this avoids the second GetNodeByIndex lookup.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float QueryDistance(ReadOnlySpan<byte> vector, ref Node to, ref long vectorReadCounter)
+        {
             if (to.QueryDistanceVersion == _queryVectorVersion)
                 return to.QueryDistanceValue;
 

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -11,6 +11,7 @@ using Sparrow.Binary;
 using Sparrow.Compression;
 using Sparrow.Platform;
 using Sparrow.Server;
+using Sparrow.Server.Tensors;
 using Sparrow.Server.Utils;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
@@ -53,6 +54,10 @@ public unsafe partial class Hnsw
             _ => throw new InvalidOperationException($"Unexpected value of {nameof(VectorEmbeddingType)}: {embeddingType}")
         };
 
+        // VectorEmbeddingType.Single is stored in the NormalizedTensor layout: unit vector followed by a trailing float L2 norm. Callers pass the raw payload size (dims * sizeof(float)); the trailing-norm bytes are added here so callers do not need to know about the layout.
+        if (embeddingType == VectorEmbeddingType.Single)
+            vectorSizeBytes += MagnitudeSizeInBytes;
+
         var options = new Options
         {
             Version = Constants.Graphs.HnswVersion.CurrentVersion,
@@ -67,6 +72,27 @@ public unsafe partial class Hnsw
         {
             Unsafe.Write(output, options);
         }
+    }
+
+    /// <summary>
+    /// Returns the distance kernel to use for a given HNSW <see cref="Options"/>. For
+    /// <see cref="SimilarityMethod.CosineSimilaritySingles"/> the kernel depends on the on-disk
+    /// version: at or above <see cref="Constants.Graphs.HnswVersion.SinglesWithL2Norm"/> the
+    /// operands are pre-normalized (NormalizedTensor layout) and the dot-only kernel applies;
+    /// below that version the operands are raw vectors and norms are recomputed per call.
+    /// </summary>
+    internal static delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> GetDistanceKernel(in Options options)
+    {
+        return options.SimilarityMethod switch
+        {
+            SimilarityMethod.CosineSimilaritySingles =>
+                options.Version >= Constants.Graphs.HnswVersion.SinglesWithL2Norm
+                    ? &CosineDistanceSinglesNormalized
+                    : &CosineDistanceSingles,
+            SimilarityMethod.CosineSimilarityI8 => &CosineDistanceI8,
+            SimilarityMethod.HammingDistance => &HammingDistance,
+            _ => throw new ArgumentOutOfRangeException(nameof(options.SimilarityMethod), options.SimilarityMethod, null)
+        };
     }
 
     private static ContainerId ReadGlobalVectorsContainerId(LowLevelTransaction llt)
@@ -110,6 +136,7 @@ public unsafe partial class Hnsw
         public readonly delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> SimilarityCalc;
         public readonly bool IsEmpty;
         private readonly HnswIndexCache _nodeCache;
+        private ByteStringContext<ByteStringMemoryCache>.InternalScope? _queryNormalizationScope;
 
         public Span<Node> Nodes => _nodes.ToSpan();
         public Tree Tree => _tree;
@@ -136,6 +163,14 @@ public unsafe partial class Hnsw
         {
         }
 
+        public SearchState(LowLevelTransaction llt, Slice name, ref Memory<byte> queryVector) : this(llt, name, null)
+        {
+            if (IsEmpty)
+                return;
+            if (TryNormalizeQueryVector(Options, Llt.Allocator, ref queryVector, out var scope))
+                _queryNormalizationScope = scope;
+        }
+
         public SearchState(LowLevelTransaction llt, Slice name, HnswIndexCache nodeCache)
         {
             Llt = llt;
@@ -158,13 +193,7 @@ public unsafe partial class Hnsw
             {
                 var options = _tree.DirectRead(OptionsSlice);
                 Options = Unsafe.Read<Options>(options);
-                SimilarityCalc = Options.SimilarityMethod switch
-                {
-                    SimilarityMethod.CosineSimilaritySingles => &CosineDistanceSingles,
-                    SimilarityMethod.CosineSimilarityI8 => &CosineDistanceI8,
-                    SimilarityMethod.HammingDistance => &HammingDistance,
-                    _ => throw new ArgumentOutOfRangeException(nameof(Options.SimilarityMethod), Options.SimilarityMethod, null)
-                };
+                SimilarityCalc = GetDistanceKernel(Options);
             }
         }
 
@@ -246,6 +275,7 @@ public unsafe partial class Hnsw
         public void RegisterNodeLocation(long nodeId, long locationId) =>
             _nodeIdToLocations.Add(nodeId, locationId);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref Node GetNodeByIndex(int index)
         {
             ref var n = ref _nodes[index];
@@ -294,10 +324,14 @@ public unsafe partial class Hnsw
         /// <see cref="LoadNodeIndexes"/> dictionary lookups are skipped entirely.
         /// May grow the nodes array — callers must re-fetch any outstanding node refs afterward.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ResolveEdgeIndexes(int nodeIndex, int level, ref NativeList<long> nodeIds, ref NativeList<int> indexes)
         {
             ref var node = ref GetNodeByIndex(nodeIndex);
 
+            // Fast path: the resolved indexes for this level are already cached on the node.
+            // The slow path (miss) is in a NoInlining helper so only this copy is inlined into
+            // callers inside the search loop.
             if (node.EdgesIndexesPerLevel.Count > level &&
                 node.EdgesIndexesPerLevel[level].Count == node.EdgesPerLevel[level].Count)
             {
@@ -305,6 +339,13 @@ public unsafe partial class Hnsw
                 return;
             }
 
+            ResolveEdgeIndexesSlow(nodeIndex, level, ref nodeIds, ref indexes);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ResolveEdgeIndexesSlow(int nodeIndex, int level, ref NativeList<long> nodeIds, ref NativeList<int> indexes)
+        {
+            ref var node = ref GetNodeByIndex(nodeIndex);
             nodeIds.ResetAndCopyFrom(Llt.Allocator, node.EdgesPerLevel[level].ToSpan());
             LoadNodeIndexes(ref nodeIds, ref indexes);
 
@@ -425,12 +466,23 @@ public unsafe partial class Hnsw
         }
 
         // Allows storing cached distance to the queried vector. Should be used only in the querying part!
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float QueryDistance(ReadOnlySpan<byte> vector, int toIdx, ref long vectorReadCounter)
         {
+            // Fast path: the distance for this (query vector, node) pair was already computed during
+            // the current traversal and is still valid (version equals _visitsCounter). The miss path
+            // — loading the stored vector and running SimilarityCalc — lives in a NoInlining helper so
+            // its register footprint does not leak into the search loop.
             ref var to = ref GetNodeByIndex(toIdx);
             if (to.QueryDistanceVersion == _queryVectorVersion)
                 return to.QueryDistanceValue;
 
+            return QueryDistanceMiss(vector, ref to, ref vectorReadCounter);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private float QueryDistanceMiss(ReadOnlySpan<byte> vector, ref Node to, ref long vectorReadCounter)
+        {
             Span<byte> v2 = to.GetVector(this);
             vectorReadCounter++;
             var distance = SimilarityCalc(vector, v2);
@@ -740,7 +792,13 @@ public unsafe partial class Hnsw
 
            _nodes.Dispose(Llt.Allocator);
 
+           if (_queryNormalizationScope is { } scope)
+           {
+               scope.Dispose();
+               _queryNormalizationScope = null;
+           }
        }
+
     }
 
     public partial class Registration : IDisposable
@@ -755,7 +813,13 @@ public unsafe partial class Hnsw
         private readonly ContainerId _globalVectorsContainerId;
         private PostingList _largePostingListSet;
 
+        // Lazy scratch used by Register to normalize raw-sized inputs in-place; one allocation per Registration.
+        private ByteStringContext<ByteStringMemoryCache>.InternalScope _normalizationScope;
+        private ByteString _normalizationBuffer;
+
         public int AmountOfModifiedVectorsInTransaction => _vectorHashCache.Count;
+
+        public Options Options => _searchState.Options;
 
         public Registration(LowLevelTransaction llt, Slice name, Random random = null)
         {
@@ -862,9 +926,9 @@ public unsafe partial class Hnsw
         {
             entryId = EntryIdToInternalEntryId(entryId);
             PortableExceptions.ThrowIfOnDebug<ArgumentOutOfRangeException>((entryId & Constants.Graphs.VectorId.EnsureIsSingleMask) != 0, "Entry ids must have the first two bits cleared, we are using those");
-            PortableExceptions.ThrowIf<ArgumentOutOfRangeException>(
-                vector.Length != _searchState.Options.VectorSizeBytes,
-                $"Vector size {vector.Length} does not match expected size: {_searchState.Options.VectorSizeBytes}");
+
+            if (vector.Length != _searchState.Options.VectorSizeBytes)
+                vector = NormalizeIntoScratch(vector);
 
             var hashBuffer = ComputeHashFor(vector);
             ref (ByteString Hash, int NodeIndex, NativeList<long> PostingList) postingList = ref CollectionsMarshal.GetValueRefOrAddDefault(_vectorHashCache, hashBuffer, out var exists);
@@ -957,6 +1021,22 @@ public unsafe partial class Hnsw
                 //container id | index    | marker
                 return new ContainerEntryId((long)containerId | (uint)(index << 1) | Constants.Graphs.VectorStorage.VectorContainerInternalIndexer);
             }
+        }
+
+        private ReadOnlySpan<byte> NormalizeIntoScratch(ReadOnlySpan<byte> vector)
+        {
+            var expected = _searchState.Options.VectorSizeBytes;
+            var floats = MemoryMarshal.Cast<byte, float>(vector);
+            PortableExceptions.ThrowIf<ArgumentOutOfRangeException>(
+                VectorNormalizationRequired(_searchState.Options) == false || TensorSizeBytes<float>(floats.Length) != expected,
+                $"Vector size {vector.Length} does not match expected size: {expected}");
+
+            if (_normalizationBuffer.HasValue == false)
+                _normalizationScope = _searchState.Llt.Allocator.Allocate(expected, out _normalizationBuffer);
+
+            var dst = _normalizationBuffer.ToSpan();
+            WriteNormalizedTensor(floats, dst);
+            return dst;
         }
 
         private ByteString ComputeHashFor(ReadOnlySpan<byte> vector)
@@ -1104,7 +1184,8 @@ public unsafe partial class Hnsw
 
         public void Dispose()
         {
-            //todo: we may wants to release the vector hash cache
+            if (_normalizationBuffer.HasValue)
+                _normalizationScope.Dispose();
         }
 
         private long UpdatePostingList(ContainerEntryId postingListId, in NativeList<long> modifications, FastPForEncoder pForEncoder, ref FastPForDecoder pForDecoder, ref ContextBoundNativeList<long> tempListBuffer)
@@ -1190,15 +1271,15 @@ public unsafe partial class Hnsw
     
     public static VectorSearchRetriever ExactNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch, ContextBoundNativeList<long>? nodesToScan = null)
     {
-        var searchState = new SearchState(llt, name);
+        var searchState = new SearchState(llt, name, ref vector);
         var results = searchState.ExactSearch(vector, hasFilterMatch, numberOfCandidates, nodesToScan);
         return new VectorSearchRetriever(searchState,  results, vector, minimumSimilarity);
     }
 
     public static VectorSearchRetriever ApproximateFilteredNearest<TEnumerator>(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, TEnumerator nodesToProbe)
-     where TEnumerator : IEnumerator<long> 
+     where TEnumerator : IEnumerator<long>
     {
-        var searchState = new SearchState(llt, name);
+        var searchState = new SearchState(llt, name, ref vector);
         var startingPointsIndexes = new ContextBoundNativeList<int>(llt.Allocator);
         var candidates = new ContextBoundNativeList<int>(llt.Allocator);
         candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
@@ -1215,7 +1296,7 @@ public unsafe partial class Hnsw
     
     public static VectorSearchRetriever ApproximateNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch = false)
     {
-        var searchState = new SearchState(llt, name);
+        var searchState = new SearchState(llt, name, ref vector);
         var nearestNodesByLevel = new ContextBoundNativeList<int>(llt.Allocator);
         nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
@@ -1239,6 +1320,7 @@ public unsafe partial class Hnsw
     /// </summary>
     public static VectorSearchRetriever ApproximateNearest(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch = false)
     {
+        TryNormalizeQueryVector(searchState.Options, searchState.Llt.Allocator, ref vector, out var queryVectorScope);
         // Bind the per-node QueryDistance cache to this query vector before SearchNearestAcrossLevels
         // reads it. Without this, a shared SearchState reuses cached distances from a prior sub-query
         // and the upper-level descent latches onto the wrong starting point.
@@ -1248,14 +1330,14 @@ public unsafe partial class Hnsw
         nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
         if (searchState.Options.CountOfVectors == 0)
-            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false);
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
 
         searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel);
         var nearest = nearestNodesByLevel[0];
         nearestNodesByLevel.Clear();
         var nearestEdgesSearch = searchState.NearestSearch(nearest, vector, 0, numberOfCandidates, nearestNodesByLevel,
             SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists, hasFilterMatch);
-        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false);
+        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
     }
 
     /// <summary>
@@ -1264,9 +1346,10 @@ public unsafe partial class Hnsw
     /// </summary>
     public static VectorSearchRetriever ExactNearest(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch, ContextBoundNativeList<long>? nodesToScan = null)
     {
+        TryNormalizeQueryVector(searchState.Options, searchState.Llt.Allocator, ref vector, out var queryVectorScope);
         searchState.OnQueryVector(vector);
         var results = searchState.ExactSearch(vector, hasFilterMatch, numberOfCandidates, nodesToScan);
-        return new VectorSearchRetriever(searchState, results, vector, minimumSimilarity, ownsSearchState: false);
+        return new VectorSearchRetriever(searchState, results, vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
     }
 
     /// <summary>
@@ -1276,6 +1359,7 @@ public unsafe partial class Hnsw
     public static VectorSearchRetriever ApproximateFilteredNearest<TEnumerator>(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, TEnumerator nodesToProbe)
         where TEnumerator : IEnumerator<long>
     {
+        TryNormalizeQueryVector(searchState.Options, searchState.Llt.Allocator, ref vector, out var queryVectorScope);
         searchState.OnQueryVector(vector);
 
         var startingPointsIndexes = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
@@ -1283,13 +1367,13 @@ public unsafe partial class Hnsw
         candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
         if (searchState.Options.CountOfVectors == 0)
-            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false);
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
 
         searchState.SearchFilteredNearest(ref startingPointsIndexes, nodesToProbe, numberOfCandidates, 16);
         candidates.Clear();
         var nearestEdgesSearch = searchState.NearestSearch(startingPointsIndexes, vector, 0, numberOfCandidates, candidates,
             SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists);
-        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false);
+        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
     }
 
     public static VectorSearchRetriever EmptySearch(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity)

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -289,6 +289,31 @@ public unsafe partial class Hnsw
         }
 
         /// <summary>
+        /// Resolves edge indexes for a node at the specified level, caching the result in
+        /// <see cref="Node.EdgesIndexesPerLevel"/>. On cache hit the expensive
+        /// <see cref="LoadNodeIndexes"/> dictionary lookups are skipped entirely.
+        /// May grow the nodes array — callers must re-fetch any outstanding node refs afterward.
+        /// </summary>
+        private void ResolveEdgeIndexes(int nodeIndex, int level, ref NativeList<long> nodeIds, ref NativeList<int> indexes)
+        {
+            ref var node = ref GetNodeByIndex(nodeIndex);
+
+            if (node.EdgesIndexesPerLevel.Count > level &&
+                node.EdgesIndexesPerLevel[level].Count == node.EdgesPerLevel[level].Count)
+            {
+                indexes.ResetAndCopyFrom(Llt.Allocator, node.EdgesIndexesPerLevel[level].ToSpan());
+                return;
+            }
+
+            nodeIds.ResetAndCopyFrom(Llt.Allocator, node.EdgesPerLevel[level].ToSpan());
+            LoadNodeIndexes(ref nodeIds, ref indexes);
+
+            node = ref GetNodeByIndex(nodeIndex);
+            node.EdgesIndexesPerLevel.SetCapacity(Llt.Allocator, level + 1);
+            node.EdgesIndexesPerLevel[level].ResetAndCopyFrom(Llt.Allocator, indexes.ToSpan());
+        }
+
+        /// <summary>
         /// This accepts a list of node ids (mutable, we do destructive updates to it) and translate
         /// that to a list of the indexes in the nodes array. If needed, it will load the nodes
         /// from the disk in a batch oriented manner.
@@ -543,10 +568,8 @@ public unsafe partial class Hnsw
                 do
                 {
                     moved = false;
-                    ref var n = ref GetNodeByIndex(currentNodeIndex);
-                    Debug.Assert(n.GetLevelCount() > level, "n.GetLevelCount() > level");
-                    nodeIds.ResetAndCopyFrom(Llt.Allocator, n.EdgesAtLevel(level));
-                    LoadNodeIndexes(ref nodeIds, ref indexes);
+                    Debug.Assert(GetNodeByIndex(currentNodeIndex).GetLevelCount() > level, "n.GetLevelCount() > level");
+                    ResolveEdgeIndexes(currentNodeIndex, level, ref nodeIds, ref indexes);
                     for (var i = 0; i < indexes.Count; i++)
                     {
                         var edgeIdx = indexes[i];

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -805,6 +805,14 @@ public unsafe partial class Hnsw
     {
         public bool IsCommited { get; private set; }
         private readonly Dictionary<ByteString, (ByteString Key, int NodeIndex, NativeList<long> PostingList)> _vectorHashCache = new(ByteStringContentComparer.Instance);
+
+        /// <summary>
+        /// Node ids whose persisted record was written or rewritten during this commit. The
+        /// post-commit cache update (HnswIndexCache.ApplyCommit) consumes this set to bring the
+        /// in-memory cache forward without re-running BFS from the entry point. Populated by
+        /// the persistence loop in Commit.
+        /// </summary>
+        public HashSet<long> DirtyNodeIds { get; } = new();
         private readonly Lookup<Int64LookupKey> _nodesByVectorId;
         private SearchState _searchState;
         public Random Random;
@@ -1073,6 +1081,7 @@ public unsafe partial class Hnsw
             for (int i = 0; i < nodes.Length; i++)
             {
                 PersistNode(ref nodes[i], ref byteBuffer);
+                DirtyNodeIds.Add(nodes[i].NodeId);
             }
 
             // flush the local modifications
@@ -1280,13 +1289,13 @@ public unsafe partial class Hnsw
      where TEnumerator : IEnumerator<long>
     {
         var searchState = new SearchState(llt, name, ref vector);
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
+
         var startingPointsIndexes = new ContextBoundNativeList<int>(llt.Allocator);
         var candidates = new ContextBoundNativeList<int>(llt.Allocator);
         candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
-        if (searchState.Options.CountOfVectors == 0)
-            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
-        
         searchState.SearchFilteredNearest(ref startingPointsIndexes, nodesToProbe, numberOfCandidates, 16);
         candidates.Clear();
         var nearestEdgesSearch = searchState.NearestSearch(startingPointsIndexes, vector, 0, numberOfCandidates, candidates,
@@ -1297,12 +1306,12 @@ public unsafe partial class Hnsw
     public static VectorSearchRetriever ApproximateNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch = false)
     {
         var searchState = new SearchState(llt, name, ref vector);
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
+
         var nearestNodesByLevel = new ContextBoundNativeList<int>(llt.Allocator);
         nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
-        if (searchState.Options.CountOfVectors == 0)
-            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
-        
         searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel);
         var nearest = nearestNodesByLevel[0];
         nearestNodesByLevel.Clear();
@@ -1326,11 +1335,11 @@ public unsafe partial class Hnsw
         // and the upper-level descent latches onto the wrong starting point.
         searchState.OnQueryVector(vector);
 
-        var nearestNodesByLevel = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
-        nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
-
         if (searchState.Options.CountOfVectors == 0)
             return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
+
+        var nearestNodesByLevel = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
+        nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
         searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel);
         var nearest = nearestNodesByLevel[0];
@@ -1362,12 +1371,12 @@ public unsafe partial class Hnsw
         TryNormalizeQueryVector(searchState.Options, searchState.Llt.Allocator, ref vector, out var queryVectorScope);
         searchState.OnQueryVector(vector);
 
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
+
         var startingPointsIndexes = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
         var candidates = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
         candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
-
-        if (searchState.Options.CountOfVectors == 0)
-            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false, queryVectorScope);
 
         searchState.SearchFilteredNearest(ref startingPointsIndexes, nodesToProbe, numberOfCandidates, 16);
         candidates.Clear();

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -194,12 +194,23 @@ public unsafe partial class Hnsw
             Options = Unsafe.Read<Options>(optionsPtr);
             SimilarityCalc = _nodeCache != null ? _nodeCache.SimilarityCalc : GetDistanceKernel(Options);
 
+            if (_nodeCache != null)
+            {
+                // Skip ~7 NativeList<Node>.Grow doublings (and Dictionary rehashes) for the typical
+                // per-query visit set when a shared cache is attached. ByteStringMemoryCache.Allocate
+                // showed 36.5s of 165s wall in NativeList<Node>.Grow under load; pre-sizing kills it.
+                _nodes.Initialize(llt.Allocator, InitialNodesCapacityWithCache);
+                _nodeIdToIdx.EnsureCapacity(InitialNodesCapacityWithCache);
+            }
+
             // Lazy lookup only: LoadNodeIndexes / GetNodeIndexById probe the shared cache
             // on demand. Eagerly materializing the entire cache into a per-query SearchState
             // dominated query wall (~49% in dotnet-trace) because the prepop work isn't
             // amortized — each Corax query builds its own IndexSearcher and SearchState.
             // Call PrepopulateFromNodeCache() explicitly for long-lived/batch SearchStates only.
         }
+
+        private const int InitialNodesCapacityWithCache = 256;
 
         public float MinimumSimilarityToDistance(float minimumSimilarity)
         {

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -99,9 +99,17 @@ public unsafe partial class Hnsw
         private readonly Tree _tree;
         private readonly Lookup<Int64LookupKey> _nodeIdToLocations;
         public readonly LowLevelTransaction Llt;
-        private int _visitsCounter;
+        // _visitsCounter versions Node.Visited; every traversal start bumps it so the visited
+        // set is reset in O(1). _queryVectorVersion versions Node.QueryDistanceVersion; it is
+        // bumped by OnQueryVector only when the query vector changes, so a node's cached distance
+        // survives across traversals that reuse the same query vector. Both start at 1 so
+        // freshly-loaded nodes (fields default to 0) never spuriously match.
+        private int _visitsCounter = 1;
+        private int _queryVectorVersion = 1;
+        private Memory<byte> _lastQueryVector;
         public readonly delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> SimilarityCalc;
         public readonly bool IsEmpty;
+        private readonly HnswIndexCache _nodeCache;
 
         public Span<Node> Nodes => _nodes.ToSpan();
         public Tree Tree => _tree;
@@ -124,9 +132,14 @@ public unsafe partial class Hnsw
         
         public Lookup<Int64LookupKey> NodeIdsByVectorId => _tree.LookupFor<Int64LookupKey>(Hnsw.NodesByVectorIdSlice);
 
-        public SearchState(LowLevelTransaction llt, Slice name)
+        public SearchState(LowLevelTransaction llt, Slice name) : this(llt, name, null)
+        {
+        }
+
+        public SearchState(LowLevelTransaction llt, Slice name, HnswIndexCache nodeCache)
         {
             Llt = llt;
+            _nodeCache = nodeCache;
             _tree = llt.Transaction.ReadTree(name);
 
             if (_tree is null || _tree.TryGetLookupFor(NodeIdToLocationSlice, out _nodeIdToLocations) == false)
@@ -135,15 +148,24 @@ public unsafe partial class Hnsw
                 return;
             }
 
-            var options = _tree.DirectRead(OptionsSlice);
-            Options = Unsafe.Read<Options>(options);
-            SimilarityCalc = Options.SimilarityMethod switch
+            if (_nodeCache != null)
             {
-                SimilarityMethod.CosineSimilaritySingles => &CosineDistanceSingles,
-                SimilarityMethod.CosineSimilarityI8 => &CosineDistanceI8,
-                SimilarityMethod.HammingDistance => &HammingDistance,
-                _ => throw new ArgumentOutOfRangeException(nameof(Options.SimilarityMethod), Options.SimilarityMethod, null)
-            };
+                // Use options and similarity calc from the cache (already resolved)
+                Options = _nodeCache.Options;
+                SimilarityCalc = _nodeCache.SimilarityCalc;
+            }
+            else
+            {
+                var options = _tree.DirectRead(OptionsSlice);
+                Options = Unsafe.Read<Options>(options);
+                SimilarityCalc = Options.SimilarityMethod switch
+                {
+                    SimilarityMethod.CosineSimilaritySingles => &CosineDistanceSingles,
+                    SimilarityMethod.CosineSimilarityI8 => &CosineDistanceI8,
+                    SimilarityMethod.HammingDistance => &HammingDistance,
+                    _ => throw new ArgumentOutOfRangeException(nameof(Options.SimilarityMethod), Options.SimilarityMethod, null)
+                };
+            }
         }
 
         public float MinimumSimilarityToDistance(float minimumSimilarity)
@@ -239,6 +261,34 @@ public unsafe partial class Hnsw
         }
 
         /// <summary>
+        /// Populate a local node from the shared HnswIndexCache. Edge slices are copied into
+        /// local <see cref="NativeList{T}"/>s because NativeLists can't be shared across
+        /// allocator boundaries. Vector span is left default — <see cref="Node.GetVectorUnmanagedSpan"/>
+        /// lazily resolves it via <c>Llt</c>, which is consistent with the cache because the
+        /// publication invariant guarantees the cache reflects state visible to this
+        /// transaction's snapshot.
+        /// </summary>
+        private void CopyNodeFromCache(in HnswIndexCache.CachedNodeView cached, ref Node local)
+        {
+            local.NodeId = cached.Header->NodeId;
+            local.PostingListId = cached.Header->PostingListId;
+            local.VectorId = cached.Header->VectorId;
+            // local._vectorSpan and per-query scratch (Visited, QueryDistance*) stay at default.
+
+            int levelCount = cached.Header->LevelCount;
+            local.EdgesPerLevel.EnsureCapacityFor(Llt.Allocator, levelCount);
+            for (int lvl = 0; lvl < levelCount; lvl++)
+            {
+                var src = cached.EdgesAtLevel(lvl);
+                var dst = new NativeList<long>();
+                dst.EnsureCapacityFor(Llt.Allocator, src.Length);
+                for (int e = 0; e < src.Length; e++)
+                    dst.AddUnsafe(src[e]);
+                local.EdgesPerLevel.AddUnsafe(dst);
+            }
+        }
+
+        /// <summary>
         /// This accepts a list of node ids (mutable, we do destructive updates to it) and translate
         /// that to a list of the indexes in the nodes array. If needed, it will load the nodes
         /// from the disk in a batch oriented manner.
@@ -252,6 +302,18 @@ public unsafe partial class Hnsw
                 {
                     indexes.AddUnsafe(index);
                     nodeIds[i] = -1;
+                    continue;
+                }
+
+                // Check the shared HnswIndexCache before going to disk
+                if (_nodeCache != null && _nodeCache.TryGetNode(nodeIds[i], out var cached))
+                {
+                    var localIdx = AllocateNodeIndex(nodeIds[i]);
+                    CopyNodeFromCache(in cached, ref _nodes[localIdx]);
+                    _nodeIdToIdx[nodeIds[i]] = localIdx;
+                    indexes.AddUnsafe(localIdx);
+                    nodeIds[i] = -1;
+                    continue;
                 }
             }
 
@@ -288,6 +350,16 @@ public unsafe partial class Hnsw
             if (exists)
                 return nodeIdx;
 
+            // Check the shared HnswIndexCache for a pre-loaded copy.
+            // Deep-copy edge lists into the local allocator (NativeLists can't cross allocator boundaries).
+            // Vector data is read on demand through this transaction; the cache itself doesn't pin pages.
+            if (_nodeCache != null && _nodeCache.TryGetNode(nodeId, out var cached))
+            {
+                nodeIdx = AllocateNodeIndex(nodeId);
+                CopyNodeFromCache(in cached, ref GetNodeByIndex(nodeIdx));
+                return nodeIdx;
+            }
+
             if (TryGetLocationForNode(nodeId, out var nodeLocation) is false)
                 throw new InvalidOperationException($"Unable to find node id {nodeId}");
 
@@ -318,12 +390,12 @@ public unsafe partial class Hnsw
             }
 
             ref var to = ref GetNodeByIndex(toIdx);
-            if (to.QueryDistance is not null)
-                return to.QueryDistance.Value;
-            
+            if (to.QueryDistanceVersion == _queryVectorVersion)
+                return to.QueryDistanceValue;
+
             Span<byte> v2 = to.GetVector(this);
             var distance = SimilarityCalc(vector, v2);
-            
+
             return distance;
         }
 
@@ -331,17 +403,30 @@ public unsafe partial class Hnsw
         public float QueryDistance(ReadOnlySpan<byte> vector, int toIdx, ref long vectorReadCounter)
         {
             ref var to = ref GetNodeByIndex(toIdx);
-            if (to.QueryDistance is not null)
-            {
-                return to.QueryDistance.Value;
-            }
-            
+            if (to.QueryDistanceVersion == _queryVectorVersion)
+                return to.QueryDistanceValue;
+
             Span<byte> v2 = to.GetVector(this);
             vectorReadCounter++;
             var distance = SimilarityCalc(vector, v2);
-            to.QueryDistance = distance;
-
+            to.QueryDistanceValue = distance;
+            to.QueryDistanceVersion = _queryVectorVersion;
             return distance;
+        }
+
+        /// <summary>
+        /// Records the query vector a searcher is about to use. Bumps <see cref="_queryVectorVersion"/>
+        /// iff the vector differs from the previously recorded one (compared by Memory identity, i.e.
+        /// same underlying buffer and range). A bump invalidates every cached QueryDistance; a no-op
+        /// keeps them valid.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void OnQueryVector(Memory<byte> queryVector)
+        {
+            if (queryVector.Equals(_lastQueryVector))
+                return;
+            _lastQueryVector = queryVector;
+            ++_queryVectorVersion;
         }
 
         public void ReadPostingList(ContainerEntryId rawPostingListId, ref ContextBoundNativeList<long> listBuffer, ref FastPForDecoder pforDecoder, out int postingListSize)
@@ -409,7 +494,7 @@ public unsafe partial class Hnsw
                 var currentNodeIndex = nodesFromFilter.Current;
                 var nodeId = GetNodeIndexById(currentNodeIndex);
                 ref var entry = ref GetNodeByIndex(nodeId);
-                var currentNodeMaximumLevel = entry.EdgesPerLevel.Count;
+                var currentNodeMaximumLevel = entry.GetLevelCount();
 
                 if (nearestCandidates.Count < candidatesRequested)
                 {
@@ -459,9 +544,8 @@ public unsafe partial class Hnsw
                 {
                     moved = false;
                     ref var n = ref GetNodeByIndex(currentNodeIndex);
-                    Debug.Assert(n.EdgesPerLevel.Count > level, "n.EdgesPerLevel.Count > level");
-                    ref var edges = ref n.EdgesPerLevel[level];
-                    nodeIds.ResetAndCopyFrom(Llt.Allocator, edges.ToSpan());
+                    Debug.Assert(n.GetLevelCount() > level, "n.GetLevelCount() > level");
+                    nodeIds.ResetAndCopyFrom(Llt.Allocator, n.EdgesAtLevel(level));
                     LoadNodeIndexes(ref nodeIds, ref indexes);
                     for (var i = 0; i < indexes.Count; i++)
                     {
@@ -603,7 +687,7 @@ public unsafe partial class Hnsw
            {
                // note, small vectors (where multiple can fit in a single page), will be 
                // partition inside the SetVector if needed
-               _nodes[nodeIndexes[i]].SetVector(this, spans[i]);
+               _nodes[nodeIndexes[i]].SetVector(Options, spans[i]);
            }
        }
 
@@ -612,14 +696,27 @@ public unsafe partial class Hnsw
            return _nodeIdToIdx.TryGetValue(nodeId, out nodeIndex);
        }
 
+       /// <summary>
+       /// Debug-only check that the candidate and nearest-edges priority queues owned by this
+       /// SearchState are empty. A searcher that reuses a shared SearchState must leave these
+       /// queues empty on Dispose; this method catches a searcher that fails to do so before the
+       /// next one starts.
+       /// </summary>
+       [Conditional("DEBUG")]
+       public void AssertSharedQueuesClean()
+       {
+           Debug.Assert(_candidatesQ.Count == 0, "_candidatesQ must be empty between sub-queries on a shared SearchState");
+           Debug.Assert(_nearestEdgesQ.Count == 0, "_nearestEdgesQ must be empty between sub-queries on a shared SearchState");
+       }
+
        public void Dispose()
        {
            _candidatesQ.Clear();
            _nearestEdgesQ.Clear();
            _newNodes.Dispose(Llt.Allocator);
-           
+
            _nodes.Dispose(Llt.Allocator);
-           
+
        }
     }
 
@@ -1108,6 +1205,68 @@ public unsafe partial class Hnsw
         var nearestEdgesSearch = searchState.NearestSearch(nearest, vector, 0, numberOfCandidates, nearestNodesByLevel,
             SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists, hasFilterMatch);
         return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity);
+    }
+
+    /// <summary>
+    /// Approximate nearest neighbor search using a caller-owned <see cref="SearchState"/>. The
+    /// caller keeps the SearchState alive across multiple queries and is responsible for
+    /// disposing it; node data loaded by earlier queries remains in SearchState for later ones,
+    /// so repeated traversals avoid the node-index resolution and container reads already paid
+    /// for on the first pass.
+    /// </summary>
+    public static VectorSearchRetriever ApproximateNearest(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch = false)
+    {
+        // Bind the per-node QueryDistance cache to this query vector before SearchNearestAcrossLevels
+        // reads it. Without this, a shared SearchState reuses cached distances from a prior sub-query
+        // and the upper-level descent latches onto the wrong starting point.
+        searchState.OnQueryVector(vector);
+
+        var nearestNodesByLevel = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
+        nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
+
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false);
+
+        searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel);
+        var nearest = nearestNodesByLevel[0];
+        nearestNodesByLevel.Clear();
+        var nearestEdgesSearch = searchState.NearestSearch(nearest, vector, 0, numberOfCandidates, nearestNodesByLevel,
+            SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists, hasFilterMatch);
+        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false);
+    }
+
+    /// <summary>
+    /// Exact nearest neighbor search using a caller-owned SearchState.
+    /// The caller is responsible for disposing the SearchState.
+    /// </summary>
+    public static VectorSearchRetriever ExactNearest(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch, ContextBoundNativeList<long>? nodesToScan = null)
+    {
+        searchState.OnQueryVector(vector);
+        var results = searchState.ExactSearch(vector, hasFilterMatch, numberOfCandidates, nodesToScan);
+        return new VectorSearchRetriever(searchState, results, vector, minimumSimilarity, ownsSearchState: false);
+    }
+
+    /// <summary>
+    /// Approximate filtered nearest neighbor search using a caller-owned SearchState.
+    /// The caller is responsible for disposing the SearchState.
+    /// </summary>
+    public static VectorSearchRetriever ApproximateFilteredNearest<TEnumerator>(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, TEnumerator nodesToProbe)
+        where TEnumerator : IEnumerator<long>
+    {
+        searchState.OnQueryVector(vector);
+
+        var startingPointsIndexes = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
+        var candidates = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
+        candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
+
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false);
+
+        searchState.SearchFilteredNearest(ref startingPointsIndexes, nodesToProbe, numberOfCandidates, 16);
+        candidates.Clear();
+        var nearestEdgesSearch = searchState.NearestSearch(startingPointsIndexes, vector, 0, numberOfCandidates, candidates,
+            SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists);
+        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false);
     }
 
     public static VectorSearchRetriever EmptySearch(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity)

--- a/src/Voron/Data/Graphs/HnswIndexCache.cs
+++ b/src/Voron/Data/Graphs/HnswIndexCache.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -14,45 +13,58 @@ using Voron.Util;
 namespace Voron.Data.Graphs;
 
 /// <summary>
-/// Per-index in-memory cache of HNSW node topology backed by a single contiguous unmanaged
-/// buffer. Each cached node is laid out as a fixed header followed by per-level offsets and
-/// the flat edge list. Lookups go through a <see cref="ConcurrentDictionary{TKey,TValue}"/>
-/// keyed by node id; the dict is the publication point for newly appended records and
-/// provides the acquire load that lets readers observe the bytes a writer placed before
-/// publishing.
+/// Per-index in-memory cache of HNSW node topology. Lookups are gated on
+/// <c>PublishedAtTxId &lt;= readerTxId</c>: a reader never sees an entry stamped by a commit
+/// it cannot see on disk. The backing buffer grows monotonically; superseded regions are
+/// not reclaimed and further appends fail gracefully once full.
 ///
-/// The cache is initially populated by <see cref="WarmFromScratch"/> (BFS from the entry
-/// point through every reachable node up to the configured budget) and incrementally
-/// maintained by <see cref="ApplyCommit"/> after each indexing commit. Capacity is
-/// provisioned at construction time; if the buffer fills, further <see cref="TryAppend"/>
-/// calls fail gracefully and those nodes simply miss the cache.
+/// Hash collisions are resolved by 1-step linear probing into a secondary slot; if both
+/// slots are held by other ids the insert is refused and the node is left uncached.
+/// A per-slot even/odd Version protects the NodeId/Offset/PublishedAtTxId triple from
+/// torn reads: writers bump the version to odd while mutating and to the next even when
+/// stable; readers fail the lookup if the version changes around their field reads. This
+/// keeps the cache lock-free with single-writer-per-cache semantics and an unbounded
+/// number of concurrent readers.
 /// </summary>
 public sealed unsafe class HnswIndexCache : IDisposable
 {
     public readonly Hnsw.Options Options;
     public readonly delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> SimilarityCalc;
 
+    private Slot* _slots;
+    private readonly int _slotCount;
+    private readonly int _slotMask;
+
     private byte* _buffer;
     private long _writeHead;
     private readonly long _capacityBytes;
-    private readonly ConcurrentDictionary<long, NodeRef> _ids;
+
+    private int _published;
+
     private int _disposed;
 
-    public int Count => _ids.Count;
+    public int Count => Volatile.Read(ref _published);
     public long CapacityBytes => _capacityBytes;
     public long UsedBytes => Volatile.Read(ref _writeHead);
+    public int SlotCount => _slotCount;
 
-    public HnswIndexCache(long capacityBytes, in Hnsw.Options options,
+    public HnswIndexCache(long capacityBytes, int slotCount, in Hnsw.Options options,
         delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> similarityCalc)
     {
         if (capacityBytes <= 0)
             throw new ArgumentOutOfRangeException(nameof(capacityBytes), capacityBytes, "capacity must be positive");
+        if (slotCount <= 0 || (slotCount & (slotCount - 1)) != 0)
+            throw new ArgumentOutOfRangeException(nameof(slotCount), slotCount, "slot count must be a positive power of two");
 
         _capacityBytes = capacityBytes;
+        _slotCount = slotCount;
+        _slotMask = slotCount - 1;
         _buffer = (byte*)NativeMemory.AlignedAlloc((nuint)capacityBytes, 4096);
         if (_buffer == null)
             throw new OutOfMemoryException($"Failed to allocate {capacityBytes} bytes for the HNSW node cache.");
-        _ids = new ConcurrentDictionary<long, NodeRef>();
+        _slots = (Slot*)NativeMemory.AlignedAlloc((nuint)(sizeof(Slot) * slotCount), 64);
+        new Span<byte>(_slots, sizeof(Slot) * slotCount).Clear();
+
         Options = options;
         SimilarityCalc = similarityCalc;
     }
@@ -69,16 +81,15 @@ public sealed unsafe class HnswIndexCache : IDisposable
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
-        var ptr = _buffer;
-        _buffer = null;
-        if (ptr != null)
-            NativeMemory.AlignedFree(ptr);
+        var buf = _buffer; _buffer = null;
+        var slots = _slots; _slots = null;
+        if (buf != null) NativeMemory.AlignedFree(buf);
+        if (slots != null) NativeMemory.AlignedFree(slots);
     }
 
-    /// <summary>
-    /// Reserve a 64-byte-aligned region of <paramref name="sizeBytes"/> in the buffer. Lock-free
-    /// CAS on <see cref="_writeHead"/>; fails when the cap is reached.
-    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int SlotIndexFor(long nodeId) => Sparrow.Hashing.Mix(nodeId) & _slotMask;
+
     public bool TryAllocate(int sizeBytes, out long offset)
     {
         int aligned = AlignUp(sizeBytes, 64);
@@ -98,22 +109,57 @@ public sealed unsafe class HnswIndexCache : IDisposable
     }
 
     /// <summary>
-    /// Append a node record. The bytes are written first; the dict entry publishes them via the
-    /// volatile store at the end of <see cref="ConcurrentDictionary{TKey,TValue}.TryAdd"/>.
-    /// Returns false on capacity exhaustion or duplicate id.
+    /// Returns false only when the buffer is full; once that happens, every subsequent
+    /// TryAppend also fails so the caller should stop. Slot collisions (both probe slots
+    /// occupied by other ids) are skipped silently — the node simply isn't cached and the
+    /// call still returns true.
     /// </summary>
-    public bool TryAppend(long nodeId, in CachedNodeBuilder src)
+    public bool TryAppend(long nodeId, long publishAtTxId, in CachedNodeBuilder src)
     {
+        Debug.Assert(publishAtTxId > 0, "publishAtTxId must be a real tx id");
         Debug.Assert(src.LevelOffsets.Length == src.LevelCount + 1, "level offsets length mismatch");
         Debug.Assert(src.Edges.Length == src.EdgesTotalCount, "edges length mismatch");
+
+        // Refuse rather than evict when both probe slots are held by other ids: silent
+        // eviction of a still-valid entry would break readers that found it cacheable a
+        // moment ago, and the warm-up path can tolerate occasional uncached nodes.
+        int chosen = PickAppendSlot(nodeId);
+        if (chosen < 0)
+            return true;
 
         int totalBytes = sizeof(CachedNodeHeader)
                          + sizeof(int) * (src.LevelCount + 1)
                          + sizeof(long) * src.EdgesTotalCount;
-
         if (TryAllocate(totalBytes, out long offset) == false)
             return false;
 
+        WriteNodeBytes(offset, nodeId, in src);
+        PublishSlot(chosen, nodeId, publishAtTxId, offset);
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int PickAppendSlot(long nodeId)
+    {
+        int primary = SlotIndexFor(nodeId);
+        if (SlotAcceptsNodeId(primary, nodeId))
+            return primary;
+        int secondary = (primary + 1) & _slotMask;
+        if (SlotAcceptsNodeId(secondary, nodeId))
+            return secondary;
+        return -1;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool SlotAcceptsNodeId(int slotIdx, long nodeId)
+    {
+        ref var slot = ref _slots[slotIdx];
+        long pub = Volatile.Read(ref slot.PublishedAtTxId);
+        return pub == 0 || Volatile.Read(ref slot.NodeId) == nodeId;
+    }
+
+    private void WriteNodeBytes(long offset, long nodeId, in CachedNodeBuilder src)
+    {
         var h = (CachedNodeHeader*)(_buffer + offset);
         h->NodeId = nodeId;
         h->PostingListId = src.PostingListId;
@@ -123,39 +169,129 @@ public sealed unsafe class HnswIndexCache : IDisposable
         h->_padding1 = 0;
         h->EdgesTotalCount = src.EdgesTotalCount;
 
-        var offsets = (int*)(h + 1);
-        src.LevelOffsets.CopyTo(new Span<int>(offsets, src.LevelCount + 1));
-
-        var edges = (long*)(offsets + src.LevelCount + 1);
+        var offs = (int*)(h + 1);
+        src.LevelOffsets.CopyTo(new Span<int>(offs, src.LevelCount + 1));
+        var edges = (long*)(offs + src.LevelCount + 1);
         src.Edges.CopyTo(new Span<long>(edges, src.EdgesTotalCount));
+    }
 
-        // Linearization point: only after the bytes above are written do readers become able to
-        // discover this record. ConcurrentDictionary does not document release semantics for the
-        // bucket store, so on weakly-ordered architectures (ARM64) the buffer writes above and the
-        // dictionary insert below could be observed out of order by a reader on another core. This
-        // fence makes the buffer writes globally visible before the record is published; the reader
-        // side gets an acquire load from the dictionary plus a control dependency on the offset.
-        Interlocked.MemoryBarrier();
-        return _ids.TryAdd(nodeId, new NodeRef(offset));
+    // Seqlock write: bump Version to odd, release the field stores, bump to next even.
+    // Readers observing the odd version (or a mismatch between their pre/post version reads)
+    // bail. Only an empty→occupied transition counts against _published.
+    private void PublishSlot(int slotIdx, long nodeId, long publishAtTxId, long offset)
+    {
+        ref var slot = ref _slots[slotIdx];
+        bool wasResident = Volatile.Read(ref slot.PublishedAtTxId) != 0;
+
+        long v = Volatile.Read(ref slot.Version);
+        Volatile.Write(ref slot.Version, v + 1);
+        Volatile.Write(ref slot.NodeId, nodeId);
+        Volatile.Write(ref slot.Offset, offset);
+        Volatile.Write(ref slot.PublishedAtTxId, publishAtTxId);
+        Volatile.Write(ref slot.Version, v + 2);
+
+        if (wasResident == false)
+            Interlocked.Increment(ref _published);
+    }
+
+    /// <summary>
+    /// Caller must invoke from the AfterCommit hook where no new reader can start: the
+    /// release-store on PublishedAtTxId must be visible before any reader at the new tx
+    /// can issue a lookup.
+    /// </summary>
+    public void Evict(long nodeId, long atTxId)
+    {
+        _ = atTxId;
+        int primary = SlotIndexFor(nodeId);
+        if (Volatile.Read(ref _slots[primary].NodeId) == nodeId)
+        {
+            EvictSlot(primary);
+            return;
+        }
+        int secondary = (primary + 1) & _slotMask;
+        if (Volatile.Read(ref _slots[secondary].NodeId) == nodeId)
+            EvictSlot(secondary);
+    }
+
+    private void EvictSlot(int slotIdx)
+    {
+        ref var slot = ref _slots[slotIdx];
+        long v = Volatile.Read(ref slot.Version);
+        Volatile.Write(ref slot.Version, v + 1);
+
+        bool wasResident = Volatile.Read(ref slot.PublishedAtTxId) != 0;
+        Volatile.Write(ref slot.PublishedAtTxId, 0);
+
+        Volatile.Write(ref slot.Version, v + 2);
+
+        if (wasResident)
+            Interlocked.Decrement(ref _published);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryGetNode(long nodeId, out CachedNodeView view)
+    public bool TryGetNode(long nodeId, long readerTxId, out CachedNodeView view)
     {
-        if (_ids.TryGetValue(nodeId, out var r) == false)
+        int primary = SlotIndexFor(nodeId);
+        if (TryReadSlot(primary, nodeId, readerTxId, out view))
+            return true;
+        return TryReadSlot((primary + 1) & _slotMask, nodeId, readerTxId, out view);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryReadSlot(int slotIdx, long nodeId, long readerTxId, out CachedNodeView view)
+    {
+        ref var slot = ref _slots[slotIdx];
+
+        // Seqlock read: capture version, observe fields, re-read version. If the writer
+        // raced through this slot the two version reads disagree (or the first is odd),
+        // and we return a clean miss — the caller will fall back to disk.
+        long v1 = Volatile.Read(ref slot.Version);
+        if ((v1 & 1) != 0)
         {
             view = default;
             return false;
         }
-        var h = (CachedNodeHeader*)(_buffer + r.Offset);
+
+        long ts = Volatile.Read(ref slot.PublishedAtTxId);
+        long slotNodeId = Volatile.Read(ref slot.NodeId);
+        long offset = Volatile.Read(ref slot.Offset);
+
+        long v2 = Volatile.Read(ref slot.Version);
+        if (v1 != v2 || ts == 0 || ts > readerTxId || slotNodeId != nodeId)
+        {
+            view = default;
+            return false;
+        }
+
+        var h = (CachedNodeHeader*)(_buffer + offset);
         var offs = (int*)(h + 1);
         var edges = (long*)(offs + h->LevelCount + 1);
         view = new CachedNodeView(h, offs, edges);
         return true;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool ContainsNode(long nodeId) => _ids.ContainsKey(nodeId);
+    public void ForEachNode(long readerTxId, Action<long, CachedNodeView> visitor)
+    {
+        for (int i = 0; i < _slotCount; i++)
+        {
+            ref var slot = ref _slots[i];
+
+            long v1 = Volatile.Read(ref slot.Version);
+            if ((v1 & 1) != 0) continue;
+
+            long ts = Volatile.Read(ref slot.PublishedAtTxId);
+            long nodeId = Volatile.Read(ref slot.NodeId);
+            long offset = Volatile.Read(ref slot.Offset);
+
+            long v2 = Volatile.Read(ref slot.Version);
+            if (v1 != v2 || ts == 0 || ts > readerTxId || nodeId == 0) continue;
+
+            var h = (CachedNodeHeader*)(_buffer + offset);
+            var offs = (int*)(h + 1);
+            var edges = (long*)(offs + h->LevelCount + 1);
+            visitor(nodeId, new CachedNodeView(h, offs, edges));
+        }
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int AlignUp(int v, int align) => (v + align - 1) & ~(align - 1);
@@ -163,11 +299,6 @@ public sealed unsafe class HnswIndexCache : IDisposable
     private static delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> ResolveSimilarityKernel(in Hnsw.Options options) =>
         Hnsw.GetDistanceKernel(options);
 
-    /// <summary>
-    /// Conservative bytes-per-node estimate used to translate a node-count budget into a buffer
-    /// size at construction time. Worst-case node has <c>2*numberOfEdges</c> entries at level 0
-    /// across the flat edge list.
-    /// </summary>
     public static int EstimateBytesPerNode(int numberOfEdges)
     {
         const int AvgLevelCount = 4;
@@ -175,6 +306,18 @@ public sealed unsafe class HnswIndexCache : IDisposable
                + sizeof(int) * (AvgLevelCount + 1)
                + sizeof(long) * 2 * numberOfEdges
                + 64;
+    }
+
+    public static int SlotCountFor(int nodeBudget) =>
+        nodeBudget <= 0 ? 1 : Sparrow.Binary.Bits.PowerOf2(nodeBudget * 2);
+
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    internal struct Slot
+    {
+        public long Version;           // seqlock: even = stable, odd = writer in progress
+        public long NodeId;            // 0 = never written
+        public long PublishedAtTxId;   // 0 = evicted; the visibility gate
+        public long Offset;
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
@@ -213,10 +356,6 @@ public sealed unsafe class HnswIndexCache : IDisposable
         }
     }
 
-    /// <summary>
-    /// Caller-built view of a node ready to be appended. The spans must remain stable for the
-    /// duration of the <see cref="TryAppend"/> call.
-    /// </summary>
     public ref struct CachedNodeBuilder
     {
         public long PostingListId;
@@ -227,16 +366,6 @@ public sealed unsafe class HnswIndexCache : IDisposable
         public ReadOnlySpan<long> Edges;
     }
 
-    private readonly record struct NodeRef(long Offset);
-
-    /// <summary>
-    /// Initial fill: BFS from the entry point. Upper levels (>= 1) are fully connected by HNSW
-    /// construction so a single sweep per level suffices. Level 0 needs full BFS because under
-    /// the standard HNSW level formula most nodes live only at level 0 and many sit &gt;1 hop
-    /// from any upper-level seed, so a single hop would silently miss them. BFS allocation
-    /// order means neighboring nodes become neighboring records in <see cref="_buffer"/>,
-    /// giving Gorder-style locality for free.
-    /// </summary>
     public static HnswIndexCache WarmFromScratch(LowLevelTransaction llt, Slice fieldName, int maxNodes)
     {
         var tree = llt.Transaction.ReadTree(fieldName);
@@ -247,8 +376,9 @@ public sealed unsafe class HnswIndexCache : IDisposable
         var simCalc = ResolveSimilarityKernel(options);
 
         long bytesPerNode = EstimateBytesPerNode(options.NumberOfEdges);
-        long capacityBytes = (long)Math.Max(1, maxNodes) * bytesPerNode * 11 / 10;
-        var cache = new HnswIndexCache(capacityBytes, options, simCalc);
+        long capacityBytes = (long)Math.Max(1, maxNodes) * bytesPerNode;
+        int slotCount = SlotCountFor(Math.Max(1, maxNodes));
+        var cache = new HnswIndexCache(capacityBytes, slotCount, options, simCalc);
 
         if (maxNodes <= 0 || locations.TryGetValue(Hnsw.EntryPointId, out _) == false)
             return cache;
@@ -273,15 +403,10 @@ public sealed unsafe class HnswIndexCache : IDisposable
                 break;
         }
 
-        builder.AppendAllPromoted(cache);
+        builder.AppendAll(cache, llt.Id);
         return cache;
     }
 
-    /// <summary>
-    /// Per-commit incremental update. Loads each dirty node from the just-committed snapshot
-    /// and appends a record. <see cref="TryAppend"/> is a no-op for nodes already present
-    /// (id collision), so re-touched nodes keep their previous cache entry.
-    /// </summary>
     public void ApplyCommit(LowLevelTransaction llt, Slice fieldName, IEnumerable<long> dirtyNodeIds)
     {
         if (dirtyNodeIds is null)
@@ -291,21 +416,17 @@ public sealed unsafe class HnswIndexCache : IDisposable
         if (tree is null || tree.TryGetLookupFor(Hnsw.NodeIdToLocationSlice, out Lookup<Int64LookupKey> locations) == false)
             return;
 
+        long txId = llt.Id;
+
         using var builder = new WarmupBuilder(llt, locations, budget: int.MaxValue);
         foreach (var nodeId in dirtyNodeIds)
         {
-            if (_ids.ContainsKey(nodeId))
-                continue;
+            Evict(nodeId, txId);
             builder.SeedAndLoad(nodeId);
         }
-        builder.AppendAllPromoted(this);
+        builder.AppendAll(this, txId);
     }
 
-    /// <summary>
-    /// BFS scratch that owns the temporary <see cref="NativeList"/>s. Emits node records in the
-    /// order they were discovered, so a subsequent bulk append produces a locality-friendly
-    /// layout in the cache buffer.
-    /// </summary>
     private sealed class WarmupBuilder : IDisposable
     {
         private readonly LowLevelTransaction _llt;
@@ -334,12 +455,6 @@ public sealed unsafe class HnswIndexCache : IDisposable
             Flush();
         }
 
-        /// <summary>
-        /// Sweep at <paramref name="level"/>: every loaded node whose level-L edge list is
-        /// non-empty contributes its neighbors to the next batch. Multiple passes are required
-        /// because a Flush appends new nodes whose own level-L edges must also be followed
-        /// before we drop down a level.
-        /// </summary>
         public void ExpandAtLevel(int level)
         {
             var seen = new HashSet<long>();
@@ -413,13 +528,7 @@ public sealed unsafe class HnswIndexCache : IDisposable
             _batch.Clear();
         }
 
-        /// <summary>
-        /// Bulk-emit every loaded node into <paramref name="cache"/>. Routers (level &gt;= 1)
-        /// and leaves (level 0 only) are both admitted; the BFS in <see cref="WarmFromScratch"/>
-        /// caps the loaded set at the configured budget, and the goal is the highest cache hit
-        /// rate over the working set rather than a structural slice of the graph.
-        /// </summary>
-        public void AppendAllPromoted(HnswIndexCache cache)
+        public void AppendAll(HnswIndexCache cache, long publishAtTxId)
         {
             Span<int> levelOffsetsScratch = stackalloc int[byte.MaxValue + 1];
             var edgesScratch = new List<long>(cache.Options.NumberOfEdges * 4);
@@ -429,7 +538,7 @@ public sealed unsafe class HnswIndexCache : IDisposable
                 ref var node = ref _working[idx];
                 int levels = node.EdgesPerLevel.Count;
                 if (levels == 0)
-                    continue; // tombstone / missing — skip
+                    continue;
 
                 edgesScratch.Clear();
                 levelOffsetsScratch[0] = 0;
@@ -450,8 +559,8 @@ public sealed unsafe class HnswIndexCache : IDisposable
                     LevelOffsets = levelOffsetsScratch[..(levels + 1)],
                     Edges = CollectionsMarshal.AsSpan(edgesScratch),
                 };
-                if (cache.TryAppend(node.NodeId, builder) == false)
-                    break; // capacity exhausted: subsequent nodes also fail, stop early
+                if (cache.TryAppend(node.NodeId, publishAtTxId, builder) == false)
+                    break;
             }
         }
 

--- a/src/Voron/Data/Graphs/HnswIndexCache.cs
+++ b/src/Voron/Data/Graphs/HnswIndexCache.cs
@@ -50,6 +50,8 @@ public sealed unsafe class HnswIndexCache : IDisposable
 
         _capacityBytes = capacityBytes;
         _buffer = (byte*)NativeMemory.AlignedAlloc((nuint)capacityBytes, 4096);
+        if (_buffer == null)
+            throw new OutOfMemoryException($"Failed to allocate {capacityBytes} bytes for the HNSW node cache.");
         _ids = new ConcurrentDictionary<long, NodeRef>();
         Options = options;
         SimilarityCalc = similarityCalc;
@@ -128,7 +130,12 @@ public sealed unsafe class HnswIndexCache : IDisposable
         src.Edges.CopyTo(new Span<long>(edges, src.EdgesTotalCount));
 
         // Linearization point: only after the bytes above are written do readers become able to
-        // discover this record. The volatile store inside TryAdd provides the release barrier.
+        // discover this record. ConcurrentDictionary does not document release semantics for the
+        // bucket store, so on weakly-ordered architectures (ARM64) the buffer writes above and the
+        // dictionary insert below could be observed out of order by a reader on another core. This
+        // fence makes the buffer writes globally visible before the record is published; the reader
+        // side gets an acquire load from the dictionary plus a control dependency on the offset.
+        Interlocked.MemoryBarrier();
         return _ids.TryAdd(nodeId, new NodeRef(offset));
     }
 

--- a/src/Voron/Data/Graphs/HnswIndexCache.cs
+++ b/src/Voron/Data/Graphs/HnswIndexCache.cs
@@ -161,13 +161,7 @@ public sealed unsafe class HnswIndexCache : IDisposable
     private static int AlignUp(int v, int align) => (v + align - 1) & ~(align - 1);
 
     private static delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> ResolveSimilarityKernel(in Hnsw.Options options) =>
-        options.SimilarityMethod switch
-        {
-            Hnsw.SimilarityMethod.CosineSimilaritySingles => &Hnsw.CosineDistanceSingles,
-            Hnsw.SimilarityMethod.CosineSimilarityI8 => &Hnsw.CosineDistanceI8,
-            Hnsw.SimilarityMethod.HammingDistance => &Hnsw.HammingDistance,
-            _ => throw new ArgumentOutOfRangeException(nameof(options.SimilarityMethod), options.SimilarityMethod, null)
-        };
+        Hnsw.GetDistanceKernel(options);
 
     /// <summary>
     /// Conservative bytes-per-node estimate used to translate a node-count budget into a buffer

--- a/src/Voron/Data/Graphs/HnswIndexCache.cs
+++ b/src/Voron/Data/Graphs/HnswIndexCache.cs
@@ -1,0 +1,463 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Sparrow;
+using Voron.Data.Containers;
+using Voron.Data.Lookups;
+using Voron.Impl;
+using Voron.Util;
+
+namespace Voron.Data.Graphs;
+
+/// <summary>
+/// Per-index in-memory cache of HNSW node topology backed by a single contiguous unmanaged
+/// buffer. Each cached node is laid out as a fixed header followed by per-level offsets and
+/// the flat edge list. Lookups go through a <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// keyed by node id; the dict is the publication point for newly appended records and
+/// provides the acquire load that lets readers observe the bytes a writer placed before
+/// publishing.
+///
+/// The cache is initially populated by <see cref="WarmFromScratch"/> (BFS from the entry
+/// point through every reachable node up to the configured budget) and incrementally
+/// maintained by <see cref="ApplyCommit"/> after each indexing commit. Capacity is
+/// provisioned at construction time; if the buffer fills, further <see cref="TryAppend"/>
+/// calls fail gracefully and those nodes simply miss the cache.
+/// </summary>
+public sealed unsafe class HnswIndexCache : IDisposable
+{
+    public readonly Hnsw.Options Options;
+    public readonly delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> SimilarityCalc;
+
+    private byte* _buffer;
+    private long _writeHead;
+    private readonly long _capacityBytes;
+    private readonly ConcurrentDictionary<long, NodeRef> _ids;
+    private int _disposed;
+
+    public int Count => _ids.Count;
+    public long CapacityBytes => _capacityBytes;
+    public long UsedBytes => Volatile.Read(ref _writeHead);
+
+    public HnswIndexCache(long capacityBytes, in Hnsw.Options options,
+        delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> similarityCalc)
+    {
+        if (capacityBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capacityBytes), capacityBytes, "capacity must be positive");
+
+        _capacityBytes = capacityBytes;
+        _buffer = (byte*)NativeMemory.AlignedAlloc((nuint)capacityBytes, 4096);
+        _ids = new ConcurrentDictionary<long, NodeRef>();
+        Options = options;
+        SimilarityCalc = similarityCalc;
+    }
+
+    ~HnswIndexCache() => DisposeNative();
+
+    public void Dispose()
+    {
+        DisposeNative();
+        GC.SuppressFinalize(this);
+    }
+
+    private void DisposeNative()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+        var ptr = _buffer;
+        _buffer = null;
+        if (ptr != null)
+            NativeMemory.AlignedFree(ptr);
+    }
+
+    /// <summary>
+    /// Reserve a 64-byte-aligned region of <paramref name="sizeBytes"/> in the buffer. Lock-free
+    /// CAS on <see cref="_writeHead"/>; fails when the cap is reached.
+    /// </summary>
+    public bool TryAllocate(int sizeBytes, out long offset)
+    {
+        int aligned = AlignUp(sizeBytes, 64);
+        long head, next;
+        do
+        {
+            head = Volatile.Read(ref _writeHead);
+            next = head + aligned;
+            if (next > _capacityBytes)
+            {
+                offset = -1;
+                return false;
+            }
+        } while (Interlocked.CompareExchange(ref _writeHead, next, head) != head);
+        offset = head;
+        return true;
+    }
+
+    /// <summary>
+    /// Append a node record. The bytes are written first; the dict entry publishes them via the
+    /// volatile store at the end of <see cref="ConcurrentDictionary{TKey,TValue}.TryAdd"/>.
+    /// Returns false on capacity exhaustion or duplicate id.
+    /// </summary>
+    public bool TryAppend(long nodeId, in CachedNodeBuilder src)
+    {
+        Debug.Assert(src.LevelOffsets.Length == src.LevelCount + 1, "level offsets length mismatch");
+        Debug.Assert(src.Edges.Length == src.EdgesTotalCount, "edges length mismatch");
+
+        int totalBytes = sizeof(CachedNodeHeader)
+                         + sizeof(int) * (src.LevelCount + 1)
+                         + sizeof(long) * src.EdgesTotalCount;
+
+        if (TryAllocate(totalBytes, out long offset) == false)
+            return false;
+
+        var h = (CachedNodeHeader*)(_buffer + offset);
+        h->NodeId = nodeId;
+        h->PostingListId = src.PostingListId;
+        h->VectorId = src.VectorId;
+        h->LevelCount = src.LevelCount;
+        h->_padding0 = 0;
+        h->_padding1 = 0;
+        h->EdgesTotalCount = src.EdgesTotalCount;
+
+        var offsets = (int*)(h + 1);
+        src.LevelOffsets.CopyTo(new Span<int>(offsets, src.LevelCount + 1));
+
+        var edges = (long*)(offsets + src.LevelCount + 1);
+        src.Edges.CopyTo(new Span<long>(edges, src.EdgesTotalCount));
+
+        // Linearization point: only after the bytes above are written do readers become able to
+        // discover this record. The volatile store inside TryAdd provides the release barrier.
+        return _ids.TryAdd(nodeId, new NodeRef(offset));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetNode(long nodeId, out CachedNodeView view)
+    {
+        if (_ids.TryGetValue(nodeId, out var r) == false)
+        {
+            view = default;
+            return false;
+        }
+        var h = (CachedNodeHeader*)(_buffer + r.Offset);
+        var offs = (int*)(h + 1);
+        var edges = (long*)(offs + h->LevelCount + 1);
+        view = new CachedNodeView(h, offs, edges);
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool ContainsNode(long nodeId) => _ids.ContainsKey(nodeId);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int AlignUp(int v, int align) => (v + align - 1) & ~(align - 1);
+
+    private static delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> ResolveSimilarityKernel(in Hnsw.Options options) =>
+        options.SimilarityMethod switch
+        {
+            Hnsw.SimilarityMethod.CosineSimilaritySingles => &Hnsw.CosineDistanceSingles,
+            Hnsw.SimilarityMethod.CosineSimilarityI8 => &Hnsw.CosineDistanceI8,
+            Hnsw.SimilarityMethod.HammingDistance => &Hnsw.HammingDistance,
+            _ => throw new ArgumentOutOfRangeException(nameof(options.SimilarityMethod), options.SimilarityMethod, null)
+        };
+
+    /// <summary>
+    /// Conservative bytes-per-node estimate used to translate a node-count budget into a buffer
+    /// size at construction time. Worst-case node has <c>2*numberOfEdges</c> entries at level 0
+    /// across the flat edge list.
+    /// </summary>
+    public static int EstimateBytesPerNode(int numberOfEdges)
+    {
+        const int AvgLevelCount = 4;
+        return sizeof(CachedNodeHeader)
+               + sizeof(int) * (AvgLevelCount + 1)
+               + sizeof(long) * 2 * numberOfEdges
+               + 64;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct CachedNodeHeader
+    {
+        public long NodeId;
+        public long PostingListId;
+        public long VectorId;
+        public byte LevelCount;
+        public byte _padding0;
+        public short _padding1;
+        public int EdgesTotalCount;
+    }
+
+    public readonly struct CachedNodeView
+    {
+        public readonly CachedNodeHeader* Header;
+        public readonly int* Offsets;
+        public readonly long* Edges;
+
+        public CachedNodeView(CachedNodeHeader* header, int* offsets, long* edges)
+        {
+            Header = header;
+            Offsets = offsets;
+            Edges = edges;
+        }
+
+        public byte LevelCount => Header->LevelCount;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlySpan<long> EdgesAtLevel(int level)
+        {
+            int start = Offsets[level];
+            int end = Offsets[level + 1];
+            return new ReadOnlySpan<long>(Edges + start, end - start);
+        }
+    }
+
+    /// <summary>
+    /// Caller-built view of a node ready to be appended. The spans must remain stable for the
+    /// duration of the <see cref="TryAppend"/> call.
+    /// </summary>
+    public ref struct CachedNodeBuilder
+    {
+        public long PostingListId;
+        public long VectorId;
+        public byte LevelCount;
+        public int EdgesTotalCount;
+        public ReadOnlySpan<int> LevelOffsets;
+        public ReadOnlySpan<long> Edges;
+    }
+
+    private readonly record struct NodeRef(long Offset);
+
+    /// <summary>
+    /// Initial fill: BFS from the entry point. Upper levels (>= 1) are fully connected by HNSW
+    /// construction so a single sweep per level suffices. Level 0 needs full BFS because under
+    /// the standard HNSW level formula most nodes live only at level 0 and many sit &gt;1 hop
+    /// from any upper-level seed, so a single hop would silently miss them. BFS allocation
+    /// order means neighboring nodes become neighboring records in <see cref="_buffer"/>,
+    /// giving Gorder-style locality for free.
+    /// </summary>
+    public static HnswIndexCache WarmFromScratch(LowLevelTransaction llt, Slice fieldName, int maxNodes)
+    {
+        var tree = llt.Transaction.ReadTree(fieldName);
+        if (tree is null || tree.TryGetLookupFor(Hnsw.NodeIdToLocationSlice, out Lookup<Int64LookupKey> locations) == false)
+            return null;
+
+        var options = Unsafe.Read<Hnsw.Options>(tree.DirectRead(Hnsw.OptionsSlice));
+        var simCalc = ResolveSimilarityKernel(options);
+
+        long bytesPerNode = EstimateBytesPerNode(options.NumberOfEdges);
+        long capacityBytes = (long)Math.Max(1, maxNodes) * bytesPerNode * 11 / 10;
+        var cache = new HnswIndexCache(capacityBytes, options, simCalc);
+
+        if (maxNodes <= 0 || locations.TryGetValue(Hnsw.EntryPointId, out _) == false)
+            return cache;
+
+        using var builder = new WarmupBuilder(llt, locations, maxNodes);
+        builder.SeedAndLoad(Hnsw.EntryPointId);
+        if (builder.LoadedCount == 0)
+            return cache;
+
+        int maxLevel = builder.NodeLevelsAt(0) - 1;
+        for (int level = maxLevel; level > 0 && builder.HasBudget; level--)
+            builder.ExpandAtLevel(level);
+
+        // Level 0 needs full BFS, not a single hop: under the standard HNSW level formula
+        // most nodes live only at level 0 and many sit >1 hop from any upper-level seed, so
+        // one ExpandAtLevel(0) call leaves them out.
+        while (builder.HasBudget)
+        {
+            int before = builder.LoadedCount;
+            builder.ExpandAtLevel(0);
+            if (builder.LoadedCount == before)
+                break;
+        }
+
+        builder.AppendAllPromoted(cache);
+        return cache;
+    }
+
+    /// <summary>
+    /// Per-commit incremental update. Loads each dirty node from the just-committed snapshot
+    /// and appends a record. <see cref="TryAppend"/> is a no-op for nodes already present
+    /// (id collision), so re-touched nodes keep their previous cache entry.
+    /// </summary>
+    public void ApplyCommit(LowLevelTransaction llt, Slice fieldName, IEnumerable<long> dirtyNodeIds)
+    {
+        if (dirtyNodeIds is null)
+            return;
+
+        var tree = llt.Transaction.ReadTree(fieldName);
+        if (tree is null || tree.TryGetLookupFor(Hnsw.NodeIdToLocationSlice, out Lookup<Int64LookupKey> locations) == false)
+            return;
+
+        using var builder = new WarmupBuilder(llt, locations, budget: int.MaxValue);
+        foreach (var nodeId in dirtyNodeIds)
+        {
+            if (_ids.ContainsKey(nodeId))
+                continue;
+            builder.SeedAndLoad(nodeId);
+        }
+        builder.AppendAllPromoted(this);
+    }
+
+    /// <summary>
+    /// BFS scratch that owns the temporary <see cref="NativeList"/>s. Emits node records in the
+    /// order they were discovered, so a subsequent bulk append produces a locality-friendly
+    /// layout in the cache buffer.
+    /// </summary>
+    private sealed class WarmupBuilder : IDisposable
+    {
+        private readonly LowLevelTransaction _llt;
+        private readonly Lookup<Int64LookupKey> _locations;
+        private readonly int _budget;
+        private readonly Dictionary<long, int> _nodeIdToIdx = new();
+        private NativeList<Hnsw.Node> _working;
+        private NativeList<long> _batch;
+
+        public bool HasBudget => _nodeIdToIdx.Count < _budget;
+        public int LoadedCount => _nodeIdToIdx.Count;
+        public int NodeLevelsAt(int index) => _working[index].EdgesPerLevel.Count;
+
+        public WarmupBuilder(LowLevelTransaction llt, Lookup<Int64LookupKey> locations, int budget)
+        {
+            _llt = llt;
+            _locations = locations;
+            _budget = budget;
+        }
+
+        public void SeedAndLoad(long nodeId)
+        {
+            if (_nodeIdToIdx.ContainsKey(nodeId))
+                return;
+            _batch.Add(_llt.Allocator, nodeId);
+            Flush();
+        }
+
+        /// <summary>
+        /// Sweep at <paramref name="level"/>: every loaded node whose level-L edge list is
+        /// non-empty contributes its neighbors to the next batch. Multiple passes are required
+        /// because a Flush appends new nodes whose own level-L edges must also be followed
+        /// before we drop down a level.
+        /// </summary>
+        public void ExpandAtLevel(int level)
+        {
+            var seen = new HashSet<long>();
+            int cursor = 0;
+            while (cursor < _working.Count && _nodeIdToIdx.Count + _batch.Count < _budget)
+            {
+                for (int i = cursor; i < _working.Count && _nodeIdToIdx.Count + _batch.Count < _budget; i++)
+                {
+                    ref var node = ref _working[i];
+                    if (node.EdgesPerLevel.Count <= level)
+                        continue;
+
+                    ref var edges = ref node.EdgesPerLevel[level];
+                    for (int e = 0; e < edges.Count; e++)
+                    {
+                        var edgeId = edges[e];
+                        if (_nodeIdToIdx.ContainsKey(edgeId) || seen.Add(edgeId) == false)
+                            continue;
+                        _batch.Add(_llt.Allocator, edgeId);
+                        if (_nodeIdToIdx.Count + _batch.Count >= _budget)
+                            break;
+                    }
+                }
+                cursor = _working.Count;
+
+                if (_batch.Count == 0)
+                    break;
+                Flush();
+            }
+        }
+
+        // Lookup<T>.GetFor walks pages left-to-right and updates LastSearchPosition, so unsorted
+        // keys produce spurious not-found results. Sort here, then map decoded results back to
+        // the original slot order so emit order matches insertion order.
+        private void Flush()
+        {
+            var keys = _batch.ToSpan();
+            int priorCount = _working.Count;
+
+            var targetSlots = new int[keys.Length];
+            _working.EnsureCapacityFor(_llt.Allocator, keys.Length);
+            for (int i = 0; i < keys.Length; i++)
+            {
+                targetSlots[i] = _working.Count;
+                _working.Add(_llt.Allocator, new Hnsw.Node { NodeId = keys[i] });
+            }
+
+            keys.Sort(targetSlots.AsSpan());
+            _locations.GetFor(keys, keys, -1);
+
+            var spans = new UnmanagedSpan[keys.Length];
+            Container.GetAll(_llt, keys, spans.AsSpan(), -1, _llt.PageLocator);
+            for (int i = 0; i < keys.Length; i++)
+            {
+                // Reachable from the post-commit hook: a throw here would block every later
+                // cache update for the index. Drop the corrupt node; the query path surfaces it.
+                if (spans[i].Length == 0)
+                    continue;
+                Hnsw.Node.Decode(_llt, spans[i].ToSpan()).LoadInto(ref _working[targetSlots[i]]);
+            }
+
+            for (int i = priorCount; i < _working.Count; i++)
+            {
+                ref var node = ref _working[i];
+                int levels = node.EdgesPerLevel.Count;
+                if (levels == 0 || levels > byte.MaxValue)
+                    continue;
+                _nodeIdToIdx[node.NodeId] = i;
+            }
+
+            _batch.Clear();
+        }
+
+        /// <summary>
+        /// Bulk-emit every loaded node into <paramref name="cache"/>. Routers (level &gt;= 1)
+        /// and leaves (level 0 only) are both admitted; the BFS in <see cref="WarmFromScratch"/>
+        /// caps the loaded set at the configured budget, and the goal is the highest cache hit
+        /// rate over the working set rather than a structural slice of the graph.
+        /// </summary>
+        public void AppendAllPromoted(HnswIndexCache cache)
+        {
+            Span<int> levelOffsetsScratch = stackalloc int[byte.MaxValue + 1];
+            var edgesScratch = new List<long>(cache.Options.NumberOfEdges * 4);
+
+            foreach (var (_, idx) in _nodeIdToIdx)
+            {
+                ref var node = ref _working[idx];
+                int levels = node.EdgesPerLevel.Count;
+                if (levels == 0)
+                    continue; // tombstone / missing — skip
+
+                edgesScratch.Clear();
+                levelOffsetsScratch[0] = 0;
+                for (int lvl = 0; lvl < levels; lvl++)
+                {
+                    var src = node.EdgesPerLevel[lvl];
+                    for (int e = 0; e < src.Count; e++)
+                        edgesScratch.Add(src[e]);
+                    levelOffsetsScratch[lvl + 1] = edgesScratch.Count;
+                }
+
+                var builder = new CachedNodeBuilder
+                {
+                    PostingListId = node.PostingListId,
+                    VectorId = node.VectorId,
+                    LevelCount = (byte)levels,
+                    EdgesTotalCount = edgesScratch.Count,
+                    LevelOffsets = levelOffsetsScratch[..(levels + 1)],
+                    Edges = CollectionsMarshal.AsSpan(edgesScratch),
+                };
+                if (cache.TryAppend(node.NodeId, builder) == false)
+                    break; // capacity exhausted: subsequent nodes also fail, stop early
+            }
+        }
+
+        public void Dispose()
+        {
+            _batch.Dispose(_llt.Allocator);
+            _working.Dispose(_llt.Allocator);
+        }
+    }
+}

--- a/src/Voron/Data/Graphs/IHNSWSearcher.cs
+++ b/src/Voron/Data/Graphs/IHNSWSearcher.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using Voron.Util;
 
 namespace Voron.Data.Graphs;
 
 public interface IHnswSearcher : IDisposable
 {
-    // Find nodes accepted by the query vector.
-    // Guarantee: always returns previously unseen nodes.
-    // To retrieve the accepted nodes, call TryGetCurrentCandidates.
-    public IEnumerable<bool> Search();
+    // Advances the search until the next batch of candidates is ready, then yields control to the caller so it can drain them via TryGetCurrentCandidates. Batches contain only previously unseen nodes. Returns true while batches remain, false once the search is exhausted.
+    public bool MoveNextBatch();
 
     // Retrieve IDs of nodes from the current search batch.
     // Guarantee: always returns previously unseen nodes.

--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -109,6 +109,12 @@ public unsafe struct NativeList<T>
         AddRangeUnsafe(src);
     }
 
+    public void ResetAndCopyFrom(ByteStringContext allocator, ReadOnlySpan<T> src)
+    {
+        ResetAndEnsureCapacity(allocator, src.Length);
+        AddRangeUnsafe(src);
+    }
+
     public void AddRangeUnsafe(ReadOnlySpan<T> range)
     {
         Debug.Assert(Count + range.Length <= Capacity);

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -87,6 +87,7 @@ namespace FastTests.Issues
                 "Indexing.Querying.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery",
                 "Indexing.Querying.Corax.NullsSortMode",
 
+                "Indexing.Corax.VectorSearch.CacheSizeInMb",
                 "Indexing.Corax.VectorSearch.DefaultMinimumSimilarity",
                 "Indexing.Corax.VectorSearch.DefaultNumberOfEdges",
                 "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForIndexing",

--- a/test/FastTests/Sparrow/TensorsTests.cs
+++ b/test/FastTests/Sparrow/TensorsTests.cs
@@ -549,5 +549,31 @@ namespace FastTests.Sparrow
                 Assert.NotEqual(Functions.HammingBitDistance<byte>(aSpan, bSpan), 0);
             }
         }
+
+        // DotProduct dispatches to a two-accumulator Vector512 kernel once size is large enough
+        // for a SIMD path. The boundary sizes — exactly one vector wide, and exactly two vectors
+        // wide — are the ones most likely to hit off-by-one conditions in the loop/tail guards.
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData(16)]
+        [InlineData(17)]
+        [InlineData(31)]
+        [InlineData(32)]
+        [InlineData(33)]
+        [InlineData(63)]
+        [InlineData(128)]
+        public void DotProduct_MatchesTensorPrimitives_AtVector512Boundaries(int size)
+        {
+            var rng = new Random(size);
+            var a = new float[size];
+            var b = new float[size];
+            for (int i = 0; i < size; i++)
+            {
+                a[i] = (float)(rng.NextDouble() * 2 - 1);
+                b[i] = (float)(rng.NextDouble() * 2 - 1);
+            }
+            var actual = Functions.DotProduct(a, b);
+            var expected = TensorPrimitives.Dot<float>(a, b);
+            Assert.InRange(actual - expected, -1e-4f, 1e-4f);
+        }
     }
 }

--- a/test/FastTests/Voron/Graphs/BasicGraphs.cs
+++ b/test/FastTests/Voron/Graphs/BasicGraphs.cs
@@ -299,10 +299,14 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             Assert.Equal(2, read);
             var v1Pos = matches.AsSpan().Slice(0, read).IndexOf(1L);
             Assert.True(int.IsPositive(v1Pos));
-            Assert.Equal(Hnsw.CosineDistanceSingles(v1.GetEmbedding(), vQ.GetEmbedding()), distances[v1Pos]);
+            // Indexed and queried vectors are stored in NormalizedTensor at-rest form; the distance
+            // kernel dots pre-normalized unit vectors, which is algebraically identical to
+            // CosineDistanceSingles but can differ in the last bit due to rounding order, so compare
+            // with a small relative tolerance.
+            Assert.Equal(Hnsw.CosineDistanceSingles(v1.GetEmbedding(), vQ.GetEmbedding()), distances[v1Pos], precision: 5);
             var v2Pos = matches.AsSpan().Slice(0, read).IndexOf(2L);
             Assert.True(int.IsPositive(v2Pos));
-            Assert.Equal(Hnsw.CosineDistanceSingles(v2.GetEmbedding(), vQ.GetEmbedding()), distances[v2Pos]);
+            Assert.Equal(Hnsw.CosineDistanceSingles(v2.GetEmbedding(), vQ.GetEmbedding()), distances[v2Pos], precision: 5);
         }
     }
     

--- a/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
+++ b/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
@@ -150,7 +150,8 @@ public unsafe class HnswIndexCacheTests(ITestOutputHelper output) : StorageTest(
         BuildGraph(treeName, vectorCount: 300, seed: 19);
 
         float[] query = RandomVector(new Random(99));
-        var queryBytes = MemoryMarshal.Cast<float, byte>(query).ToArray();
+        var queryBytes = new byte[Hnsw.TensorSizeBytes<float>(query.Length)];
+        Hnsw.WriteNormalizedTensor(query, queryBytes);
 
         using (var tx = Env.ReadTransaction())
         {
@@ -208,6 +209,7 @@ public unsafe class HnswIndexCacheTests(ITestOutputHelper output) : StorageTest(
         }
         tx.Commit();
     }
+
 
     private static float[] RandomVector(Random random)
     {

--- a/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
+++ b/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
@@ -235,9 +235,11 @@ public unsafe class HnswIndexCacheTests(ITestOutputHelper output) : StorageTest(
     /// </summary>
     private static unsafe IEnumerable<(long NodeId, HnswIndexCache.CachedNodeView View)> EnumerateCache(HnswIndexCache cache, int upper)
     {
+        // long.MaxValue as the reader tx id disables the visibility gate so this iterator
+        // surfaces every entry currently resident, regardless of when it was published.
         for (long nodeId = 1; nodeId <= upper; nodeId++)
         {
-            if (cache.TryGetNode(nodeId, out var view))
+            if (cache.TryGetNode(nodeId, long.MaxValue, out var view))
                 yield return (nodeId, view);
         }
     }

--- a/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
+++ b/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Graphs;
+using Xunit;
+using VectorEmbeddingType = Voron.Data.Graphs.VectorEmbeddingType;
+
+namespace FastTests.Voron.Graphs;
+
+public unsafe class HnswIndexCacheTests(ITestOutputHelper output) : StorageTest(output)
+{
+    private const string TreeName = "test";
+    private const int VectorDimensions = 16;
+    private const int VectorSizeInBytes = VectorDimensions * sizeof(float);
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void EmptyGraphReturnsEmptyCache()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        using (var tx = Env.WriteTransaction())
+        {
+            Hnsw.Create(tx.LowLevelTransaction, treeName, VectorSizeInBytes, 3, 12, VectorEmbeddingType.Single);
+            tx.Commit();
+        }
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: 1024);
+            Assert.NotNull(cache);
+            Assert.Equal(0, cache.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void ZeroBudgetReturnsEmptyCache()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        BuildGraph(treeName, vectorCount: 50, seed: 42);
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: 0);
+            Assert.NotNull(cache);
+            Assert.Equal(0, cache.Count);
+        }
+    }
+
+    // With a budget that exceeds the graph size, BFS from the entry point must reach every
+    // node — including level-0 leaves — and admit it. The cache count therefore equals the
+    // full vector count.
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void BudgetLargerThanGraphCachesAllNodes()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        const int vectorCount = 200;
+        BuildGraph(treeName, vectorCount, seed: 42);
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: 10_000);
+            Assert.Equal(vectorCount, cache.Count);
+        }
+    }
+
+    // When the budget caps below the graph size, BFS must fill the cache exactly to the
+    // budget — no fewer (otherwise we are starving the cache and missing reachable nodes).
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void CacheFullyUsesBudgetWhenGraphIsLargerThanBudget()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        const int vectorCount = 1500;
+        const int budget = 400;
+        BuildGraph(treeName, vectorCount, seed: 42);
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: budget);
+            Assert.InRange(cache.Count, budget * 9 / 10, budget);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void CachedEdgesMatchFreshlyLoadedEdges()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        BuildGraph(treeName, vectorCount: 500, seed: 7);
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: 10_000);
+            Assert.True(cache.Count > 0);
+
+            // Load a fresh SearchState for ground-truth edges.
+            using var state = new Hnsw.SearchState(tx.LowLevelTransaction, treeName);
+
+            foreach (var (nodeId, view) in EnumerateCache(cache, 500))
+            {
+                int stateIdx = state.GetNodeIndexById(nodeId);
+                ref var stateNode = ref state.GetNodeByIndex(stateIdx);
+
+                Assert.Equal(stateNode.NodeId, view.Header->NodeId);
+                Assert.Equal(stateNode.VectorId, view.Header->VectorId);
+                Assert.Equal(stateNode.PostingListId, view.Header->PostingListId);
+                Assert.Equal(stateNode.EdgesPerLevel.Count, view.LevelCount);
+
+                for (int lvl = 0; lvl < view.LevelCount; lvl++)
+                {
+                    var cachedEdges = view.EdgesAtLevel(lvl);
+                    var stateEdges = stateNode.EdgesPerLevel[lvl];
+
+                    Assert.Equal(stateEdges.Count, cachedEdges.Length);
+                    for (int e = 0; e < cachedEdges.Length; e++)
+                        Assert.Equal(stateEdges[e], cachedEdges[e]);
+                }
+            }
+        }
+    }
+
+    // The cache reflects the snapshot of the LLT it was built from. A cache built from an older
+    // read tx must not surface nodes that were committed after that snapshot.
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void CacheBuiltFromOlderSnapshotDoesNotIncludeLaterNodes()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        BuildGraph(treeName, vectorCount: 200, seed: 11);
+
+        long countAtSnapshot;
+        using (var readTx = Env.ReadTransaction())
+        {
+            using var state = new Hnsw.SearchState(readTx.LowLevelTransaction, treeName);
+            countAtSnapshot = state.Options.CountOfVectors;
+
+            // Add MORE vectors in a write tx AFTER the read snapshot was opened.
+            AddVectors(treeName, vectorCount: 100, firstId: (int)countAtSnapshot + 1, seed: 22);
+
+            using var cache = HnswIndexCache.WarmFromScratch(readTx.LowLevelTransaction, treeName, maxNodes: 10_000);
+
+            foreach (var (nodeId, _) in EnumerateCache(cache, (int)countAtSnapshot))
+                Assert.InRange(nodeId, 1L, countAtSnapshot);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void SearchStateCanQueryUsingACache()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        BuildGraph(treeName, vectorCount: 300, seed: 19);
+
+        float[] query = RandomVector(new Random(99));
+        var queryBytes = MemoryMarshal.Cast<float, byte>(query).ToArray();
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: 10_000);
+            Assert.True(cache.Count > 0);
+
+            using var state = new Hnsw.SearchState(tx.LowLevelTransaction, treeName, cache);
+            using var retriever = Hnsw.ApproximateNearest(state, numberOfCandidates: 32, queryBytes, minimumSimilarity: 0f);
+
+            var scores = new float[32];
+            var docs = new long[32];
+            int total = 0;
+            int read;
+            do
+            {
+                read = retriever.Fill(docs, scores, filter: null);
+                total += read;
+            } while (read != 0);
+
+            Assert.True(total > 0, "search with cache returned no results");
+        }
+    }
+
+    private void BuildGraph(Slice treeName, int vectorCount, int seed)
+    {
+        var random = new Random(seed);
+        using var tx = Env.WriteTransaction();
+        Hnsw.Create(tx.LowLevelTransaction, treeName, VectorSizeInBytes, numberOfEdges: 12,
+            numberOfCandidates: 16, VectorEmbeddingType.Single);
+
+        using (var registration = Hnsw.RegistrationFor(tx.LowLevelTransaction, treeName, random))
+        {
+            for (int i = 1; i <= vectorCount; i++)
+            {
+                var v = RandomVector(random);
+                registration.Register(i, MemoryMarshal.Cast<float, byte>(v));
+            }
+            registration.Commit(CancellationToken.None);
+        }
+        tx.Commit();
+    }
+
+    private void AddVectors(Slice treeName, int vectorCount, int firstId, int seed)
+    {
+        var random = new Random(seed);
+        using var tx = Env.WriteTransaction();
+        using (var registration = Hnsw.RegistrationFor(tx.LowLevelTransaction, treeName, random))
+        {
+            for (int i = 0; i < vectorCount; i++)
+            {
+                var v = RandomVector(random);
+                registration.Register(firstId + i, MemoryMarshal.Cast<float, byte>(v));
+            }
+            registration.Commit(CancellationToken.None);
+        }
+        tx.Commit();
+    }
+
+    private static float[] RandomVector(Random random)
+    {
+        var v = new float[VectorDimensions];
+        float sumSq = 0;
+        for (int i = 0; i < VectorDimensions; i++)
+        {
+            v[i] = (float)(random.NextDouble() * 2 - 1);
+            sumSq += v[i] * v[i];
+        }
+        var norm = MathF.Sqrt(sumSq);
+        if (norm > 0)
+        {
+            for (int i = 0; i < VectorDimensions; i++)
+                v[i] /= norm;
+        }
+        return v;
+    }
+
+    /// <summary>
+    /// Probe ids 1..upper and yield those that are present. Iteration order is not part of the
+    /// cache contract, so this iterator works against the public TryGetNode surface.
+    /// </summary>
+    private static unsafe IEnumerable<(long NodeId, HnswIndexCache.CachedNodeView View)> EnumerateCache(HnswIndexCache cache, int upper)
+    {
+        for (long nodeId = 1; nodeId <= upper; nodeId++)
+        {
+            if (cache.TryGetNode(nodeId, out var view))
+                yield return (nodeId, view);
+        }
+    }
+}

--- a/test/FastTests/Voron/Graphs/HnswTests/L2NormCaching.cs
+++ b/test/FastTests/Voron/Graphs/HnswTests/L2NormCaching.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Numerics.Tensors;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Graphs;
+using Xunit;
+using VectorEmbeddingType = Voron.Data.Graphs.VectorEmbeddingType;
+
+namespace FastTests.Voron.Graphs.HnswTests;
+
+public class L2NormCaching(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    [InlineData(128)]
+    [InlineData(384)]
+    [InlineData(768)]
+    [InlineData(1536)]
+    public void LegacyAndNormalizedKernelsAgree(int dims)
+    {
+        // For random f32 vectors, the legacy CosineDistanceSingles (which recomputes both norms
+        // per call) and the new CosineDistanceSinglesNormalized (which reads the trailing norm
+        // and dots pre-normalized unit vectors) must return the same distance up to rounding.
+        var rng = new Random(dims);
+        var a = RandomFloats(rng, dims, scale: 3.0f);
+        var b = RandomFloats(rng, dims, scale: 5.0f);
+
+        var legacy = global::Voron.Data.Graphs.Hnsw.CosineDistanceSingles(
+            MemoryMarshal.AsBytes(a.AsSpan()),
+            MemoryMarshal.AsBytes(b.AsSpan()));
+
+        var aAtRest = new byte[Hnsw.TensorSizeBytes<float>(dims)];
+        var bAtRest = new byte[Hnsw.TensorSizeBytes<float>(dims)];
+        Hnsw.WriteNormalizedTensor(a, aAtRest);
+        Hnsw.WriteNormalizedTensor(b, bAtRest);
+
+        var normalized = global::Voron.Data.Graphs.Hnsw.CosineDistanceSinglesNormalized(aAtRest, bAtRest);
+
+        // Allow a small absolute tolerance; the two kernels differ only in float rounding order.
+        Assert.InRange(normalized - legacy, -1e-5f, 1e-5f);
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void NormalizeRoundTrip()
+    {
+        var rng = new Random(42);
+        const int dims = 64;
+        var raw = RandomFloats(rng, dims, scale: 7.0f);
+        var expectedNorm = MathF.Sqrt(TensorPrimitives.SumOfSquares(raw));
+
+        var atRest = new byte[Hnsw.TensorSizeBytes<float>(dims)];
+        var returnedNorm = Hnsw.WriteNormalizedTensor(raw, atRest);
+
+        Assert.Equal(expectedNorm, returnedNorm, precision: 4);
+        Assert.Equal(expectedNorm, Hnsw.ReadTensorMagnitude(atRest), precision: 4);
+
+        var unit = Hnsw.ReadTensorVector<float>(atRest);
+        Assert.Equal(dims, unit.Length);
+
+        // Dividing by the norm should leave a unit vector.
+        var unitSumSq = TensorPrimitives.SumOfSquares(unit);
+        Assert.Equal(1.0, (double)unitSumSq, precision: 4);
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void ZeroNormAdversarial()
+    {
+        const int dims = 16;
+        var zero = new float[dims];
+        var nonZero = RandomFloats(new Random(1), dims, scale: 1.0f);
+
+        var zeroAtRest = new byte[Hnsw.TensorSizeBytes<float>(dims)];
+        var nonZeroAtRest = new byte[Hnsw.TensorSizeBytes<float>(dims)];
+        Hnsw.WriteNormalizedTensor(zero, zeroAtRest);
+        Hnsw.WriteNormalizedTensor(nonZero, nonZeroAtRest);
+
+        // Both operands zero: kernel returns NaN (matches the semantics of the recompute-norms
+        // path, which divides by zero and produces NaN).
+        var bothZero = global::Voron.Data.Graphs.Hnsw.CosineDistanceSinglesNormalized(zeroAtRest, zeroAtRest);
+        Assert.True(float.IsNaN(bothZero));
+
+        // Exactly one operand zero: kernel returns 1f (distance = 1, similarity = 0). The spec
+        // does not prescribe more than "not NaN" for this case; 1f is the documented contract.
+        var mixedA = global::Voron.Data.Graphs.Hnsw.CosineDistanceSinglesNormalized(zeroAtRest, nonZeroAtRest);
+        var mixedB = global::Voron.Data.Graphs.Hnsw.CosineDistanceSinglesNormalized(nonZeroAtRest, zeroAtRest);
+        Assert.False(float.IsNaN(mixedA));
+        Assert.False(float.IsNaN(mixedB));
+        Assert.Equal(1f, mixedA);
+        Assert.Equal(1f, mixedB);
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void EndToEndHnswSearchReturnsCorrectNearestNeighbour()
+    {
+        using var _ = Slice.From(Allocator, "l2norm-e2e", out var treeName);
+        const int dims = 32;
+        var sizeBytes = dims * sizeof(float);
+
+        // Hand-crafted vectors chosen so vector #5 is clearly closest to the query.
+        var v1 = FilledVector(dims, 0.1f);
+        var v2 = FilledVector(dims, 0.5f);
+        var v3 = FilledVector(dims, -0.2f);
+        var v4 = FilledVector(dims, 1.5f);
+        var v5 = FilledVector(dims, 2.0f);
+
+        var query = FilledVector(dims, 1.95f); // closest to v5 by cosine similarity
+
+        using (var tx = Env.WriteTransaction())
+        {
+            global::Voron.Data.Graphs.Hnsw.Create(tx.LowLevelTransaction, treeName, sizeBytes, 8, 16, VectorEmbeddingType.Single);
+            using (var registration = global::Voron.Data.Graphs.Hnsw.RegistrationFor(tx.LowLevelTransaction, treeName, new Random(7)))
+            {
+                registration.Register(1, MemoryMarshal.Cast<float, byte>(v1));
+                registration.Register(2, MemoryMarshal.Cast<float, byte>(v2));
+                registration.Register(3, MemoryMarshal.Cast<float, byte>(v3));
+                registration.Register(4, MemoryMarshal.Cast<float, byte>(v4));
+                registration.Register(5, MemoryMarshal.Cast<float, byte>(v5));
+                registration.Commit(CancellationToken.None);
+            }
+            tx.Commit();
+        }
+
+        using (var tx = Env.ReadTransaction())
+        {
+            var queryBytes = MemoryMarshal.AsBytes(query.AsSpan()).ToArray();
+            using var retriever = global::Voron.Data.Graphs.Hnsw.ApproximateNearest(
+                tx.LowLevelTransaction, treeName, numberOfCandidates: 8, queryBytes, 0f);
+
+            Span<long> matches = stackalloc long[8];
+            Span<float> distances = stackalloc float[8];
+            var read = retriever.Fill(matches, distances, filter: null);
+            Assert.True(read >= 1);
+            Assert.Equal(5L, matches[0]);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void LegacyVersionOptionsYieldLegacyKernel()
+    {
+        // Construct an Options struct pinned to the InitialVersion on-disk layout and verify
+        // the kernel dispatcher selects the norm-recomputing path. Locks the version gate so
+        // an accidental bump cannot silently break indexes written under that layout.
+        var legacyOptions = new global::Voron.Data.Graphs.Hnsw.Options
+        {
+            Version = global::Voron.Global.Constants.Graphs.HnswVersion.InitialVersion,
+            SimilarityMethod = global::Voron.Data.Graphs.Hnsw.SimilarityMethod.CosineSimilaritySingles,
+            VectorSizeBytes = 64,
+        };
+        var newOptions = legacyOptions;
+        newOptions.Version = global::Voron.Global.Constants.Graphs.HnswVersion.SinglesWithL2Norm;
+        newOptions.VectorSizeBytes = 68;
+
+        unsafe
+        {
+            var legacyKernel = global::Voron.Data.Graphs.Hnsw.GetDistanceKernel(in legacyOptions);
+            var newKernel = global::Voron.Data.Graphs.Hnsw.GetDistanceKernel(in newOptions);
+
+            // Evaluate each kernel on payloads sized to match its expected on-disk layout. The
+            // legacy kernel consumes 64 bytes of raw floats; the new kernel consumes 68 bytes
+            // (16 unit floats + trailing norm). Confirming each kernel accepts only its own
+            // layout proves the dispatcher selects different code paths.
+            var rng = new Random(11);
+            var a = RandomFloats(rng, 16, scale: 1.0f);
+            var b = RandomFloats(rng, 16, scale: 1.0f);
+            var aRaw = MemoryMarshal.AsBytes(a.AsSpan());
+            var bRaw = MemoryMarshal.AsBytes(b.AsSpan());
+            var legacyVal = legacyKernel(aRaw, bRaw);
+            Assert.False(float.IsNaN(legacyVal));
+
+            var aAtRest = new byte[Hnsw.TensorSizeBytes<float>(16)];
+            var bAtRest = new byte[Hnsw.TensorSizeBytes<float>(16)];
+            Hnsw.WriteNormalizedTensor(a, aAtRest);
+            Hnsw.WriteNormalizedTensor(b, bAtRest);
+            var newVal = newKernel(aAtRest, bAtRest);
+            Assert.False(float.IsNaN(newVal));
+            // Mathematically equivalent, so the magnitudes must agree to float tolerance.
+            Assert.InRange(newVal - legacyVal, -1e-5f, 1e-5f);
+        }
+    }
+
+    private static float[] RandomFloats(Random rng, int dims, float scale)
+    {
+        var v = new float[dims];
+        for (int i = 0; i < dims; i++)
+            v[i] = (float)((rng.NextDouble() * 2 - 1) * scale);
+        return v;
+    }
+
+    private static float[] FilledVector(int dims, float value)
+    {
+        var v = new float[dims];
+        for (int i = 0; i < dims; i++)
+            v[i] = value + 0.001f * i;
+        return v;
+    }
+}

--- a/test/SlowTests/Corax/Vectors/HnswIndexCacheLifecycle.cs
+++ b/test/SlowTests/Corax/Vectors/HnswIndexCacheLifecycle.cs
@@ -1,0 +1,108 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Corax.Vectors;
+
+public class HnswIndexCacheLifecycle(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private const int DocCount = 200;
+
+    // Vector search must remain consistent across writes that mutate cached HNSW nodes.
+    // After the upper-level node cache has been warmed at index open, updating documents whose
+    // vectors participate in the graph must not leave the cache pointing at stale topology:
+    // a subsequent query must return correct results, not throw and not read freed slots.
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void VectorSearchRemainsConsistentAfterUpdatingCachedDocuments()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        options.RunInMemory = false;
+        options.Path = NewDataPath();
+        options.ModifyDocumentStore = s => s.Conventions.MaxNumberOfRequestsPerSession = 10_000;
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            for (int i = 1; i <= DocCount; i++)
+                session.Store(new Item { Id = $"items/{i}", Description = i % 2 == 0 ? "cat" : "bike" });
+            session.SaveChanges();
+
+            _ = session.Query<Item>()
+                .VectorSearch(f => f.WithText(x => x.Description), factory => factory.ByText("cat"))
+                .ToList();
+            Indexes.WaitForIndexing(store);
+        }
+
+        // Force the index-open path to seed its upper-level node cache from the populated graph.
+        var off = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, disable: true));
+        Assert.True(off.Success && off.Disabled);
+        var on = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, disable: false));
+        Assert.True(on.Success && on.Disabled == false);
+
+        using (var session = store.OpenSession())
+        {
+            for (int i = 1; i <= DocCount / 2; i++)
+                session.Load<Item>($"items/{i}").Description = "fish";
+            session.SaveChanges();
+            Indexes.WaitForIndexing(store);
+
+            var result = session.Query<Item>()
+                .VectorSearch(f => f.WithText(x => x.Description), factory => factory.ByText("cat"), numberOfCandidates: 8)
+                .ToList();
+
+            Assert.NotEmpty(result);
+        }
+    }
+
+    // The per-field HNSW node cache must be available to readers immediately after the first
+    // commit that populates the graph. A database that started empty and then ingested vector
+    // data should serve subsequent queries through the cache without needing an index or
+    // database restart to materialize it.
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void VectorCacheIsAvailableAfterFirstCommitWithoutRestart()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        options.RunInMemory = false;
+        options.Path = NewDataPath();
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            for (int i = 1; i <= DocCount; i++)
+                session.Store(new Item { Id = $"items/{i}", Description = i % 2 == 0 ? "cat" : "bike" });
+            session.SaveChanges();
+
+            _ = session.Query<Item>()
+                .VectorSearch(f => f.WithText(x => x.Description), factory => factory.ByText("cat"))
+                .ToList();
+            Indexes.WaitForIndexing(store);
+        }
+
+        var database = Databases.GetDocumentDatabaseInstanceFor(store).Result;
+        var indexName = database.IndexStore.GetIndexes().Single().Name;
+        var index = database.IndexStore.GetIndex(indexName);
+
+        var persistenceField = index.GetType()
+            .GetField("IndexPersistence", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(persistenceField);
+        var persistence = persistenceField.GetValue(index);
+        Assert.NotNull(persistence);
+
+        var cachesField = persistence.GetType()
+            .GetField("_hnswCaches", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(cachesField);
+
+        var caches = cachesField.GetValue(persistence) as System.Collections.IDictionary;
+        Assert.True(caches != null && caches.Count > 0,
+            "Per-field HNSW node cache must be materialized after the first commit that populates the graph.");
+    }
+
+    private sealed class Item
+    {
+        public string Id { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/test/SlowTests/Corax/Vectors/VectorSearchWithHnswIndexCache.cs
+++ b/test/SlowTests/Corax/Vectors/VectorSearchWithHnswIndexCache.cs
@@ -1,0 +1,397 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Corax;
+using Corax.Indexing;
+using Corax.Mappings;
+using Corax.Querying;
+using Corax.Utils;
+using FastTests.Voron;
+using Nito.Disposables;
+using Raven.Server.Documents.Indexes.VectorSearch;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Graphs;
+using Xunit;
+
+namespace SlowTests.Corax.Vectors;
+
+public class VectorSearchWithHnswIndexCache(ITestOutputHelper output) : StorageTest(output)
+{
+    // 128-D random unit vectors admit a non-trivial nearest-neighbor graph (at very low
+    // dimensions uniform random vectors become nearly equidistant and HNSW quality collapses).
+    private const int VectorDimensions = 128;
+    private const int VectorByteSize = VectorDimensions * sizeof(float);
+
+    // Queries must return the same matches whether or not a cache is attached, and whether
+    // the cache contains all nodes or just a subset. The partial-cache variant exercises
+    // the mixed code path: cache hits for upper-level nodes, disk loads for the remainder.
+    // Binary is excluded because hamming distance at small dimensions produces many nodes at
+    // equal distance, so which ones land in top-K depends on priority-queue tie-breaking —
+    // an ambiguity that is unrelated to whether the cache is used.
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [InlineData(VectorEmbeddingType.Single, 10_000)] // cache holds every node
+    [InlineData(VectorEmbeddingType.Single, 50)]     // cache holds only upper-level nodes
+    [InlineData(VectorEmbeddingType.Int8, 10_000)]
+    [InlineData(VectorEmbeddingType.Int8, 50)]
+    public void ResultsAreIdenticalWithAndWithoutCache(VectorEmbeddingType embedding, int cacheBudget)
+        => RunParityCheck(embedding, cacheBudget, baseSeed: 23);
+
+    private void RunParityCheck(VectorEmbeddingType embedding, int cacheBudget, int baseSeed)
+    {
+        using var _ = GetMappings(embedding, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+        const int docCount = 500;
+        const int queryCount = 25;
+        const int k = 16;
+
+        BuildIndex(mapping, docCount, seed: 7);
+        var caches = BuildCaches(metadata.FieldName, cacheBudget);
+
+        for (int i = 0; i < queryCount; i++)
+        {
+            long[] uncached, cached;
+            using (var searcher = new IndexSearcher(Env, mapping))
+                uncached = TopK(searcher, metadata, NewQueryVector(bsc, seed: baseSeed + i), k);
+
+            using (var searcher = new IndexSearcher(Env, mapping))
+            {
+                searcher.AttachVectorNodeCaches(caches);
+                cached = TopK(searcher, metadata, NewQueryVector(bsc, seed: baseSeed + i), k);
+            }
+
+            Assert.Equal(uncached, cached);
+        }
+    }
+
+    // When no cache is attached to an IndexSearcher, queries must still work — it's the
+    // happy-path for indexes that have disabled the cache (CoraxVectorSearchCacheSize=0) or
+    // haven't committed yet so no cache exists. Results must also be meaningful: every returned
+    // id must map to a real doc and the top-K must agree with an exact scan on most of its
+    // entries (HNSW is approximate; we require high recall, not byte-identity).
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [InlineData(17, 71)]
+    [InlineData(null, null)]
+    public void SearchWorksWithNoCacheAttached(int? buildSeed, int? querySeed)
+    {
+        var (bSeed, qSeed) = MaterializeSeeds(buildSeed, querySeed);
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+        BuildIndex(mapping, docCount: 200, seed: bSeed);
+
+        long[] truth, returned;
+        using (var searcher = new IndexSearcher(Env, mapping))
+            truth = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16, isExact: true);
+
+        using (var searcher = new IndexSearcher(Env, mapping))
+        {
+            // Deliberately do NOT call AttachVectorNodeCaches.
+            returned = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16);
+        }
+
+        Assert.Equal(16, returned.Length);
+        Assert.Equal(returned.Distinct().Count(), returned.Length);
+        foreach (var id in returned)
+            Assert.InRange(id, 1L, 200L);
+        // At least one returned id must overlap the exact top-K — lower bound on recall that
+        // catches "the search returned random ids" without being sensitive to approximate-search
+        // jitter on adversarial random seeds.
+        Assert.True(Recall(truth, returned) > 0, $"no overlap with exact top-K (buildSeed={bSeed}, querySeed={qSeed})");
+    }
+
+    // When a cache is attached but empty (e.g. the graph has fewer nodes than the cache
+    // budget could hold but none were persisted yet), queries must fall back to disk loads
+    // and still return meaningful results.
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [InlineData(19, 73)]
+    [InlineData(null, null)]
+    public void SearchWorksWithEmptyCacheDictionaryAttached(int? buildSeed, int? querySeed)
+    {
+        var (bSeed, qSeed) = MaterializeSeeds(buildSeed, querySeed);
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+        BuildIndex(mapping, docCount: 200, seed: bSeed);
+
+        long[] truth, returned;
+        using (var searcher = new IndexSearcher(Env, mapping))
+            truth = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16, isExact: true);
+
+        using (var searcher = new IndexSearcher(Env, mapping))
+        {
+            searcher.AttachVectorNodeCaches(new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance));
+            returned = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16);
+        }
+
+        Assert.Equal(16, returned.Length);
+        Assert.Equal(returned.Distinct().Count(), returned.Length);
+        foreach (var id in returned)
+            Assert.InRange(id, 1L, 200L);
+        // At least one returned id must overlap the exact top-K — lower bound on recall that
+        // catches "the search returned random ids" without being sensitive to approximate-search
+        // jitter on adversarial random seeds.
+        Assert.True(Recall(truth, returned) > 0, $"no overlap with exact top-K (buildSeed={bSeed}, querySeed={qSeed})");
+    }
+
+    private (int BuildSeed, int QuerySeed) MaterializeSeeds(int? buildSeed, int? querySeed)
+    {
+        if (buildSeed.HasValue && querySeed.HasValue)
+            return (buildSeed.Value, querySeed.Value);
+        var rng = new Random();
+        var b = buildSeed ?? rng.Next();
+        var q = querySeed ?? rng.Next();
+        Output.WriteLine($"Random seeds: buildSeed={b}, querySeed={q} (re-run with fixed seeds to reproduce)");
+        return (b, q);
+    }
+
+    // Randomized variant of the parity theory: picks a fresh seed at test time and logs it
+    // so a regression can be reproduced. Fixed-seed variants cover the deterministic path.
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void ResultsAreIdenticalWithAndWithoutCache_RandomSeed()
+    {
+        var seed = unchecked((int)DateTime.UtcNow.Ticks);
+        Output.WriteLine($"Random seed: {seed} (re-run with fixed seed to reproduce)");
+        RunParityCheck(VectorEmbeddingType.Single, cacheBudget: 10_000, baseSeed: seed);
+    }
+
+    // The cached path must agree with the exact scan on most top-K. HNSW params are sized
+    // so intrinsic recall vs exact is high enough (~0.83) that the 0.75 threshold is a
+    // quality gate rather than a "not random ids" sanity check. The parity tests above
+    // cover the aggressive-params path with a tight ef.
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [InlineData(10_000)] // cache holds every node
+    [InlineData(50)]     // cache holds only upper-level nodes
+    public void CachedSearchAchievesGoodRecallAgainstExactScan(int cacheBudget)
+    {
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping, numberOfEdges: 32, numberOfCandidates: 256);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+        const int docCount = 500;
+        const int queryCount = 10;
+        const int k = 16;
+
+        BuildIndex(mapping, docCount, seed: 7);
+        var caches = BuildCaches(metadata.FieldName, cacheBudget);
+
+        double totalRecall = 0;
+        for (int i = 0; i < queryCount; i++)
+        {
+            long[] truth, cached;
+            using (var searcher = new IndexSearcher(Env, mapping))
+                truth = TopK(searcher, metadata, NewQueryVector(bsc, seed: 23 + i), k, isExact: true);
+
+            using (var searcher = new IndexSearcher(Env, mapping))
+            {
+                searcher.AttachVectorNodeCaches(caches);
+                cached = TopK(searcher, metadata, NewQueryVector(bsc, seed: 23 + i), k);
+            }
+
+            totalRecall += Recall(truth, cached);
+        }
+
+        var avgRecall = totalRecall / queryCount;
+        Output.WriteLine($"Average recall@{k} with cacheBudget={cacheBudget}: {avgRecall:F3}");
+        Assert.True(avgRecall >= 0.75, $"HNSW recall@{k} dropped to {avgRecall:F3} (threshold 0.75) with cacheBudget={cacheBudget}");
+    }
+
+    // Multi-vector queries internally share a SearchState across sub-searches. The cache
+    // must interoperate correctly with that reuse path.
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void MultiVectorSearchResultsAreIdenticalWithAndWithoutCache()
+    {
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+        BuildIndex(mapping, docCount: 400, seed: 13);
+
+        long[] Run(bool withCache)
+        {
+            using var searcher = new IndexSearcher(Env, mapping);
+            if (withCache)
+                searcher.AttachVectorNodeCaches(BuildCaches(metadata.FieldName));
+
+            // Query vectors are allocated per-run because each IndexSearcher disposal
+            // releases the ByteStringContext-backed VectorValue buffers.
+            var queryVectors = new[] { NewQueryVector(bsc, seed: 29), NewQueryVector(bsc, seed: 30), NewQueryVector(bsc, seed: 31) };
+            var match = searcher.MultiVectorSearch(metadata, queryVectors, 0.0f, 16, false, false, filterQuery: null, scanningThreshold: 0);
+            var collected = new List<long>();
+            Span<long> ids = stackalloc long[16];
+            int read;
+            while ((read = match.Fill(ids)) > 0)
+                for (int i = 0; i < read; i++)
+                    collected.Add(ids[i]);
+            collected.Sort();
+            return collected.ToArray();
+        }
+
+        Assert.Equal(Run(withCache: false), Run(withCache: true));
+    }
+
+    // A query opened BEFORE new vectors were committed must see its own snapshot, even when
+    // the HnswIndexCache it was given was built AT OR BEFORE that snapshot. A cache that predates
+    // the query's tx is always valid; the query must never see vectors added after it started.
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void QueryAtOlderTxDoesNotSeeVectorsCommittedAfterItStarted()
+    {
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+
+        BuildIndex(mapping, docCount: 200, seed: 41);
+        var caches = BuildCaches(metadata.FieldName); // cache reflects the first 200 vectors
+
+        // Take a snapshot by creating the IndexSearcher now. Subsequent writes must be
+        // invisible to queries issued on this searcher.
+        using var snapshotSearcher = new IndexSearcher(Env, mapping);
+        snapshotSearcher.AttachVectorNodeCaches(caches);
+
+        AppendDocuments(mapping, docCount: 200, firstId: 201, seed: 53);
+
+        var q = NewQueryVector(bsc, seed: 61);
+        var ids = TopK(snapshotSearcher, metadata, q, k: 200);
+
+        // Max docId at the snapshot is 200. Anything >= 201 was committed later and must
+        // not be returned.
+        foreach (var id in ids)
+            Assert.InRange(id, 1L, 200L);
+    }
+
+    // A cache built after both commits should yield results equivalent to a fresh searcher
+    // with no cache: the cache sees everything, queries see everything.
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void CacheBuiltAfterAllCommitsAgreesWithUncachedSearcher()
+    {
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+
+        BuildIndex(mapping, docCount: 200, seed: 41);
+        AppendDocuments(mapping, docCount: 200, firstId: 201, seed: 53);
+
+        var caches = BuildCaches(metadata.FieldName);
+
+        long[] cached, uncached;
+        {
+            using var searcher = new IndexSearcher(Env, mapping);
+            searcher.AttachVectorNodeCaches(caches);
+            cached = TopK(searcher, metadata, NewQueryVector(bsc, seed: 61), k: 16);
+        }
+        {
+            using var searcher = new IndexSearcher(Env, mapping);
+            uncached = TopK(searcher, metadata, NewQueryVector(bsc, seed: 61), k: 16);
+        }
+
+        Assert.Equal(uncached, cached);
+    }
+
+    private void BuildIndex(IndexFieldsMapping mapping, int docCount, int seed)
+    {
+        var random = new Random(seed);
+        using var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All);
+        for (int i = 1; i <= docCount; i++)
+        {
+            var id = $"docs/{i}";
+            using var entry = indexWriter.Index(id);
+            entry.Write(0, System.Text.Encoding.UTF8.GetBytes(id));
+            entry.WriteVector(1, "Vector", MemoryMarshal.Cast<float, byte>(RandomVector(random)));
+            entry.EndWriting();
+        }
+        indexWriter.Commit();
+    }
+
+    private void AppendDocuments(IndexFieldsMapping mapping, int docCount, int firstId, int seed)
+    {
+        var random = new Random(seed);
+        using var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All);
+        for (int i = 0; i < docCount; i++)
+        {
+            var docId = firstId + i;
+            var id = $"docs/{docId}";
+            using var entry = indexWriter.Index(id);
+            entry.Write(0, System.Text.Encoding.UTF8.GetBytes(id));
+            entry.WriteVector(1, "Vector", MemoryMarshal.Cast<float, byte>(RandomVector(random)));
+            entry.EndWriting();
+        }
+        indexWriter.Commit();
+    }
+
+    private Dictionary<Slice, HnswIndexCache> BuildCaches(Slice fieldName, int maxNodes = 10_000)
+    {
+        using var tx = Env.ReadTransaction();
+        var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, fieldName, maxNodes);
+        var dict = new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance);
+        if (cache != null && cache.Count > 0)
+            dict[fieldName] = cache;
+        return dict;
+    }
+
+    private static VectorValue NewQueryVector(ByteStringContext bsc, int seed)
+    {
+        var v = RandomVector(new Random(seed));
+        var scope = bsc.Allocate(VectorByteSize, out Memory<byte> buffer);
+        MemoryMarshal.Cast<float, byte>(v).CopyTo(buffer.Span);
+        return GenerateEmbeddings.FromArray(bsc, scope, buffer, Raven.Client.Documents.Indexes.Vector.VectorOptions.Default, VectorByteSize);
+    }
+
+    private static long[] TopK(IndexSearcher searcher, FieldMetadata metadata, VectorValue query, int k, bool isExact = false)
+    {
+        var match = searcher.VectorSearch(metadata, query, 0.0f, k, isExact, false);
+        var collected = new List<long>();
+        Span<long> ids = stackalloc long[k];
+        int read;
+        while ((read = match.Fill(ids)) > 0)
+        {
+            for (int i = 0; i < read; i++)
+                collected.Add(ids[i]);
+        }
+        collected.Sort();
+        return collected.ToArray();
+    }
+
+    private static float[] RandomVector(Random random)
+    {
+        var v = new float[VectorDimensions];
+        float sumSq = 0;
+        for (int i = 0; i < VectorDimensions; i++)
+        {
+            v[i] = (float)(random.NextDouble() * 2 - 1);
+            sumSq += v[i] * v[i];
+        }
+        var norm = MathF.Sqrt(sumSq);
+        if (norm > 0)
+        {
+            for (int i = 0; i < VectorDimensions; i++)
+                v[i] /= norm;
+        }
+        return v;
+    }
+
+    private static IDisposable GetMappings(VectorEmbeddingType embedding, out ByteStringContext bsc, out IndexFieldsMapping mapping, int numberOfEdges = 8, int numberOfCandidates = 16)
+    {
+        var bscLocal = new ByteStringContext(SharedMultipleUseFlag.None);
+        var mappingLocal = IndexFieldsMappingBuilder
+            .CreateForWriter(false)
+            .AddBinding(0, "id()")
+            .AddBinding(1, "Vector", vectorOptions: new VectorOptions { NumberOfEdges = numberOfEdges, NumberOfCandidates = numberOfCandidates, VectorEmbeddingType = embedding })
+            .Build();
+
+        bsc = bscLocal;
+        mapping = mappingLocal;
+
+        return Disposable.Create(() =>
+        {
+            bscLocal.Dispose();
+            mappingLocal.Dispose();
+        });
+    }
+
+    private static double Recall(long[] truth, long[] returned)
+    {
+        if (truth.Length == 0)
+            return 1.0;
+        var set = new HashSet<long>(truth);
+        int hits = 0;
+        foreach (var id in returned)
+            if (set.Contains(id))
+                hits++;
+        return (double)hits / truth.Length;
+    }
+}

--- a/test/SlowTests/Corax/Vectors/VectorSearchWithHnswIndexCache.cs
+++ b/test/SlowTests/Corax/Vectors/VectorSearchWithHnswIndexCache.cs
@@ -33,12 +33,13 @@ public class VectorSearchWithHnswIndexCache(ITestOutputHelper output) : StorageT
     // equal distance, so which ones land in top-K depends on priority-queue tie-breaking —
     // an ambiguity that is unrelated to whether the cache is used.
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    [InlineData(VectorEmbeddingType.Single, 10_000)] // cache holds every node
-    [InlineData(VectorEmbeddingType.Single, 50)]     // cache holds only upper-level nodes
-    [InlineData(VectorEmbeddingType.Int8, 10_000)]
-    [InlineData(VectorEmbeddingType.Int8, 50)]
-    public void ResultsAreIdenticalWithAndWithoutCache(VectorEmbeddingType embedding, int cacheBudget)
-        => RunParityCheck(embedding, cacheBudget, baseSeed: 23);
+    [InlineData(VectorEmbeddingType.Single, 10_000, 23)] // cache holds every node
+    [InlineData(VectorEmbeddingType.Single, 50, 23)]     // cache holds only upper-level nodes
+    [InlineData(VectorEmbeddingType.Int8, 10_000, 23)]
+    [InlineData(VectorEmbeddingType.Int8, 50, 23)]
+    [InlineDataWithRandomSeed(VectorEmbeddingType.Single, 10_000)]
+    public void ResultsAreIdenticalWithAndWithoutCache(VectorEmbeddingType embedding, int cacheBudget, int baseSeed)
+        => RunParityCheck(embedding, cacheBudget, baseSeed);
 
     private void RunParityCheck(VectorEmbeddingType embedding, int cacheBudget, int baseSeed)
     {
@@ -73,23 +74,22 @@ public class VectorSearchWithHnswIndexCache(ITestOutputHelper output) : StorageT
     // id must map to a real doc and the top-K must agree with an exact scan on most of its
     // entries (HNSW is approximate; we require high recall, not byte-identity).
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    [InlineData(17, 71)]
-    [InlineData(null, null)]
-    public void SearchWorksWithNoCacheAttached(int? buildSeed, int? querySeed)
+    [InlineData(17)]
+    [InlineDataWithRandomSeed]
+    public void SearchWorksWithNoCacheAttached(int seed)
     {
-        var (bSeed, qSeed) = MaterializeSeeds(buildSeed, querySeed);
         using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
         var metadata = mapping.GetByFieldId(1).Metadata;
-        BuildIndex(mapping, docCount: 200, seed: bSeed);
+        BuildIndex(mapping, docCount: 200, seed: seed);
 
         long[] truth, returned;
         using (var searcher = new IndexSearcher(Env, mapping))
-            truth = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16, isExact: true);
+            truth = TopK(searcher, metadata, NewQueryVector(bsc, seed: seed + 1), k: 16, isExact: true);
 
         using (var searcher = new IndexSearcher(Env, mapping))
         {
             // Deliberately do NOT call AttachVectorNodeCaches.
-            returned = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16);
+            returned = TopK(searcher, metadata, NewQueryVector(bsc, seed: seed + 1), k: 16);
         }
 
         Assert.Equal(16, returned.Length);
@@ -99,30 +99,29 @@ public class VectorSearchWithHnswIndexCache(ITestOutputHelper output) : StorageT
         // At least one returned id must overlap the exact top-K — lower bound on recall that
         // catches "the search returned random ids" without being sensitive to approximate-search
         // jitter on adversarial random seeds.
-        Assert.True(Recall(truth, returned) > 0, $"no overlap with exact top-K (buildSeed={bSeed}, querySeed={qSeed})");
+        Assert.True(Recall(truth, returned) > 0, $"no overlap with exact top-K (seed={seed})");
     }
 
     // When a cache is attached but empty (e.g. the graph has fewer nodes than the cache
     // budget could hold but none were persisted yet), queries must fall back to disk loads
     // and still return meaningful results.
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    [InlineData(19, 73)]
-    [InlineData(null, null)]
-    public void SearchWorksWithEmptyCacheDictionaryAttached(int? buildSeed, int? querySeed)
+    [InlineData(19)]
+    [InlineDataWithRandomSeed]
+    public void SearchWorksWithEmptyCacheDictionaryAttached(int seed)
     {
-        var (bSeed, qSeed) = MaterializeSeeds(buildSeed, querySeed);
         using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
         var metadata = mapping.GetByFieldId(1).Metadata;
-        BuildIndex(mapping, docCount: 200, seed: bSeed);
+        BuildIndex(mapping, docCount: 200, seed: seed);
 
         long[] truth, returned;
         using (var searcher = new IndexSearcher(Env, mapping))
-            truth = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16, isExact: true);
+            truth = TopK(searcher, metadata, NewQueryVector(bsc, seed: seed + 1), k: 16, isExact: true);
 
         using (var searcher = new IndexSearcher(Env, mapping))
         {
             searcher.AttachVectorNodeCaches(new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance));
-            returned = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16);
+            returned = TopK(searcher, metadata, NewQueryVector(bsc, seed: seed + 1), k: 16);
         }
 
         Assert.Equal(16, returned.Length);
@@ -132,28 +131,7 @@ public class VectorSearchWithHnswIndexCache(ITestOutputHelper output) : StorageT
         // At least one returned id must overlap the exact top-K — lower bound on recall that
         // catches "the search returned random ids" without being sensitive to approximate-search
         // jitter on adversarial random seeds.
-        Assert.True(Recall(truth, returned) > 0, $"no overlap with exact top-K (buildSeed={bSeed}, querySeed={qSeed})");
-    }
-
-    private (int BuildSeed, int QuerySeed) MaterializeSeeds(int? buildSeed, int? querySeed)
-    {
-        if (buildSeed.HasValue && querySeed.HasValue)
-            return (buildSeed.Value, querySeed.Value);
-        var rng = new Random();
-        var b = buildSeed ?? rng.Next();
-        var q = querySeed ?? rng.Next();
-        Output.WriteLine($"Random seeds: buildSeed={b}, querySeed={q} (re-run with fixed seeds to reproduce)");
-        return (b, q);
-    }
-
-    // Randomized variant of the parity theory: picks a fresh seed at test time and logs it
-    // so a regression can be reproduced. Fixed-seed variants cover the deterministic path.
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void ResultsAreIdenticalWithAndWithoutCache_RandomSeed()
-    {
-        var seed = unchecked((int)DateTime.UtcNow.Ticks);
-        Output.WriteLine($"Random seed: {seed} (re-run with fixed seed to reproduce)");
-        RunParityCheck(VectorEmbeddingType.Single, cacheBudget: 10_000, baseSeed: seed);
+        Assert.True(Recall(truth, returned) > 0, $"no overlap with exact top-K (seed={seed})");
     }
 
     // The cached path must agree with the exact scan on most top-K. HNSW params are sized

--- a/test/SlowTests/Voron/Graphs/HnswSearch.cs
+++ b/test/SlowTests/Voron/Graphs/HnswSearch.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using FastTests.Voron;
+using FastTests.Voron.Graphs;
 using Sparrow.Server.Collections;
 using Tests.Infrastructure;
 using Voron;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26405

Source pull requests (rebased and combined here):
- [#2 RavenDB-26405](https://github.com/redknightlois/ravendb/pull/2) — HNSW node-cache pipeline ([YouTrack](https://issues.hibernatingrhinos.com/issue/RavenDB-26405))
- [#3 RavenDB-26419](https://github.com/redknightlois/ravendb/pull/3) — Neighbor vector prefetch ([YouTrack](https://issues.hibernatingrhinos.com/issue/RavenDB-26419))
- [#4 RavenDB-26421](https://github.com/redknightlois/ravendb/pull/4) — Cache resolved edge indexes ([YouTrack](https://issues.hibernatingrhinos.com/issue/RavenDB-26421))
- [#5 RavenDB-26423](https://github.com/redknightlois/ravendb/pull/5) — L2-norm cache + FMA DotProduct ([YouTrack](https://issues.hibernatingrhinos.com/issue/RavenDB-26423))
- [#6 RavenDB-26536](https://github.com/redknightlois/ravendb/pull/6) — State-machine searcher + incremental commit application ([YouTrack](https://issues.hibernatingrhinos.com/issue/RavenDB-26536))
- [#7 RavenDB-26537](https://github.com/redknightlois/ravendb/pull/7) — Leaf-inclusive cache + inner-loop tuning ([YouTrack](https://issues.hibernatingrhinos.com/issue/RavenDB-26537))

### Additional description

Combined HNSW vector-search optimization series, originally landed as six stacked PRs against `redknightlois/ravendb`. Squashed onto a single branch for review/merge. Commits, in order:

1. **[RavenDB-26405](https://issues.hibernatingrhinos.com/issue/RavenDB-26405)** ([#2](https://github.com/redknightlois/ravendb/pull/2)) — Vector search foundation: HNSW node-cache pipeline. Introduces `HnswIndexCache` (cross-query cache of upper-level graph nodes). Adds `HnswIndexCacheTests` (FastTests) and `VectorSearchWithHnswIndexCache` (SlowTests).
2. **[RavenDB-26419](https://issues.hibernatingrhinos.com/issue/RavenDB-26419)** ([#3](https://github.com/redknightlois/ravendb/pull/3)) — Neighbor vector prefetch in the HNSW inner search loop.
3. **[RavenDB-26421](https://issues.hibernatingrhinos.com/issue/RavenDB-26421)** ([#4](https://github.com/redknightlois/ravendb/pull/4)) — Cache resolved edge indexes in HNSW search loops to avoid repeated lookups.
4. **[RavenDB-26423](https://issues.hibernatingrhinos.com/issue/RavenDB-26423)** ([#5](https://github.com/redknightlois/ravendb/pull/5)) — Cache per-vector L2 norm in HNSW f32 cosine.
5. **[RavenDB-26423](https://issues.hibernatingrhinos.com/issue/RavenDB-26423)** ([#5](https://github.com/redknightlois/ravendb/pull/5)) — Add Vector512-shaped FMA `DotProduct` kernel for HNSW.
6. **[RavenDB-26536](https://issues.hibernatingrhinos.com/issue/RavenDB-26536)** ([#6](https://github.com/redknightlois/ravendb/pull/6)) — Replace HNSW searcher iterator with a state machine.
7. **[RavenDB-26536](https://issues.hibernatingrhinos.com/issue/RavenDB-26536)** ([#6](https://github.com/redknightlois/ravendb/pull/6)) — Apply HNSW commits incrementally via `DirtyNodeIds`.
8. **[RavenDB-26537](https://issues.hibernatingrhinos.com/issue/RavenDB-26537)** ([#7](https://github.com/redknightlois/ravendb/pull/7)) — Leaf-inclusive cache and inner-loop hot-path tuning.

Net effect: faster HNSW search (prefetch + edge cache + FMA dot product + state-machine searcher), lower per-query allocation pressure (node cache shared across queries, L2-norm cache), and cheaper commits (incremental application via dirty-node set). No public API changes.

**New configuration key:** `Indexing.Corax.VectorSearch.CacheSizeInMb` — controls the size of the cross-query HNSW node cache introduced in RavenDB-26405. Scope: server-wide, per-database, or per-index. Default: 10 MB. Changing it triggers an index refresh; no re-indexing required.

Studio needs to expose `Indexing.Corax.VectorSearch.CacheSizeInMb` in the per-index configuration UI (size-in-MB input, default 10) alongside the other `Indexing.Corax.VectorSearch.*` entries.

Note: shares files with [PR #22712](https://github.com/ravendb/ravendb/pull/22712) ([RavenDB-26465](https://issues.hibernatingrhinos.com/issue/RavenDB-26465), parallel-placement hot path). Cleanly auto-merges with it — `src/Voron/Data/Graphs/Hnsw.cs` is the only overlap and resolves automatically.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

No on-disk format change. New config key has a safe default.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
