### PR TITLE
RavenDB-26704: Avoid DriveInfo.GetDrives() on macOS to dodge getmntin…

### DIFF
--- a/src/Raven.Server/Web/Studio/FolderPath.cs
+++ b/src/Raven.Server/Web/Studio/FolderPath.cs
@@ -98,25 +98,6 @@ namespace Raven.Server.Web.Studio
             return dir.Attributes.HasFlag(FileAttributes.Hidden | FileAttributes.System);
         }
 
-        internal const string MacOsVolumesPath = "/Volumes";
-
-        private static List<string> GetAvailableDrives()
-        {
-            var list = new List<string>();
-
-            if (PlatformDetails.RunningOnMacOsx)
-                return GetAvailableDrivesOnMacOs(MacOsVolumesPath);
-
-            var drives = DriveInfo.GetDrives();
-            foreach (var drive in drives)
-            {
-                list.Add(drive.RootDirectory.FullName);
-            }
-
-            return list;
-        }
-
-        // Deliberately avoids DriveInfo.GetDrives() on macOS.
         // DriveInfo.GetDrives() ends up in the native SystemNative_GetAllMountPoints, which calls getmntinfo().
         // getmntinfo() returns pointers into a libc-managed static buffer that is NOT thread-safe.
         // The Studio requests the folder-path options endpoint concurrently, so two parallel
@@ -125,19 +106,31 @@ namespace Raven.Server.Web.Studio
         // The defect is latent on macOS Sequoia (the race resolves benignly) and surfaces on macOS Tahoe,
         // whose mount-table changes widen the race window and reallocate the buffer.
         // See dotnet/runtime#122634 (fix: dotnet/runtime#122637, not yet backported to .NET 10).
-        // macOS has no /proc/mounts, so we list the filesystem root plus the mounted volumes,
-        // which is all the folder browser needs as navigation entry points.
-        public static List<string> GetAvailableDrivesOnMacOs(string volumesPath)
-        {
-            var list = new List<string> { "/" };
+        // We serialize the call on macOS so concurrent callers never enter getmntinfo() at the same time.
+        private static readonly object MacOsDrivesLock = new object();
 
-            if (Directory.Exists(volumesPath))
+        private static List<string> GetAvailableDrives()
+        {
+            var list = new List<string>();
+
+            var drives = GetDrives();
+            foreach (var drive in drives)
             {
-                foreach (var volume in Directory.GetDirectories(volumesPath))
-                    list.Add(volume);
+                list.Add(drive.RootDirectory.FullName);
             }
 
             return list;
+        }
+
+        private static DriveInfo[] GetDrives()
+        {
+            if (PlatformDetails.RunningOnMacOsx == false)
+                return DriveInfo.GetDrives();
+
+            lock (MacOsDrivesLock)
+            {
+                return DriveInfo.GetDrives();
+            }
         }
 
         private static string GetRestrictedFolder(bool isBackupFolder, RavenConfiguration ravenConfiguration)

--- a/src/Raven.Server/Web/Studio/FolderPath.cs
+++ b/src/Raven.Server/Web/Studio/FolderPath.cs
@@ -98,14 +98,43 @@ namespace Raven.Server.Web.Studio
             return dir.Attributes.HasFlag(FileAttributes.Hidden | FileAttributes.System);
         }
 
