### PR TITLE
RavenDB-26746 Tree rebalancing corrupted the tree when re-adding a separator split ancestor pages

### DIFF
--- a/src/Voron/Data/BTrees/ParentPageAction.cs
+++ b/src/Voron/Data/BTrees/ParentPageAction.cs
@@ -27,15 +27,21 @@ namespace Voron.Data.BTrees
 
         public TreePage ParentOfAddedPageRef { get; private set; }
 
+        public bool PerformedSplit { get; private set; }
+
         public byte* AddSeparator(Slice separator, long pageRefNumber, int? nodePos = null)
         {
             var originalLastSearchPositionOfParent = _parentPage.LastSearchPosition;
 
-            if (nodePos == null)
-                nodePos = _parentPage.NodePositionFor(_tx, separator); // select the appropriate place for this
-
             if (_parentPage.HasSpaceFor(_tx, TreeSizeOf.BranchEntry(separator) + Constants.Tree.NodeOffsetSize) == false)
             {
+                PerformedSplit = true;
+
+                // the splitter decides the split shape based on _parentPage.LastSearchPosition - including
+                // the sequential-insert optimization that appends without a key search - so it must reflect
+                // the position of this separator instead of a leftover from the descent or another fix-up
+                _parentPage.NodePositionFor(_tx, separator);
+
                 var pageSplitter = new TreePageSplitter(_tx, _tree, separator, -1, pageRefNumber, TreeNodeFlags.PageRef, _cursor);
 
                 var posToInsert = pageSplitter.Execute();
@@ -78,6 +84,9 @@ namespace Voron.Data.BTrees
             }
 
             ParentOfAddedPageRef = _parentPage;
+
+            if (nodePos == null)
+                nodePos = _parentPage.NodePositionFor(_tx, separator); // select the appropriate place for this
 
             var pos = _parentPage.AddPageRefNode(nodePos.Value, separator, pageRefNumber);
 

--- a/src/Voron/Data/BTrees/TreePageSplitter.cs
+++ b/src/Voron/Data/BTrees/TreePageSplitter.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Text;
 using Voron.Data.Compression;
+using Voron.Exceptions;
 using Voron.Global;
 using Voron.Impl;
 using Voron.Impl.FreeSpace;
@@ -167,6 +168,14 @@ namespace Voron.Data.BTrees
 
                     TreeNodeHeader* node = _page.GetNode(_page.NumberOfEntries - 1);
                     Debug.Assert(node->Flags == TreeNodeFlags.PageRef);
+
+                    using (TreeNodeHeader.ToSlicePtr(_tx.Allocator, node, out Slice stolenKey))
+                    {
+                        if (SliceComparer.CompareInline(_newKey, stolenKey) <= 0)
+                            VoronUnrecoverableErrorException.Raise(_tx,
+                                $"Sequential-insert split optimization of branch page {_page.PageNumber} attempted with a non-sequential key (new key '{_newKey}' does not sort after the last entry '{stolenKey}'), tree: {_tree.Name}");
+                    }
+
                     rightPage.AddPageRefNode(0, Slices.BeforeAllKeys, node->PageNumber);
                     pos = AddNodeToPage(rightPage, 1);
 
@@ -191,6 +200,17 @@ namespace Voron.Data.BTrees
             }
             else
             {
+                if (_page.NumberOfEntries > 0)
+                {
+                    TreeNodeHeader* lastNode = _page.GetNode(_page.NumberOfEntries - 1);
+                    using (TreeNodeHeader.ToSlicePtr(_tx.Allocator, lastNode, out Slice lastKey))
+                    {
+                        if (SliceComparer.CompareInline(_newKey, lastKey) <= 0)
+                            VoronUnrecoverableErrorException.Raise(_tx,
+                                $"Sequential-insert split optimization of leaf page {_page.PageNumber} attempted with a non-sequential key (new key '{_newKey}' does not sort after the last entry '{lastKey}'), tree: {_tree.Name}");
+                    }
+                }
+
                 AddSeparatorToParentPage(rightPage.PageNumber, _newKey, out branchOfSeparator);
                 pos = AddNodeToPage(rightPage, 0);
             }

--- a/src/Voron/Data/BTrees/TreeRebalancer.cs
+++ b/src/Voron/Data/BTrees/TreeRebalancer.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Sparrow;
 using Sparrow.Server;
 using Voron.Data.Compression;
+using Voron.Exceptions;
 using Voron.Impl;
 using Voron.Impl.FreeSpace;
 using Constants = Voron.Global.Constants;
