### PR TITLE
RavenDB-26789 - Attachment put over a tombstone produces a successor of the tombstone change vector (v6.2)

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -179,9 +179,10 @@ namespace Raven.Server.Documents
                 {
                     Debug.Assert(base64Hash.Size == 44, $"Hash size should be 44 but was: {keySlice.Size}");
 
-                    DeleteTombstoneIfNeeded(context, keySlice);
-
-                    var changeVector = _documentsStorage.GetNewChangeVector(context, attachmentEtag);
+                    ChangeVector changeVector = null;
+                    if (DeleteTombstoneIfNeeded(context, keySlice, out var tombstoneChangeVector))
+                        changeVector = ChangeVector.GetLocalCvFromPriorAndUpdateDbCv(context, tombstoneChangeVector, _documentDatabase, attachmentEtag);
+                    changeVector ??= _documentsStorage.GetNewChangeVector(context, attachmentEtag);
                     Debug.Assert(changeVector != null);
 
                     var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
@@ -328,12 +329,14 @@ namespace Raven.Server.Documents
 
             var newEtag = _documentsStorage.GenerateNextEtag();
 
+            var hadTombstone = DeleteTombstoneIfNeeded(context, key, out var tombstoneChangeVector);
             if (string.IsNullOrEmpty(changeVector))
             {
-                changeVector = _documentsStorage.GetNewChangeVector(context, newEtag);
+                changeVector = hadTombstone
+                    ? ChangeVector.GetLocalCvFromPriorAndUpdateDbCv(context, tombstoneChangeVector, _documentDatabase, newEtag).AsString()
+                    : _documentsStorage.GetNewChangeVector(context, newEtag);
             }
             Debug.Assert(changeVector != null);
-            DeleteTombstoneIfNeeded(context, key);
 
             var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
             using (Slice.From(context.Allocator, changeVector, out var changeVectorSlice))
@@ -1125,10 +1128,16 @@ namespace Raven.Server.Documents
             context.Transaction.CheckIfShouldDeleteAttachmentStream(hash);
         }
 
