### PR TITLE
RavenDB-26719: fixed migration being stuck in case there are revisions/attachments tombstones and added logs

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -88,7 +88,7 @@ namespace Raven.Server.Documents
         private static readonly Slice GlobalFullChangeVectorSlice;
         private readonly Action<LogMode, string> _addToInitLog;
 
-        private readonly Logger _logger;
+        protected readonly Logger _logger;
         private readonly string _name;
 
         private static readonly Slice FixCountersLastKeySlice;

--- a/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Background/ShardedDocumentsMigrator.cs
@@ -32,6 +32,9 @@ namespace Raven.Server.Documents.Sharding.Background
                 if (configuration.HasActiveMigrations())
                     return;
 
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Documents migration scan (shard {_database.ShardNumber}) proceeding past HasActiveMigrations check; scanning for buckets that belong to another shard.");
+
                 int bucket = -1;
                 int moveToShard = -1;
                 using (_database.ShardedDocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
@@ -61,7 +64,12 @@ namespace Raven.Server.Documents.Sharding.Background
                 }
 
                 if (bucket != -1)
+                {
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Documents migration scan found bucket '{bucket}' on shard {_database.ShardNumber} that should be moved to shard {moveToShard}. Starting bucket migration.");
+
                     await MoveDocumentsToShardAsync(bucket, moveToShard, configuration);
+                }
             }
             catch (Exception e)
             {
@@ -69,7 +77,7 @@ namespace Raven.Server.Documents.Sharding.Background
                     return;
 
                 if (_logger.IsOperationsEnabled)
-                    _logger.Operations($"Failed to execute documents migration for '{_database.Name}'", e);
+                    _logger.Operations("Failed to execute documents migration.", e);
 
                 throw;
             }
@@ -100,11 +108,17 @@ namespace Raven.Server.Documents.Sharding.Background
                             tombstone.Flags.Contain(DocumentFlags.FromResharding))
                             continue;
 
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info($"Bucket '{bucket}' (shard {_database.ShardNumber}) has no documents but contains a non-artificial tombstone '{tombstone.LowerId}' (type {tombstone.Type}, etag {tombstone.Etag}); marking it for migration.");
+
                         return true;
                     }
 
                     continue;
                 }
+
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Bucket '{bucket}' (shard {_database.ShardNumber}) contains {bucketStats.NumberOfDocuments} document(s) that belong to another shard; marking it for migration.");
 
                 return true;
             }
@@ -143,6 +157,9 @@ namespace Raven.Server.Documents.Sharding.Background
                 _database.ShardedDatabaseName, 
                 prefix,
                 raftId: $"{Guid.NewGuid()}/{bucket}");
+
+            if (_logger.IsInfoEnabled)
+                _logger.Info($"Sending StartBucketMigrationCommand for bucket '{bucket}' from shard {_database.ShardNumber} to shard {moveToShard} (prefix: '{prefix}').");
 
             await _database.ServerStore.SendToLeaderAsync(cmd);
         }

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -137,6 +137,15 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
 
                             t = ServerStore.Sharding.DestinationMigrationConfirm(ShardedDatabaseName, process.Bucket, process.MigrationIndex);
                         }
+
+                        if (_logger.IsInfoEnabled)
+                        {
+                            if (status == ConflictStatus.AlreadyMerged)
+                                _logger.Info($"Bucket '{process.Bucket}' migration {process.MigrationIndex}: destination shard {process.DestinationShard} (node {ServerStore.NodeTag}) received all source data; sending DestinationMigrationConfirm (source CV: '{process.LastSourceChangeVector}').");
+                            else
+                                _logger.Info($"Bucket '{process.Bucket}' migration {process.MigrationIndex}: destination shard {process.DestinationShard} (node {ServerStore.NodeTag}) has not yet received all source data " +
+                                             $"(current bucket CV: '{current}', required source CV: '{process.LastSourceChangeVector}', status: {status}). Waiting before confirming.");
+                        }
                     }
                 }
             }
@@ -153,6 +162,9 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
 
                 Debug.Assert(process.ConfirmationIndex.HasValue, $"invalid ShardBucketMigration for bucket '{process.Bucket}', " +
                                                                  "got Status = OwnershipTransferred but no ConfirmationIndex");
+
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Bucket '{process.Bucket}' migration {process.MigrationIndex}: ownership transferred to shard {process.DestinationShard}; starting source cleanup on shard {ShardNumber} (upTo: '{process.LastSourceChangeVector}').");
 
                 // cleanup values
                 t = DeleteBucketAsync(process.Bucket, process.MigrationIndex, process.ConfirmationIndex.Value, process.LastSourceChangeVector);
