### PR TITLE
RavenDB-26787 Incoming revision items no longer advance the database change vector

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -318,6 +318,13 @@ namespace Raven.Server.Documents.Replication.Incoming
 
             protected virtual ChangeVector PreProcessItem(DocumentsOperationContext context, ReplicationBatchItem item)
             {
+                if (item is DocumentReplicationItem doc &&
+                    (doc.Flags.Contain(DocumentFlags.Revision) || doc.Flags.Contain(DocumentFlags.DeleteRevision)))
+                    return context.GetEmptyChangeVector();
+
+                if (item is RevisionTombstoneReplicationItem)
+                    return context.GetEmptyChangeVector();
+
                 return context.GetChangeVector(item.ChangeVector).Order;
             }
 

--- a/test/SlowTests/Issues/RavenDB_26787.cs
+++ b/test/SlowTests/Issues/RavenDB_26787.cs
@@ -1,0 +1,115 @@
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26787 : ReplicationTestBase
+    {
+        public RavenDB_26787(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions)]
+        public async Task ReplicatedRevisionsShouldNotInflateDestinationDatabaseChangeVector()
+        {
+            using (var storeA = GetDocumentStore())
+            using (var storeB = GetDocumentStore())
+            using (var storeC = GetDocumentStore())
+            {
+                var revisionsConfiguration = new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = false
+                    }
+                };
+
+                await RevisionsHelper.SetupRevisionsAsync(storeA, configuration: revisionsConfiguration);
+                await RevisionsHelper.SetupRevisionsAsync(storeB, configuration: revisionsConfiguration);
+                await RevisionsHelper.SetupRevisionsAsync(storeC, configuration: revisionsConfiguration);
+
+                // history is authored on A
+                using (var session = storeA.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "v1" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = storeA.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>("users/1");
+                    user.Name = "v2";
+                    await session.SaveChangesAsync();
+                }
+
+                await SetupReplicationAsync(storeA, storeB);
+                Assert.NotNull(await WaitForDocumentToReplicateAsync<User>(storeB, "users/1", 15_000));
+
+                // B continues the history, so B's revisions carry A's change-vector entries
+                using (var session = storeB.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>("users/1");
+                    user.Name = "v3";
+                    await session.SaveChangesAsync();
+                }
+
+                // delete the document on B and purge its tombstone BEFORE B->C replication exists,
+                // so the only items C can ever receive from B are revisions
+                using (var session = storeB.OpenAsyncSession())
+                {
+                    session.Delete("users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var databaseB = await Databases.GetDocumentDatabaseInstanceFor(storeB);
+                await databaseB.TombstoneCleaner.ExecuteCleanup();
+
+                using (databaseB.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    Assert.Equal(0, databaseB.DocumentsStorage.GetNumberOfTombstones(ctx));
+                }
+
+                var databaseA = await Databases.GetDocumentDatabaseInstanceFor(storeA);
+                var dbIdA = databaseA.DbBase64Id;
+
+                // sanity: the revisions survived the tombstone cleanup on B
+                var statsB = await storeB.Maintenance.SendAsync(new GetStatisticsOperation());
+                Assert.Equal(4, statsB.CountOfRevisionDocuments);
+
+                // C has its own history, so its database change vector stays in Conflict with B's.
+                // That keeps the batch-level wholesale merge of the source change vector
+                // (MergedUpdateDatabaseChangeVectorCommand) out of the picture - only per-item
+                // contributions can add foreign entries to C's frontier.
+                using (var session = storeC.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "local" }, "locals/1");
+                    await session.SaveChangesAsync();
+                }
+
+                await SetupReplicationAsync(storeB, storeC);
+
+                // C receives the revisions (v1, v2, v3 and the delete-revision) on top of its own local revision
+                var revisionsOnC = await WaitForValueAsync(async () =>
+                {
+                    var stats = await storeC.Maintenance.SendAsync(new GetStatisticsOperation());
+                    return stats.CountOfRevisionDocuments;
+                }, 5, timeout: 60_000);
+                Assert.Equal(5, revisionsOnC);
+
+                var statsC = await storeC.Maintenance.SendAsync(new GetStatisticsOperation());
+
+                // C never replicated with A and never received any live item from A,
+                // so its database change vector must not claim A's lineage
+                Assert.DoesNotContain(dbIdA, statsC.DatabaseChangeVector ?? string.Empty);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26787

### Additional description

`MergedDocumentReplicationCommand.PreProcessItem` returned the item change-vector `Order` for every replicated item, so incoming revision documents, delete-revision documents and revision tombstones advanced the destination database change vector with lineage the destination never received as live data. When the destination has its own history (its database change vector is in conflict with the source's), nothing masks this, and the destination frontier ends up claiming foreign lineage — later replication from the claimed database can then skip documents permanently.

The fix makes revision-family items contribute an empty change vector to database change-vector preprocessing.

The repro test reproduces the inflation through a real replication chain (`A -> B -> C`, where `C` receives only revisions for the document and has local writes of its own).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed