### PR TITLE
RavenDB-26788 - Time series deleted after bucket migration can be resurrected by a source-failover bucket re-send (v6.2)

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2201,6 +2201,8 @@ namespace Raven.Server.Documents
 
             internal AsyncManualResetEvent DelayQueryByPatch;
 
+            internal AsyncManualResetEvent DelayDeleteBucket;
+
             internal bool EnableWritesToTheWrongShard = false;
 
             internal IDisposable CallDuringDocumentDatabaseInternalDispose(Action action)

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -225,6 +225,9 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
 
     public async Task DeleteBucketAsync(int bucket, long migrationIndex, long confirmationIndex, string uptoChangeVector)
     {
+        if (ForTestingPurposes?.DelayDeleteBucket != null)
+            await ForTestingPurposes.DelayDeleteBucket.WaitAsync(DatabaseShutdown);
+
         if (string.IsNullOrEmpty(uptoChangeVector))
         {
             if (_logger.IsInfoEnabled)

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -678,12 +678,10 @@ namespace Raven.Server.Documents.TimeSeries
                 return false;
             }
 
-            if (Stats.GetStats(context, documentId, name) == default &&
-                SegmentAlreadyDeleted(context, documentId, name, changeVector, collectionName, segment, baseline))
+            if (SegmentAlreadyDeleted(context, documentId, name, changeVector, collectionName, segment, baseline))
             {
-                // if we reach this point, it means the entire time series was deleted,
-                // and the deletion has a newer change vector than this segment.
-                // since the deletion is more recent, we are up-to-date and can safely return
+                // The exact segment row is absent. It may be covered by a deleted range even
+                // when the same time series still has other live segments.
                 return true;
             }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -220,12 +220,39 @@ namespace Raven.Server.Documents.TimeSeries
             from = EnsureMillisecondsPrecision(from);
             to = EnsureMillisecondsPrecision(to);
 
+            ChangeVector predecessorChangeVector = null;
+            if (remoteChangeVector == null)
+            {
+                using (var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name))
+                {
+                    foreach ((_, Table.TableValueHolder tableValueHolder) in table.SeekByPrimaryKeyPrefix(sliceHolder.TimeSeriesPrefixSlice, Slices.Empty, skip: 0))
+                    {
+                        var existingFrom = DocumentsStorage.TableValueToDateTime((int)DeletedRangeTable.From, ref tableValueHolder.Reader);
+                        var existingTo = DocumentsStorage.TableValueToDateTime((int)DeletedRangeTable.To, ref tableValueHolder.Reader);
+
+                        // A local delete-range update continues only existing ranges that touch the same time interval.
+                        if (existingFrom > to || existingTo < from)
+                            continue;
+
+                        ChangeVector currentPredecessorChangeVector = ExtractDeletedRangeChangeVector(context, ref tableValueHolder.Reader);
+                        predecessorChangeVector = predecessorChangeVector == null
+                            ? currentPredecessorChangeVector
+                            : ChangeVector.Merge(predecessorChangeVector, currentPredecessorChangeVector, context);
+                    }
+                }
+            }
+
             long etag;
             ChangeVector changeVector;
             if (remoteChangeVector != null)
             {
                 changeVector = remoteChangeVector;
                 etag = _documentsStorage.GenerateNextEtag();
+            }
+            else if (predecessorChangeVector != null)
+            {
+                etag = _documentsStorage.GenerateNextEtag();
+                changeVector = ChangeVector.GetLocalCvFromPriorAndUpdateDbCv(context, predecessorChangeVector, _documentDatabase, etag);
             }
             else
             {

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -223,6 +223,8 @@ namespace Raven.Server.Documents.TimeSeries
             ChangeVector predecessorChangeVector = null;
             if (remoteChangeVector == null)
             {
+                // A local deleted range can supersede a migrated composite range. Keep the predecessor
+                // version lineage so stale source segments can later be recognized as already deleted.
                 using (var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name))
                 {
                     foreach ((_, Table.TableValueHolder tableValueHolder) in table.SeekByPrimaryKeyPrefix(sliceHolder.TimeSeriesPrefixSlice, Slices.Empty, skip: 0))
@@ -885,7 +887,7 @@ namespace Raven.Server.Documents.TimeSeries
                         continue;
 
                     var deletedRangeChangeVector = context.GetChangeVector(item.ChangeVector);
-                    if (ChangeVectorUtils.GetConflictStatus(changeVector, deletedRangeChangeVector) == ConflictStatus.AlreadyMerged)
+                    if (ChangeVectorUtils.GetConflictStatus(changeVector, deletedRangeChangeVector, _documentsStorage.UnusedDatabaseIds) == ConflictStatus.AlreadyMerged)
                         return true;
                 }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -864,10 +864,15 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        private bool SegmentAlreadyDeleted(DocumentsOperationContext context, string documentId, string name, string changeVector, 
+        private bool SegmentAlreadyDeleted(DocumentsOperationContext context, string documentId, string name, ChangeVector changeVector,
             CollectionName collectionName, TimeSeriesValuesSegment segment, DateTime baseline)
         {
-            var hash = (long)Hashing.XXHash64.Calculate(changeVector, Encoding.UTF8);
+            // Hash and compare on the version part only. An incoming segment may carry a composite
+            // 'order|version' change vector (e.g. after a bucket migration), and the string overload of
+            // GetConflictStatus flattens the composite into a single list: the freshly assigned order part
+            // can never be dominated by a stored deleted-range change vector, so the comparison would never
+            // return AlreadyMerged and the deleted series would be resurrected.
+            var hash = (long)Hashing.XXHash64.Calculate(changeVector.Version.AsString(), Encoding.UTF8);
             using (var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name).WithChangeVectorHash(hash))
             {
                 var table = GetOrCreateDeleteRangesTable(context.Transaction.InnerTransaction, collectionName);
@@ -877,11 +882,12 @@ namespace Raven.Server.Documents.TimeSeries
                 foreach (var (_, tableValueHolder) in table.SeekByPrimaryKeyPrefix(sliceHolder.TimeSeriesPrefixSlice, Slices.Empty, skip: 0))
                 {
                     var item = CreateDeletedRangeItem(context, ref tableValueHolder.Reader);
-                    
+
                     if (item.From > baseline || item.To < segment.GetLastTimestamp(baseline))
                         continue;
 
-                    if (ChangeVectorUtils.GetConflictStatus(changeVector, item.ChangeVector) == ConflictStatus.AlreadyMerged)
+                    var deletedRangeChangeVector = context.GetChangeVector(item.ChangeVector);
+                    if (ChangeVectorUtils.GetConflictStatus(changeVector, deletedRangeChangeVector) == ConflictStatus.AlreadyMerged)
                         return true;
                 }
 

--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -196,6 +196,18 @@ public sealed class ChangeVector
         return changeVector.MergeOrderWith(context.LastDatabaseChangeVector, context);
     }
 
+    internal static ChangeVector GetLocalCvFromPriorAndUpdateDbCv(DocumentsOperationContext context, ChangeVector priorChangeVector, DocumentDatabase database, long etag)
+    {
+        ArgumentNullException.ThrowIfNull(priorChangeVector);
+
+        ChangeVector changeVector = MergeWithDatabaseChangeVector(context, priorChangeVector);
+        changeVector = changeVector.UpdateVersion(database.ServerStore.NodeTag, database.DbBase64Id, etag, context);
+        changeVector = changeVector.UpdateOrder(database.ServerStore.NodeTag, database.DbBase64Id, etag, context);
+        context.LastDatabaseChangeVector = changeVector.Order;
+
+        return changeVector;
+    }
+
     public static void MergeWithDatabaseChangeVector(DocumentsOperationContext context, string changeVector)
     {
         if (changeVector == null)

--- a/test/SlowTests/Issues/RavenDB_26788.cs
+++ b/test/SlowTests/Issues/RavenDB_26788.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26788 : ClusterTestBase
+    {
+        public RavenDB_26788(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Sharding)]
+        public async Task LocalDeletedRangeUpdateShouldSupersedeMigratedDeletedRange()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                var baseline = RavenTestHelper.UtcToday;
+                const string id = "users/ayende";
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), id);
+
+                    var tsf = session.TimeSeriesFor(id, "Heartrate");
+                    tsf.Append(baseline.AddMinutes(1), 59d);
+                    tsf.Append(baseline.AddMinutes(2), 69d);
+                    tsf.Append(baseline.AddMinutes(3), 79d);
+                    session.SaveChanges();
+                }
+
+                // a deleted range authored on the original shard
+                using (var session = store.OpenSession())
+                {
+                    session.TimeSeriesFor(id, "Heartrate").Delete(baseline.AddMinutes(1), baseline.AddMinutes(2));
+                    session.SaveChanges();
+                }
+
+                // bucket migration rewrites the deleted-range change vector into the composite 'order|version' shape
+                await Sharding.Resharding.MoveShardForId(store, id);
+
+                var newLocation = await Sharding.GetShardNumberForAsync(store, id);
+                var newShard = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, newLocation));
+
+                string migratedRangeChangeVector;
+                using (newShard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    migratedRangeChangeVector = newShard.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(ctx, 0).Single().ChangeVector;
+                }
+
+                // precondition: the migrated deleted range carries a composite change vector
+                Assert.Contains("|", migratedRangeChangeVector);
+
+                // a local delete that overlaps the migrated range must supersede it, not conflict with it
+                using (var session = store.OpenSession())
+                {
+                    session.TimeSeriesFor(id, "Heartrate").Delete(baseline.AddMinutes(1), baseline.AddMinutes(3));
+                    session.SaveChanges();
+                }
+
+                using (newShard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var latestDeletedRange = newShard.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(ctx, 0).OrderByDescending(x => x.Etag).First();
+                    var status = ChangeVector.GetConflictStatus(ctx, migratedRangeChangeVector, latestDeletedRange.ChangeVector);
+                    Assert.Equal(ConflictStatus.AlreadyMerged, status);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_26788.cs
+++ b/test/SlowTests/Issues/RavenDB_26788.cs
@@ -2,13 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Server;
 using Raven.Server.Config;
-using Raven.Server.Documents;
 using Raven.Server.Documents.Replication.Incoming;
 using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Sharding;
@@ -96,8 +95,10 @@ namespace SlowTests.Issues
         // The series must remain deleted after that resend. This verifies that the destination deleted-range
         // preserves predecessor version lineage, and that stale incoming segments are checked against deleted
         // ranges by version instead of by the flattened change-vector order.
-        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Replication | RavenTestCategory.TimeSeries)]
-        public async Task DeletedTimeSeriesShouldStayDeletedAfterBucketResendAfterMigrationSourceFailover()
+        [RavenTheory(RavenTestCategory.Sharding | RavenTestCategory.Replication | RavenTestCategory.TimeSeries)]
+        [InlineData(false)]
+        [InlineData(true)] // Keeps another live segment, so deleted-range coverage is verified when time-series stats are not empty.
+        public async Task DeletedTimeSeriesShouldStayDeletedAfterBucketResendAfterMigrationSourceFailover(bool keepSeparateLocalSegment)
         {
             var settings = new Dictionary<string, string>
             {
@@ -207,19 +208,34 @@ namespace SlowTests.Issues
                 Assert.NotNull(migratedRangeChangeVector);
                 Assert.Contains("|", migratedRangeChangeVector);
 
-                // the user deletes the entire series; the write is routed to the destination shard
-                using (var session = store.OpenAsyncSession())
+                if (keepSeparateLocalSegment)
                 {
-                    session.TimeSeriesFor(id, "HeartRates").Delete();
-                    await session.SaveChangesAsync();
+                    // delete the migrated segment range, then append a value far enough away to create
+                    // a separate storage segment. The re-sent stale source segment is still covered by
+                    // the deleted range, but the time series itself is no longer empty.
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        session.TimeSeriesFor(id, "HeartRates").Delete(baseline.AddMinutes(1), baseline.AddMinutes(10));
+                        await session.SaveChangesAsync();
+                    }
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        session.TimeSeriesFor(id, "HeartRates").Append(baseline.AddDays(30), 30);
+                        await session.SaveChangesAsync();
+                    }
+                }
+                else
+                {
+                    // the user deletes the entire series; the write is routed to the destination shard
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        session.TimeSeriesFor(id, "HeartRates").Delete();
+                        await session.SaveChangesAsync();
+                    }
                 }
 