-        private void DeleteTombstoneIfNeeded(DocumentsOperationContext context, Slice keySlice)
+        private bool DeleteTombstoneIfNeeded(DocumentsOperationContext context, Slice keySlice, out ChangeVector changeVector)
         {
+            changeVector = null;
             var table = context.Transaction.InnerTransaction.OpenTable(_documentDatabase.DocumentsStorage.TombstonesSchema, AttachmentsTombstonesSlice);
-            table.DeleteByKey(keySlice);
+            if (table.ReadByKey(keySlice, out var existingTombstoneTvr) == false)
+                return false;
+
+            changeVector = TableValueToChangeVector(context, (int)TombstoneTable.ChangeVector, ref existingTombstoneTvr);
+            table.Delete(existingTombstoneTvr.Id);
+            return true;
         }
 
         private void CreateTombstone(DocumentsOperationContext context, Slice keySlice, long attachmentEtag,

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -182,8 +182,6 @@ namespace Raven.Server.Documents
                     ChangeVector changeVector = null;
                     if (DeleteTombstoneIfNeeded(context, keySlice, out var tombstoneChangeVector))
                         changeVector = ChangeVector.GetLocalCvFromPriorAndUpdateDbCv(context, tombstoneChangeVector, _documentDatabase, attachmentEtag);
-                    changeVector ??= _documentsStorage.GetNewChangeVector(context, attachmentEtag);
-                    Debug.Assert(changeVector != null);
 
                     var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
                     void SetTableValue(TableValueBuilder tvb, Slice cv)
@@ -202,12 +200,12 @@ namespace Raven.Server.Documents
                         // This is an update to the attachment with the same stream and content type
                         // Just updating the etag and casing of the name and the content type.
 
-                        if (expectedChangeVector != null)
-                        {
-                            var oldChangeVector = TableValueToChangeVector(context, (int)AttachmentsTable.ChangeVector, ref oldValue);
-                            if (ChangeVector.CompareVersion(oldChangeVector, expectedChangeVector, context) != 0)
-                                ThrowConcurrentException(documentId, name, expectedChangeVector, oldChangeVector);
-                        }
+                        var oldChangeVector = TableValueToChangeVector(context, (int)AttachmentsTable.ChangeVector, ref oldValue);
+                        if (expectedChangeVector != null && ChangeVector.CompareVersion(oldChangeVector, expectedChangeVector, context) != 0)
+                            ThrowConcurrentException(documentId, name, expectedChangeVector, oldChangeVector);
+
+                        changeVector = ChangeVector.GetLocalCvFromPriorAndUpdateDbCv(context, oldChangeVector, _documentDatabase, attachmentEtag);
+                        Debug.Assert(changeVector != null);
 
                         using (Slice.From(context.Allocator, changeVector, out var changeVectorSlice))
                         using (table.Allocate(out TableValueBuilder tvb))
@@ -227,12 +225,12 @@ namespace Raven.Server.Documents
                             if (table.SeekOnePrimaryKeyPrefix(partialKeySlice, out TableValueReader partialTvr))
                             {
                                 attachmentExists = true;
-                                if (expectedChangeVector != null)
-                                {
-                                    var oldChangeVector = TableValueToChangeVector(context, (int)AttachmentsTable.ChangeVector, ref partialTvr);
-                                    if (ChangeVector.CompareVersion(oldChangeVector, expectedChangeVector, context) != 0)
-                                        ThrowConcurrentException(documentId, name, expectedChangeVector, oldChangeVector);
-                                }
+
+                                var oldChangeVector = TableValueToChangeVector(context, (int)AttachmentsTable.ChangeVector, ref partialTvr);
+                                if (expectedChangeVector != null && ChangeVector.CompareVersion(oldChangeVector, expectedChangeVector, context) != 0)
+                                    ThrowConcurrentException(documentId, name, expectedChangeVector, oldChangeVector);
+
+                                changeVector = ChangeVector.GetLocalCvFromPriorAndUpdateDbCv(context, oldChangeVector, _documentDatabase, attachmentEtag);
 
                                 if (fromSmuggler == false)
                                 {
@@ -279,6 +277,9 @@ namespace Raven.Server.Documents
                         {
                             PutAttachmentStream(context, keySlice, base64Hash, stream);
                         }
+
+                        changeVector ??= _documentsStorage.GetNewChangeVector(context, attachmentEtag);
+                        Debug.Assert(changeVector != null);
 
                         using (Slice.From(context.Allocator, changeVector, out var changeVectorSlice))
                         using (table.Allocate(out TableValueBuilder tvb))

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2201,6 +2201,8 @@ namespace Raven.Server.Documents
 
             internal AsyncManualResetEvent DelayQueryByPatch;
 
+            internal AsyncManualResetEvent DelayDeleteBucket;
+
             internal bool EnableWritesToTheWrongShard = false;
 
             internal IDisposable CallDuringDocumentDatabaseInternalDispose(Action action)

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -225,6 +225,9 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
 
     public async Task DeleteBucketAsync(int bucket, long migrationIndex, long confirmationIndex, string uptoChangeVector)
     {
+        if (ForTestingPurposes?.DelayDeleteBucket != null)
+            await ForTestingPurposes.DelayDeleteBucket.WaitAsync(DatabaseShutdown);
+
         if (string.IsNullOrEmpty(uptoChangeVector))
         {
             if (_logger.IsInfoEnabled)

--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -196,6 +196,18 @@ public sealed class ChangeVector
         return changeVector.MergeOrderWith(context.LastDatabaseChangeVector, context);
     }
 
+    internal static ChangeVector GetLocalCvFromPriorAndUpdateDbCv(DocumentsOperationContext context, ChangeVector priorChangeVector, DocumentDatabase database, long etag)
+    {
+        ArgumentNullException.ThrowIfNull(priorChangeVector);
+
+        ChangeVector changeVector = MergeWithDatabaseChangeVector(context, priorChangeVector);
+        changeVector = changeVector.UpdateVersion(database.ServerStore.NodeTag, database.DbBase64Id, etag, context);
+        changeVector = changeVector.UpdateOrder(database.ServerStore.NodeTag, database.DbBase64Id, etag, context);
+        context.LastDatabaseChangeVector = changeVector.Order;
+
+        return changeVector;
+    }
+
     public static void MergeWithDatabaseChangeVector(DocumentsOperationContext context, string changeVector)
     {
         if (changeVector == null)

--- a/test/SlowTests/Issues/RavenDB_26789.cs
+++ b/test/SlowTests/Issues/RavenDB_26789.cs
@@ -1,0 +1,80 @@
+using System.IO;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26789 : ClusterTestBase
+    {
+        public RavenDB_26789(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Attachments)]
+        public async Task PuttingAttachmentOverMigratedTombstoneShouldPreserveTombstoneChangeVector()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                const string id = "users/1";
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "1" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var stream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    await store.Operations.SendAsync(new PutAttachmentOperation(id, "a1", stream, "a1/png"));
+                }
+
+                await store.Operations.SendAsync(new DeleteAttachmentOperation(id, "a1"));
+
+                var bucket = await Sharding.GetBucketAsync(store, id);
+
+                // bucket migration rewrites the attachment tombstone change vector into the composite 'order|version' shape
+                await Sharding.Resharding.MoveShardForId(store, id);
+
+                var newLocation = await Sharding.GetShardNumberForAsync(store, id);
+                var newShard = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, newLocation));
+                var storage = (ShardedDocumentsStorage)newShard.DocumentsStorage;
+
+                string tombstoneChangeVector = null;
+                using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    foreach (var tombstone in storage.RetrieveTombstonesByBucketFrom(context, bucket, 0))
+                    {
+                        if (tombstone.Type == Tombstone.TombstoneType.Attachment)
+                            tombstoneChangeVector = tombstone.ChangeVector;
+                    }
+                }
+
+                // preconditions: the tombstone was migrated and carries a composite change vector
+                Assert.NotNull(tombstoneChangeVector);
+                Assert.Contains("|", tombstoneChangeVector);
+
+                // recreating the attachment over the migrated tombstone must supersede the tombstone
+                AttachmentDetails putResult;
+                using (var stream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    putResult = await store.Operations.SendAsync(new PutAttachmentOperation(id, "a1", stream, "a1/png"));
+                }
+
+                using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                {
+                    var status = ChangeVector.GetConflictStatus(context, tombstoneChangeVector, putResult.ChangeVector);
+                    Assert.Equal(ConflictStatus.AlreadyMerged, status);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_26789.cs
+++ b/test/SlowTests/Issues/RavenDB_26789.cs
@@ -1,11 +1,22 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Server;
+using Raven.Server.Config;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Replication.Incoming;
+using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -74,6 +85,242 @@ namespace SlowTests.Issues
                     var status = ChangeVector.GetConflictStatus(context, tombstoneChangeVector, putResult.ChangeVector);
                     Assert.Equal(ConflictStatus.AlreadyMerged, status);
                 }
+            }
+        }
+
+        // Production scenario: a bucket migration source shard has two replicas. The node that owns the
+        // migration dies in the window after ownership was transferred to the destination but before the
+        // source cleanup removed the bucket data. The surviving source replica takes over the migration
+        // task and re-sends the whole bucket: the migration replication type persists no per-source
+        // checkpoint (IncomingMigrationReplicationHandler.SaveSourceEtag is a no-op), so the surviving
+        // replica's fresh outgoing handler re-scans from etag 0. Every re-sent item is re-processed on the
+        // destination with a freshly assigned 'order' part (IncomingMigrationReplicationHandler.PreProcessItem
+        // keeps the 'version', assigns a new receiver-local 'order'), so the only causal link between the
+        // re-sent stale items and the destination's current state is the 'version' part of the change vector.
+        //
+        // An attachment that was deleted on the source before the migration and re-created on the
+        // destination after the migration must therefore carry the migrated tombstone's version lineage
+        // in its own change vector. If PutAttachment loses that lineage (creates a plain new change
+        // vector instead of a successor of the tombstone it just replaced), the re-sent stale tombstone
+        // compares as Conflict against the re-created attachment and deletes it - the user's newer write
+        // is silently destroyed by an older delete.
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Replication | RavenTestCategory.Attachments)]
+        public async Task ReputAttachmentShouldSurviveBucketResendAfterMigrationSourceFailover()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "1",
+                [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
+            };
+
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, customSettings: settings);
+            Assert.Equal("A", leader.ServerStore.NodeTag);
+
+            var options = new Options
+            {
+                Server = leader,
+                DatabaseMode = RavenDatabaseMode.Sharded,
+                ModifyDatabaseRecord = record => record.Sharding = new ShardingConfiguration
+                {
+                    Orchestrator = new OrchestratorConfiguration
+                    {
+                        Topology = new OrchestratorTopology { Members = new List<string> { "A" } }
+                    },
+                    Shards = new Dictionary<int, DatabaseTopology>
+                    {
+                        { 0, new DatabaseTopology { Members = new List<string> { "B", "C" }, DynamicNodesDistribution = false } },
+                        { 1, new DatabaseTopology { Members = new List<string> { "A" }, DynamicNodesDistribution = false } }
+                    }
+                }
+            };
+
+            using (var store = GetDocumentStore(options))
+            {
+                // a document whose bucket lives on shard 0 (the future migration source)
+                string id = null;
+                for (var i = 0; i < 5000; i++)
+                {
+                    var candidate = $"users/1$s{i}";
+                    if (await Sharding.GetShardNumberForAsync(store, candidate) == 0)
+                    {
+                        id = candidate;
+                        break;
+                    }
+                }
+                Assert.NotNull(id);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "owner" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var stream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    await store.Operations.SendAsync(new PutAttachmentOperation(id, "a1", stream, "image/png"));
+                }
+
+                // the stale state: an attachment tombstone, present on BOTH source replicas
+                await store.Operations.SendAsync(new DeleteAttachmentOperation(id, "a1"));
+
+                var bucket = await Sharding.GetBucketAsync(store, id);
+                var shard0Name = ShardHelper.ToShardName(store.Database, 0);
+                var shard1Name = ShardHelper.ToShardName(store.Database, 1);
+
+                var serverB = nodes.Single(s => s.ServerStore.NodeTag == "B");
+                var serverC = nodes.Single(s => s.ServerStore.NodeTag == "C");
+
+                var shard0OnB = ShardedDocumentDatabase.CastToShardedDocumentDatabase(
+                    await serverB.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(shard0Name));
+                var shard0OnC = ShardedDocumentDatabase.CastToShardedDocumentDatabase(
+                    await serverC.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(shard0Name));
+
+                foreach (var sourceShard in new[] { shard0OnB, shard0OnC })
+                {
+                    var hasTombstone = await WaitForValueAsync(
+                        () => Task.FromResult(GetAttachmentTombstoneChangeVector(sourceShard, bucket) != null),
+                        true, timeout: 30_000, interval: 333);
+                    Assert.True(hasTombstone,
+                        $"the attachment tombstone did not reach shard 0 replica on node {sourceShard.ServerStore.NodeTag}");
+                }
+
+                // hold the source bucket cleanup on both source replicas, so the surviving replica still
+                // has the stale bucket data when it takes over the migration (in production this is the
+                // natural window between ownership transfer and cleanup)
+                shard0OnB.ForTestingPurposesOnly().DelayDeleteBucket = new AsyncManualResetEvent();
+                shard0OnC.ForTestingPurposesOnly().DelayDeleteBucket = new AsyncManualResetEvent();
+
+                await Sharding.Resharding.StartMovingShardForId(store, id, toShard: 1, servers: nodes);
+
+                var status = await WaitForValueAsync(async () =>
+                {
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.BucketMigrations.TryGetValue(bucket, out var migration)
+                        ? migration.Status
+                        : (MigrationStatus?)null;
+                }, MigrationStatus.OwnershipTransferred, timeout: 60_000, interval: 333);
+                Assert.Equal(MigrationStatus.OwnershipTransferred, status);
+
+                var shard1OnA = ShardedDocumentDatabase.CastToShardedDocumentDatabase(
+                    await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(shard1Name));
+
+                // the migrated tombstone arrived at the destination with a composite (order|version) change vector
+                var migratedTombstoneChangeVector = GetAttachmentTombstoneChangeVector(shard1OnA, bucket);
+                Assert.NotNull(migratedTombstoneChangeVector);
+                Assert.Contains("|", migratedTombstoneChangeVector);
+
+                // the user re-creates the attachment with the same content (the attachment key includes the
+                // content hash, so only a same-content re-put replaces the migrated tombstone); the write is
+                // routed to the destination shard
+                using (var stream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    await store.Operations.SendAsync(new PutAttachmentOperation(id, "a1", stream, "image/png"));
+                }
+
+                Assert.Null(GetAttachmentTombstoneChangeVector(shard1OnA, bucket));
+                using (var session = store.OpenAsyncSession())
+                {
+                    Assert.True(await session.Advanced.Attachments.ExistsAsync(id, "a1"));
+                }
+
+                // find which source replica owns the migration (it keeps the connection open for leftovers)
+                RavenServer migrationOwner = null;
+                var hasOwner = await WaitForValueAsync(() =>
+                {
+                    foreach (var (server, shardDb) in new[] { (serverB, shard0OnB), (serverC, shard0OnC) })
+                    {
+                        if (shardDb.ReplicationLoader.OutgoingHandlers.OfType<OutgoingMigrationReplicationHandler>().Any())
+                        {
+                            migrationOwner = server;
+                            return Task.FromResult(true);
+                        }
+                    }
+                    return Task.FromResult(false);
+                }, true, timeout: 30_000, interval: 333);
+                Assert.True(hasOwner, "no outgoing migration handler found on either source replica");
+
+                var survivorShard0 = migrationOwner == serverB ? shard0OnC : shard0OnB;
+
+                // the cleanup hold kept the stale bucket data (incl. the attachment tombstone) on the survivor
+                Assert.NotNull(GetAttachmentTombstoneChangeVector(survivorShard0, bucket));
+
+                long survivorLastEtag;
+                using (survivorShard0.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    survivorLastEtag = survivorShard0.DocumentsStorage.ReadLastEtag(context.Transaction.InnerTransaction);
+                }
+
+                var preKillIncomingHandlers = shard1OnA.ReplicationLoader.IncomingHandlers
+                    .OfType<IncomingMigrationReplicationHandler>().ToHashSet();
+
+                // kill the migration owner; the surviving source replica takes over the migration task
+                // and re-sends the whole bucket from scratch
+                await DisposeServerAndWaitForFinishOfDisposalAsync(migrationOwner);
+
+                var resendCompleted = await WaitForValueAsync(() =>
+                {
+                    foreach (var handler in shard1OnA.ReplicationLoader.IncomingHandlers.OfType<IncomingMigrationReplicationHandler>())
+                    {
+                        // a NEW incoming migration connection (from the surviving replica) that has
+                        // processed everything the survivor holds
+                        if (preKillIncomingHandlers.Contains(handler) == false &&
+                            handler.LastDocumentEtag >= survivorLastEtag)
+                            return Task.FromResult(true);
+                    }
+                    return Task.FromResult(false);
+                }, true, timeout: 120_000, interval: 333);
+
+                if (resendCompleted == false)
+                {
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    var shard0Topology = record.Sharding.Shards[0];
+                    var diagnostics = new System.Text.StringBuilder()
+                        .AppendLine($"survivor: {survivorShard0.ServerStore.NodeTag}, survivorLastEtag: {survivorLastEtag}")
+                        .AppendLine($"shard0 members: [{string.Join(",", shard0Topology.Members)}], rehabs: [{string.Join(",", shard0Topology.Rehabs)}]")
+                        .AppendLine($"migration record present: {record.Sharding.BucketMigrations.ContainsKey(bucket)}" +
+                                    (record.Sharding.BucketMigrations.TryGetValue(bucket, out var m) ? $", status: {m.Status}" : string.Empty))
+                        .AppendLine($"survivor outgoing handlers: [{string.Join(",", survivorShard0.ReplicationLoader.OutgoingHandlers.Select(h => $"{h.GetType().Name}->{h.Destination?.Database}@{h.Destination?.Url}"))}]")
+                        .AppendLine($"dest incoming handlers: [{string.Join(",", shard1OnA.ReplicationLoader.IncomingHandlers.Select(h => $"{h.GetType().Name} src={h.ConnectionInfo?.SourceDatabaseId} lastDocEtag={h.LastDocumentEtag}"))}]");
+                    Assert.Fail("the surviving source replica did not re-send the bucket to the destination." + Environment.NewLine + diagnostics);
+                }
+
+                // the re-created attachment is causally NEWER than the re-sent stale tombstone and must survive it
+                using (var session = store.OpenAsyncSession())
+                {
+                    Assert.True(await session.Advanced.Attachments.ExistsAsync(id, "a1"),
+                        "the re-created attachment was deleted by the re-sent stale attachment tombstone - " +
+                        "its change vector did not preserve the version lineage of the tombstone it replaced");
+
+                    var attachment = await session.Advanced.Attachments.GetAsync(id, "a1");
+                    Assert.NotNull(attachment);
+                    Assert.Equal(new byte[] { 1, 2, 3 }, await ReadAll(attachment.Stream));
+                }
+            }
+        }
+
+        private static string GetAttachmentTombstoneChangeVector(ShardedDocumentDatabase shardDatabase, int bucket)
+        {
+            var storage = (ShardedDocumentsStorage)shardDatabase.DocumentsStorage;
+            using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                foreach (var tombstone in storage.RetrieveTombstonesByBucketFrom(context, bucket, 0))
+                {
+                    if (tombstone.Type == Tombstone.TombstoneType.Attachment)
+                        return tombstone.ChangeVector;
+                }
+            }
+
+            return null;
+        }
+
+        private static async Task<byte[]> ReadAll(Stream stream)
+        {
+            using (var ms = new MemoryStream())
+            {
+                await stream.CopyToAsync(ms);
+                return ms.ToArray();
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_26789.cs
+++ b/test/SlowTests/Issues/RavenDB_26789.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
@@ -18,6 +19,7 @@ using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Server;
 using Tests.Infrastructure;
+using Voron;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -88,22 +90,84 @@ namespace SlowTests.Issues
             }
         }
 