@@ -15,6 +17,8 @@ namespace Voron.Data.BTrees
         private readonly LowLevelTransaction _tx;
         private readonly Tree _tree;
         private readonly TreeCursor _cursor;
+
+        private bool _ancestorsChanged;
 
         public TreeRebalancer(LowLevelTransaction tx, Tree tree, TreeCursor cursor)
         {
@@ -48,17 +52,57 @@ namespace Voron.Data.BTrees
                 var parentPage = _tree.ModifyPage(_cursor.CurrentPage);
                 _cursor.Update(_cursor.Pages, parentPage);
 
+                // when an earlier iteration of this cascade re-added a separator into a full ancestor page,
+                // that page got split. A split can move pages under different parents and change node
+                // positions, so the cursor built during the descent may no longer match the tree.
+                // An empty page is possible only on the first iteration, before any split could happen.
+                if (_ancestorsChanged && page.NumberOfEntries > 0)
+                {
+                    RebuildCursorAbovePage(page);
+
+                    // we could reset the flag here, but it is safer to keep rebuilding until the rebalancing ends - the
+                    // extra cost is a few page reads per level and is only paid when an ancestor was already split
+                    //_ancestorsChanged = false;
+
+                    parentPage = _tree.ModifyPage(_cursor.CurrentPage);
+                    _cursor.Update(_cursor.Pages, parentPage);
+                }
+
+                int positionInParent = -1;
+                for (int i = 0; i < parentPage.NumberOfEntries; i++)
+                {
+                    if (parentPage.GetNode(i)->PageNumber == page.PageNumber)
+                    {
+                        positionInParent = i;
+                        break;
+                    }
+                }
+
+                if (positionInParent == -1)
+                    VoronUnrecoverableErrorException.Raise(_tx,
+                        $"The page {page.PageNumber} being rebalanced is not referenced by its cursor parent page {parentPage.PageNumber}, tree: {_tree.Name}");
+
+                parentPage.LastSearchPosition = positionInParent;
+
                 if (page.NumberOfEntries == 0) // empty page, just delete it and fixup parent
                 {
                     // need to change the implicit left page
                     if (parentPage.LastSearchPosition == 0 && parentPage.NumberOfEntries > 2)
                     {
+                        if (parentPage.GetNode(0)->PageNumber != page.PageNumber)
+                            VoronUnrecoverableErrorException.Raise(_tx,
+                                $"About to remove the wrong node from parent page {parentPage.PageNumber} (node 0 references {parentPage.GetNode(0)->PageNumber} instead of the emptied page {page.PageNumber}), tree: {_tree.Name}");
+
                         var newImplicit = parentPage.GetNode(1)->PageNumber;
                         parentPage.RemoveNode(0);
                         parentPage.ChangeImplicitRefPageNode(newImplicit);
                     }
                     else // will be set to rights by the next rebalance call
                     {
+                        if (parentPage.GetNode(parentPage.LastSearchPositionOrLastEntry)->PageNumber != page.PageNumber)
+                            VoronUnrecoverableErrorException.Raise(_tx,
+                                $"About to remove the wrong node from parent page {parentPage.PageNumber} (node {parentPage.LastSearchPositionOrLastEntry} references {parentPage.GetNode(parentPage.LastSearchPositionOrLastEntry)->PageNumber} instead of the emptied page {page.PageNumber}), tree: {_tree.Name}");
+
                         parentPage.RemoveNode(parentPage.LastSearchPositionOrLastEntry);
                     }
 
@@ -177,10 +221,41 @@ namespace Voron.Data.BTrees
                 Memory.Copy(left.Base, mergedPage.Base, left.PageSize);
             }
 
+            if (parentPage.GetNode(parentPage.LastSearchPositionOrLastEntry)->PageNumber != right.PageNumber)
+                VoronUnrecoverableErrorException.Raise(_tx,
+                    $"About to unlink the wrong node from parent page {parentPage.PageNumber} (node {parentPage.LastSearchPositionOrLastEntry} references {parentPage.GetNode(parentPage.LastSearchPositionOrLastEntry)->PageNumber} instead of the merged right page {right.PageNumber}), tree: {_tree.Name}");
+
             parentPage.RemoveNode(parentPage.LastSearchPositionOrLastEntry); // unlink the right sibling
             _tree.FreePage(right);
 
             return true;
+        }
+
+        private void RebuildCursorAbovePage(TreePage page)
+        {
+            using (GetActualKey(page, 0, out Slice key))
+            {
+                _tree.FindPageFor(key, node: out TreeNodeHeader* _, cursor: out TreeCursorConstructor cursorConstructor, allowCompressed: true);
+
+                using (TreeCursor fresh = cursorConstructor.Build(key))
+                {
+                    var path = new List<TreePage>();
+                    while (fresh.PageCount > 0)
+                        path.Add(fresh.Pop()); // leaf .. root order
+
+                    int pageIndex = path.FindIndex(p => p.PageNumber == page.PageNumber);
+
+                    if (pageIndex == -1)
+                        VoronUnrecoverableErrorException.Raise(_tx,
+                            $"Could not rebuild the cursor for rebalanced page {page.PageNumber}: descending by its first key does not reach the page, tree: {_tree.Name}");
+
+                    while (_cursor.PageCount > 0)
+                        _cursor.Pop();
+
+                    for (int i = path.Count - 1; i > pageIndex; i--)
+                        _cursor.Push(path[i]);
+                }
+            }
         }
 
         private TreePage SetupMoveOrMerge(TreePage page, TreePage parentPage)
