### PR TITLE
RavenDB-25278 - Wait etl base on etag and add debug info

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24644.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24644.cs
@@ -12,6 +12,8 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Json;
+using Raven.Server.Documents.ETL;
+using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -134,6 +136,9 @@ ai.genContext({}).withPdf(pdf);
                     }
                 }
                 sb.Append("]");
+                sb.AppendLine().AppendLine("Logs:").AppendLine(await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+                sb.AppendLine().AppendLine("GenAI batch errors (which item failed + the actual exception):")
+                    .AppendLine(await GetGenAiBatchErrorsAsync(store));
                 throw new AggregateException("Conversation Docs: " + Environment.NewLine + sb, e);
             }
         }
@@ -173,8 +178,8 @@ ai.genContext({}).withPdf(pdf);
             else
                 Assert.Null(oldHash2);
 
-            // Change + add attachments
-            var etl = Etl.WaitForEtlToComplete(store);
+            var etl = await GetEtlMre(store);
+
             using (var session = store.OpenAsyncSession())
             {
                 await using var file1 = GetEmbeddedPdfStream("Hibernating.pdf");
@@ -185,7 +190,7 @@ ai.genContext({}).withPdf(pdf);
                 await session.SaveChangesAsync();
             }
 
-            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+            await EtlWait(etl);
 
             // Wait until hashes reflect the change
             string hash1 = string.Empty, hash2 = string.Empty;
@@ -198,17 +203,18 @@ ai.genContext({}).withPdf(pdf);
                 Assert.False(hash2 == null, $"oldHash1={oldHash1}, oldHash2={oldHash2}, hash1={hash1}, hash2={hash2}");
                 Assert.NotEqual(oldHash1, hash1);
                 Assert.NotEqual(oldHash2, hash1);
-            });
+            }, Debugger.IsAttached ? 1200 : 120);
 
-            // Delete attachment from items/1
-            etl = Etl.WaitForEtlToComplete(store);
+
+            etl = await GetEtlMre(store);
+
             using (var session = store.OpenAsyncSession())
             {
                 session.Advanced.Attachments.Delete(FirstItemId, AttachmentName);
                 await session.SaveChangesAsync();
             }
 
-            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+            await EtlWait(etl);
 
             await WaitForAssertionAsync(async () =>
             {
@@ -217,7 +223,55 @@ ai.genContext({}).withPdf(pdf);
                     Assert.NotEqual(hash1, newHash1);
                 else
                     Assert.Null(newHash1); // doc1 produces no context objects now - metadata hashes gets cleared
-            });
+            }, Debugger.IsAttached ? 1200 : 120);
+        }
+
+        private async Task EtlWait(AsyncManualResetEvent etl)
+        {
+            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        }
+
+        private async Task<AsyncManualResetEvent> GetEtlMre(DocumentStore store)
+        {
+            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            var baselineEtag = db.EtlLoader.Processes.Single().Statistics.LastProcessedEtag;
+            var etl = Etl.WaitForEtlToComplete(store, predicate: (_, statistics) => statistics.LastProcessedEtag > baselineEtag);
+            return etl;
+        }
+
+        // Debug helper: surfaces, per GenAI task, exactly which request/item failed in the batch and the actual
+        // exception. The GenAI ETL records this in TaskErrorsStorage:
+        //  - item load errors  (GenAiTask: "Model call failed for context in document '<id>' (<ExType>). Context was: ... <full exception>")
+        //  - process/batch load errors (the whole-batch AggregateException + fallback message)
+        // We also dump the per-task counters so it's clear whether nothing was sent, something errored, or it stalled.
+        private async Task<string> GetGenAiBatchErrorsAsync(DocumentStore store)
+        {
+            var sb = new StringBuilder();
+            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+
+            foreach (var process in db.EtlLoader.Processes)
+            {
+                var stats = process.Statistics;
+                sb.AppendLine(
+                    $"Task '{process.Name}' [{process.TaskCategory}] - " +
+                    $"LoadSuccesses={stats.LoadSuccesses}, LoadErrors={stats.LoadErrors}, " +
+                    $"TransformationErrors={stats.TransformationErrors}, LastProcessedEtag={stats.LastProcessedEtag}");
+
+                var itemErrors = db.TaskErrorsStorage.ReadItemErrorsOfTask(process.TaskCategory, process.Name);
+                foreach (var err in itemErrors)
+                    sb.AppendLine($"  ITEM  [{err.CreatedAt:O}] step={(TaskErrorStep)err.Step} doc='{err.DocumentId}'" +
+                                  $"{Environment.NewLine}        {err.Error}");
+
+                var processErrors = db.TaskErrorsStorage.ReadProcessErrorsOfTask(process.TaskCategory, process.Name);
+                foreach (var err in processErrors)
+                    sb.AppendLine($"  BATCH [{err.CreatedAt:O}] step={(TaskErrorStep)err.Step} affected={err.AffectedDocumentsCount}" +
+                                  $"{Environment.NewLine}        {err.Error}");
+
+                if (itemErrors.Count == 0 && processErrors.Count == 0)
+                    sb.AppendLine("  (no stored load/transformation errors)");
+            }
+
+            return sb.ToString();
         }
 
         private static Stream GetEmbeddedPdfStream(string fileName)

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24644.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24644.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Json;
+using Raven.Server.Documents;
 using Raven.Server.Documents.ETL;
 using Sparrow.Server;
 using Tests.Infrastructure;
