### PR TITLE
RavenDB-26799 ChatAiAgent failing test in CI

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.spec.tsx
@@ -51,7 +51,7 @@ describe("AiAgentMessages", () => {
             <ChatAiAgentStory conversationDocument={conversationDocument} />
         );
 
-        expect(screen.getByText("System prompt")).toBeInTheDocument();
+        expect(await screen.findByText("System prompt")).toBeInTheDocument();
         expect(screen.getByText(systemPromptText)).toBeInTheDocument();
     });
 
@@ -102,7 +102,7 @@ describe("AiAgentMessages", () => {
             <ChatAiAgentStory conversationDocument={conversationDocument} />
         );
 
-        const transcriptButton = screen.getByText("Query tool: " + queryToolName);
+        const transcriptButton = await screen.findByText("Query tool: " + queryToolName);
         await fireClick(transcriptButton);
         expect(screen.getByText("Parameters filled by LLM")).toBeInTheDocument();
         expect(screen.getByText("Query tool result")).toBeInTheDocument();
@@ -147,7 +147,7 @@ describe("AiAgentMessages", () => {
             <ChatAiAgentStory conversationDocument={conversationDocument} />
         );
 
-        expect(screen.getByText("Action tool: " + actionToolName)).toBeInTheDocument();
+        expect(await screen.findByText("Action tool: " + actionToolName)).toBeInTheDocument();
 
         expect(screen.getByText(/Enter a response after completing action/)).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
@@ -184,7 +184,7 @@ describe("AiAgentMessages", () => {
             <ChatAiAgentStory conversationDocument={conversationDocument} />
         );
 
-        expect(screen.getByText("Action tool: " + actionToolName)).toBeInTheDocument();
+        expect(await screen.findByText("Action tool: " + actionToolName)).toBeInTheDocument();
 
         expect(screen.getByText(/Response from action tool/)).toBeInTheDocument();
         expect(screen.getByText("Submitted")).toBeInTheDocument();
@@ -222,7 +222,7 @@ describe("AiAgentMessages", () => {
             <ChatAiAgentStory conversationDocument={conversationDocument} />
         );
 
-        const transcriptButton = screen.getByText("Sub-agent: " + subAgentId);
+        const transcriptButton = await screen.findByText("Sub-agent: " + subAgentId);
         await fireClick(transcriptButton);
         expect(screen.getByText("Parameters filled by LLM")).toBeInTheDocument();
         expect(screen.getByText("Sub-conversation created")).toBeInTheDocument();
@@ -260,7 +260,7 @@ describe("AiAgentMessages", () => {
             <ChatAiAgentStory conversationDocument={conversationDocument} />
         );
 
-        const transcriptButton = screen.getByText("Tool: " + toolName);
+        const transcriptButton = await screen.findByText("Tool: " + toolName);
         await fireClick(transcriptButton);
         expect(screen.getByText("Parameters filled by LLM")).toBeInTheDocument();
     });


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26799/ChatAiAgent-failing-test-in-CI

### Additional description

Use async findByText instead of getByText

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