-                Assert.Equal(0, CountTimeSeriesSegments(shard1OnA, id));
-                using (var session = store.OpenAsyncSession())
-                {
-                    var values = await session.TimeSeriesFor(id, "HeartRates").GetAsync();
-                    Assert.True(values == null || values.Length == 0);
-                }
+                await AssertExpectedTimeSeriesValuesAsync(store, id, keepSeparateLocalSegment);
 
                 // find which source replica owns the migration (it keeps the connection open for leftovers)
                 RavenServer migrationOwner = null;
@@ -283,16 +299,29 @@ namespace SlowTests.Issues
                     Assert.Fail("the surviving source replica did not re-send the bucket to the destination." + Environment.NewLine + diagnostics);
                 }
 
-                // the full-series delete is causally NEWER than the re-sent stale segment - the series must stay deleted
-                Assert.Equal(0, CountTimeSeriesSegments(shard1OnA, id));
-                using (var session = store.OpenAsyncSession())
+                // the local delete is causally NEWER than the re-sent stale segment - deleted values must stay deleted
+                await AssertExpectedTimeSeriesValuesAsync(store, id, keepSeparateLocalSegment);
+            }
+        }
+
+        private static async Task AssertExpectedTimeSeriesValuesAsync(IDocumentStore store, string id, bool keepSeparateLocalSegment)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var values = await session.TimeSeriesFor(id, "HeartRates").GetAsync();
+
+                if (keepSeparateLocalSegment == false)
                 {
-                    var values = await session.TimeSeriesFor(id, "HeartRates").GetAsync();
                     Assert.True(values == null || values.Length == 0,
                         $"the fully deleted time series was resurrected by the re-sent stale segment " +
                         $"(got {values?.Length} values back) - the local deleted-range change vector has no causal " +
                         "relation to the re-sent segment, or SegmentAlreadyDeleted failed to recognize the coverage");
+                    return;
                 }