@@ -215,6 +227,9 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
     {
         if (string.IsNullOrEmpty(uptoChangeVector))
         {
+            if (_logger.IsInfoEnabled)
+                _logger.Info($"Bucket '{bucket}' migration {migrationIndex}: no source change vector recorded (empty bucket); sending SourceMigrationCleanup directly.");
+
             await ServerStore.Sharding.SourceMigrationCleanup(ShardedDatabaseName, bucket, migrationIndex);
             return;
         }
@@ -240,7 +255,10 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
 
                 if (delay >= TimeSpan.FromMinutes(5))
                 {
-                    // if the delay exceeds the maximum timeout, throw an exception and break the loop
+                    // if the delay exceeds the maximum timeout, throw an exception and break the loop.
+                    if (_logger.IsOperationsEnabled)
+                        _logger.Operations($"Bucket '{bucket}' migration {migrationIndex}: giving up source cleanup on shard {ShardNumber} after backoff exceeded {TimeSpan.FromMinutes(5)}; the resharding task will now fault.", exception);
+
                     await Task.FromException(exception);
                     return;
                 }
@@ -254,15 +272,25 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
             {
                 // no documents in the bucket / everything was deleted
                 case DeleteBucketCommand.DeleteBucketResult.Empty:
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Bucket '{bucket}' migration {migrationIndex}: source cleanup on shard {ShardNumber} completed (bucket empty); sending SourceMigrationCleanup.");
+
                     await ServerStore.Sharding.SourceMigrationCleanup(ShardedDatabaseName, bucket, migrationIndex);
                     DismissNotificationOnDeleteBucketSuccessIfNeeded();
                     return;
                 // some documents skipped and left in the bucket
                 case DeleteBucketCommand.DeleteBucketResult.Skipped:
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Bucket '{bucket}' migration {migrationIndex}: source cleanup on shard {ShardNumber} was SKIPPED - some documents/tombstones are not yet covered by the migration change vector (upTo: '{uptoChangeVector}'). " +
+                                     "Cleanup will be retried on the next resharding cycle (database record change). See the ShardedDocumentsStorage log for the specific document/tombstone that blocked cleanup.");
+
                     return;
                 // we have more docs, batch limit reached.
                 case DeleteBucketCommand.DeleteBucketResult.FullBatch:
                 case DeleteBucketCommand.DeleteBucketResult.ReachedTransactionLimit:
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Bucket '{bucket}' migration {migrationIndex}: source cleanup on shard {ShardNumber} processed a batch (result: {cmd.Result}); continuing with the next batch.");
+
                     delay = TimeSpan.FromSeconds(1);
                     continue;
                 default:

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -346,8 +346,13 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         foreach (var document in docs)
         {
             var docCv = context.GetChangeVector(document.ChangeVector);
-            if (ChangeVectorUtils.GetConflictStatus(docCv, upTo) != ConflictStatus.AlreadyMerged)
+            if (ChangeVectorUtils.GetConflictStatus(docCv, upTo, UnusedDatabaseIds) != ConflictStatus.AlreadyMerged)
             {
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Skipping cleanup of bucket '{bucket}': document '{document.Id}' is not covered by the migration change vector " +
+                                 $"(document CV: '{docCv}', upTo: '{upTo}', unused ids: [{(UnusedDatabaseIds == null ? string.Empty : string.Join(", ", UnusedDatabaseIds))}]). " +
+                                 "The bucket cannot be cleaned up until this document is covered by 'upTo'.");
+
                 result = ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult.Skipped;
                 break;
             }
@@ -355,6 +360,10 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
             // check change vectors of all document extensions
             if (HasDocumentExtensionWithGreaterChangeVector(context, document.Id, upTo))
             {
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Skipping deletion of document '{document.Id}' in bucket '{bucket}': it has a counter/time-series/attachment/revision " +
+                                 $"with a change vector greater than the migration change vector (upTo: '{upTo}'). The bucket cleanup will be marked as skipped.");
+
                 result = ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult.Skipped;
                 continue;
             }
@@ -390,17 +399,46 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
                     continue;
 
                 var tombstoneChangeVector = context.GetChangeVector(tombstone.ChangeVector);
-                if (ChangeVectorUtils.GetConflictStatus(upTo, tombstoneChangeVector) != ConflictStatus.AlreadyMerged)
-                    break;
-
-                var collection = tombstone.Collection;
-                if (collectionNames.TryGetValue(collection, out var collectionName) == false)
+                if (ChangeVectorUtils.GetConflictStatus(tombstoneChangeVector, upTo, UnusedDatabaseIds) != ConflictStatus.AlreadyMerged)
                 {
-                    collectionNames[collection] = collectionName = new CollectionName(collection);
-                    collectionNamesUpdated = true;
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Not marking tombstone '{tombstone.LowerId}' (type {tombstone.Type}, etag {tombstone.Etag}) in bucket '{bucket}' as artificial: " +
+                                     $"it is not covered by the migration change vector (tombstone CV: '{tombstoneChangeVector}', upTo: '{upTo}', " +
+                                     $"unused ids: [{(UnusedDatabaseIds == null ? string.Empty : string.Join(", ", UnusedDatabaseIds))}]). " +
+                                     "While this tombstone stays non-artificial it keeps the bucket eligible for re-migration.");
+
+                    lastProcessedEtag = tombstone.Etag;
+                    continue;
                 }
 
-                var writeTable = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema, collectionName.GetTableName(CollectionTableType.Tombstones));
+                Table writeTable;
+                switch (tombstone.Type)
+                {
+                    case Tombstone.TombstoneType.Document:
+                        var collection = tombstone.Collection;
+                        if (collectionNames.TryGetValue(collection, out var collectionName) == false)
+                        {
+                            collectionNames[collection] = collectionName = new CollectionName(collection);
+                            collectionNamesUpdated = true;
+                        }
+
+                        writeTable = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema, collectionName.GetTableName(CollectionTableType.Tombstones));
+                        break;
+
+                    case Tombstone.TombstoneType.Revision:
+                        writeTable = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema, RevisionsTombstonesSlice);
+                        break;
+
+                    case Tombstone.TombstoneType.Attachment:
+                        writeTable = context.Transaction.InnerTransaction.OpenTable(TombstonesSchema, AttachmentsTombstonesSlice);
+                        break;
+
+                    default:
+                        System.Diagnostics.Debug.Assert(false, $"Unexpected tombstone type '{tombstone.Type}' in MarkTombstonesAsArtificial (bucket {bucket}).");
+
+                        lastProcessedEtag = tombstone.Etag;
+                        continue;
+                }
 
                 var newEtag = GenerateNextEtag();
                 var cv = ChangeVector.MergeWithDatabaseChangeVector(context, tombstoneChangeVector);
