### PR TITLE
RavenDB-26770: Weaken BadApiKey Google assertion - Gemini changes the bad-key error message frequently

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
@@ -211,12 +211,8 @@ public class AiAgentErrors : RavenTestBase
                 Assert.Contains("Incorrect API key provided", e.Message);
                 break;
             case AiConnectorType.Google:
-                Assert.True(
-                    e.Message.Contains("API_KEY_INVALID", StringComparison.OrdinalIgnoreCase) ||
-                    e.Message.Contains("API key not valid", StringComparison.OrdinalIgnoreCase) ||
-                    (e.Message.Contains("InternalServerError", StringComparison.OrdinalIgnoreCase) &&
-                     e.Message.Contains("Internal error encountered", StringComparison.OrdinalIgnoreCase)),
-                    $"Expected an invalid-API-key error (or Google's '500 INTERNAL') but got: {e.Message}");
+                Assert.True(e.Message.Contains("Failed to communicate with the agent"),
+                    $"Expected the bad-key failure to surface as an agent communication error, but got: {e.Message}");
                 break;
             default:
                 throw new InvalidOperationException($"Unknown provider '{provider}'");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26770/SlowTests.Server.Documents.AI.AiAgent.AiAgentErrors.BadApiKeyoptions-DatabaseMode-Single-config-GoogleAiIntegrationTask#focus=Comments-67-1085126.0-0

### Additional description

Gemini's OpenAI-compatible endpoint (/v1beta/openai) keeps changing
what it returns for an invalid key.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
