### PR TITLE
RavenDB-26792 FreeSpaceSnapshot endpoint returns the requested environment.

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -338,13 +338,13 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 throw new InvalidOperationException($"The storage with name '{name}' and type '{type}' was not found.");
                     
             var hex = this.GetBoolValueQueryString("hex", false) ?? true;
-            using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            using (context.OpenReadTransaction())
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (var rTx = storage.Environment.ReadTransaction())
             {
                 var freeSpaceHandling = storage.Environment.FreeSpaceHandling;
                 await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
-                    var json = freeSpaceHandling.FreeSpaceSnapshot(context.Transaction.InnerTransaction.LowLevelTransaction, hex);
+                    var json = freeSpaceHandling.FreeSpaceSnapshot(rTx.LowLevelTransaction, hex);
                     context.Write(write, json);
                 }
             }

--- a/test/SlowTests.Issues/Issues/RavenDB-26792.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26792.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26792(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Voron)]
+    public async Task FreeSpaceSnapshotEndpointShouldReturnTheRequestedEnvironment()
+    {
+        using (var store = GetDocumentStore())
+        {
+            await new Orders_ByName().ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
+
+            var random = new Random(2024);
+            const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+            var chars = new char[64 * 1024];
+            for (var i = 0; i < chars.Length; i++)
+                chars[i] = alphabet[random.Next(alphabet.Length)];
+            var payload = new string(chars);
+
+            using (var session = store.OpenSession())
+            {
+                for (var i = 0; i < 8; i++)
+                    session.Store(new Item { Payload = payload }, "items/" + i);
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                for (var i = 0; i < 8; i++)
+                    session.Delete("items/" + i);
+                session.SaveChanges();
+            }
+
+            var database = await GetDatabase(store.Database);
+            var documentsEnvironment = database.DocumentsStorage.Environment;
+            var index = database.IndexStore.GetIndexes().Single();
+            var indexEnvironment = index._indexStorage.Environment();
+
+            long documentsFreePages;
+            long indexFreePages;
+            using (var dbReadTransaction = documentsEnvironment.ReadTransaction())
+                documentsFreePages = documentsEnvironment.FreeSpaceHandling.GetFreePagesCount(dbReadTransaction.LowLevelTransaction);
+            using (var indexReadTransaction = indexEnvironment.ReadTransaction())
+                indexFreePages = indexEnvironment.FreeSpaceHandling.GetFreePagesCount(indexReadTransaction.LowLevelTransaction);
+
+            Assert.True(documentsFreePages > indexFreePages + 16,
+                $"fixture failed to diverge the environments: documents={documentsFreePages}, index={indexFreePages}");
+
+            using (var commands = store.Commands())
+            {
+                var documentsJson = commands.RawGetJson<BlittableJsonReaderObject>(
+                    $"/debug/storage/environment/free-space-snapshot?name={Uri.EscapeDataString(store.Database)}&type=Documents");
+                Assert.True(documentsJson.TryGet("FreePagesCount", out long endpointDocumentsFreePages));
+
+                var indexJson = commands.RawGetJson<BlittableJsonReaderObject>(
+                    $"/debug/storage/environment/free-space-snapshot?name={Uri.EscapeDataString(index.Name)}&type=Index");
+                Assert.True(indexJson.TryGet("FreePagesCount", out long endpointIndexFreePages));
+
+                Assert.Equal(documentsFreePages, endpointDocumentsFreePages);
+                Assert.Equal(indexFreePages, endpointIndexFreePages);
+            }
+        }
+    }
+
+    private class Item
+    {
+        public string Payload { get; set; }
+    }
+
+    private class Order
+    {
+        public string Name { get; set; }
+    }
+
+    private class Orders_ByName : AbstractIndexCreationTask<Order>
+    {
+        public Orders_ByName()
+        {
+            Map = orders => from order in orders
+                select new
+                {
+                    order.Name
+                };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26792

### Additional description

Pass the correct storage environment for statistics calculation.
 
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