@@ -408,23 +446,37 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
 
                 using (Slice.From(context.Allocator, cv, out var cvSlice))
                 using (Slice.External(context.Allocator, tombstone.LowerId, out var keySlice))
-                using (DocumentIdWorker.GetStringPreserveCase(context, collection, out Slice collectionSlice))
                 using (writeTable.Allocate(out TableValueBuilder tvb))
                 {
                     var clonedKey = keySlice.Clone(context.Allocator);
 
-                    tvb.Add(clonedKey.Content.Ptr, clonedKey.Size);
-                    tvb.Add(Bits.SwapBytes(newEtag));
-                    tvb.Add(Bits.SwapBytes(tombstone.DeletedEtag));
-                    tvb.Add(tombstone.TransactionMarker);
-                    tvb.Add((byte)tombstone.Type);
-                    tvb.Add(collectionSlice);
-                    tvb.Add((int)flags);
-                    tvb.Add(cvSlice.Content.Ptr, cvSlice.Size);
-                    tvb.Add(tombstone.LastModified.Ticks);
+                    var hasCollection = tombstone.Collection != null;
+                    Slice collectionSlice = default;
+                    ByteStringContext.InternalScope collectionScope = default;
+                    if (hasCollection)
+                        collectionScope = DocumentIdWorker.GetStringPreserveCase(context, tombstone.Collection, out collectionSlice);
 
-                    writeTable.Update(tombstone.StorageId, tvb);
-                    context.Allocator.Release(ref clonedKey.Content);
+                    using (collectionScope)
+                    {
+                        tvb.Add(clonedKey.Content.Ptr, clonedKey.Size);
+                        tvb.Add(Bits.SwapBytes(newEtag));
+                        tvb.Add(Bits.SwapBytes(tombstone.DeletedEtag));
+                        tvb.Add(tombstone.TransactionMarker);
+                        tvb.Add((byte)tombstone.Type);
+
+                        // Document/revision tombstones carry a collection; attachment tombstones don't, so we
+                        // write an empty 0-byte column - the same as AttachmentsStorage.CreateTombstone (tvb.Add(null, 0)).
+                        if (hasCollection)
+                            tvb.Add(collectionSlice);
+                        else
+                            tvb.Add(null, 0);
+                        tvb.Add((int)flags);
+                        tvb.Add(cvSlice.Content.Ptr, cvSlice.Size);
+                        tvb.Add(tombstone.LastModified.Ticks);
+
+                        writeTable.Update(tombstone.StorageId, tvb);
+                        context.Allocator.Release(ref clonedKey.Content);
+                    }
                 }
 
                 // need to re open the read iterator after we modified the tree
@@ -456,7 +508,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         foreach (var counter in counters)
         {
             var counterCv = context.GetChangeVector(counter.ChangeVector);
-            if (ChangeVectorUtils.GetConflictStatus(counterCv, upTo) == ConflictStatus.Update)
+            if (ChangeVectorUtils.GetConflictStatus(counterCv, upTo, UnusedDatabaseIds) == ConflictStatus.Update)
                 return true;
         }
 
@@ -466,7 +518,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
             foreach (var segment in segments)
             {
                 var tsCv = context.GetChangeVector(segment.ChangeVector);
-                if (ChangeVectorUtils.GetConflictStatus(tsCv, upTo) == ConflictStatus.Update)
+                if (ChangeVectorUtils.GetConflictStatus(tsCv, upTo, UnusedDatabaseIds) == ConflictStatus.Update)
                     return true;
             }
         }
@@ -477,7 +529,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
             foreach (var attachment in attachments)
             {
                 var attachmentCv = context.GetChangeVector(attachment.ChangeVector);
-                if (ChangeVectorUtils.GetConflictStatus(attachmentCv, upTo) == ConflictStatus.Update)
+                if (ChangeVectorUtils.GetConflictStatus(attachmentCv, upTo, UnusedDatabaseIds) == ConflictStatus.Update)
                     return true;
             }
         }
@@ -486,7 +538,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         foreach (var revision in revisions)
         {
             var revisionCv = context.GetChangeVector(revision.ChangeVector);
-            if (ChangeVectorUtils.GetConflictStatus(revisionCv, upTo) == ConflictStatus.Update)
+            if (ChangeVectorUtils.GetConflictStatus(revisionCv, upTo, UnusedDatabaseIds) == ConflictStatus.Update)
                 return true;
         }
 

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -615,13 +615,12 @@ namespace SlowTests.Sharding.Cluster
 
                 var id = $"users/1${suffix}";
                 var oldLocation = await Sharding.GetShardNumberForAsync(store, id);
-                var lastProcessedEtag = 0L;
 
                 var oldLocationShard = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, oldLocation));
                 using (oldLocationShard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var tombs = oldLocationShard.DocumentsStorage.GetTombstonesFrom(context, lastProcessedEtag).ToList();
+                    var tombs = oldLocationShard.DocumentsStorage.GetTombstonesFrom(context, 0).ToList();
                     Assert.Equal(3, tombs.Count);
 
                     foreach (var tomb in tombs)
@@ -631,8 +630,6 @@ namespace SlowTests.Sharding.Cluster
                         Assert.NotNull(replicationItem);
                         Assert.False(replicationItem.Flags.Contain(DocumentFlags.Artificial));
                         Assert.False(replicationItem.Flags.Contain(DocumentFlags.FromResharding));
-
-                        lastProcessedEtag = replicationItem.Etag;
                     }
                 }
 
