### PR TITLE
RavenDB-26754 Discover HNSW vector fields from index definition during cache warming

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -30,6 +30,7 @@ using Raven.Client.Documents.Indexes.Vector;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes.VectorSearch;
 using Sparrow.Binary;
+using Voron;
 using static Raven.Server.Config.Categories.IndexingConfiguration;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax;
@@ -116,6 +117,25 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
     }
     
     public IndexFieldsMapping GetKnownFieldsForQuerying() => _knownFieldsForReaders.Value;
+
+    /// <summary>
+    /// Returns the field-name slices (Voron tree names) of the index's vector fields, allocated on the converter's
+    /// long-lived <see cref="Allocator"/>.
+    /// </summary>
+    internal List<Slice> GetVectorFieldNames()
+    {
+        List<Slice> result = null;
+        foreach (var field in _index.Definition.IndexFields.Values)
+        {
+            if (field.Vector is null || field.Id == CoraxConstants.IndexWriter.DynamicField)
+                continue;
+
+            Slice.From(Allocator, field.Name, ByteStringType.Immutable, out var fieldName);
+            (result ??= new List<Slice>()).Add(fieldName);
+        }
+
+        return result;
+    }
 
     private IndexFieldsMapping CreateKnownFieldsForWriter()
     {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -283,29 +283,26 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     private void WarmInitialCaches(Transaction tx)
     {
-        var mapping = _converter?.GetKnownFieldsForQuerying();
-        if (mapping is null)
-            return;
-
         var maxNodes = GetMaxNodesForVectorCache();
         if (maxNodes <= 0)
             return;
 
+        // Vector fields are read from the index definition, not the fields mapping: field discovery during
+        // initialization must stay independent of analyzer construction.
+        var vectorFieldNames = _converter?.GetVectorFieldNames();
+        if (vectorFieldNames is null)
+            return;
+
         var llt = tx.LowLevelTransaction;
-        foreach (var field in mapping)
+        foreach (var fieldName in vectorFieldNames)
         {
-            if (field.VectorOptions is null)
-                continue;
-            var cache = HnswIndexCache.WarmFromScratch(llt, field.FieldName, maxNodes);
+            Debug.Assert(fieldName.HasValue && fieldName.Size > 0,
+                "Vector field name must be allocated and non-empty for cache keying");
+            var cache = HnswIndexCache.WarmFromScratch(llt, fieldName, maxNodes);
             if (cache is null)
                 continue;
             _hnswCaches ??= new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance);
-            // FieldName is allocated against _converter's persistent scope; _converter is
-            // disposed only when this CoraxIndexPersistence is disposed, which outlives any
-            // open read tx's ImmutableExternalState reference.
-            Debug.Assert(field.FieldName.HasValue && field.FieldName.Size > 0,
-                "Vector field name must be allocated and non-empty for cache keying");
-            _hnswCaches[field.FieldName] = cache;
+            _hnswCaches[fieldName] = cache;
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26754
https://issues.hibernatingrhinos.com/issue/RavenDB-26755
https://issues.hibernatingrhinos.com/issue/RavenDB-26756
https://issues.hibernatingrhinos.com/issue/RavenDB-26757

### Additional description

Discover vector fields directly from the index definition. Added `CoraxDocumentConverterBase.GetVectorFieldNames()`, which returns the vector field-name slices (the Voron tree names) allocated on the converter's long-lived allocator, keeping index initialization independent of analyzer construction. The cache is keyed identically (same field-name bytes via SliceComparer), so the dirty-commit path in RecreateSearcher is unchanged.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
