### PR TITLE
RavenDB-26718 Use test-runner from storybook

### DIFF
--- a/.github/workflows/StudioTests.yml
+++ b/.github/workflows/StudioTests.yml
@@ -51,10 +51,6 @@ jobs:
       run: npm run test
       working-directory: ./src/Raven.Studio
 
-    - name: Install Playwright
-      run: npx playwright install --with-deps chromium
-      working-directory: ./src/Raven.Studio
-
     - name: Build Storybook
       run: npm run build-storybook --quiet
       working-directory: ./src/Raven.Studio

--- a/src/Raven.Studio/.storybook/test-runner-jest.config.js
+++ b/src/Raven.Studio/.storybook/test-runner-jest.config.js
@@ -1,0 +1,16 @@
+const { getJestConfig } = require("@storybook/test-runner");
+
+const testRunnerConfig = getJestConfig();
+const jestPlaywrightConfig = testRunnerConfig.testEnvironmentOptions["jest-playwright"];
+
+module.exports = {
+    ...testRunnerConfig,
+    testEnvironmentOptions: {
+        ...testRunnerConfig.testEnvironmentOptions,
+        "jest-playwright": {
+            ...jestPlaywrightConfig,
+            // GitHub's Ubuntu runner already includes Chrome, so CI does not need a Playwright browser download.
+            launchOptions: process.env.GITHUB_ACTIONS === "true" ? { channel: "chrome" } : {},
+        },
+    },
+};


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26718/Install-Playwright-timeout

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