@@ -647,14 +644,17 @@ namespace SlowTests.Sharding.Cluster
                 using (oldLocationShard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var tombs = oldLocationShard.DocumentsStorage.GetTombstonesFrom(context, lastProcessedEtag + 1).ToList();
-                    Assert.Equal(1, tombs.Count);
+                    var tombs = oldLocationShard.DocumentsStorage.GetTombstonesFrom(context, 0).ToList();
+                    Assert.Equal(4, tombs.Count);
 
-                    var replicationItem = tombs[0] as DocumentReplicationItem;
+                    foreach (var tomb in tombs)
+                    {
+                        var replicationItem = tomb as DocumentReplicationItem;
 
-                    Assert.NotNull(replicationItem);
-                    Assert.True(replicationItem.Flags.Contain(DocumentFlags.Artificial));
-                    Assert.True(replicationItem.Flags.Contain(DocumentFlags.FromResharding));
+                        Assert.NotNull(replicationItem);
+                        Assert.True(replicationItem.Flags.Contain(DocumentFlags.Artificial));
+                        Assert.True(replicationItem.Flags.Contain(DocumentFlags.FromResharding));
+                    }
                 }
 
                 var newLocation = await Sharding.GetShardNumberForAsync(store, id);
@@ -748,7 +748,7 @@ namespace SlowTests.Sharding.Cluster
                 using (context.OpenReadTransaction())
                 {
                     var tombs = oldLocationShard.DocumentsStorage.GetTombstonesFrom(context, lastProcessedEtag + 1).ToList();
-                    Assert.Equal(1, tombs.Count);
+                    Assert.Equal(4, tombs.Count);
 
                     var replicationItem = tombs[0] as DocumentReplicationItem;
 
@@ -785,6 +785,104 @@ namespace SlowTests.Sharding.Cluster
 
                 await Sharding.EnsureNoDatabaseChangeVectorLeakAsync(store.Database);
             }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task BucketDeletionShouldMarkExistingRevisionAndAttachmentTombstonesAsArtificial()
+        {
+            // RavenDB-19197: pre-existing revision + attachment tombstones left in a bucket before it migrates
+            // must also be re-stamped Artificial|FromResharding during source cleanup (not just document
+            // tombstones) - MarkTombstonesAsArtificial routes each type to the table that owns its StorageId.
+            using (var store = Sharding.GetDocumentStore())
+            {
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration { Disabled = false }
+                }));
+
+                const string suffix = "eu";
+                var id = $"users/1${suffix}";
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "v1" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                // add an attachment, then create a few revisions
+                await using (var stream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.Attachments.Store(id, "file.bin", stream);
+                    await session.SaveChangesAsync();
+                }
+
+                for (int i = 2; i <= 4; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    var user = await session.LoadAsync<User>(id);
+                    user.Name = $"v{i}";
+                    await session.SaveChangesAsync();
+                }
+
+                var oldLocation = await Sharding.GetShardNumberForAsync(store, id);
+                var bucket = await Sharding.GetBucketAsync(store, id);
+                var oldShard = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, oldLocation));
+
+                // create the PRE-EXISTING non-document tombstones, BEFORE migration:
+                //   - delete the attachment -> plain attachment tombstone (null collection, Attachments.Tombstones)
+                //   - delete the revisions  -> plain revision tombstone(s) (Revisions.Tombstones)
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.Attachments.Delete(id, "file.bin");
+                    await session.SaveChangesAsync();
+                }
+                await store.Maintenance.SendAsync(new DeleteRevisionsOperation(id));
+
+                // sanity: before migration the bucket holds PLAIN (non-artificial) revision + attachment tombstones
+                var before = CountTombstonesByTypeAndFlag(oldShard, bucket);
+                Assert.True(before.plainAttachment > 0, $"expected a plain attachment tombstone before migration {before}");
+                Assert.True(before.plainRevision > 0, $"expected a plain revision tombstone before migration {before}");
+                Assert.Equal(0, before.artificialAttachment);
+                Assert.Equal(0, before.artificialRevision);
+
+                // migrate the bucket (the live doc moves; source cleanup runs MarkTombstonesAsArtificial)
+                await Sharding.Resharding.MoveShardForId(store, id);
+
+                // after migration: the pre-existing revision + attachment tombstones must be Artificial|FromResharding
+                var after = CountTombstonesByTypeAndFlag(oldShard, bucket);
+                Assert.Equal(0, after.plainAttachment);
+                Assert.Equal(0, after.plainRevision);
+                Assert.True(after.artificialAttachment > 0,
+                    $"RavenDB-19197: pre-existing attachment tombstone was not tagged Artificial|FromResharding after migration {after}.");
+                Assert.True(after.artificialRevision > 0,
+                    $"RavenDB-19197: pre-existing revision tombstone was not tagged Artificial|FromResharding after migration {after}.");
+            }
+        }
+
+        private static (int plainRevision, int artificialRevision, int plainAttachment, int artificialAttachment)
+            CountTombstonesByTypeAndFlag(DocumentDatabase db, int bucket)
+        {
+            var storage = (ShardedDocumentsStorage)db.DocumentsStorage;
+            int plainRevision = 0, artificialRevision = 0, plainAttachment = 0, artificialAttachment = 0;
+            using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                foreach (var tomb in storage.RetrieveTombstonesByBucketFrom(context, bucket, 0))
+                {
+                    var artificial = tomb.Flags.Contain(DocumentFlags.Artificial) && tomb.Flags.Contain(DocumentFlags.FromResharding);
+                    switch (tomb.Type)
+                    {
+                        case Tombstone.TombstoneType.Revision:
+                            if (artificial) artificialRevision++; else plainRevision++;
+                            break;
+                        case Tombstone.TombstoneType.Attachment:
+                            if (artificial) artificialAttachment++; else plainAttachment++;
+                            break;
+                    }
+                }
+            }
+            return (plainRevision, artificialRevision, plainAttachment, artificialAttachment);
         }
 
         [RavenFact(RavenTestCategory.Sharding)]

