### PR TITLE
RavenDB-26217 Error during compaction of TimeSeries.Stats

### DIFF
--- a/src/Voron/Impl/Compaction/StorageCompaction.cs
+++ b/src/Voron/Impl/Compaction/StorageCompaction.cs
@@ -464,6 +464,10 @@ namespace Voron.Impl.Compaction
             var lastSlice = Slices.BeforeAllKeys;
             long lastFixedIndex = 0L;
 
+            // RavenDB-26217: rows already copied under 'lastSlice'. A non-unique secondary index can hold
+            // many rows per key, so on resume we skip exactly these instead of a constant 1.
+            long committedUnderLastSlice = 0L;
+
             Report(copiedTrees, totalTreesCount, copiedEntries, numberOfEntries, progressReport, $"Copying table tree '{treeName}'. Progress: {copiedEntries:#,#;;0}/{numberOfEntries:#,#;;0} entries.", treeName);
             using (var txw = compactedEnv.WriteTransaction(context))
             {
@@ -495,11 +499,17 @@ namespace Voron.Impl.Compaction
                         {
                             // We have a variable size index, use it
 
-                            // In case we continue an existing compaction, skip to the next slice
-                            var skip = 0;
-                            // can't use SliceComparer.Compare here
+                            // On resume, skip the rows already copied under 'lastSlice'.
+                            var skip = 0L;
                             if (lastSlice.Options != Slices.BeforeAllKeys.Options)
-                                skip = 1;
+                                skip = committedUnderLastSlice;
+
+                            // Track the run of rows sharing the current secondary-index key so we can resume
+                            // exactly if the batch breaks mid-run. The allocator is reset on each key change.
+                            using var currentKeyAllocator = new ByteStringContext(SharedMultipleUseFlag.None);
+                            var currentKey = lastSlice;
+                            var committedUnderCurrentKey = committedUnderLastSlice;
+                            var haveCurrentKey = lastSlice.Options != Slices.BeforeAllKeys.Options;
 
                             foreach (var tvr in inputTable.SeekForwardFrom(variableSizeIndex, lastSlice, skip))
                             {
@@ -508,13 +518,27 @@ namespace Voron.Impl.Compaction
                                 copiedEntries++;
                                 transactionSize += tvr.Result.Reader.Size;
 
+                                // Count rows under the current key (SliceComparer compares bytes; ByteString '==' is reference equality).
+                                if (haveCurrentKey && SliceComparer.AreEqual(currentKey, tvr.Key))
+                                {
+                                    committedUnderCurrentKey++;
+                                }
+                                else
+                                {
+                                    currentKeyAllocator.Reset();
+                                    currentKey = tvr.Key.Clone(currentKeyAllocator);
+                                    committedUnderCurrentKey = 1;
+                                    haveCurrentKey = true;
+                                }
+
                                 ReportIfNeeded(sp, copiedTrees, totalTreesCount, copiedEntries, numberOfEntries, progressReport, $"Copying table tree '{treeName}'. Progress: {copiedEntries:#,#;;0}/{numberOfEntries:#,#;;0} entries.", treeName);
 
-                                // The transaction has surpassed the allowed
-                                // size before a flush
-                                if (lastSlice.Equals(tvr.Key) == false && transactionSize >= compactedEnv.Options.MaxScratchBufferSize / 2 || ShouldCloseTxFor32Bit(transactionSize, compactedEnv))
+                                // Transaction surpassed the allowed size before a flush. Breaking mid-run is
+                                // safe: we record how many rows of this key were copied to resume past them.
+                                if (transactionSize >= compactedEnv.Options.MaxScratchBufferSize / 2 || ShouldCloseTxFor32Bit(transactionSize, compactedEnv))
                                 {
                                     lastSlice = tvr.Key.Clone(lastSliceAllocator);
+                                    committedUnderLastSlice = committedUnderCurrentKey;
                                     break;
                                 }
                                 innerTxr.ForgetAbout(tvr.Result.Reader.Id);

--- a/test/SlowTests/Issues/TimeSeriesCompactionTests.cs
+++ b/test/SlowTests/Issues/TimeSeriesCompactionTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class TimeSeriesCompactionTests : RavenTestBase
+    {
+        public TimeSeriesCompactionTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // Regression test for a bug in StorageCompaction.CopyTableTree.
+        //
+        // TimeSeriesStats uses a global primary key (TimeSeriesStatsKey, IsGlobal=true).
+        // Compaction therefore falls back to iterating via the first local secondary index,
+        // which is PolicyIndex.  PolicyIndex is non-unique: every raw time-series entry
+        // maps to the same key "rawpolicy\x1E".
+        //
+        // The compaction pagination checkpoint (lastSlice) starts as Slices.BeforeAllKeys.
+        // The guard that prevents mid-group breaks reads:
+        //
+        //   if (lastSlice.Equals(tvr.Key) == false && transactionSize >= limit)
+        //       break;
+        //
+        // Because BeforeAllKeys is never equal to any real key, this condition is always
+        // true from the very first row.  (In fact lastSlice.Equals is reference/pointer
+        // equality, so it stays true on every batch even after lastSlice holds a real key.)
+        // The first time the transaction exceeds limit the
+        // batch breaks mid-"rawpolicy\x1E" group.  On the next batch skip=1 is used, which
+        // skips only one row instead of all already-committed rows, causing re-insertion
+        // of already-copied entries and a:
+        //
+        //   VoronConcurrencyErrorException: Value already exists, but requested NewOnly
+        //
+        // Setting Storage.MaxScratchBufferSizeInMb to a small value forces the break to
+        // occur with a tractable number of entries (limit = MaxScratchBufferSize/2).
+        [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Voron)]
+        public async Task Compaction_ManyRawTimeSeries_ShouldNotFailWithDuplicateKey()
+        {
+            // 1 MB scratch → limit = 512 KB ≈ 5 000 entries/batch at ~100 B/entry.
+            // 10 000 entries ensures the first batch breaks mid-group.
+            using (var store = GetDocumentStore(new Options
+                   {
+                       RunInMemory = false,
+                       ModifyDatabaseRecord = record =>
+                           record.Settings["Storage.MaxScratchBufferSizeInMb"] = "1"
+                   }))
+            {
+                const int documentCount = 10_000;
+                var baseline = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+                // Write documentCount documents, each with one raw time-series append.
+                // All stats entries land in PolicyIndex under the same key "rawpolicy\x1E".
+                using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < documentCount; i++)
+                    {
+                        await bulk.StoreAsync(new { }, $"products/{i}");
+                        using (var ts = bulk.TimeSeriesFor($"products/{i}", "Revenue"))
+                            await ts.AppendAsync(baseline, new[] { (double)i });
+                    }
+                }
+
+                var compactOperation = await store.Maintenance.Server.SendAsync(
+                    new CompactDatabaseOperation(new CompactSettings
+                    {
+                        DatabaseName = store.Database,
+                        Documents = true
+                    }));
+
+                // Before the fix this throws:
+                //   InvalidOperationException: Failed to execute compaction
+                //   ---> VoronConcurrencyErrorException: Value already exists, but requested NewOnly
+                await compactOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(120));
+
+                // After the fix all data must be readable in the compacted database.
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.MaxNumberOfRequestsPerSession = documentCount + 1;
+
+                    for (int i = 0; i < documentCount; i++)
+                    {
+                        var entries = session.TimeSeriesFor($"products/{i}", "Revenue").Get();
+                        Assert.NotNull(entries);
+                        Assert.Equal(1, entries.Length);
+                        Assert.Equal((double)i, entries[0].Values[0]);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26217

### Additional description

Compacting a database with many raw time series failed with VoronConcurrencyErrorException: Value already exists, but requested NewOnly while copying the TimeSeriesStats tree. TimeSeriesStats has a global primary key, so compaction paginates via the first local index,
  PolicyIndex — which is non-unique: every raw entry maps to the same key "rawpolicy\x1E". When a size-bounded batch broke in the middle of that one huge key group, the next batch resumed with a hard-coded skip=1, re-inserting the rows already copied and colliding on the global
  PK. (The guard meant to prevent mid-group breaks was dead code — it compared keys by ByteString reference equality, which never matches a cloned checkpoint.)

  Solution. Track how many rows under the current secondary key have already been copied and resume with skip = that count (comparing keys by bytes via SliceComparer, not by pointer). This lands exactly on the first un-copied row, so batches can still split mid-group safely — a
  single giant key group is paged across batches instead of forced into one unbounded transaction. Scoped to the variable-size-index branch; 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
