### PR TITLE
RavenDB-26261: Better error message when the provider does not support a file format

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -321,6 +321,33 @@ public class ChatCompletionClient : IDisposable
         return (r.Result.ToString(), r.Message.ToString());
     }
 
+    private const string AcceptsImageInputProbePngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+    public async Task<bool> TestAcceptsImageInputAsync(CancellationToken token)
+    {
+        try
+        {
+            using var _ = _contextPool.AllocateOperationContext(out JsonOperationContext context);
+
+            var attachment = new AiAttachment("probe.png", Constants.AttachmentsRequestFields.MediaTypeImagePng, AiAttachmentSource.FromAttachment, AcceptsImageInputProbePngBase64);
+
+            var userMessage = context.ReadObject(new DynamicJsonValue
+            {
+                [Constants.RequestFields.Role] = Constants.RequestFields.RoleUserValue,
+                [Constants.RequestFields.Content] = "describe the image"
+            }, "probe/user");
+
+            var request = CreateCompletionRequest(context, messages: [userMessage], attachments: [attachment], tools: null, useTools: false, streaming: false, EmptySchema);
+            await CompleteAsync(context, request, new AiUsage(), trace: null, token);
+            return true;
+        }
+        catch (Exception) when (token.IsCancellationRequested == false)
+        {
+            return false;
+        }
+    }
+
     public async Task<AiResponse> CompleteAsync(JsonOperationContext context, HttpRequestMessage request, AiUsage usage, AiDebugTrace trace, CancellationToken token)
     {
         AddDefaultHeaders(request);
@@ -648,18 +675,10 @@ public class ChatCompletionClient : IDisposable
             {
                 return await _settings.TryGetResponseContentAsync(context, ms).ConfigureAwait(false);
             }
-            catch (InvalidDataException ide) when (ide.Message.Contains("Cannot have a '<' in this position at  (1,2) around:")) // likely HTML response
+            catch (Exception)
             {
-                ms.Position = 0;
-                string content = Encoding.UTF8.GetString(ms.GetMemory().Span[..contentLength]);
-
-                throw UnexpectedResponseException.Create(message: "Received an unrecognized response from the server", response, content);
-            }
-            catch (Exception e)
-            {
-                ms.Position = 0;
-                string content = Encoding.UTF8.GetString(ms.GetMemory().Span[..contentLength]);
-                throw UnexpectedResponseException.Create(message: "Received an unrecognized response from the server", response, content, e);
+                var rawBody = Encoding.UTF8.GetString(ms.GetBuffer(), 0, contentLength);
+                throw UnexpectedResponseException.Create(message: "Received an unrecognized response from the server", response, rawBody);
             }
         }
     }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
@@ -33,6 +33,7 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
         var modelType = RequestHandler.GetEnumQueryString<AiModelType>("modelType");
 
         InMemoryLoggerProvider logger = null;
+        bool acceptsImageInput = false;
         try
         {
             using (var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken())
@@ -103,7 +104,8 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
                         using (var client = ChatCompletionClient.CreateChatCompletionClient( ServerStore.ContextPool, aiConnectionString))
                         {
                             var schema = ChatCompletionClient.GetSchemaFromSampleObject("{\"answer\":\"the answer to the user's prompt\"}");
-                            await client.TestCompleteAsync("Reply with exact word only: raven", "hi", schema, HttpContext.RequestAborted);
+                            await client.TestCompleteAsync("Reply with exact word only: raven", "hi", schema, token.Token);
+                            acceptsImageInput = await client.TestAcceptsImageInputAsync(token.Token);
                         }
 
                         break;
@@ -111,7 +113,11 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
                         throw new ArgumentOutOfRangeException("Invalid model type: " + aiConnectionString.ModelType);
                     }
 
-                var result = new DynamicJsonValue { [nameof(NodeConnectionTestResult.Success)] = true };
+                var result = new DynamicJsonValue
+                {
+                    [nameof(NodeConnectionTestResult.Success)] = true,
+                    [nameof(NodeConnectionTestResult.AcceptsImageInput)] = acceptsImageInput
+                };
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                 {

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -135,6 +135,8 @@ namespace Raven.Server.Web.System
         public string Error;
         public List<string> Log;
 
+        public bool AcceptsImageInput;
+
         public DynamicJsonValue ToJson()
         {
             var djv = new DynamicJsonValue

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -617,6 +617,7 @@ export class DatabasesStubs {
             TcpServerUrl: null,
             Log: [],
             Error: "System.UriFormatException: Invalid URI: The format of the URI could not be determined.\n   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)\n   at System.Uri..ctor(String uriString)\n   at Raven.Server.Documents.ETL.Providers.Queue.QueueBrokerConnectionHelper.CreateRabbitMqConnection(RabbitMqConnectionSettings settings) in D:\\Builds\\RavenDB-6.0-Nightly\\20231123-0200\\src\\Raven.Server\\Documents\\ETL\\Providers\\Queue\\QueueBrokerConnectionHelper.cs:line 80",
+            AcceptsImageInput: false,
         };
     }
 
@@ -627,6 +628,7 @@ export class DatabasesStubs {
             TcpServerUrl: null,
             Log: [],
             Error: null,
+            AcceptsImageInput: false,
         };
     }
 