-        // Production scenario: a bucket migration source shard has two replicas. The node that owns the
-        // migration dies in the window after ownership was transferred to the destination but before the
-        // source cleanup removed the bucket data. The surviving source replica takes over the migration
-        // task and re-sends the whole bucket: the migration replication type persists no per-source
-        // checkpoint (IncomingMigrationReplicationHandler.SaveSourceEtag is a no-op), so the surviving
-        // replica's fresh outgoing handler re-scans from etag 0. Every re-sent item is re-processed on the
-        // destination with a freshly assigned 'order' part (IncomingMigrationReplicationHandler.PreProcessItem
-        // keeps the 'version', assigns a new receiver-local 'order'), so the only causal link between the
-        // re-sent stale items and the destination's current state is the 'version' part of the change vector.
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Attachments)]
+        public async Task PutDirectOverMigratedTombstoneShouldPreserveTombstoneChangeVector()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                const string id = "users/1";
+                const string name = "a1";
+                const string contentType = "image/png";
+                var attachmentBytes = new byte[] { 1, 2, 3 };
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "1" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                AttachmentDetails putResult;
+                using (var stream = new MemoryStream(attachmentBytes))
+                {
+                    putResult = await store.Operations.SendAsync(new PutAttachmentOperation(id, name, stream, contentType));
+                }
+
+                await store.Operations.SendAsync(new DeleteAttachmentOperation(id, name));
+
+                var bucket = await Sharding.GetBucketAsync(store, id);
+                await Sharding.Resharding.MoveShardForId(store, id);
+
+                var newLocation = await Sharding.GetShardNumberForAsync(store, id);
+                var newShard = ShardedDocumentDatabase.CastToShardedDocumentDatabase(
+                    await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, newLocation)));
+
+                var tombstone = GetAttachmentTombstone(newShard, bucket);
+                Assert.NotNull(tombstone.ChangeVector);
+                Assert.NotNull(tombstone.Key);
+                Assert.Contains("|", tombstone.ChangeVector);
+
+                var storage = newShard.DocumentsStorage;
+                using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenWriteTransaction())
+                using (DocumentIdWorker.GetLowerIdSliceAndStorageKeyForBackwardCompatibility(context, name, out _, out Slice nameSlice))
+                using (DocumentIdWorker.GetLowerIdSliceAndStorageKeyForBackwardCompatibility(context, contentType, out _, out Slice contentTypeSlice))
+                using (Slice.From(context.Allocator, putResult.Hash, out Slice base64Hash))
+                using (Slice.From(context.Allocator, tombstone.Key, out Slice keySlice))
+                using (var stream = new MemoryStream(attachmentBytes))
+                {
+                    storage.AttachmentsStorage.PutAttachmentStream(context, keySlice, base64Hash, stream);
+                    storage.AttachmentsStorage.PutDirect(context, keySlice, nameSlice, contentTypeSlice, base64Hash);
+
+                    tx.Commit();
+                }
+
+                Assert.Null(GetAttachmentTombstoneChangeVector(newShard, bucket));
+
+                using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var attachment = storage.AttachmentsStorage.GetAttachment(context, id, name, AttachmentType.Document, null,
+                        putResult.Hash, contentType, usePartialKey: false);
+                    Assert.NotNull(attachment);
+
+                    var status = ChangeVector.GetConflictStatus(context, tombstone.ChangeVector, attachment.ChangeVector);
+                    Assert.Equal(ConflictStatus.AlreadyMerged, status);
+                }
+            }
+        }
+
+        // Regression setup: after bucket ownership is transferred, source cleanup can still be pending.
+        // If the migration owner dies in that window, another source replica can take over and resend
+        // stale bucket data from scratch.
         //
