### PR TITLE
RavenDB-26709 - Address PR comments & display Hub/Sink cursors in Studio

### DIFF
--- a/src/Raven.Client/Documents/Operations/OngoingTasks/GetTaskInfoResult.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/GetTaskInfoResult.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.DataArchival;
-using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ETL;
@@ -242,6 +241,9 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
         public string[] AllowedHubToSinkPaths { get; set; }
         public string[] AllowedSinkToHubPaths { get; set; }
 
+        public string HubCursor { get; set; }
+        public string SinkCursor { get; set; }
+
         public override DynamicJsonValue ToJson()
         {
             var json = base.ToJson();
@@ -257,6 +259,8 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
             json[nameof(AllowedSinkToHubPaths)] = AllowedSinkToHubPaths;
             json[nameof(MentorNode)] = MentorNode;
             json[nameof(PinToMentorNode)] = PinToMentorNode;
+            json[nameof(HubCursor)] = HubCursor;
+            json[nameof(SinkCursor)] = SinkCursor;
             return json;
         }
     }

--- a/src/Raven.Server/Documents/OngoingTasks/AbstractOngoingTasks.cs
+++ b/src/Raven.Server/Documents/OngoingTasks/AbstractOngoingTasks.cs
@@ -110,10 +110,10 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
             yield return CreateSnowflakeEtlTaskInfo(clusterTopology, databaseRecord, snowflakeEtl);
     }
 
-    private IEnumerable<OngoingTaskPullReplicationAsSink> GetPullReplicationAsSinkTasks(ClusterTopology clusterTopology, DatabaseRecord databaseRecord)
+    private IEnumerable<OngoingTaskPullReplicationAsSink> GetPullReplicationAsSinkTasks(ClusterTopology clusterTopology, DatabaseRecord databaseRecord, ClusterOperationContext context)
     {
         foreach (var sinkReplication in databaseRecord.SinkPullReplications)
-            yield return CreatePullReplicationAsSinkTaskInfo(clusterTopology, databaseRecord, sinkReplication);
+            yield return CreatePullReplicationAsSinkTaskInfo(clusterTopology, databaseRecord, sinkReplication, context);
     }
 
     protected abstract IEnumerable<OngoingTaskPullReplicationAsHub> GetPullReplicationAsHubTasks(JsonOperationContext context, ClusterTopology clusterTopology, DatabaseRecord databaseRecord);
@@ -183,7 +183,7 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
         foreach (var task in GetSnowflakeEtlTasks(clusterTopology, databaseRecord))
             yield return task;
 
-        foreach (var task in GetPullReplicationAsSinkTasks(clusterTopology, databaseRecord))
+        foreach (var task in GetPullReplicationAsSinkTasks(clusterTopology, databaseRecord, context))
             yield return task;
 
         foreach (var task in GetPullReplicationAsHubTasks(context, clusterTopology, databaseRecord))
@@ -225,7 +225,7 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
                 if (sinkReplication == null)
                     return null;
 
-                return CreatePullReplicationAsSinkTaskInfo(clusterTopology, databaseRecord, sinkReplication);
+                return CreatePullReplicationAsSinkTaskInfo(clusterTopology, databaseRecord, sinkReplication, context);
 
             case OngoingTaskType.Backup:
 
@@ -597,7 +597,7 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
         };
     }
 