@@ -178,7 +179,8 @@ ai.genContext({}).withPdf(pdf);
             else
                 Assert.Null(oldHash2);
 
-            var etl = await GetEtlMre(store);
+            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            var etl = await GetEtlMre(db, store);
 
             using (var session = store.OpenAsyncSession())
             {
@@ -202,11 +204,11 @@ ai.genContext({}).withPdf(pdf);
                 Assert.NotNull(hash1);
                 Assert.False(hash2 == null, $"oldHash1={oldHash1}, oldHash2={oldHash2}, hash1={hash1}, hash2={hash2}");
                 Assert.NotEqual(oldHash1, hash1);
-                Assert.NotEqual(oldHash2, hash1);
-            }, Debugger.IsAttached ? 1200 : 120);
+                Assert.NotEqual(oldHash2, hash2);
+            }, Debugger.IsAttached ? 1_200_000 : 120_000);
 
 
-            etl = await GetEtlMre(store);
+            etl = await GetEtlMre(db, store);
 
             using (var session = store.OpenAsyncSession())
             {
@@ -223,7 +225,7 @@ ai.genContext({}).withPdf(pdf);
                     Assert.NotEqual(hash1, newHash1);
                 else
                     Assert.Null(newHash1); // doc1 produces no context objects now - metadata hashes gets cleared
-            }, Debugger.IsAttached ? 1200 : 120);
+            }, Debugger.IsAttached ? 1_200_000 : 120_000);
         }
 
         private async Task EtlWait(AsyncManualResetEvent etl)
@@ -231,9 +233,8 @@ ai.genContext({}).withPdf(pdf);
             Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
         }
 
-        private async Task<AsyncManualResetEvent> GetEtlMre(DocumentStore store)
+        private async Task<AsyncManualResetEvent> GetEtlMre(DocumentDatabase db, DocumentStore store)
         {
-            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
             var baselineEtag = db.EtlLoader.Processes.Single().Statistics.LastProcessedEtag;
             var etl = Etl.WaitForEtlToComplete(store, predicate: (_, statistics) => statistics.LastProcessedEtag > baselineEtag);
             return etl;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25278/SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB24644.SelectivePdfDescriptionTransformWhenSomeAttachmentsAreMissingoptions

### Additional description

The predicate in Etl.WaitForEtlToComplete checks whether statistics.LoadSuccesses > 0.
The problem is that after the first batch completes successfully, this condition will always be true for all subsequent batches. Because of that, I decided to rely on comparing the ETL state before and after the batch (using the etag) instead of LoadSuccesses, so the test waits for actual progress made by the batch under test rather than a cumulative counter that may already be satisfied.
Also added additional debug information for future failures..

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