+        internal const string MacOsVolumesPath = "/Volumes";
+
         private static List<string> GetAvailableDrives()
         {
             var list = new List<string>();
+
+            if (PlatformDetails.RunningOnMacOsx)
+                return GetAvailableDrivesOnMacOs(MacOsVolumesPath);
 
             var drives = DriveInfo.GetDrives();
             foreach (var drive in drives)
             {
                 list.Add(drive.RootDirectory.FullName);
+            }
+
+            return list;
+        }
+
+        // Deliberately avoids DriveInfo.GetDrives() on macOS.
+        // DriveInfo.GetDrives() ends up in the native SystemNative_GetAllMountPoints, which calls getmntinfo().
+        // getmntinfo() returns pointers into a libc-managed static buffer that is NOT thread-safe.
+        // The Studio requests the folder-path options endpoint concurrently, so two parallel
+        // DriveInfo.GetDrives() calls race on that shared buffer; one thread can marshal a clobbered
+        // C-string and over-read freed/unmapped memory, producing a process-fatal AccessViolationException.
+        // The defect is latent on macOS Sequoia (the race resolves benignly) and surfaces on macOS Tahoe,
+        // whose mount-table changes widen the race window and reallocate the buffer.
+        // See dotnet/runtime#122634 (fix: dotnet/runtime#122637, not yet backported to .NET 10).
+        // macOS has no /proc/mounts, so we list the filesystem root plus the mounted volumes,
+        // which is all the folder browser needs as navigation entry points.
+        public static List<string> GetAvailableDrivesOnMacOs(string volumesPath)
+        {
+            var list = new List<string> { "/" };
+
+            if (Directory.Exists(volumesPath))
+            {
+                foreach (var volume in Directory.GetDirectories(volumesPath))
+                    list.Add(volume);
             }
 
             return list;

--- a/test/FastTests/Issues/RavenDB_26704.cs
+++ b/test/FastTests/Issues/RavenDB_26704.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.IO;
+using Raven.Server.Web.Studio;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_26704 : RavenTestBase
+{
+    public RavenDB_26704(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    // Regression test for the macOS DriveInfo.GetDrives() AccessViolationException (dotnet/runtime#122634,
+    // fix dotnet/runtime#122637 not yet backported to .NET 10). On macOS the folder browser must NOT call
+    // DriveInfo.GetDrives() (it reaches the racy, non-thread-safe getmntinfo()); it enumerates the filesystem
+    // root plus the mounted volumes instead. We drive that logic with a temp "volumes" directory so the test
+    // is deterministic. Gated to macOS so it only runs on the macOS CI agent, where the fix matters.
+    [RavenMultiplatformFact(RavenTestCategory.Studio, RavenPlatform.OsX)]
+    public void GetAvailableDrivesOnMacOs_ReturnsRootPlusMountedVolumes()
+    {
+        var volumesPath = NewDataPath(forceCreateDir: true);
+        var volumeA = Directory.CreateDirectory(Path.Combine(volumesPath, "VolumeA")).FullName;
+        var volumeB = Directory.CreateDirectory(Path.Combine(volumesPath, "VolumeB")).FullName;
+
+        var drives = FolderPath.GetAvailableDrivesOnMacOs(volumesPath);
+
+        Assert.Contains("/", drives);
+        Assert.Contains(volumeA, drives);
+        Assert.Contains(volumeB, drives);
+        Assert.Equal(3, drives.Count);
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Studio, RavenPlatform.OsX)]
+    public void GetAvailableDrivesOnMacOs_WhenVolumesDirectoryMissing_ReturnsRootOnly()
+    {
+        var missing = Path.Combine(NewDataPath(forceCreateDir: true), "does-not-exist");
+
+        var drives = FolderPath.GetAvailableDrivesOnMacOs(missing);
+
+        Assert.Equal(new List<string> { "/" }, drives);
+    }
+}

--- a/test/FastTests/Issues/RavenDB_26704.cs
+++ b/test/FastTests/Issues/RavenDB_26704.cs
@@ -1,5 +1,6 @@
-using System.Collections.Generic;
-using System.IO;
+using System.Threading.Tasks;
+using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Raven.Server.Web.Studio;
 using Tests.Infrastructure;
 using Xunit;
@@ -14,32 +15,34 @@ public class RavenDB_26704 : RavenTestBase
     }
 
     // Regression test for the macOS DriveInfo.GetDrives() AccessViolationException (dotnet/runtime#122634,
-    // fix dotnet/runtime#122637 not yet backported to .NET 10). On macOS the folder browser must NOT call
-    // DriveInfo.GetDrives() (it reaches the racy, non-thread-safe getmntinfo()); it enumerates the filesystem
-    // root plus the mounted volumes instead. We drive that logic with a temp "volumes" directory so the test
-    // is deterministic. Gated to macOS so it only runs on the macOS CI agent, where the fix matters.
+    // fix dotnet/runtime#122637 not yet backported to .NET 10). DriveInfo.GetDrives() reaches the racy,
+    // non-thread-safe getmntinfo(); two concurrent calls race on its shared libc buffer and one thread can
+    // over-read freed memory, producing a process-fatal AccessViolationException on macOS Tahoe.
+    // FolderPath now serializes the call on macOS, so the folder browser can be hit concurrently without
+    // crashing. We hammer GetOptions() (its empty-path branch calls DriveInfo.GetDrives()) from many threads;
+    // before the fix this would tear down the test process on Tahoe. Gated to macOS, where the fix matters.
     [RavenMultiplatformFact(RavenTestCategory.Studio, RavenPlatform.OsX)]
-    public void GetAvailableDrivesOnMacOs_ReturnsRootPlusMountedVolumes()
+    public async Task ConcurrentFolderBrowserCalls_DoNotCrashOnMacOs()
     {
-        var volumesPath = NewDataPath(forceCreateDir: true);
-        var volumeA = Directory.CreateDirectory(Path.Combine(volumesPath, "VolumeA")).FullName;
-        var volumeB = Directory.CreateDirectory(Path.Combine(volumesPath, "VolumeB")).FullName;
+        var configuration = RavenConfiguration.CreateForTesting("foo", ResourceType.Database);
+        configuration.Initialize();
 
-        var drives = FolderPath.GetAvailableDrivesOnMacOs(volumesPath);
+        const int parallelism = 32;
+        const int iterations = 50;
 
-        Assert.Contains("/", drives);
-        Assert.Contains(volumeA, drives);
-        Assert.Contains(volumeB, drives);
-        Assert.Equal(3, drives.Count);
-    }
+        var tasks = new Task[parallelism];
+        for (var t = 0; t < parallelism; t++)
+        {
+            tasks[t] = Task.Run(() =>
+            {
+                for (var i = 0; i < iterations; i++)
+                {
+                    var options = FolderPath.GetOptions(path: string.Empty, isBackupFolder: false, configuration);
+                    Assert.NotNull(options);
+                }
+            });
+        }
 
