### PR TITLE
RavenDB-25135 Restore GetPageWithoutCache on the encrypted VoronStream read path

### DIFF
--- a/src/Voron/Data/VoronStream.cs
+++ b/src/Voron/Data/VoronStream.cs
@@ -171,7 +171,7 @@ namespace Voron.Data
                 Llt.TryReleasePage(LastPage.PageNumber);
             }
 
-            LastPage = Llt.GetPage(pageNumber);
+            LastPage = Llt.GetPageWithoutCache(pageNumber);
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -615,6 +615,15 @@ namespace Voron.Impl
             return p;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Page GetPageWithoutCache(long pageNumber)
+        {
+            if (_txState != TxState.None)
+                ThrowObjectDisposed();
+
+            return GetPageInternal(pageNumber);
+        }
+
         private Page GetPageInternal(long pageNumber)
         {
             // Check if we can hit the lowest level locality cache.

--- a/test/SlowTests/Voron/Issues/RavenDB_25135.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_25135.cs
@@ -116,5 +116,96 @@ namespace SlowTests.Voron.Issues
                 Assert.Equal(pageNumber, refetched.PageNumber);
             }
         }
+
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Encryption)]
+        public void Encrypted_Page_Shared_By_Two_Streams_Must_Be_Refcounted_Per_Reader()
+        {
+            RequireFileBasedPager();
+
+            const int size = 40_000;
+            var data = new byte[size];
+            for (int i = 0; i < size; i++)
+                data[i] = (byte)(i % 251);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Data");
+                tree.AddStream("stream1", new MemoryStream(data));
+                tx.Commit();
+            }
+
+            Env.FlushLogToDataFile();
+            RestartDatabase();
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var llt = tx.LowLevelTransaction;
+                var tree = tx.ReadTree("Data");
+
+                // The first chunk lives on its own (overflow) page that, after flush+restart, is served
+                // by CryptoPager (decrypted into a per-transaction EncryptionBuffer).
+                Slice.From(tx.Allocator, "stream1", out var key);
+                var chunks = tree.ReadTreeChunks(key, out _);
+                Assert.True(chunks.Length >= 2, $"expected the stream to span >=2 chunks, got {chunks.Length}");
+                long p0 = chunks[0].PageNumber;
+                int chunk0Size = chunks[0].ChunkSize;
+
+                // Two independent VoronStreams over the same key model two cloned Lucene index inputs
+                // sharing one read transaction (hence the same crypto state and the same page locator).
+                var streamA = tree.ReadStream(key);
+                var streamB = tree.ReadStream(key);
+
+                // A reads the first chunk -> page p0 is decrypted into a fresh buffer (Usages = 1) and,
+                // on the regressed code path, cached in the page locator.
+                Assert.NotEqual(-1, streamA.ReadByte());
+                Assert.Equal(1, GetUsages(llt, p0));
+
+                // B reads the same page. It MUST take its own reference (Usages -> 2). On the regressed
+                // path VoronStream uses Llt.GetPage(), whose page-locator HIT returns the cached pointer
+                // WITHOUT AcquirePagePointer, so Usages stays 1 - an un-refcounted second holder. That is
+                // the root cause of the AVE: a single TryReleasePage then frees a buffer still in use.
+                Assert.NotEqual(-1, streamB.ReadByte());
+                Assert.Equal(2, GetUsages(llt, p0));
+
+                // ---- use-after-free demonstration ----
+                // A consumes the rest of chunk 0 (staying on p0) and then steps into chunk 1, which makes
+                // VoronStream release p0 via TryReleasePage.
+                var discard = new byte[chunk0Size];
+                ReadExactly(streamA, discard, chunk0Size - 1);
+                Assert.NotEqual(-1, streamA.ReadByte());
+
+                // B still references p0, so the buffer must not have been freed.
+                Assert.True(GetUsages(llt, p0) >= 1,
+                    $"page {p0} buffer was freed while stream B still references it (use-after-free)");
+
+                // B reads the remainder of chunk 0; against a freed/zeroed buffer this returns garbage.
+                var fromB = new byte[chunk0Size - 1];
+                ReadExactly(streamB, fromB, fromB.Length);
+                for (int i = 0; i < fromB.Length; i++)
+                    Assert.Equal((byte)((i + 1) % 251), fromB[i]);
+            }
+
+            static int GetUsages(LowLevelTransaction llt, long page)
+            {
+                var state = (IPagerLevelTransactionState)llt;
+                if (state.CryptoPagerTransactionState == null)
+                    return -1;
+                foreach (var kvp in state.CryptoPagerTransactionState)
+                    if (kvp.Value.TryGetValue(page, out var buffer))
+                        return buffer.Usages;
+                return 0; // released / never decrypted
+            }
+
+            static void ReadExactly(System.IO.Stream stream, byte[] buffer, int count)
+            {
+                int read = 0;
+                while (read < count)
+                {
+                    int n = stream.Read(buffer, read, count - read);
+                    Assert.True(n > 0, "unexpected end of stream");
+                    read += n;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25135

### Additional description

This partially reverts #22574. It restores `LowLevelTransaction.GetPageWithoutCache`
and points `VoronStream.UpdateLastPageIfNeeded`'s encrypted path back at it. The
`CryptoPager.TryReleasePage` page-locator `Reset` introduced by #22574 is **kept**.

#### What #22574 changed, and why removing `GetPageWithoutCache` was wrong
#22574 made two changes:
1. `Reset` the page locator entry inside `CryptoPager.TryReleasePage` when a buffer
   is freed (defensive — kept).
2. Removed `GetPageWithoutCache` and switched the encrypted `VoronStream` read path
   to the locator-backed `LowLevelTransaction.GetPage`, on the assumption that the
   `Reset` made the cache safe again.

Assumption (2) does not hold. `GetPageWithoutCache` was not merely dodging a stale locator entry - it forced every stream page acquire through `CryptoPager.AcquirePagePointer`, which increments `EncryptionBuffer.Usages`.
`GetPage` does **not**: on a page-locator hit it returns the cached decrypted-buffer pointer *without* `AcquirePagePointer`, so no `Usages++`. `VoronStream`, however pairs each acquire with `TryReleasePage`, which always does `Usages--`.

So when two index readers in the **same read transaction** touch the same decrypted page (e.g. two `SegmentTermDocs` under one `BooleanScorer`, or any cloned Lucene inputs - note that with compound files all logical files share one underlying `VoronBufferedInput`, so this is the norm), the second reader's acquire is a locator hit that takes no reference. The first reader's page advance then drives `Usages` to 0, and `CryptoPager` zeroes the buffer and returns it to `EncryptionBuffersPool` (freed straight to the OS for >1MB buffers, or trimmed later under memory pressure) while the second reader still holds a `LastPage` pointer into it → AVE.

The `Reset` does not address this: the surviving reader dereferences its own cached `LastPage` struct copy and never re-consults the page locator, so invalidating the locator entry is irrelevant to it. The fix is correct ref-counting - every acquire must take a reference - which `GetPageWithoutCache` guarantees by bypassing the locator.

### Reproduction
- **Deterministic unit test** (added): two `VoronStream`s over one key in a single encrypted read transaction (post flush + restart, so pages are served by   `CryptoPager`). On the regressed code the second reader's `GetPage` is a locator it, so `EncryptionBuffer.Usages == 1` for two live holders, and a single  `TryReleasePage` frees a buffer still in use. With the fix, `Usages == 2` and the  shared page survives.
- **End-to-end:** a real server, encrypted DB, 300k docs, full-text index with  stored fields, multi-worker query storm. The regressed build hard-crashes with  `System.AccessViolationException` in  `BufferedIndexInput.ReadBytes → … → ReadVInt → SegmentTermDocs.Read →  BooleanScorer → IndexSearcher.Search → … → QueriesHandler.Post`. With the fix the identical storm ran 63,863 queries with no AVE.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low  - restores previously shipped behavior (`GetPageWithoutCache` predates #22574 and existed since RavenDB-20555). The `Reset` from #22574 is retained.
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