+
+                Assert.NotNull(values);
+                Assert.Single(values);
+                Assert.Equal(30d, values[0].Value);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_26788.cs
+++ b/test/SlowTests/Issues/RavenDB_26788.cs
@@ -89,25 +89,13 @@ namespace SlowTests.Issues
             }
         }
 
-        // Production scenario: a bucket migration source shard has two replicas. The node that owns the
-        // migration dies in the window after ownership was transferred to the destination but before the
-        // source cleanup removed the bucket data. The surviving source replica takes over the migration
-        // task and re-sends the whole bucket: the migration replication type persists no per-source
-        // checkpoint (IncomingMigrationReplicationHandler.SaveSourceEtag is a no-op), so the surviving
-        // replica's fresh outgoing handler re-scans from etag 0. Every re-sent item is re-processed on the
-        // destination with a freshly assigned 'order' part (IncomingMigrationReplicationHandler.PreProcessItem
-        // keeps the 'version', assigns a new receiver-local 'order'), so the only causal link between the
-        // re-sent stale items and the destination's current state is the 'version' part of the change vector.
+        // Simulate a source-replica failover after bucket ownership moved to shard 1 but before shard 0
+        // cleaned up its bucket data. The surviving replica re-sends the bucket from scratch, so stale
+        // time-series segments reach the destination with a fresh receiver-local order in their change vector.
         //