-    private OngoingTaskPullReplicationAsSink CreatePullReplicationAsSinkTaskInfo(ClusterTopology clusterTopology, DatabaseRecord databaseRecord, PullReplicationAsSink sinkReplication)
+    private OngoingTaskPullReplicationAsSink CreatePullReplicationAsSinkTaskInfo(ClusterTopology clusterTopology, DatabaseRecord databaseRecord, PullReplicationAsSink sinkReplication, ClusterOperationContext context)
     {
         var sinkReplicationStatus = GetReplicationTaskConnectionStatus(GetDatabaseTopology(databaseRecord), clusterTopology, sinkReplication, 
             databaseRecord.RavenConnectionStrings, out _, out var sinkReplicationTag, out var sinkReplicationConnection, out _, out var error);
@@ -624,8 +624,8 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
             AccessName = sinkReplication.AccessName,
             AllowedHubToSinkPaths = sinkReplication.AllowedHubToSinkPaths,
             AllowedSinkToHubPaths = sinkReplication.AllowedSinkToHubPaths,
-            HubCursor = ReplicationUtils.ReadCursorFromClusterFor(_server, databaseRecord.DatabaseName, sinkReplication.TaskId, ExternalReplicationState.ReplicationStateType.HubCursor),
-            SinkCursor = ReplicationUtils.ReadCursorFromClusterFor(_server, databaseRecord.DatabaseName, sinkReplication.TaskId, ExternalReplicationState.ReplicationStateType.SinkCursor),
+            HubCursor = ReplicationUtils.ReadCursorFromClusterFor(_server, databaseRecord.DatabaseName, sinkReplication.TaskId, ExternalReplicationState.ReplicationStateType.HubCursor, context),
+            SinkCursor = ReplicationUtils.ReadCursorFromClusterFor(_server, databaseRecord.DatabaseName, sinkReplication.TaskId, ExternalReplicationState.ReplicationStateType.SinkCursor, context),
             Error = error
         };
 
@@ -642,7 +642,7 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
 
         return sinkInfo;
     }
-    
+
     private OngoingTaskQueueSink CreateQueueSinkTaskInfo(ClusterTopology clusterTopology, DatabaseRecord databaseRecord, QueueSinkConfiguration queueSink)
     {
         databaseRecord.QueueConnectionStrings.TryGetValue(queueSink.ConnectionStringName, out var connection);

--- a/src/Raven.Server/Documents/OngoingTasks/AbstractOngoingTasks.cs
+++ b/src/Raven.Server/Documents/OngoingTasks/AbstractOngoingTasks.cs
@@ -25,6 +25,7 @@ using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Server.Web.System;
 using Sparrow.Json;
 
@@ -623,6 +624,8 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
             AccessName = sinkReplication.AccessName,
             AllowedHubToSinkPaths = sinkReplication.AllowedHubToSinkPaths,
             AllowedSinkToHubPaths = sinkReplication.AllowedSinkToHubPaths,
+            HubCursor = ReplicationUtils.ReadCursorFromClusterFor(_server, databaseRecord.DatabaseName, sinkReplication.TaskId, ExternalReplicationState.ReplicationStateType.HubCursor),
+            SinkCursor = ReplicationUtils.ReadCursorFromClusterFor(_server, databaseRecord.DatabaseName, sinkReplication.TaskId, ExternalReplicationState.ReplicationStateType.SinkCursor),
             Error = error
         };
 

--- a/src/Raven.Server/Documents/Replication/AbstractReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/AbstractReplicationLoader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -293,7 +293,7 @@ namespace Raven.Server.Documents.Replication
         protected virtual DynamicJsonValue GetInitialRequestMessage(ReplicationLatestEtagRequest replicationLatestEtagRequest,
             ReplicationLoader.PullReplicationParams replParams = null)
         {
-            return new DynamicJsonValue
+            var response = new DynamicJsonValue
             {
                 [nameof(ReplicationMessageReply.Type)] = nameof(ReplicationMessageReply.ReplyType.Ok),
                 [nameof(ReplicationMessageReply.MessageType)] = ReplicationMessageType.Heartbeat,
@@ -301,6 +301,11 @@ namespace Raven.Server.Documents.Replication
                 [nameof(ReplicationMessageReply.AcceptablePaths)] = replParams?.AllowedPaths,
                 [nameof(ReplicationMessageReply.PreventDeletionsMode)] = replParams?.PreventDeletionsMode,
             };
+
+            if (replParams != null && replParams.Mode == PullReplicationMode.HubToSink)
+                response[nameof(ReplicationMessageReply.LastConfirmedChangeVector)] = ReplicationUtils.ReadCursorFromClusterFor(Server, _databaseName, replParams.TaskId, ExternalReplicationState.ReplicationStateType.HubCursor);
+
+            return response;
         }
 
         public ClusterTopology GetClusterTopology()

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
@@ -7,6 +7,7 @@ using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.ServerWide.Commands;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -50,21 +51,28 @@ namespace Raven.Server.Documents.Replication.Incoming
             // and persist it as the hub cursor for failover.
             // _lastBatchChangeVector is filled only when we send a batch of items OR we are skipping items through a heartbeat
             if (_hubBatchHistory.ComputeConfirmedChangeVector(_lastBatchChangeVector) is { } confirmedHubCv)