--- a/test/SlowTests/Sharding/Cluster/ReshardingTombstoneRepickLoop.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTombstoneRepickLoop.cs
@@ -1,0 +1,470 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Server;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Cluster
+{
+    public class 
+        ReshardingTombstoneRepickLoop : ClusterTestBase
+    {
+        public ReshardingTombstoneRepickLoop(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // Migrate a bucket that holds a live doc + pre-existing plain tombstones. Source cleanup must tag
+        // those tombstones Artificial|FromResharding; otherwise the migrator re-picks the bucket forever
+        // ("Only one bucket can be transferred at a time"). Regression guard for the re-pick loop.
+        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        public async Task ExistingTombstones_ShouldBeMarkedArtificial_AndBucketNotRepicked()
+        {
+            using var store = Sharding.GetDocumentStore();
+
+            const string suffix = "eu";
+
+            // 5 docs in the same bucket (sticky suffix).
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User(), $"users/1${suffix}");
+                await session.StoreAsync(new User(), $"users/2${suffix}");
+                await session.StoreAsync(new User(), $"users/3${suffix}");
+                await session.StoreAsync(new User(), $"users/4${suffix}");
+                await session.StoreAsync(new User(), $"users/5${suffix}");
+                await session.SaveChangesAsync();
+            }
+
+            // Delete 3 → 3 plain tombstones. users/1 and users/5 stay live docs.
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete($"users/2${suffix}");
+                session.Delete($"users/3${suffix}");
+                session.Delete($"users/4${suffix}");
+                await session.SaveChangesAsync();
+            }
+
+            var id = $"users/1${suffix}";
+            var oldLocation = await Sharding.GetShardNumberForAsync(store, id);
+            var bucket = await Sharding.GetBucketAsync(store, id);
+
+            var oldShard = (ShardedDocumentDatabase)await GetDocumentDatabaseInstanceFor(
+                store, ShardHelper.ToShardName(store.Database, oldLocation));
+
+            // Sanity: 3 plain tombstones, 0 artificial, before migration.
+            var (plainBefore, artificialBefore) = CountTombstoneFlags(oldShard, bucket);
+            Assert.Equal(3, plainBefore);
+            Assert.Equal(0, artificialBefore);
+
+            // Migrate the bucket away from oldLocation.
+            await Sharding.Resharding.MoveShardForId(store, id);
+
+            var recordAfterMigration = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            Assert.Empty(recordAfterMigration.Sharding.BucketMigrations);
+
+            // ---- ASSERTION 1: the pre-existing tombstones must now be Artificial|FromResharding ----
+            var (plainAfter, artificialAfter) = CountTombstoneFlags(oldShard, bucket);
+            Assert.True(plainAfter == 0,
+                $"{plainAfter} pre-existing tombstone(s) in bucket {bucket} were NOT marked Artificial|FromResharding " +
+                $"after migration (artificial={artificialAfter}); they would keep the bucket eligible for re-migration forever.");
+
+            // ---- ASSERTION 2: firing the auto-migrator must NOT re-pick the already-migrated bucket ----
+            await oldShard.DocumentsMigrator.ExecuteMoveDocumentsAsync();
+
+            var rePicked = await WaitForValueAsync(async () =>
+            {
+                var rec = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                return rec.Sharding.BucketMigrations.ContainsKey(bucket);
+            }, expectedVal: true, timeout: 5_000, interval: 100);
+            Assert.False(rePicked,
+                $"bucket {bucket} was RE-PICKED by the auto-migrator after it was already migrated and cleaned up - " +
+                "the infinite re-pick loop that rejects concurrent migrations with 'Only one bucket can be transferred at a time'.");
+        }
+
+        // Same re-pick guard on a customer-like cluster: 4 nodes, 4 shards (RF=2), docs spread across all
+        // shards (each bucket = live docs + pre-existing plain tombstones). Migrate one bucket, assert no re-pick.
+        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        public async Task Mode3_MultiShard_CustomerLikeTopology_DoesNotRepickBucket()
+        {
+            var (nodes, leader) = await CreateRaftCluster(4, watcherCluster: true);
+            var dbName = GetDatabaseName();
+
+            // 4 shards, replication factor 2, spread across the 4 nodes — mirrors the customer's
+            // shard layout (each shard lives on two nodes).
+            var options = new Options
+            {
+                Server = leader,
+                DatabaseMode = RavenDatabaseMode.Sharded,
+                ReplicationFactor = 2,
+                ModifyDatabaseRecord = r => r.Sharding = new ShardingConfiguration
+                {
+                    Orchestrator = new OrchestratorConfiguration
+                    {
+                        Topology = new OrchestratorTopology { Members = new List<string> { "A", "B", "C", "D" } }
+                    },
+                    Shards = new Dictionary<int, DatabaseTopology>
+                    {
+                        { 0, new DatabaseTopology { Members = new List<string> { "A", "B" } } },
+                        { 1, new DatabaseTopology { Members = new List<string> { "B", "C" } } },
+                        { 2, new DatabaseTopology { Members = new List<string> { "C", "D" } } },
+                        { 3, new DatabaseTopology { Members = new List<string> { "D", "A" } } },
+                    }
+                }
+            };
+
+            using var store = GetDocumentStore(options, dbName);
+
+            // Find a sticky suffix that lands on each of the 4 shards, so we can place a controlled
+            // bucket (with live docs + tombstones) on every shard.
+            var suffixPerShard = new Dictionary<int, string>();
+            int probe = 0;
+            while (suffixPerShard.Count < 4)
+            {
+                Assert.True(probe < 5000, "couldn't find a suffix for every shard");
+                var suffix = $"s{probe++}";
+                var shard = await Sharding.GetShardNumberForAsync(store, $"users/1${suffix}");
+                suffixPerShard.TryAdd(shard, suffix);
+            }
+
+            // Spread docs across all shards: per shard, 8 docs in one bucket, then delete 5 of them
+            // → each shard ends up with 3 live docs + 5 PLAIN tombstones in a single bucket.
+            const int docsPerShard = 8;
+            const int deletesPerShard = 5;
+            var bucketPerShard = new Dictionary<int, int>();
+
+            foreach (var (shard, suffix) in suffixPerShard)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 1; i <= docsPerShard; i++)
+                        await session.StoreAsync(new User { Name = $"shard{shard}-{i}" }, $"users/{i}${suffix}");
+                    await session.SaveChangesAsync();
+                }
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 1; i <= deletesPerShard; i++)
+                        session.Delete($"users/{i}${suffix}");
+                    await session.SaveChangesAsync();
+                }
+
+                bucketPerShard[shard] = await Sharding.GetBucketAsync(store, $"users/{deletesPerShard + 1}${suffix}");
+            }
+
+            // Pick shard 0 as the one we migrate away. Its bucket has live docs (to move) and
+            // plain tombstones (to be left behind ungated → re-pick fuel).
+            var srcShard = 0;
+            var srcSuffix = suffixPerShard[srcShard];
+            var srcBucket = bucketPerShard[srcShard];
+            var migrateId = $"users/{deletesPerShard + 1}${srcSuffix}";
+
+            // shard 0 lives on nodes A & B — grab the instance from A.
+            var srcServer = nodes.Single(n => n.ServerStore.NodeTag == "A");
+            var srcShardDb = (ShardedDocumentDatabase)await Databases.GetDocumentDatabaseInstanceFor(
+                srcServer, store, ShardHelper.ToShardName(store.Database, srcShard));
+
+            // Migrate the bucket off shard 0.
+            await Sharding.Resharding.MoveShardForId(store, migrateId, servers: nodes);
+
+            // ---- ASSERTION 1: pre-existing document tombstones on the source must be tagged ----
+            var (plainAfter, artificialAfter) = CountTombstoneFlags(srcShardDb, srcBucket);
+            Assert.True(plainAfter == 0,
+                $"{plainAfter} pre-existing tombstone(s) in shard {srcShard} bucket {srcBucket} were NOT " +
+                $"marked Artificial|FromResharding after migration (artificial={artificialAfter}).");
+
+            // ---- ASSERTION 2: the auto-migrator must NOT re-pick the already-migrated bucket ----
+            await srcShardDb.DocumentsMigrator.ExecuteMoveDocumentsAsync();
+
+            var rePicked = await WaitForValueAsync(async () =>
+            {
+                var rec = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                return rec.Sharding.BucketMigrations.ContainsKey(srcBucket);
+            }, expectedVal: true, timeout: 5_000, interval: 100);
+
+            Assert.False(rePicked,
+                $"bucket {srcBucket} was RE-PICKED after it was already migrated and cleaned up - " +
+                "the infinite re-pick loop that produces the customer's 'Only one bucket can be transferred at a time' error.");
+        }
+
+        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        public async Task UnusedDatabaseIds_DocumentCleanup_StripsOrphanDbId_EndToEnd()
+        {
+            // we flip ServerStore.Sharding.ManualMigration (a server-global flag) below, so don't share the server.
+            DoNotReuseServer();
+
+            using var store = Sharding.GetDocumentStore();
+            const string id = "users/1$cleanup-doc";
+
+            // Initial write -> bucket CV = shardDbId@N
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "v1" }, id);
+                await session.SaveChangesAsync();
+            }
+
+            var shardNumber = await Sharding.GetShardNumberForAsync(store, id);
+            var bucket = await Sharding.GetBucketAsync(store, id);
+            var shardDb = (ShardedDocumentDatabase)await GetDocumentDatabaseInstanceFor(
+                store, ShardHelper.ToShardName(store.Database, shardNumber));
+            var shardDbId = shardDb.DbBase64Id;
+
+            // Disable the auto-migrator so it can't race our direct DeleteBucket invocation.
+            shardDb.ServerStore.Sharding.ManualMigration = true;
+            try
+            {
+                // Snapshot upTo = current bucket CV (= shardDbId@N).
+                string snapshotUpTo;
+                using (shardDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    snapshotUpTo = shardDb.ShardedDocumentsStorage
+                        .GetMergedChangeVectorInBucket(context, bucket).AsString();
+                }
+
+                // Second write -> doc CV = shardDbId@(N+1), strictly ahead of snapshotUpTo (=shardDbId@N).
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    user.Name = "v2";
+                    await session.SaveChangesAsync();
+                }
+
+                // Without UnusedDatabaseIds: the orphan etag makes the doc look ahead of upTo -> Skipped.
+                shardDb.ShardedDocumentsStorage.UnusedDatabaseIds = null;
+                var resultWithout = await RunDeleteBucketViaMergerAsync(shardDb, bucket, snapshotUpTo);
+                Assert.Equal(ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult.Skipped, resultWithout);
+
+                // With UnusedDatabaseIds = { shardDbId }: orphan stripped -> AlreadyMerged -> cleanup proceeds -> Empty.
+                shardDb.ShardedDocumentsStorage.UnusedDatabaseIds = new HashSet<string> { shardDbId };
+                var resultWith = await RunDeleteBucketViaMergerAsync(shardDb, bucket, snapshotUpTo);
+                Assert.Equal(ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult.Empty, resultWith);
+            }
+            finally
+            {
+                shardDb.ShardedDocumentsStorage.UnusedDatabaseIds = null;
+                shardDb.ServerStore.Sharding.ManualMigration = false;
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        public async Task UnusedDatabaseIds_TombstoneCleanup_StripsOrphanDbId_EndToEnd()
+        {
+            // we flip ServerStore.Sharding.ManualMigration (a server-global flag) below, so don't share the server.
+            DoNotReuseServer();
+
+            using var store = Sharding.GetDocumentStore();
+            const string id = "users/1$cleanup-tomb";
+
+            // Initial write -> bucket CV = shardDbId@N.
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "v1" }, id);
+                await session.SaveChangesAsync();
+            }
+
+            var shardNumber = await Sharding.GetShardNumberForAsync(store, id);
+            var bucket = await Sharding.GetBucketAsync(store, id);
+            var shardDb = (ShardedDocumentDatabase)await GetDocumentDatabaseInstanceFor(
+                store, ShardHelper.ToShardName(store.Database, shardNumber));
+            var shardDbId = shardDb.DbBase64Id;
+
+            shardDb.ServerStore.Sharding.ManualMigration = true;
+            try
+            {
+                // Snapshot upTo BEFORE the delete (= shardDbId@N).
+                string snapshotUpTo;
+                using (shardDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    snapshotUpTo = shardDb.ShardedDocumentsStorage
+                        .GetMergedChangeVectorInBucket(context, bucket).AsString();
+                }
+
+                // Delete -> tombstone CV = shardDbId@(N+1), strictly ahead of snapshotUpTo.
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                var (plainBefore, artificialBefore) = CountTombstoneFlags(shardDb, bucket);
+                Assert.Equal(1, plainBefore);
+                Assert.Equal(0, artificialBefore);
+
+                // Without UnusedDatabaseIds: tombstone CV looks ahead of upTo -> not tagged (stays plain).
+                shardDb.ShardedDocumentsStorage.UnusedDatabaseIds = null;
+                await RunDeleteBucketViaMergerAsync(shardDb, bucket, snapshotUpTo);
+                var (plainAfterWithout, artificialAfterWithout) = CountTombstoneFlags(shardDb, bucket);
+                Assert.Equal(plainBefore, plainAfterWithout);
+                Assert.Equal(artificialBefore, artificialAfterWithout);
+
+                // With UnusedDatabaseIds = { shardDbId }: orphan stripped -> AlreadyMerged -> tagged Artificial|FromResharding.
+                shardDb.ShardedDocumentsStorage.UnusedDatabaseIds = new HashSet<string> { shardDbId };
+                await RunDeleteBucketViaMergerAsync(shardDb, bucket, snapshotUpTo);
+                var (plainAfterWith, artificialAfterWith) = CountTombstoneFlags(shardDb, bucket);
+                Assert.Equal(0, plainAfterWith);
+                Assert.True(artificialAfterWith > artificialBefore,
+                    $"expected the existing tombstone to be tagged Artificial|FromResharding, but artificial count did not increase ({artificialBefore} -> {artificialAfterWith}).");
+            }
+            finally
+            {
+                shardDb.ShardedDocumentsStorage.UnusedDatabaseIds = null;
+                shardDb.ServerStore.Sharding.ManualMigration = false;
+            }
+        }
+
+        // Runs the real DeleteBucket path via the TxMerger (as DeleteBucketAsync does), so the CV checks
+        // inside DeleteBucket / MarkTombstonesAsArtificial are exercised end-to-end, not bypassed.
+        private static async Task<ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult> RunDeleteBucketViaMergerAsync(
+            ShardedDocumentDatabase shardDb, int bucket, string upToChangeVector)
+        {
+            var cmd = new ShardedDocumentDatabase.DeleteBucketCommand(shardDb, bucket, upToChangeVector);
+            await shardDb.TxMerger.Enqueue(cmd);
+            return cmd.Result;
+        }
+
+        // One case per extension CV check in HasDocumentExtensionWithGreaterChangeVector. Calls the private
+        // method via reflection: in a full DeleteBucket the doc CV check fires first, and natural writes bump
+        // doc + extension CV together, so the extension branch can't be isolated otherwise. Each case asserts
+        // the branch returns true without UnusedDatabaseIds and false with it (i.e. Phase 4 wired the arg in).
+        public enum ExtensionKind { Counter, TimeSeries, Attachment, Revision }
+
+        [RavenTheory(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        [InlineData(ExtensionKind.Counter)]
+        [InlineData(ExtensionKind.TimeSeries)]
+        [InlineData(ExtensionKind.Attachment)]
+        [InlineData(ExtensionKind.Revision)]
+        public async Task UnusedDatabaseIds_HasDocumentExtensionCheck_StripsOrphanDbId_PerExtension(ExtensionKind kind)
+        {
+            // we flip ServerStore.Sharding.ManualMigration (a server-global flag) below, so don't share the server.
+            DoNotReuseServer();
+
+            using var store = Sharding.GetDocumentStore();
+
+            // revisions enabled for all cases (documents commonly have revisions, and revision-attachments etc. coexist).
+            await store.Maintenance.ForDatabase(store.Database).SendAsync(
+                new ConfigureRevisionsOperation(new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration { Disabled = false }
+                }));
+
+            const string id = "users/1$ext-cleanup";
+
+            // Step 1: write the bare doc. Bucket CV = shardDbId@N.
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "v1" }, id);
+                await session.SaveChangesAsync();
+            }
+
+            var shardNumber = await Sharding.GetShardNumberForAsync(store, id);
+            var bucket = await Sharding.GetBucketAsync(store, id);
+            var shardDb = (ShardedDocumentDatabase)await GetDocumentDatabaseInstanceFor(
+                store, ShardHelper.ToShardName(store.Database, shardNumber));
+            var shardDbId = shardDb.DbBase64Id;
+
+            shardDb.ServerStore.Sharding.ManualMigration = true;
+            try
+            {
+                // Step 2: snapshot upTo = current bucket CV (= shardDbId@N), BEFORE writing the extension.
+                string upToString;
+                using (shardDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    upToString = shardDb.ShardedDocumentsStorage.GetMergedChangeVectorInBucket(context, bucket).AsString();
+                }
+
+                // Step 3: write the extension via normal session APIs -> its CV is now shardDbId@(N+1), ahead of upTo.
+                MemoryStream attachmentStream = null;
+                try
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        switch (kind)
+                        {
+                            case ExtensionKind.Counter:
+                                session.CountersFor(id).Increment("downloads", 1);
+                                break;
+                            case ExtensionKind.TimeSeries:
+                                session.TimeSeriesFor(id, "Heartrate").Append(DateTime.UtcNow, 60d);
+                                break;
+                            case ExtensionKind.Attachment:
+                                attachmentStream = new MemoryStream(new byte[] { 1, 2, 3 });
+                                session.Advanced.Attachments.Store(id, "file.bin", attachmentStream);
+                                break;
+                            case ExtensionKind.Revision:
+                                var user = await session.LoadAsync<User>(id);
+                                user.Name = "v2";
+                                break;
+                        }
+                        await session.SaveChangesAsync();
+                    }
+                }
+                finally
+                {
+                    attachmentStream?.Dispose();
+                }
+
+                // Step 4: invoke the private HasDocumentExtensionWithGreaterChangeVector directly (the method Phase 4 modified).
+                var method = typeof(ShardedDocumentsStorage).GetMethod(
+                    "HasDocumentExtensionWithGreaterChangeVector",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(method);
+
+                using (shardDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var upTo = context.GetChangeVector(upToString);
+
+                    // Without UnusedDatabaseIds: extension CV is ahead of upTo -> returns true (would block cleanup).
+                    shardDb.ShardedDocumentsStorage.UnusedDatabaseIds = null;
+                    var resultWithout = (bool)method.Invoke(shardDb.ShardedDocumentsStorage, new object[] { context, id, upTo });
+                    Assert.True(resultWithout,
+                        $"[{kind}] without UnusedDatabaseIds, HasDocumentExtensionWithGreaterChangeVector should return true (the {kind} CV is ahead of upTo).");
+
+                    // With UnusedDatabaseIds = { shardDbId }: orphan stripped -> AlreadyMerged -> returns false.
+                    shardDb.ShardedDocumentsStorage.UnusedDatabaseIds = new HashSet<string> { shardDbId };
+                    var resultWith = (bool)method.Invoke(shardDb.ShardedDocumentsStorage, new object[] { context, id, upTo });
+                    Assert.False(resultWith,
+                        $"[{kind}] with UnusedDatabaseIds = {{ shardDbId }}, HasDocumentExtensionWithGreaterChangeVector should return false. " +
+                        $"If this fails after a code change, suspect that the UnusedDatabaseIds arg was removed from the {kind} branch of HasDocumentExtensionWithGreaterChangeVector.");
+                }
+            }
+            finally
+            {
+                shardDb.ShardedDocumentsStorage.UnusedDatabaseIds = null;
+                shardDb.ServerStore.Sharding.ManualMigration = false;
+            }
+        }
+
+        private static (int plain, int artificial) CountTombstoneFlags(ShardedDocumentDatabase shard, int bucket)
+        {
+            int plain = 0, artificial = 0;
+            using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                foreach (var tomb in shard.ShardedDocumentsStorage.RetrieveTombstonesByBucketFrom(context, bucket, 0))
+                {
+                    if (tomb.Flags.Contain(DocumentFlags.Artificial) && tomb.Flags.Contain(DocumentFlags.FromResharding))
+                        artificial++;
+                    else
+                        plain++;
+                }
+            }
+            return (plain, artificial);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26719/Resharding-stuck-leftover-tombstones-are-never-marked-causing-an-infinite-bucket-migration

### Additional description

Fixed the sharded resharding repick loop / stuck-migration bug by restoring the correct GetConflictStatus operand order, changing break to continue, and threading UnusedDatabaseIds through all the cleanup change-vector checks (DeleteBucket, MarkTombstonesAsArtificial, and the four HasDocumentExtensionWithGreaterChangeVector branches).
MarkTombstonesAsArtificial now routes each tombstone to the table that owns its StorageId and correctly tags revision/attachment tombstones Artificial|FromResharding, added diagnostic logging across the migration path, and made DocumentsStorage._logger protected so the sharded subclass reuses it.
Added tests and restored the pre-PR strong assertion in BucketDeletionShouldMarkExistingTombstonesAsArtificial.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