@@ -246,6 +321,11 @@ namespace Voron.Data.BTrees
                 from.RemoveNode(from.LastSearchPositionOrLastEntry);
 
                 var pos = parentPage.LastSearchPositionOrLastEntry;
+
+                if (parentPage.GetNode(pos)->PageNumber != to.PageNumber && parentPage.GetNode(pos)->PageNumber != from.PageNumber)
+                    VoronUnrecoverableErrorException.Raise(_tx,
+                        $"About to remove the wrong separator from parent page {parentPage.PageNumber} (node {pos} references {parentPage.GetNode(pos)->PageNumber} while moving a leaf node between {from.PageNumber} and {to.PageNumber}), tree: {_tree.Name}");
+
                 parentPage.RemoveNode(pos);
 
                 Slice newSeparatorKey;
@@ -274,6 +354,9 @@ namespace Voron.Data.BTrees
             var parent = new ParentPageAction(parentPage, childPage, _tree, _cursor, _tx);
 
             parent.AddSeparator(seperatorKey, pageNumber, separatorKeyPosition);
+
+            if (parent.PerformedSplit)
+                _ancestorsChanged = true;
         }
 
         private void MoveBranchNode(TreePage parentPage, TreePage from, TreePage to)
@@ -339,6 +422,11 @@ namespace Voron.Data.BTrees
             }
 
             var pos = parentPage.LastSearchPositionOrLastEntry;
+
+            if (parentPage.GetNode(pos)->PageNumber != to.PageNumber && parentPage.GetNode(pos)->PageNumber != from.PageNumber)
+                VoronUnrecoverableErrorException.Raise(_tx,
+                    $"About to remove the wrong separator from parent page {parentPage.PageNumber} (node {pos} references {parentPage.GetNode(pos)->PageNumber} while moving a branch node between {from.PageNumber} and {to.PageNumber}), tree: {_tree.Name}");
+
             parentPage.RemoveNode(pos);
             Slice newSeparatorKey;
             var scope = GetActualKey(to, 0, out newSeparatorKey); // get the next smallest key it has now

--- a/src/Voron/Data/BTrees/TreeRebalancer.cs
+++ b/src/Voron/Data/BTrees/TreeRebalancer.cs
@@ -49,9 +49,6 @@ namespace Voron.Data.BTrees
 
                 _cursor.Pop();
 
-                var parentPage = _tree.ModifyPage(_cursor.CurrentPage);
-                _cursor.Update(_cursor.Pages, parentPage);
-
                 // when an earlier iteration of this cascade re-added a separator into a full ancestor page,
                 // that page got split. A split can move pages under different parents and change node
                 // positions, so the cursor built during the descent may no longer match the tree.
@@ -63,10 +60,10 @@ namespace Voron.Data.BTrees
                     // we could reset the flag here, but it is safer to keep rebuilding until the rebalancing ends - the
                     // extra cost is a few page reads per level and is only paid when an ancestor was already split
                     //_ancestorsChanged = false;
-
-                    parentPage = _tree.ModifyPage(_cursor.CurrentPage);
-                    _cursor.Update(_cursor.Pages, parentPage);
                 }
+
+                var parentPage = _tree.ModifyPage(_cursor.CurrentPage);
+                _cursor.Update(_cursor.Pages, parentPage);
 
                 int positionInParent = -1;
                 for (int i = 0; i < parentPage.NumberOfEntries; i++)

