### PR TITLE
RavenDB-26665 /  RavenDB-26715 Stabilize RavenDB_17867 recursion tests

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17867.cs
+++ b/test/SlowTests/Issues/RavenDB-17867.cs
@@ -37,6 +37,7 @@ namespace SlowTests.Issues
                         ["PeopleUtil"] = @"
 public static class PeopleUtil
 {
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
     public static string CalculatePersonEmail(string name)
     {
         return CalculatePersonEmail(name);
@@ -52,6 +53,9 @@ public static class PeopleUtil
                 }
 
                 Indexes.WaitForIndexing(store, allowErrors: true);
+
+                var mapErrors = WaitForValue(() =>
+                    store.Maintenance.Send(new GetIndexStatisticsOperation("Companies/WithRecursion")).MapErrors > 0, true);
 
                 var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation("Companies/WithRecursion"));
 
@@ -87,6 +91,7 @@ public static class PeopleUtil
                         ["TreeUtil"] = @"
 public static class TreeUtil
 {
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
     public static int GetDepth(string name) => 1 + GetDepth(name);
 }"
                     }
@@ -99,6 +104,9 @@ public static class TreeUtil
                 }
 
                 Indexes.WaitForIndexing(store, allowErrors: true);
+
+                var mapErrors = WaitForValue(() =>
+                    store.Maintenance.Send(new GetIndexStatisticsOperation("Companies/WithExpressionBodyRecursion")).MapErrors > 0, true);
 
                 var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation("Companies/WithExpressionBodyRecursion"));
 
@@ -134,8 +142,10 @@ public static class TreeUtil
                         ["Helper"] = @"
 public static class Helper
 {
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
     public static string Process(string name)
     {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining | System.Runtime.CompilerServices.MethodImplOptions.NoOptimization)]
         string Inner(string n) { return Inner(n); }
         return Inner(name);
     }
@@ -150,6 +160,9 @@ public static class Helper
                 }
 
                 Indexes.WaitForIndexing(store, allowErrors: true);
+
+                var mapErrors = WaitForValue(() =>
+                    store.Maintenance.Send(new GetIndexStatisticsOperation("Companies/WithLocalFunctionRecursion")).MapErrors > 0, true);
 
                 var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation("Companies/WithLocalFunctionRecursion"));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26715
### Additional description

Backport of  https://github.com/ravendb/ravendb/pull/22851/changes/fb455a10886e01beeb716eb8cd53817395e25b6f from https://github.com/ravendb/ravendb/pull/22851 PR

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