-            {
-                var command = new UpdateExternalReplicationStateCommand(ReplicationLoaderParent.Database.Name, RaftIdGenerator.NewId())
-                {
-                    ExternalReplicationState = new ExternalReplicationState
-                    {
-                        TaskId = IncomingPullReplicationParams.TaskId,
-                        NodeTag = ReplicationLoaderParent._server.NodeTag,
-                        SourceChangeVector = confirmedHubCv,
-                        Type = ExternalReplicationState.ReplicationStateType.HubCursor
-                    }
-                };
-                ReplicationLoaderParent._server.SendToLeaderAsync(command).IgnoreUnobservedExceptions();
-            }
+                PersistHubCursor(confirmedHubCv);
 
             return heartbeat;
+        }
+
+        private void PersistHubCursor(string confirmedHubCv)
+        {
+            var existingCv = ReplicationUtils.ReadCursorFromClusterFor(ReplicationLoaderParent.Server, ReplicationLoaderParent.Database.Name, IncomingPullReplicationParams.TaskId, ExternalReplicationState.ReplicationStateType.HubCursor);
+            if (existingCv == confirmedHubCv)
+                return;
+
+            var command = new UpdateExternalReplicationStateCommand(ReplicationLoaderParent.Database.Name, RaftIdGenerator.NewId())
+            {
+                ExternalReplicationState = new ExternalReplicationState
+                {
+                    TaskId = IncomingPullReplicationParams.TaskId,
+                    NodeTag = ReplicationLoaderParent._server.NodeTag,
+                    SourceChangeVector = confirmedHubCv,
+                    Type = ExternalReplicationState.ReplicationStateType.HubCursor
+                }
+            };
+            ReplicationLoaderParent._server.SendToLeaderAsync(command).IgnoreUnobservedExceptions();
         }
 
         protected override DocumentMergedTransactionCommand GetMergeDocumentsCommand(DocumentsOperationContext context, DataForReplicationCommand data, long lastDocumentEtag)

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
@@ -69,7 +69,8 @@ namespace Raven.Server.Documents.Replication.Incoming
                     TaskId = IncomingPullReplicationParams.TaskId,
                     NodeTag = ReplicationLoaderParent._server.NodeTag,
                     SourceChangeVector = confirmedHubCv,
-                    Type = ExternalReplicationState.ReplicationStateType.HubCursor
+                    Type = ExternalReplicationState.ReplicationStateType.HubCursor,
+                    FromToString = FromToString
                 }
             };
             ReplicationLoaderParent._server.SendToLeaderAsync(command).IgnoreUnobservedExceptions();

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
@@ -48,6 +48,7 @@ namespace Raven.Server.Documents.Replication.Incoming
 
             // Here we check *locally* in the sink what is the last hub change vector that was replicated to all the nodes in the sink cluster
             // and persist it as the hub cursor for failover.