-        // A time series that was migrated into the destination and then deleted there in full must stay
-        // deleted when the stale segment is re-sent. That requires both:
-        //   1. the locally created deleted-range to carry the version lineage of the overlapping
-        //      deleted-ranges it supersedes (otherwise its change vector has no causal relation to the
-        //      migrated segment at all) - RavenDB-26788, and
-        //   2. SegmentAlreadyDeleted to compare the incoming segment against the stored deleted-ranges
-        //      by version (the flattened string comparison is defeated by the freshly assigned order of
-        //      the re-sent segment, which no stored deleted-range can ever dominate) - RavenDB-26790.
-        // If either is missing, the re-sent stale segment resurrects the deleted series.
+        // The series must remain deleted after that resend. This verifies that the destination deleted-range
+        // preserves predecessor version lineage, and that stale incoming segments are checked against deleted
+        // ranges by version instead of by the flattened change-vector order.
         [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Replication | RavenTestCategory.TimeSeries)]
         public async Task DeletedTimeSeriesShouldStayDeletedAfterBucketResendAfterMigrationSourceFailover()
         {

--- a/test/SlowTests/Issues/RavenDB_26788.cs
+++ b/test/SlowTests/Issues/RavenDB_26788.cs
@@ -1,9 +1,23 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Replication.Incoming;
+using Raven.Server.Documents.Replication.Outgoing;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
+using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -73,6 +87,257 @@ namespace SlowTests.Issues
                     Assert.Equal(ConflictStatus.AlreadyMerged, status);
                 }
             }
