### PR TITLE
RavenDB-26062 stop backup test from disposing the live database

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -197,6 +197,8 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         public string WhoseTaskIsIt(long taskId)
         {
+            Debug.Assert(_disposed == false, "PeriodicBackupRunner is already disposed");
+
             if (_periodicBackups.TryGetValue(taskId, out var periodicBackup) == false)
             {
                 throw new InvalidOperationException($"Backup task id: {taskId} doesn't exist");

--- a/test/SlowTests/Issues/RavenDB-19922.cs
+++ b/test/SlowTests/Issues/RavenDB-19922.cs
@@ -118,12 +118,8 @@ namespace SlowTests.Issues
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 0 1 1 *", mentorNode: mentorNode.ServerStore.NodeTag, name: "backup");
                 long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
 
-                var database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
-                string tag1;
-                using (var db = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database))
-                {
-                    tag1 = db.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
-                }
+                var db = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                string tag1 = db.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
 
                 CheckDecisionLog(leaderServer, new MentorNode(tag1, config.Name).ReasonForDecisionLog);
 
@@ -134,10 +130,8 @@ namespace SlowTests.Issues
                 //Wait for new responsible node
                 await WaitForValueAsync(async () =>
                 {
-                    using (var db = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database))
-                    {
-                        tag2 = db.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
-                    }
+                    var db = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                    tag2 = db.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
                     return tag1.Equals(tag2);
                 }, false);
                 Assert.NotEqual(tag1, tag2);
@@ -154,12 +148,12 @@ namespace SlowTests.Issues
                 nodes.Add(server);
 
                 await WaitAndAssertForValueAsync(async () => await GetClusterSize(store), clusterSize);
-                await WaitAndAssertForValueAsync(async () => await GetRehabCount(store), 0);
+                await WaitAndAssertForValueAsync(async () => await GetRehabCount(store), 0, 30000);
                 await WaitAndAssertForValueAsync(async () => await GetMembersCount(store), clusterSize);
 
                 await WaitForValueAsync(async () =>
                 {
-                    database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    var database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                     tag2 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
                     return tag1.Equals(tag2);
                 }, true);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26062

### Additional description
The DocumentDatabase should not be disposed

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test fix

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