+            // _lastBatchChangeVector is filled only when we send a batch of items OR we are skipping items through a heartbeat
             if (_hubBatchHistory.ComputeConfirmedChangeVector(_lastBatchChangeVector) is { } confirmedHubCv)
             {
                 var command = new UpdateExternalReplicationStateCommand(ReplicationLoaderParent.Database.Name, RaftIdGenerator.NewId())

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -189,6 +189,10 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
         private void PersistSinkCursor(string confirmedSinkCv)
         {
+            var existingCv = ReplicationUtils.ReadCursorFromClusterFor(_parent.Server, _database.Name, _node.TaskId, ExternalReplicationState.ReplicationStateType.SinkCursor);
+            if (existingCv == confirmedSinkCv)
+                return;
+
             var command = new UpdateExternalReplicationStateCommand(_database.Name, RaftIdGenerator.NewId())
             {
                 ExternalReplicationState = new ExternalReplicationState
@@ -199,7 +203,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
                     Type = ExternalReplicationState.ReplicationStateType.SinkCursor
                 }
             };
-            _parent._server.SendToLeaderAsync(command).IgnoreUnobservedExceptions();
+            _parent.Server.SendToLeaderAsync(command).IgnoreUnobservedExceptions();
         }
 
         internal override bool CanFilterOutSourceItemsByPreventingSinkToHubDeletions =>

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -200,7 +200,8 @@ namespace Raven.Server.Documents.Replication.Outgoing
                     TaskId = _node.TaskId,
                     NodeTag = _parent._server.NodeTag,
                     SourceChangeVector = confirmedSinkCv,
-                    Type = ExternalReplicationState.ReplicationStateType.SinkCursor
+                    Type = ExternalReplicationState.ReplicationStateType.SinkCursor,
+                    FromToString = FromToString
                 }
             };
             _parent.Server.SendToLeaderAsync(command).IgnoreUnobservedExceptions();

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -95,7 +95,7 @@ namespace Raven.Server.Documents.Replication
         public IReadOnlyDictionary<IncomingConnectionInfo, ConcurrentQueue<IncomingConnectionRejectionInfo>> IncomingRejectionStats => _incomingRejectionStats;
         public List<ReplicationNode> Destinations => _destinations;
 
-        public int NumberOfSiblingsInInternalReplication { get; internal set; }
+        public int NumberOfSiblingsInInternalReplication { get; private set; }
 
         private sealed class HubInfoForCleaner
         {
@@ -978,7 +978,7 @@ namespace Raven.Server.Documents.Replication
             destinations.AddRange(_externalDestinations);
             _destinations = destinations;
 
-            NumberOfSiblingsInInternalReplication = newRecord.Topology.Count - 1;
+            NumberOfSiblingsInInternalReplication = Math.Max(newRecord.Topology.Members.Count + newRecord.Topology.Rehabs.Count - 1, 0);
             _numberOfSiblings = _destinations.Select(x => x.Url).Intersect(_clusterTopology.AllNodes.Select(x => x.Value)).Count();
 
             DisposeConnections(instancesToDispose);

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -86,13 +86,21 @@ namespace Raven.Server.Utils
             using (serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
-                var key = ExternalReplicationState.GenerateItemName(databaseName, taskId, type);
-                var stateBlittable = serverStore.Cluster.Read(context, key);
-                if (stateBlittable == null)
-                    return null;
+                return ReadCursorFromClusterFor(serverStore, databaseName, taskId, type, context);
+            }
+        }
 
