### PR TITLE
RavenDB-23197 Wait for the actual backup status raft commands to be applied instead 

### DIFF
--- a/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
+++ b/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
@@ -18,7 +18,9 @@ using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Sharding;
+using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands.PeriodicBackup;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
@@ -545,7 +547,15 @@ namespace SlowTests.Sharding.Backup
                 var (backupTaskId, op) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config);
 
                 Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
-                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(backupTaskId + 3, TimeSpan.FromSeconds(10));
+
+                // RavenDB-23197 : wait for all the shard backup status commands to be applied on all nodes,
+                // so that any node serving the status request can read all the shard statuses.
+                // the status commands are committed by now (all the backups completed), but other commands
+                // (e.g. UpdateResponsibleNodeForTasksCommand) may have interleaved after the configuration update,
+                // so their indexes are not necessarily backupTaskId + 1 .. backupTaskId + 3
+                var lastStatusCommandIndex = Cluster.GetRaftCommands(cluster.Leader, nameof(UpdatePeriodicBackupStatusCommand))
+                    .Max(entry => long.Parse(entry[nameof(RachisLogHistory.LogHistoryColumn.Index)].ToString()));
+                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(lastStatusCommandIndex, TimeSpan.FromSeconds(30));
 
                 var dirs = Directory.GetDirectories(backupPath).ToList();
                 Assert.Equal(cluster.Nodes.Count, dirs.Count);


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23197

### Additional description

This pull request updates the sharded backup tests to ensure more reliable verification of backup status across all nodes in the cluster. The main improvement is a more robust synchronization step that waits for all relevant backup status commands to be applied, rather than relying on a simple index calculation.

**Test reliability improvements:**

* In `ShardedBackupTests .cs`, the test now waits for all `UpdatePeriodicBackupStatusCommand` raft commands to be applied on all nodes by dynamically determining the highest index, ensuring that status queries on any node reflect the latest backup state. This replaces the previous logic that assumed a fixed offset from `backupTaskId`.

**Dependency updates:**

* Added missing `using` statements for `Raven.Server.Rachis` and `Raven.Server.ServerWide.Commands.PeriodicBackup` to support the new synchronization logic.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
