### PR TITLE
RavenDB-26529 - Fix audit logging for pull replication sink updates (v6.2)

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractPullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractPullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.OngoingTasks;
@@ -29,11 +29,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         {
             if (_pullReplication == null)
             {
-                if (configuration.TryGet(nameof(UpdatePullReplicationAsSinkCommand.PullReplicationAsSink), out BlittableJsonReaderObject pullReplicationBlittable) == false)
-                {
-                    throw new InvalidDataException($"{nameof(UpdatePullReplicationAsSinkCommand.PullReplicationAsSink)} was not found.");
-                }
-
+                var pullReplicationBlittable = GetPullReplicationAsSinkConfiguration(configuration);
                 _pullReplication = JsonDeserializationClient.PullReplicationAsSink(pullReplicationBlittable);
             }
 
@@ -49,8 +45,16 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
 
         protected override ValueTask OnAfterUpdateConfiguration(TransactionOperationContext context, BlittableJsonReaderObject configuration, string raftRequestId)
         {
-            RequestHandler.LogTaskToAudit(Web.RequestHandler.UpdatePullReplicationOnSinkNodeDebugTag, _taskId, configuration);
+            RequestHandler.LogTaskToAudit(Web.RequestHandler.UpdatePullReplicationOnSinkNodeDebugTag, _taskId, GetPullReplicationAsSinkConfiguration(configuration));
             return ValueTask.CompletedTask;
+        }
+
+        private static BlittableJsonReaderObject GetPullReplicationAsSinkConfiguration(BlittableJsonReaderObject configuration)
+        {
+            if (configuration.TryGet(nameof(UpdatePullReplicationAsSinkCommand.PullReplicationAsSink), out BlittableJsonReaderObject pullReplicationBlittable))
+                return pullReplicationBlittable;
+
+            throw new InvalidDataException($"{nameof(UpdatePullReplicationAsSinkCommand.PullReplicationAsSink)} was not found.");
         }
     }
 }

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -15,10 +16,12 @@ using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
+using Sparrow.Logging;
 using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
@@ -208,12 +211,18 @@ namespace SlowTests.Server.Replication
             }
         }
 
-        [RavenFact(RavenTestCategory.Replication)]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Logging)]
         public async Task UpdatePullReplicationOnSink()
         {
             var definitionName1 = $"pull-replication {GetDatabaseName()}";
             var definitionName2 = $"pull-replication {GetDatabaseName()}";
             var timeout = 3000;
+            var auditLogPath = NewDataPath(suffix: "AuditLog");
+
+            LoggingSource.AuditLog.SetupLogMode(LogMode.Information, auditLogPath, TimeSpan.MaxValue, long.MaxValue, compress: false);
+            using var disposableAction = new DisposableAction(() => LoggingSource.AuditLog.SetupLogMode(LogMode.None, auditLogPath, TimeSpan.MaxValue, long.MaxValue, compress: false));
+
+            Assert.True(LoggingSource.AuditLog.IsInfoEnabled);
 
             using (var sink = GetDocumentStore())
             using (var hub = GetDocumentStore())
@@ -236,6 +245,16 @@ namespace SlowTests.Server.Replication
                     TaskId = pullTasks[0].TaskId
                 };
                 await AddWatcherToReplicationTopology(sink, pull, hub2.Urls);
+                await WaitForAssertionAsync(() =>
+                {
+                    var auditLog = ReadAuditLog();
+                    var updateSinkAuditLines = auditLog
+                        .Split(Environment.NewLine)
+                        .Where(x => x.Contains("update-sink-pull-replication"));
+
+                    Assert.Contains(updateSinkAuditLines, x => x.Contains(definitionName2));
+                    return Task.CompletedTask;
+                }, TimeSpan.FromSeconds(5));
 
                 using (var main = hub.OpenSession())
                 {
@@ -250,6 +269,23 @@ namespace SlowTests.Server.Replication
                     main.SaveChanges();
                 }
                 Assert.True(WaitForDocument(sink, "hub2", timeout), sink.Identifier);
+            }
+
+            return;
+
+            string ReadAuditLog()
+            {
+                return Directory.Exists(auditLogPath)
+                    ? string.Join(Environment.NewLine, Directory.GetFiles(auditLogPath, "*.log").Select(ReadAuditLogFile))
+                    : string.Empty;
+            }
+
+            static string ReadAuditLogFile(string path)
+            {
+                using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                using var reader = new StreamReader(stream);
+
+                return reader.ReadToEnd();
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26529
This is a v6.2 backport of https://github.com/ravendb/ravendb/pull/22987

### Additional description

Fixes audit logging for pull replication sink task updates.

The update endpoint receives a wrapper object containing `PullReplicationAsSink`, while the audit formatter expects the direct sink configuration. Passing the wrapper caused audit serialization to fail and prevented the expected audit entry from being written.

The fix reuses a single helper to extract the inner `PullReplicationAsSink` configuration both for response handling and audit logging.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
