### PR TITLE
RavenDB-26770: accept Gemini OpenAI-compatible 500 INTERNAL on invalid key (was 400 API_KEY_INVALID only)

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
@@ -211,7 +211,12 @@ public class AiAgentErrors : RavenTestBase
                 Assert.Contains("Incorrect API key provided", e.Message);
                 break;
             case AiConnectorType.Google:
-                Assert.Contains("API key not valid.", e.Message);
+                Assert.True(
+                    e.Message.Contains("API_KEY_INVALID", StringComparison.OrdinalIgnoreCase) ||
+                    e.Message.Contains("API key not valid", StringComparison.OrdinalIgnoreCase) ||
+                    (e.Message.Contains("InternalServerError", StringComparison.OrdinalIgnoreCase) &&
+                     e.Message.Contains("Internal error encountered", StringComparison.OrdinalIgnoreCase)),
+                    $"Expected an invalid-API-key error (or Google's '500 INTERNAL') but got: {e.Message}");
                 break;
             default:
                 throw new InvalidOperationException($"Unknown provider '{provider}'");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26770/SlowTests.Server.Documents.AI.AiAgent.AiAgentErrors.BadApiKeyoptions-DatabaseMode-Single-config-GoogleAiIntegrationTask

### Additional description

Fixes the flaky SlowTests.Server.Documents.AI.AiAgent.AiAgentErrors.BadApiKey test for the Google provider.

Gemini's OpenAI-compatible endpoint (/v1beta/openai) no longer returns the native 400 API_KEY_INVALID for an invalid key — it now returns a generic 500 INTERNAL ("Internal error encountered."). The test asserted on "API key not valid.", which that response no longer contains, so it failed on CI.

I found no evidence of this change documented anywhere online, so I verified it myself: the OpenAI-compat endpoint deterministically returns 500 INTERNAL for a wrong key, while the native endpoint still returns the clean 400. This is a Google-side change in their beta compat shim — not a RavenDB bug; RavenDB faithfully surfaces whatever Google returns, and valid keys still work.

The fix updates only the Google assertion to accept either the clean key error or the 500 INTERNAL signature, so the test reflects Gemini's actual behavior and won't flake if Google reverts. OpenAI branch unchanged; no production code changed.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