-        // An attachment that was deleted on the source before the migration and re-created on the
-        // destination after the migration must therefore carry the migrated tombstone's version lineage
-        // in its own change vector. If PutAttachment loses that lineage (creates a plain new change
-        // vector instead of a successor of the tombstone it just replaced), the re-sent stale tombstone
-        // compares as Conflict against the re-created attachment and deletes it - the user's newer write
-        // is silently destroyed by an older delete.
+        // Migration replication rewrites the receiver-local 'order' but keeps the original 'version'
+        // lineage. Therefore, when the destination re-creates an attachment over a migrated tombstone,
+        // the new attachment CV must inherit the tombstone's version lineage; otherwise a re-sent stale
+        // tombstone compares as Conflict and can delete the newer write.
+        //
+        // Relevant internals:
+        // - IncomingMigrationReplicationHandler.SaveSourceEtag intentionally does not checkpoint.
+        // - IncomingMigrationReplicationHandler.PreProcessItem keeps version and assigns new order.
         [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Replication | RavenTestCategory.Attachments)]
         public async Task ReputAttachmentShouldSurviveBucketResendAfterMigrationSourceFailover()
         {
@@ -301,6 +365,11 @@ namespace SlowTests.Issues
 
         private static string GetAttachmentTombstoneChangeVector(ShardedDocumentDatabase shardDatabase, int bucket)
         {
+            return GetAttachmentTombstone(shardDatabase, bucket).ChangeVector;
+        }
+
+        private static (string ChangeVector, string Key) GetAttachmentTombstone(ShardedDocumentDatabase shardDatabase, int bucket)
+        {
             var storage = (ShardedDocumentsStorage)shardDatabase.DocumentsStorage;
             using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
@@ -308,11 +377,11 @@ namespace SlowTests.Issues
                 foreach (var tombstone in storage.RetrieveTombstonesByBucketFrom(context, bucket, 0))
                 {
                     if (tombstone.Type == Tombstone.TombstoneType.Attachment)
-                        return tombstone.ChangeVector;
+                        return (tombstone.ChangeVector, tombstone.LowerId.ToString());
                 }
             }
 
-            return null;
+            return (null, null);
         }
 
         private static async Task<byte[]> ReadAll(Stream stream)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26789

