### PR TITLE
RavenDB-26682 Add size to alloc failure message

### DIFF
--- a/src/Sparrow.Server/Platform/PlatformSpecific.cs
+++ b/src/Sparrow.Server/Platform/PlatformSpecific.cs
@@ -56,7 +56,7 @@ namespace Sparrow.Server.Platform
                     Win32MemoryProtectMethods.MemoryProtection.READWRITE);
 
                 if (allocate4KbAlignedMemory == null)
-                    ThrowFailedToAllocate();
+                    ThrowFailedToAllocate(size);
 
                 return allocate4KbAlignedMemory;
             }
@@ -87,9 +87,10 @@ namespace Sparrow.Server.Platform
             }
 
             [DoesNotReturn]
-            private static void ThrowFailedToAllocate()
+            private static void ThrowFailedToAllocate(long size)
             {
-                throw new Win32Exception("Could not allocate memory");
+                var error = Marshal.GetLastWin32Error();
+                throw new Win32Exception(error, $"Could not allocate memory (allocation size: {size} bytes). {Marshal.GetPInvokeErrorMessage(error)}");
             }
 
             [DoesNotReturn]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26682

### Additional description

We've been getting a Win32Exception (87) ("Could not allocate memory") from VirtualAlloc during encrypted journal recovery. Error code 87 is ERROR_INVALID_PARAMETER ("The parameter is incorrect"), which means the requested size was not valid — not that the machine ran out of memory (that would be 1455 or 8).

This PR doesn't fix the root cause. It only adds the requested allocation size (and the OS error message) to the exception, so next time this happens we can see what size was actually requested and understand the issue.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] More info on failure

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [x] Yes. Please list the affected platforms. - Windows
- [ ] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