-                var state = JsonDeserializationCluster.ExternalReplicationState(stateBlittable);
-                return state.SourceChangeVector;
+        public static string ReadCursorFromClusterFor(ServerStore serverStore, string databaseName, long taskId, ExternalReplicationState.ReplicationStateType type, ClusterOperationContext context)
+        {
+            var key = ExternalReplicationState.GenerateItemName(databaseName, taskId, type);
+            var stateBlittable = serverStore.Cluster.Read(context, key);
+            if (stateBlittable == null)
+                return null;
+
+            using (stateBlittable)
+            {
+                stateBlittable.TryGet(nameof(ExternalReplicationState.SourceChangeVector), out string sourceChangeVector);
+                return sourceChangeVector;
             }
         }
 

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -83,7 +83,7 @@ namespace Raven.Server.Utils
 
         public static string ReadCursorFromClusterFor(ServerStore serverStore, string databaseName, long taskId, ExternalReplicationState.ReplicationStateType type)
         {
-            using (serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
                 var key = ExternalReplicationState.GenerateItemName(databaseName, taskId, type);

--- a/src/Raven.Studio/typescript/components/models/tasks.ts
+++ b/src/Raven.Studio/typescript/components/models/tasks.ts
@@ -137,6 +137,8 @@ export interface OngoingTaskReplicationSinkSharedInfo extends OngoingTaskSharedI
     topologyDiscoveryUrls: string[];
     hubName: string;
     mode: PullReplicationMode;
+    hubCursor: string;
+    sinkCursor: string;
 }
 
 export interface OngoingTaskQueueSinkSharedInfo extends OngoingTaskSharedInfo {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationHubDefinitionPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationHubDefinitionPanel.tsx
@@ -1,6 +1,7 @@
 ﻿import React from "react";
 import {
     BaseOngoingTaskPanelProps,
+    formatReplicationMode,
     OngoingTaskActions,
     OngoingTaskName,
     OngoingTaskStatus,
@@ -41,7 +42,9 @@ function Details(props: ReplicationHubPanelProps & { canEdit: boolean }) {
         <div>
             <RichPanelDetails>
                 {delayHumane && <RichPanelDetailItem label="Replication Delay Time">{delayHumane}</RichPanelDetailItem>}
-                <RichPanelDetailItem label="Replication Mode">{data.shared.taskMode}</RichPanelDetailItem>
+                <RichPanelDetailItem label="Replication Mode">
+                    {formatReplicationMode(data.shared.taskMode)}
+                </RichPanelDetailItem>
                 <RichPanelDetailItem label="Has Filtering">
                     {data.shared.hasFiltering ? "True" : "False"}
                 </RichPanelDetailItem>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationSinkPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationSinkPanel.tsx
@@ -3,6 +3,7 @@ import {
     BaseOngoingTaskPanelProps,
     ConnectionStringItem,
     DestinationUrlItem,
+    formatReplicationMode,
     OngoingTaskActions,
     OngoingTaskName,
     OngoingTaskResponsibleNode,
@@ -29,24 +30,6 @@ import { ExternalReplicationTaskDistribution } from "components/pages/database/t
 import { Icon } from "components/common/Icon";
 
 type ReplicationSinkPanelProps = BaseOngoingTaskPanelProps<OngoingTaskReplicationSinkInfo>;
-
-// Mode is a [Flags] enum, so the bidirectional case arrives as a combined string (e.g. "HubToSink, SinkToHub").
-// Use includes() to stay robust to the flag formatting and render a readable label.
-function formatReplicationMode(mode: Raven.Client.Documents.Operations.Replication.PullReplicationMode): string {
-    const hubToSink = mode?.includes("HubToSink");
-    const sinkToHub = mode?.includes("SinkToHub");
-
-    if (hubToSink && sinkToHub) {
-        return "Hub to Sink & Sink to Hub";
-    }
-    if (hubToSink) {
-        return "Hub to Sink";
-    }
-    if (sinkToHub) {
-        return "Sink to Hub";
-    }
-    return null;
-}
 
 function Details(props: ReplicationSinkPanelProps & { canEdit: boolean }) {
     const { data, canEdit } = props;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationSinkPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationSinkPanel.tsx
@@ -30,6 +30,24 @@ import { Icon } from "components/common/Icon";
 
 type ReplicationSinkPanelProps = BaseOngoingTaskPanelProps<OngoingTaskReplicationSinkInfo>;
 
+// Mode is a [Flags] enum, so the bidirectional case arrives as a combined string (e.g. "HubToSink, SinkToHub").
+// Use includes() to stay robust to the flag formatting and render a readable label.
+function formatReplicationMode(mode: Raven.Client.Documents.Operations.Replication.PullReplicationMode): string {
+    const hubToSink = mode?.includes("HubToSink");
+    const sinkToHub = mode?.includes("SinkToHub");
+
+    if (hubToSink && sinkToHub) {
+        return "Hub to Sink & Sink to Hub";
+    }
+    if (hubToSink) {
+        return "Hub to Sink";
+    }
+    if (sinkToHub) {
+        return "Sink to Hub";
+    }
+    return null;
+}
+
 function Details(props: ReplicationSinkPanelProps & { canEdit: boolean }) {
     const { data, canEdit } = props;
     const connectionStringDefined = !!data.shared.destinationDatabase;
@@ -38,9 +56,12 @@ function Details(props: ReplicationSinkPanelProps & { canEdit: boolean }) {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const connectionStringsUrl = appUrl.forConnectionStrings(databaseName, "Raven", data.shared.connectionStringName);
 
+    const mode = formatReplicationMode(data.shared.mode);
+
     return (
         <RichPanelDetails>
             <RichPanelDetailItem label="Hub Name">{data.shared.hubName}</RichPanelDetailItem>
+            {mode && <RichPanelDetailItem label="Mode">{mode}</RichPanelDetailItem>}
             <ConnectionStringItem
                 connectionStringDefined={connectionStringDefined}
                 canEdit={canEdit}
@@ -57,6 +78,13 @@ function Details(props: ReplicationSinkPanelProps & { canEdit: boolean }) {
                     {url}
                 </RichPanelDetailItem>
             ))}
+
+            {data.shared.hubCursor && (
+                <RichPanelDetailItem label="Hub Cursor">{data.shared.hubCursor}</RichPanelDetailItem>
+            )}
+            {data.shared.sinkCursor && (
+                <RichPanelDetailItem label="Sink Cursor">{data.shared.sinkCursor}</RichPanelDetailItem>
+            )}
         </RichPanelDetails>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingTasksReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingTasksReducer.ts
@@ -436,6 +436,8 @@ function mapSharedInfo(task: OngoingTask): OngoingTaskSharedInfo {
                 topologyDiscoveryUrls: incoming.TopologyDiscoveryUrls,
                 hubName: incoming.HubName,
                 mode: incoming.Mode,
+                hubCursor: incoming.HubCursor,
+                sinkCursor: incoming.SinkCursor,
             };
             return result;
         }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/shared/shared.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/shared/shared.tsx
@@ -262,6 +262,24 @@ export function DestinationUrlItem({
     );
 }
 
+// Mode is a [Flags] enum, so the bidirectional case arrives as a combined string (e.g. "HubToSink, SinkToHub").
+// Use includes() to stay robust to the flag formatting and render a readable label.
+export function formatReplicationMode(mode: Raven.Client.Documents.Operations.Replication.PullReplicationMode): string {
+    const hubToSink = mode?.includes("HubToSink");
+    const sinkToHub = mode?.includes("SinkToHub");
+
+    if (hubToSink && sinkToHub) {
+        return "Hub to Sink & Sink to Hub";
+    }
+    if (hubToSink) {
+        return "Hub to Sink";
+    }
+    if (sinkToHub) {
+        return "Sink to Hub";
+    }
+    return null;
+}
+
 export function EmptyScriptsWarning(props: { task: AnyEtlOngoingTaskInfo }) {
     const emptyScripts = findScriptsWithOutMatchingDocuments(props.task);
 

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -620,6 +620,8 @@ export class TasksStubs {
             AccessName: null,
             CertificatePublicKey: null,
             PinToMentorNode: false,
+            HubCursor: "A:123-aaaaaaaaaaaaaaaaaaaaaa",
+            SinkCursor: "B:456-bbbbbbbbbbbbbbbbbbbbbb",
         };
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26709/SinkToHub-pull-replication-re-sends-all-documents-from-scratch-after-hub-node-failover

### Additional description

Follow-up to the RavenDB-26709 pull replication cursor work. Two parts:

### Address PR comments (server)
- Derive `NumberOfSiblingsInInternalReplication` from the topology Members and Rehabs.
- Use `ClusterOperationContext` when reading the replication cursor from cluster state.
- Move the request parameters into `GetInitialRequestMessage`.
- Minor cleanups + comment.

### Studio
- Add `HubCursor` and `SinkCursor` to `OngoingTaskPullReplicationAsSink` (populated from cluster state via `ReplicationUtils.ReadCursorFromClusterFor`).
- Show **Mode**, **Hub Cursor**, and **Sink Cursor** in the Replication Sink task panel. Mode is a `[Flags]` enum, so the bidirectional case is rendered with a readable label ("Hub to Sink & Sink to Hub") rather than the raw combined string.

No schema/protocol changes; cursors are read from existing cluster state, so the panel works from any node.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