### Additional description

`AttachmentsStorage.PutAttachment`/`PutDirect` delete the matching attachment tombstone but discard its change vector, creating the new attachment with a plain new change vector. When the tombstone carries lineage that the local database change vector does not cover — which is what bucket migration produces (composite `order|version` change vectors whose version side is never merged into the destination's database change vector) — the re-created attachment does not dominate the tombstone it replaced.

This becomes data loss through the bucket-migration re-send path: with a source shard of RF >= 2, if the node that owns the migration fails after ownership transfer but before source cleanup, the surviving source replica takes over the migration task and re-sends the whole bucket (the migration replication type persists no per-source checkpoint — `SaveSourceEtag` is a no-op — so the surviving replica's fresh outgoing handler re-scans from etag 0). Each re-sent item is re-processed with a freshly assigned order (`IncomingMigrationReplicationHandler.PreProcessItem`), so incoming comparisons rest on version lineage (`ChangeVectorUtils.GetConflictStatus` defaults to Version mode). The re-sent stale attachment tombstone then compares as Conflict against the user's newer re-created attachment, and `DeleteAttachmentDirect` silently destroys it.

The fix: when an attachment put replaces a tombstone, the new attachment change vector is created as a local successor of the tombstone's change vector (`DeleteTombstoneIfNeeded` now returns the tombstone's change vector; `ChangeVector.GetLocalCvFromPriorAndUpdateDbCv` merges it with the database change vector and stamps the new local version+order). The re-sent stale tombstone then compares as AlreadyMerged and is ignored — the same protection documents already have, because a local document update merges the old document change vector.

The backport also mirrors the final `feature/revisions` behavior for ordinary attachment updates: when a put updates an existing attachment row, the new attachment change vector is derived as a local successor of the previous attachment change vector instead of starting from a fresh local CV. This keeps attachment lineage consistent with the final reviewed 7.2 implementation.

Tests:
- `RavenDB_26789.PuttingAttachmentOverMigratedTombstoneShouldPreserveTombstoneChangeVector` — storage-level invariant: an attachment put over a migrated (composite-CV) tombstone yields AlreadyMerged vs the tombstone.
- `RavenDB_26789.PutDirectOverMigratedTombstoneShouldPreserveTombstoneChangeVector` — storage-level invariant for the direct put path: PutDirect over a migrated attachment tombstone also preserves tombstone lineage.
- `RavenDB_26789.ReputAttachmentShouldSurviveBucketResendAfterMigrationSourceFailover` — end-to-end behavioral repro of the production scenario (cluster, source shard RF=2, migration owner failover, bucket re-send); red without the fix (the re-created attachment is deleted by the re-sent stale tombstone), green with it.
- A `ForTestingPurposes` hook (`DelayDeleteBucket`) holds the source bucket cleanup so the post-ownership-transfer window is deterministic in the test.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed