### PR TITLE
RavenDB-26801 Unify GetDiskSpaceInfo behavior on Windows

### DIFF
--- a/src/Raven.Server/Utils/ExceptionHelper.cs
+++ b/src/Raven.Server/Utils/ExceptionHelper.cs
@@ -63,12 +63,11 @@ namespace Raven.Server.Utils
         [DoesNotReturn]
         public static void ThrowDiskFullException(string path) // Can be the folder path of the fole absolute path
         {
-            var folderPath = Path.GetDirectoryName(path); // file Absolute Path
-            var driveInfo = DiskUtils.GetDiskSpaceInfo(folderPath);
+            var driveInfo = DiskUtils.GetDiskSpaceInfoForFile(path);
             var freeSpace = driveInfo != null ? driveInfo.TotalFreeSpace.ToString() : "N/A";
             var totalSize = driveInfo != null ? driveInfo.TotalSize.ToString() : "N/A";
 
-            throw new DiskFullException($"There isn't enough space to flush the buffer in: {folderPath}. " +
+            throw new DiskFullException($"There isn't enough space to flush the buffer in: {path}. " +
                                         $"Currently available space: {freeSpace}/{totalSize}");
         }
     }

--- a/src/Sparrow.Server/Utils/DiskUtils.cs
+++ b/src/Sparrow.Server/Utils/DiskUtils.cs
@@ -2,7 +2,6 @@
 using System.Buffers;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
 using Sparrow.Logging;
 using Sparrow.Platform;
 using Sparrow.Server.Logging;
@@ -20,6 +19,14 @@ namespace Sparrow.Server.Utils
         public const short WindowsMaxPath = short.MaxValue;
 
         public const int LinuxMaxPath = 4096;
+
+        public static DiskSpaceResult GetDiskSpaceInfoForFile(string fileName, DriveInfoBase driveInfoBase = null)
+        {
+            if (Path.GetDirectoryName(fileName) is { Length: > 0 } parent)
+                return GetDiskSpaceInfo(parent, driveInfoBase);
+
+            return GetDiskSpaceInfo(fileName, driveInfoBase);
+        }
 
         public static DiskSpaceResult GetDiskSpaceInfo(string pathToCheck, DriveInfoBase driveInfoBase = null)
         {

--- a/src/Voron/Impl/Paging/Pager.cs
+++ b/src/Voron/Impl/Paging/Pager.cs
@@ -114,7 +114,7 @@ public unsafe partial class Pager : IDisposable
         }
         catch (DiskFullException dfEx)
         {
-            var diskSpaceResult = DiskUtils.GetDiskSpaceInfo(filename);
+            var diskSpaceResult = DiskUtils.GetDiskSpaceInfoForFile(filename);
             throw new DiskFullException(filename, initialFileSize, diskSpaceResult?.TotalFreeSpace.GetValue(SizeUnit.Bytes), dfEx.Message);
         }
     }

--- a/src/Voron/Platform/Win32/Win32NativeFileMethods.cs
+++ b/src/Voron/Platform/Win32/Win32NativeFileMethods.cs
@@ -115,9 +115,7 @@ namespace Voron.Platform.Win32
                 var lastError = Marshal.GetLastWin32Error();
                 if (lastError == (int) Win32NativeFileErrors.ERROR_DISK_FULL)
                 {
-                    var directoryPath = Path.GetDirectoryName(filePath);
-                    // disk space info is expecting the directory path and not the file path
-                    var driveInfo = DiskUtils.GetDiskSpaceInfo(directoryPath);
+                    var driveInfo = DiskUtils.GetDiskSpaceInfoForFile(filePath);
                     throw new DiskFullException(filePath, length, driveInfo?.TotalFreeSpace.GetValue(SizeUnit.Bytes), new Win32Exception(lastError).Message);
                 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26801

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