--- a/test/SlowTests/Voron/Issues/RavenDB_26746.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26746.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FastTests.Voron;
+using FastTests.Voron.FixedSize;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.BTrees;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_26746 : StorageTest
+    {
+        public RavenDB_26746(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // Reproduces structural tree corruption caused by rebalancing with a stale cursor.
+        // During a delete, the rebalance cascade re-adds separators of moved pages into their parents.
+        // With large keys a parent can overflow, so the re-add splits it (possibly recursively), moving
+        // pages under different parents and changing node positions. Later iterations of the cascade
+        // used the stale descent-time positions and could unlink a wrong subtree (lost entries),
+        // reference the same page from two branches and insert out-of-order separators, leaving keys
+        // visible to iteration but unreachable for searches (deletes silently no-op).
+        // The workload mimics the original scenario: tombstone-like keys (short ids mixed with ~1.5 KB
+        // change-vector suffixes, so branch pages hold only a few nodes), waves of sorted inserts
+        // followed by mass deletes.
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(15, 4)]
+        [InlineData(15, 5)]
+        [InlineData(15, 10)]
+        [InlineData(50, 3)] // on unfixed code this seed failed with the search-misroute symptom (out-of-order separators)
+        [InlineDataWithRandomSeed(20)]
+        public void Rebalancing_must_not_corrupt_tree_when_separator_readd_splits_ancestors(int maxCycles, int seed)
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tombstones");
+                tx.Commit();
+            }
+
+            var rng = new Random(seed);
+            var generations = new Dictionary<long, int>();
+            var live = new HashSet<string>(StringComparer.Ordinal);
+
+            for (int cycle = 0; cycle < maxCycles; cycle++)
+            {
+                int toInsert = 15_000 + rng.Next(15_000);
+                var insertBatch = new List<string>(toInsert);
+                for (int i = 0; i < toInsert; i++)
+                {
+                    long docId = 8_000_000 + rng.Next(120_000);
+                    bool docTombstoneStyle = rng.Next(5) == 0; // bare key, reused and re-put across cycles
+                    string key;
+                    if (docTombstoneStyle)
+                    {
+                        key = $"tombstones/{docId}";
+                    }
+                    else
+                    {
+                        generations.TryGetValue(docId, out int gen);
+                        generations[docId] = gen + 1;
+                        key = MakeChangeVectorLikeKey(docId, gen, seed);
+                    }
+
+                    if (live.Add(key) || docTombstoneStyle)
+                        insertBatch.Add(key);
+                }
+
+                // ascending order packs pages full through the sequential-insert split path,
+                // so later rebalances meet full parents
+                insertBatch.Sort(StringComparer.Ordinal);
+                ApplyBatches(insertBatch, isInsert: true, rng);
+
+                var liveList = live.ToList();
+                liveList.Sort(StringComparer.Ordinal);
+
+                int toDelete = (int)(liveList.Count * (0.3 + rng.NextDouble() * 0.6));
+                var deleteBatch = new List<string>(toDelete);
+
+                if (rng.Next(4) == 0 && liveList.Count > 1000)
+                {
+                    int start = rng.Next(liveList.Count / 2);
+                    int len = Math.Min(toDelete, liveList.Count - start);
+                    for (int i = start; i < start + len; i++)
+                        deleteBatch.Add(liveList[i]);
+                }
+                else
+                {
+                    foreach (string key in liveList.OrderBy(_ => rng.Next()).Take(toDelete))
+                        deleteBatch.Add(key);
+
+                    if (seed % 3 == 0)
+                        deleteBatch.Sort(StringComparer.Ordinal);
+                }
+
+                foreach (string key in deleteBatch)
+                    live.Remove(key);
+
+                ApplyBatches(deleteBatch, isInsert: false, rng);
+
+                AssertTreeMatchesShadowSet(live, cycle);
+            }
+        }
+
+        private void ApplyBatches(List<string> keys, bool isInsert, Random rng)
+        {
+            int pos = 0;
+            while (pos < keys.Count)
+            {
+                int batchSize = 100 + rng.Next(400);
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.ReadTree("tombstones");
+                    for (int i = 0; i < batchSize && pos < keys.Count; i++, pos++)
+                    {
+                        using (Slice.From(tx.Allocator, keys[pos], ByteStringType.Immutable, out Slice keySlice))
+                        {
+                            if (isInsert)
+                            {
+                                using (Slice.From(tx.Allocator, BitConverter.GetBytes((long)pos), ByteStringType.Immutable, out Slice value))
+                                    tree.Add(keySlice, value);
+                            }
+                            else
+                            {
+                                tree.Delete(keySlice);
+                            }
+                        }
+                    }
+
+                    tx.Commit();
+                }
+            }
+        }
+
+        private void AssertTreeMatchesShadowSet(HashSet<string> live, int cycle)
+        {
+            using (var tx = Env.ReadTransaction())
+            {
+                Tree tree = tx.ReadTree("tombstones");
+
+                Assert.True(live.Count == tree.State.Header.NumberOfEntries,
+                    $"cycle {cycle}: tree header says {tree.State.Header.NumberOfEntries} entries but {live.Count} keys should be live (deletes silently missed keys or subtrees were lost)");
+
+                var seen = new HashSet<string>(StringComparer.Ordinal);
+                using (var it = tree.Iterate(prefetch: false))
+                {
+                    if (it.Seek(Slices.BeforeAllKeys))
+                    {
+                        do
+                        {
+                            string key = it.CurrentKey.ToString();
+                            Assert.True(seen.Add(key), $"cycle {cycle}: key '{key}' was iterated twice (duplicate page reference)");
+                        } while (it.MoveNext());
+                    }
+                }
+
+                Assert.True(seen.Count == live.Count,
+                    $"cycle {cycle}: iteration found {seen.Count} entries, expected {live.Count}");
+
+                foreach (string key in live)
+                {
+                    Assert.True(seen.Contains(key), $"cycle {cycle}: live key '{key}' was not seen by iteration (lost subtree)");
+
+                    using (Slice.From(tx.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
+                    {
+                        Assert.True(tree.Read(keySlice) != null,
+                            $"cycle {cycle}: live key '{key}' is not reachable by search (misrouted by out-of-order separators) although iteration {(seen.Contains(key) ? "sees" : "does not see")} it");
+                    }
+                }
+            }
+        }
+
+        private static string MakeChangeVectorLikeKey(long docId, int generation, int seed)
+        {
+            // deterministic per (seed, docId, generation), ~1.2-1.8 KB so a branch page holds only
+            // a few nodes and separator re-adds regularly overflow the parents
+            int stableSeed = unchecked((int)((seed * 1000003L) ^ (docId * 31L) ^ (generation * 514229L)));
+            var keyRng = new Random(stableSeed);
+            var sb = new StringBuilder(2000);
+            sb.Append("tombstones/").Append(docId);
+            sb.Append('\x1e');
+            int segments = 28 + keyRng.Next(12);
+            const string b64Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+            for (int i = 0; i < segments; i++)
+            {
+                if (i > 0)
+                    sb.Append(", ");
+                sb.Append((char)('A' + keyRng.Next(4))).Append(':');
+                sb.Append(1_000_000 + keyRng.Next(2_000_000_000));
+                sb.Append('-');
+                for (int j = 0; j < 22; j++)
+                    sb.Append(b64Chars[keyRng.Next(64)]);
+            }
+
+            sb.Append("==gen:").Append(generation);
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26746
 
### Additional description

During a delete, the rebalancing cascade re-adds separators of moved pages into their parents. With large keys (e.g. tombstone keys carrying long change vectors) the parent can overflow, so the re-add splits it, possibly recursively, moving pages of the descent path under different parents and shifting node positions along the ancestor chain. Later cascade iterations kept using the descent-time cursor and could then pick a wrong sibling, unlink an innocent subtree (lost entries), reference the same page from two branches and insert out-of-order separators. Keys in the affected ranges remained visible to iteration but unreachable for searches, so further deletes silently no-oped and the damage compounded over time.

The fix:
- once a separator re-add splits an ancestor, rebuild the cursor above the rebalanced page by descending from the root with the page's first actual key, and keep doing so for all remaining iterations of the cascade
- re-derive the page's position in its cursor parent on every cascade iteration, also when no split happened, as a cheap safety measure that makes the position correct by construction for everything that follows
- set `LastSearchPosition` to the separator's actual position before splitting a parent, so the splitter's sequential-insert optimization cannot insert a non-sequential key at a fixed position

Added invariant checks that fail the transaction instead of committing the corruption (wrong-node removals in the rebalancer, non-sequential keys in the splitter shortcuts). They are unreachable while the fix holds and act as regression detectors.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