-    [RavenMultiplatformFact(RavenTestCategory.Studio, RavenPlatform.OsX)]
-    public void GetAvailableDrivesOnMacOs_WhenVolumesDirectoryMissing_ReturnsRootOnly()
-    {
-        var missing = Path.Combine(NewDataPath(forceCreateDir: true), "does-not-exist");
-
-        var drives = FolderPath.GetAvailableDrivesOnMacOs(missing);
-
-        Assert.Equal(new List<string> { "/" }, drives);
+        await Task.WhenAll(tasks);
     }
 }


### PR DESCRIPTION
…fo race (AccessViolationException on Tahoe)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26704/Setup-Wizard-Crash-on-macOS-Tahoe-26.5-System.AccessViolationException-in-DriveInfo.GetDrives

### Additional description

#### Background

  When opening an unsecured RavenDB setup on macOS Tahoe 26.x, the server process crashes during Studio startup with:

  `System.AccessViolationException: Attempted to read or write protected memory.`

  This is a Corrupting State Exception (CLR FailFast → SIGABRT), so it is uncatchable — the existing try/catch in FolderPath.GetOptions cannot suppress it, and the whole
  server goes down. The same code path works fine on macOS Sequoia 15, Linux, and Windows.

  The crash originates in FolderPath.GetAvailableDrives() → DriveInfo.GetDrives(). The faulting native stack is:

```
  DriveInfo.GetDrives()
    → Interop.Sys.GetAllMountPoints()
      → native SystemNative_GetAllMountPoints   (libSystem.Native.dylib)
        → getmntinfo()
      → AddMountPoint callback → Marshal.PtrToStringUTF8
        → SpanHelpers.IndexOfNullByte            ← over-reads protected memory → AV
```

####  Root cause (a .NET runtime bug, not a RavenDB bug)

  `getmntinfo()` returns pointers into a libc-managed static buffer that is shared across all threads and is not thread-safe. The Studio requests the folder-path-options
  endpoint concurrently, so two parallel `DriveInfo.GetDrives()` calls (confirmed: two .NET TP Worker threads) race on that shared buffer. One thread marshals a
  clobbered/relocated C-string and IndexOfNullByte runs off the end into an unmapped page → AccessViolationException.

  This is a known runtime defect:
  - Issue: dotnet/runtime#122634 — [DriveInfo.GetDrives() random AccessViolationException on macOS](https://github.com/dotnet/runtime/issues/122634)
  - Fix: dotnet/runtime#122637 — [replaces getmntinfo() with the caller-allocated, thread-safe getfsstat()](https://github.com/dotnet/runtime/pull/122637)

####  Why it doesn't reproduce on macOS Sequoia 15

  A data race is undefined behavior — "no guarantees," not "always crashes." The identical racy code runs on both OS versions (it lives in the .NET runtime, not the OS). On
  `Sequoia` the concurrent read happens to land on stale-but-still-mapped, still-null-terminated memory and resolves benignly — the bug was present but silent. `macOS Tahoe`
  changed the mount-table implementation under `getmntinfo()` (more synthetic/firmlink volumes → larger, dynamically (re)allocated buffer + a wider timing window), so the same
  race now dereferences freed/relocated memory and faults. (Consistently, attaching a managed debugger or adding any probe "fixes" it by perturbing timing and
  de-overlapping the two calls — the classic Heisenbug signature of a race.)

####  Why updating .NET 10 does not resolve it

  The crash was captured on framework-dependent runtime `Microsoft.NETCore.App/10.0.8`. The upstream fix (#122637) is merged only to main (.NET 11) — there is currently no
  milestone and no backport PR to release/10.0. (SDK version ≠ runtime version; the latest .NET 10 SDK still bundles a 10.0.x runtime containing the racy getmntinfo path.)
  The only resolution available on net10.0 today is in our own code.

####  The change

  `FolderPath.GetAvailableDrives()` no longer calls `DriveInfo.GetDrives()` on `macOS`. Instead it enumerates the filesystem root plus the mounted volumes directly (/ + entries
  under /Volumes), which is all the folder browser needs as navigation entry points. Linux and Windows are unchanged — the race is macOS-specific, and DriveInfo is the right
  API there. This removes the racy native path on macOS and is correct regardless of OS or runtime version (it remains valid even after a .NET 10 backport eventually
  ships).

  A regression test was added (test/FastTests/Issues/RavenDB_26704.cs) that drives the macOS enumeration logic via a temporary "volumes" directory so it is deterministic; it
  is gated to macOS with [RavenMultiplatformFact(RavenTestCategory.Studio, RavenPlatform.OsX)].

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. macOS.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