--- a/src/Raven.Studio/typescript/test/stubs/SharedStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/SharedStubs.ts
@@ -6,6 +6,7 @@ export class SharedStubs {
             TcpServerUrl: null,
             Log: [],
             Error: "System.UriFormatException: Invalid URI: The format of the URI could not be determined.\n   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)\n   at System.Uri..ctor(String uriString)\n   at Raven.Server.Documents.ETL.Providers.Queue.QueueBrokerConnectionHelper.CreateRabbitMqConnection(RabbitMqConnectionSettings settings) in D:\\Builds\\RavenDB-6.0-Nightly\\20231123-0200\\src\\Raven.Server\\Documents\\ETL\\Providers\\Queue\\QueueBrokerConnectionHelper.cs:line 80",
+            AcceptsImageInput: false,
         };
     }
 
@@ -16,6 +17,7 @@ export class SharedStubs {
             TcpServerUrl: null,
             Log: [],
             Error: null,
+            AcceptsImageInput: false,
         };
     }
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26261.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26261.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents;
+using Raven.Server.Documents.AI;
+using Raven.Server.Documents.AI.Settings;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Raven.Server.Logging;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Logging;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_26261(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        private const string ConnectionStringName = "mock-ai-connection";
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task AzureOpenAiStyleTextPlainResponse_SurfacesCleanError()
+        {
+            using var store = GetDocumentStore();
+            await PutDummyConnectionStringAsync(store);
+
+            var agent = BuildAgentConfig();
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var handler = new MockHandler(Server.ServerStore, database, MockResponseBehavior.AzureGatewayTextPlain)
+                {
+                    Authentication = null
+                };
+                handler.Initialize(agent, "Dummy", new RequestBody
+                {
+                    Parameters = null,
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "describe the attached PDF"
+                }, changeVector: null);
+
+                var ex = await Assert.ThrowsAnyAsync<Exception>(
+                    () => handler.HandleRequest(context, CancellationToken.None));
+
+                var full = ex.ToString();
+
+                Assert.DoesNotContain("InvalidDataException", full);
+                Assert.DoesNotContain("Cannot have a", full);
+
+                Assert.Contains("text/plain", full);
+                Assert.Contains("Bad Request", full);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task TestConnection_AcceptsText_RejectsImages_ProbeReturnsFalse()
+        {
+            var connection = new AiConnectionString
+            {
+                Name = ConnectionStringName,
+                ModelType = AiModelType.Chat,
+                OpenAiSettings = new OpenAiSettings(apiKey: "sk-test-dummy", endpoint: "https://api.openai.com/", model: "gpt-4.1-mini")
+            };
+
+            Assert.True(AbstractChatCompletionClientSettings.TryGetParameters(connection, out var settings));
+
+            using var storageEnv = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnlyForTests());
+            using var contextPool = new TransactionContextPool(RavenLogManager.Instance.CreateNullLogger(), storageEnv);
+            using var client = new MockLlm(contextPool, settings, ChatCompletionClient.ConventionsToUse, MockResponseBehavior.AcceptsTextRejectsImages);
+
+            var schema = ChatCompletionClient.GetSchemaFromSampleObject("{}");
+            await client.TestCompleteAsync("Reply with exact word only: raven", "hi", schema, CancellationToken.None);
+
+            var acceptsImageInput = await client.TestAcceptsImageInputAsync(CancellationToken.None);
+            Assert.False(acceptsImageInput);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task TestConnection_AcceptsTextAndImages_ProbeReturnsTrue()
+        {
+            var connection = new AiConnectionString
+            {
+                Name = ConnectionStringName,
+                ModelType = AiModelType.Chat,
+                OpenAiSettings = new OpenAiSettings(apiKey: "sk-test-dummy", endpoint: "https://api.openai.com/", model: "gpt-4.1-mini")
+            };
+
+            Assert.True(AbstractChatCompletionClientSettings.TryGetParameters(connection, out var settings));
+
+            using var storageEnv = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnlyForTests());
+            using var contextPool = new TransactionContextPool(RavenLogManager.Instance.CreateNullLogger(), storageEnv);
+            using var client = new MockLlm(contextPool, settings, ChatCompletionClient.ConventionsToUse, MockResponseBehavior.OpenAiSuccess);
+
+            var schema = ChatCompletionClient.GetSchemaFromSampleObject("{}");
+            await client.TestCompleteAsync("Reply with exact word only: raven", "hi", schema, CancellationToken.None);
+
+            var acceptsImageInput = await client.TestAcceptsImageInputAsync(CancellationToken.None);
+            Assert.True(acceptsImageInput);
+
+            // The probe must actually send the image, exactly once (guards against a dropped image or a re-introduced double-send).
+            Assert.Equal(1, Regex.Matches(client.LastRequestBody, "data:image/png;base64,").Count);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.AzureOpenAI | RavenAiIntegration.Google, DatabaseMode = RavenDatabaseMode.Single)]
+        public void TestConnection_RealProvider_ReportsAcceptsImageInputTrue(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+
+            var op = new AiConnectionTests.TestAiConnectionStringOperation(config.Connection);
+            var r = store.Maintenance.Send(op);
+
+            Assert.True(r.Error == null, r.Error);
+            Assert.True(r.Success);
+            Assert.True(r.AcceptsImageInput);
+        }
+
+        private static AiAgentConfiguration BuildAgentConfig()
+        {
+            var agent = new AiAgentConfiguration("pdf-analyzer", ConnectionStringName,
+                "You are a helpful assistant. Describe attached files.")
+            {
+                SampleObject = "{\"Answer\":\"description of the PDF\"}"
+            };
+            return agent;
+        }
+
+        private static async Task PutDummyConnectionStringAsync(Raven.Client.Documents.IDocumentStore store)
+        {
+            var connection = new AiConnectionString
+            {
+                Name = ConnectionStringName,
+                ModelType = AiModelType.Chat,
+                OpenAiSettings = new OpenAiSettings(apiKey: "sk-test-dummy", endpoint: "https://api.openai.com/", model: "gpt-4.1-mini")
+            };
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(connection));
+        }
+
+        private enum MockResponseBehavior
+        {
+            OpenAiSuccess,
+            AzureGatewayTextPlain,
+            AcceptsTextRejectsImages,
+        }
+
+        private sealed class MockHandler : ConversationHandler
+        {
+            private readonly DocumentDatabase _database;
+            private readonly MockResponseBehavior _behavior;
+
+            public MockHandler(Raven.Server.ServerWide.ServerStore server, DocumentDatabase database, MockResponseBehavior behavior)
+                : base(server, database)
+            {
+                _database = database;
+                _behavior = behavior;
+            }
+
+            protected internal override ChatCompletionClient CreateClient()
+            {
+                var connection = GetAiConnectionString();
+                if (AbstractChatCompletionClientSettings.TryGetParameters(connection, out var settings) == false)
+                    throw new NotSupportedException($"The specified provider (\"{connection.GetActiveProvider()}\") is not supported.");
+
+                return new MockLlm(_database.DocumentsStorage.ContextPool, settings, ChatCompletionClient.ConventionsToUse, _behavior);
+            }
+        }
+
+        private sealed class MockLlm : ChatCompletionClient
+        {
+            private readonly MockResponseBehavior _behavior;
+
+            internal MockLlm(IMemoryContextPool contextPool, AbstractChatCompletionClientSettings settings, DocumentConventions conventions, MockResponseBehavior behavior)
+                : base(contextPool, settings, conventions)
+            {
+                _behavior = behavior;
+            }
+
+            public string LastRequestBody;
+
+            protected override async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token)
+            {
+                LastRequestBody = request.Content != null ? await request.Content.ReadAsStringAsync(token) : null;
+
+                return _behavior switch
+                {
+                    MockResponseBehavior.OpenAiSuccess => OpenAiSuccess(),
+
+                    MockResponseBehavior.AzureGatewayTextPlain => AzureGatewayBadRequest(),
+
+                    MockResponseBehavior.AcceptsTextRejectsImages => RequestContainsImagePngDataUrl(LastRequestBody)
+                        ? AzureGatewayBadRequest()
+                        : OpenAiSuccess(),
+
+                    _ => throw new InvalidOperationException($"Unknown behavior: {_behavior}")
+                };
+
+                static HttpResponseMessage OpenAiSuccess() => new(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(OpenAiStyleSuccessResponse, Encoding.UTF8, "application/json")
+                };
+
+                static HttpResponseMessage AzureGatewayBadRequest() => new(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent("Bad Request", Encoding.UTF8, "text/plain")
+                };
+
+                static bool RequestContainsImagePngDataUrl(string body) => body.Contains("data:image/png;base64,");
+            }
+        }
+
+        private const string OpenAiStyleSuccessResponse =
+            "{\"id\":\"chatcmpl-mock\",\"object\":\"chat.completion\",\"created\":1754549498,\"model\":\"gpt-4.1-mini\"," +
+            "\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"{\\\"Answer\\\":\\\"PDF received\\\"}\",\"refusal\":null,\"annotations\":[]}," +
+            "\"logprobs\":null,\"finish_reason\":\"stop\"}]," +
+            "\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15," +
+            "\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0}," +
+            "\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}}," +
+            "\"service_tier\":\"default\",\"system_fingerprint\":\"fp_mock\"}";
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26261/Better-error-message-when-the-provider-does-not-support-a-file-format

### Additional description

Two fixes for when a provider gets a file it can't handle:

Cleaner errors - non JSON error responses (e.g. Azure gateway text/plain "Bad Request") no longer surface as a confusing parser InvalidDataException. We now return the real body and status. Raw body is read only in the failure path.

Image-support detection — TestAcceptsImageInputAsync sends a 1x1 PNG probe during Test Connection and reports AcceptsImageInput, so the Studio knows up front whether a model accepts images. Non-vision models return 4xx and the probe reports false.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