+        }
+
+        // Production scenario: a bucket migration source shard has two replicas. The node that owns the
+        // migration dies in the window after ownership was transferred to the destination but before the
+        // source cleanup removed the bucket data. The surviving source replica takes over the migration
+        // task and re-sends the whole bucket: the migration replication type persists no per-source
+        // checkpoint (IncomingMigrationReplicationHandler.SaveSourceEtag is a no-op), so the surviving
+        // replica's fresh outgoing handler re-scans from etag 0. Every re-sent item is re-processed on the
+        // destination with a freshly assigned 'order' part (IncomingMigrationReplicationHandler.PreProcessItem
+        // keeps the 'version', assigns a new receiver-local 'order'), so the only causal link between the
+        // re-sent stale items and the destination's current state is the 'version' part of the change vector.
+        //
+        // A time series that was migrated into the destination and then deleted there in full must stay
+        // deleted when the stale segment is re-sent. That requires both:
+        //   1. the locally created deleted-range to carry the version lineage of the overlapping
+        //      deleted-ranges it supersedes (otherwise its change vector has no causal relation to the
+        //      migrated segment at all) - RavenDB-26788, and
+        //   2. SegmentAlreadyDeleted to compare the incoming segment against the stored deleted-ranges
+        //      by version (the flattened string comparison is defeated by the freshly assigned order of
+        //      the re-sent segment, which no stored deleted-range can ever dominate) - RavenDB-26790.
+        // If either is missing, the re-sent stale segment resurrects the deleted series.
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Replication | RavenTestCategory.TimeSeries)]
+        public async Task DeletedTimeSeriesShouldStayDeletedAfterBucketResendAfterMigrationSourceFailover()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "1",
+                [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
+            };
+
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, customSettings: settings);
+            Assert.Equal("A", leader.ServerStore.NodeTag);
+
+            var options = new Options
+            {
+                Server = leader,
+                DatabaseMode = RavenDatabaseMode.Sharded,
+                ModifyDatabaseRecord = record => record.Sharding = new ShardingConfiguration
+                {
+                    Orchestrator = new OrchestratorConfiguration
+                    {
+                        Topology = new OrchestratorTopology { Members = new List<string> { "A" } }
+                    },
+                    Shards = new Dictionary<int, DatabaseTopology>
+                    {
+                        { 0, new DatabaseTopology { Members = new List<string> { "B", "C" }, DynamicNodesDistribution = false } },
+                        { 1, new DatabaseTopology { Members = new List<string> { "A" }, DynamicNodesDistribution = false } }
+                    }
+                }
+            };
+
+            using (var store = GetDocumentStore(options))
+            {
+                // a document whose bucket lives on shard 0 (the future migration source)
+                string id = null;
+                for (var i = 0; i < 5000; i++)
+                {
+                    var candidate = $"users/1$s{i}";
+                    if (await Sharding.GetShardNumberForAsync(store, candidate) == 0)
+                    {
+                        id = candidate;
+                        break;
+                    }
+                }
+                Assert.NotNull(id);
+
+                var baseline = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "owner" }, id);
+                    var ts = session.TimeSeriesFor(id, "HeartRates");
+                    for (var i = 1; i <= 10; i++)
+                        ts.Append(baseline.AddMinutes(i), i);
+                    await session.SaveChangesAsync();
+                }
+
+                // a deleted range authored on the source BEFORE the migration; after the migration it is
+                // the only carrier of the source's version lineage among the destination's deleted ranges
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.TimeSeriesFor(id, "HeartRates").Delete(baseline.AddMinutes(1), baseline.AddMinutes(5));
+                    await session.SaveChangesAsync();
+                }
+
+                var bucket = await Sharding.GetBucketAsync(store, id);
+                var shard0Name = ShardHelper.ToShardName(store.Database, 0);
+                var shard1Name = ShardHelper.ToShardName(store.Database, 1);
+
+                var serverB = nodes.Single(s => s.ServerStore.NodeTag == "B");
+                var serverC = nodes.Single(s => s.ServerStore.NodeTag == "C");
+
+                var shard0OnB = ShardedDocumentDatabase.CastToShardedDocumentDatabase(
+                    await serverB.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(shard0Name));
+                var shard0OnC = ShardedDocumentDatabase.CastToShardedDocumentDatabase(
+                    await serverC.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(shard0Name));
+
+                foreach (var sourceShard in new[] { shard0OnB, shard0OnC })
+                {
+                    var hasSeries = await WaitForValueAsync(
+                        () => Task.FromResult(CountTimeSeriesSegments(sourceShard, id) > 0 && CountDeletedRanges(sourceShard, id) > 0),
+                        true, timeout: 30_000, interval: 333);
+                    Assert.True(hasSeries,
+                        $"the time series data did not reach shard 0 replica on node {sourceShard.ServerStore.NodeTag}");
+                }
+
+                // hold the source bucket cleanup on both source replicas, so the surviving replica still
+                // has the stale bucket data when it takes over the migration (in production this is the
+                // natural window between ownership transfer and cleanup)
+                shard0OnB.ForTestingPurposesOnly().DelayDeleteBucket = new AsyncManualResetEvent();
+                shard0OnC.ForTestingPurposesOnly().DelayDeleteBucket = new AsyncManualResetEvent();
+
+                await Sharding.Resharding.StartMovingShardForId(store, id, toShard: 1, servers: nodes);
+
+                var status = await WaitForValueAsync(async () =>
+                {
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.BucketMigrations.TryGetValue(bucket, out var migration)
+                        ? migration.Status
+                        : (MigrationStatus?)null;
+                }, MigrationStatus.OwnershipTransferred, timeout: 60_000, interval: 333);
+                Assert.Equal(MigrationStatus.OwnershipTransferred, status);
+
+                var shard1OnA = ShardedDocumentDatabase.CastToShardedDocumentDatabase(
+                    await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(shard1Name));
+
+                // the migrated time series arrived at the destination with composite (order|version) change vectors
+                Assert.True(CountTimeSeriesSegments(shard1OnA, id) > 0);
+                var migratedRangeChangeVector = GetDeletedRangeChangeVectors(shard1OnA, id).SingleOrDefault();
+                Assert.NotNull(migratedRangeChangeVector);
+                Assert.Contains("|", migratedRangeChangeVector);
+
+                // the user deletes the entire series; the write is routed to the destination shard
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.TimeSeriesFor(id, "HeartRates").Delete();
+                    await session.SaveChangesAsync();
+                }
+
+                Assert.Equal(0, CountTimeSeriesSegments(shard1OnA, id));
+                using (var session = store.OpenAsyncSession())
+                {
+                    var values = await session.TimeSeriesFor(id, "HeartRates").GetAsync();
+                    Assert.True(values == null || values.Length == 0);
+                }
+
+                // find which source replica owns the migration (it keeps the connection open for leftovers)
+                RavenServer migrationOwner = null;
+                var hasOwner = await WaitForValueAsync(() =>
+                {
+                    foreach (var (server, shardDb) in new[] { (serverB, shard0OnB), (serverC, shard0OnC) })
+                    {
+                        if (shardDb.ReplicationLoader.OutgoingHandlers.OfType<OutgoingMigrationReplicationHandler>().Any())
+                        {
+                            migrationOwner = server;
+                            return Task.FromResult(true);
+                        }
+                    }
+                    return Task.FromResult(false);
+                }, true, timeout: 30_000, interval: 333);
+                Assert.True(hasOwner, "no outgoing migration handler found on either source replica");
+
+                var survivorShard0 = migrationOwner == serverB ? shard0OnC : shard0OnB;
+
+                // the cleanup hold kept the stale bucket data (incl. the segment) on the survivor
+                Assert.True(CountTimeSeriesSegments(survivorShard0, id) > 0);
+
+                long survivorLastEtag;
+                using (survivorShard0.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    survivorLastEtag = survivorShard0.DocumentsStorage.ReadLastEtag(context.Transaction.InnerTransaction);
+                }
+
+                var preKillIncomingHandlers = shard1OnA.ReplicationLoader.IncomingHandlers
+                    .OfType<IncomingMigrationReplicationHandler>().ToHashSet();
+
+                // kill the migration owner; the surviving source replica takes over the migration task
+                // and re-sends the whole bucket from scratch
+                await DisposeServerAndWaitForFinishOfDisposalAsync(migrationOwner);
+
+                var resendCompleted = await WaitForValueAsync(() =>
+                {
+                    foreach (var handler in shard1OnA.ReplicationLoader.IncomingHandlers.OfType<IncomingMigrationReplicationHandler>())
+                    {
+                        // a NEW incoming migration connection (from the surviving replica) that has
+                        // processed everything the survivor holds
+                        if (preKillIncomingHandlers.Contains(handler) == false &&
+                            handler.LastDocumentEtag >= survivorLastEtag)
+                            return Task.FromResult(true);
+                    }
+                    return Task.FromResult(false);
+                }, true, timeout: 120_000, interval: 333);
+
+                if (resendCompleted == false)
+                {
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    var shard0Topology = record.Sharding.Shards[0];
+                    var diagnostics = new System.Text.StringBuilder()
+                        .AppendLine($"survivor: {survivorShard0.ServerStore.NodeTag}, survivorLastEtag: {survivorLastEtag}")
+                        .AppendLine($"shard0 members: [{string.Join(",", shard0Topology.Members)}], rehabs: [{string.Join(",", shard0Topology.Rehabs)}]")
+                        .AppendLine($"migration record present: {record.Sharding.BucketMigrations.ContainsKey(bucket)}" +
+                                    (record.Sharding.BucketMigrations.TryGetValue(bucket, out var m) ? $", status: {m.Status}" : string.Empty))
+                        .AppendLine($"survivor outgoing handlers: [{string.Join(",", survivorShard0.ReplicationLoader.OutgoingHandlers.Select(h => $"{h.GetType().Name}->{h.Destination?.Database}@{h.Destination?.Url}"))}]")
+                        .AppendLine($"dest incoming handlers: [{string.Join(",", shard1OnA.ReplicationLoader.IncomingHandlers.Select(h => $"{h.GetType().Name} src={h.ConnectionInfo?.SourceDatabaseId} lastDocEtag={h.LastDocumentEtag}"))}]");
+                    Assert.Fail("the surviving source replica did not re-send the bucket to the destination." + Environment.NewLine + diagnostics);
+                }
+
+                // the full-series delete is causally NEWER than the re-sent stale segment - the series must stay deleted
+                Assert.Equal(0, CountTimeSeriesSegments(shard1OnA, id));
+                using (var session = store.OpenAsyncSession())
+                {
+                    var values = await session.TimeSeriesFor(id, "HeartRates").GetAsync();
+                    Assert.True(values == null || values.Length == 0,
+                        $"the fully deleted time series was resurrected by the re-sent stale segment " +
+                        $"(got {values?.Length} values back) - the local deleted-range change vector has no causal " +
+                        "relation to the re-sent segment, or SegmentAlreadyDeleted failed to recognize the coverage");
+                }
+            }
+        }
+
+        private static int CountTimeSeriesSegments(ShardedDocumentDatabase shardDatabase, string docId)
+        {
+            using (shardDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                return shardDatabase.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, 0, long.MaxValue)
+                    .Count(s => s.DocId.ToString().Equals(docId, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        private static int CountDeletedRanges(ShardedDocumentDatabase shardDatabase, string docId)
+        {
+            return GetDeletedRangeChangeVectors(shardDatabase, docId).Count;
+        }
+
+        private static List<string> GetDeletedRangeChangeVectors(ShardedDocumentDatabase shardDatabase, string docId)
+        {
+            var result = new List<string>();
+            using (shardDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                foreach (var deletedRange in shardDatabase.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(context, 0))
+                {
+                    TimeSeriesValuesSegment.ParseTimeSeriesKey(deletedRange.Key, context, out LazyStringValue rangeDocId, out _);
+                    if (string.Equals(rangeDocId, docId, StringComparison.OrdinalIgnoreCase))
+                        result.Add(deletedRange.ChangeVector);
+                }
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26788

### Additional description

A time series that was migrated to a destination shard during resharding and then deleted on the destination can be silently resurrected (old values come back) when the migration source shard re-sends the bucket after a source-node failover. The visible corruption can happen both when the whole time series was deleted and when the stale segment is covered by a deleted range while another segment in the same time series remains alive.

**The scenario.** Source shard of replication factor >= 2; the node that owns a bucket migration fails after the migration reaches `OwnershipTransferred` but before the source cleanup (`DeleteBucketAsync`) runs. The surviving source replica takes over the migration task (`ShardReplicationLoader.HandleMigrationReplication` keeps the connection for "left overs"). The migration replication type persists no per-source checkpoint (`IncomingMigrationReplicationHandler.SaveSourceEtag` is a no-op), so the surviving replica's fresh `OutgoingMigrationReplicationHandler` re-scans and re-sends the whole bucket from etag 0. Every re-sent item is re-processed on the destination with a freshly assigned `order` part (`IncomingMigrationReplicationHandler.PreProcessItem` keeps the `version`, assigns a new receiver-local `order`), so the only causal link between a re-sent stale item and the destination's current state is the `version` part of its change vector.

The resurrection has three root causes, all on the deleted-time-series path; the fix has a corresponding part for each.

1. `TimeSeriesStorage.InsertDeletedRange` (local path) created the new deleted range with a plain new change vector, ignoring overlapping ranges already stored - including the migrated range whose composite `order|version` change vector carries the source's version lineage (which never enters the destination shard's database change vector). The locally-created full-delete range therefore had no causal relation to the migrated series. Fix: merge the change vectors of all overlapping existing deleted ranges into the new range as a local successor (`ChangeVector.GetLocalCvFromPriorAndUpdateDbCv`).

2. `TimeSeriesStorage.SegmentAlreadyDeleted` compared the incoming segment's change vector against the stored deleted ranges with the string overload of `GetConflictStatus`. The string parser advances a fixed width past each `tag:etag-<dbid>` entry and then skips exactly one separator char - comma, whitespace, or the `|` of a composite change vector - without examining it, so a composite `order|version` change vector is parsed into one combined list (order entries concatenated with version entries) rather than rejected. The order-side entries (the `MOVE` entry and the re-sent segment's freshly assigned destination order) are absent from any stored deleted-range change vector, so the comparison never returns AlreadyMerged and `TryPutSegmentDirectly` re-appends the segment. Fix: compare with the `ChangeVector` overload (Version mode), which ignores the order side. The companion hash change (hash the version part, aligned with `InsertDeletedRange`) is for read/write consistency only - `SegmentAlreadyDeleted`'s seek is by a hash-independent series prefix, so it does not affect which ranges are scanned.

3. `TryAppendEntireSegment` only consulted `SegmentAlreadyDeleted` when `Stats.GetStats(...) == default`, so deleted-range coverage was checked only for an effectively empty time series. If the deleted range covered the stale incoming segment but another storage segment in the same time series was still alive, the stale segment skipped the deleted-range check and was written by `TryPutSegmentDirectly`. Fix: when the exact segment row is absent, always check whether the incoming segment is already covered by a deleted range.

All parts are required: preserving predecessor lineage gives the local deleted range the source version to compare against; Version-mode comparison makes the composite segment comparable; and removing the stats gate ensures the deleted-range coverage is used even when the same time series still has other live segments.

Tests:
- `RavenDB_26788.LocalDeletedRangeUpdateShouldSupersedeMigratedDeletedRange` - storage-level invariant: a local deleted range that overlaps a migrated (composite-CV) range yields AlreadyMerged against it.
- `RavenDB_26788.DeletedTimeSeriesShouldStayDeletedAfterBucketResendAfterMigrationSourceFailover(false)` - end-to-end behavioral repro (cluster, source shard RF=2, migration owner failover, bucket re-send); red without the fix (the fully deleted series comes back with old values), green with it.
- `RavenDB_26788.DeletedTimeSeriesShouldStayDeletedAfterBucketResendAfterMigrationSourceFailover(true)` - same production path, but keeps another live segment in the time series. This proves the deleted-range check is needed even when time-series stats are not empty; with the old stats gate the test resurrects stale values.
- A `ForTestingPurposes` hook (`DelayDeleteBucket`) holds the source bucket cleanup so the post-ownership-transfer window is deterministic in the test.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed