### PR TITLE
RavenDB-26707 Clean up already-synced branch journals stranded acrossa numbering gap

### DIFF
--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -115,6 +115,8 @@ namespace Voron.Impl.Journal
         /// </summary>
         public long Write(long posBy4Kb, Span<Pal.journal_entry> entries)
         {
+            Debug.Assert(DoneWriting is null || DoneWriting.IsRaised() == false, $"Journal {Number} was written after DoneWriting was raised.");
+
             long totalNumberOf4Kbs = 0;
             for (int i = 0; i < entries.Length; i++)
             {

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -297,15 +297,7 @@ namespace Voron.Impl.Journal
             
             if (_env.Options.IncrementalBackupEnabled == false && _env.Options.CopyOnWriteMode == false)
             {
-                // we want to check that we clean up old log files if they aren't needed
-                // this is more just to be safe than anything else, they shouldn't be there.
-                var unusedFiles = logInfo.LastSyncedJournal;
-                while (true)
-                {
-                    unusedFiles--;
-                    if (_env.Options.TryDeleteJournal(unusedFiles) == false)
-                        break;
-                }
+                _env.Options.DeleteJournalsBelow(logInfo.LastSyncedJournal);
             }
 
             var modifiedPages = new HashSet<long>();
@@ -394,15 +386,21 @@ namespace Voron.Impl.Journal
                         journalPager.Dispose(); // need to close it before we open the journal writer
                     }
 
-                    
-                    if (_env.Options.RootJournal is null)
+                    bool isHardLinked = _env.Options.IsJournalHardLinked(journalNumber);
+
+
+                    if (_env.Options.RootJournal is null || isHardLinked == false)
                     {
-                        // A standalone env may still find local journals that are hard-linked to another env's journals,
-                        // left over from a previous run with shared journals enabled. We must never write to such a file -
-                        // it would corrupt the env owning the other link. Hard-linked journals are kept read-only for the
-                        // duration of recovery, and the env will allocate a fresh journal for any subsequent writes.
-                        // See RavenDB-26655.
-                        bool isHardLinked = _env.Options.IsJournalHardLinked(journalNumber);
+                        // We could have switched from non-shared to shared journals mode, or vice versa - two kinds of leftover journal can show up here:
+
+                        // Non-shared (standalone) mode tracks all of its journals, but it can still find local journals that are
+                        // hard-linked to another env's journals, left over from a previous run with shared journals enabled. We must
+                        // never write to such a file - it would corrupt the env owning the other link - so hard-linked journals are
+                        // kept read-only for the duration of recovery, and the env allocates a fresh journal for subsequent writes.
+
+                        // Shared (branch) mode can still find non-hard-linked journals left over from a non-shared interlude. We never
+                        // write to them, but we track them in journalFiles so the normal flush/sync path reclaims them instead of
+                        // leaking them as orphans.
 
                         var jrnlWriter = isHardLinked
                             ? _env.Options.CreateReadOnlyJournalWriter(journalNumber, journalPagerState.TotalAllocatedSize)
@@ -413,9 +411,15 @@ namespace Voron.Impl.Journal
                             IsHardLinked = isHardLinked
                         };
                         jrnlFile.DoneWriting = new SingleUseFlag();
+                        
+                        
+                        if (isHardLinked || _env.Options.RootJournal != null)
+                        {
+                            // a hard link is read-only and a branch writes via the root's merger - in both cases mark the journal
+                            // done-writing so it is never adopted as a writable current file
 
-                        if (isHardLinked)
                             jrnlFile.DoneWriting.Raise();
+                        }
 
                         jrnlFile.InitFrom(_env, journalReader, transactionHeaders);
                         jrnlFile.AddRef(); // creator reference - write ahead log
@@ -568,11 +572,12 @@ namespace Voron.Impl.Journal
                     _files[i].DoneWriting.Raise();
                 }
                 var lastFile = _files[^1];
-                bool mustRollToNewFile = _env.Options.RootJournal is null
-                                         && _env.Options.IsJournalHardLinked(lastFile.Number);
+
+                bool mustRollToNewFile = lastFile.DoneWriting.IsRaised();
+
                 if (lastFile.GetAvailable4Kbs(_env.CurrentStateRecord) >= 2 && // room for next tx header + 4kb of data
                     lastFile.HasLegacyTransaction is false && // legacy txs cannot be mixed with new ones in the same file
-                    mustRollToNewFile is false) // standalone env must not append to a hard-linked journal - would corrupt the env owning the other link
+                    mustRollToNewFile is false)
                 {
                     CurrentFile = lastFile;
                 }
@@ -581,7 +586,7 @@ namespace Voron.Impl.Journal
                     lastFile.DoneWriting.Raise();
                     if (mustRollToNewFile)
                         addToInitLog?.Invoke(LogLevel.Info,
-                            $"Journal '{lastFile.JournalWriter.FileName.FullPath}' is hard-linked; rolling to a new file.");
+                            $"Journal '{lastFile.JournalWriter.FileName.FullPath}' is hard-linked or owned by a branch; rolling to a new file.");
                 }
             }
 

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -232,6 +232,8 @@ namespace Voron
 
         public abstract JournalWriter CreateJournalWriterForBranchEnvironment(long journalNumber, string fileName, JournalFile journalFile);
 
+        public abstract void DeleteJournalsBelow(long journalNumber);
+
         public abstract VoronPathSetting GetJournalPath(long journalNumber);
 
         public virtual bool IsJournalHardLinked(long journalNumber) => false;
@@ -598,6 +600,18 @@ namespace Voron
                     return null;
                 
                 return long.Parse(Path.GetFileNameWithoutExtension(latestJournalName));
+            }
+
+            public override void DeleteJournalsBelow(long journalNumber)
+            {
+                if (Directory.Exists(JournalPath.FullPath) == false)
+                    return;
+
+                foreach (string file in Directory.GetFiles(JournalPath.FullPath, "*.journal"))
+                {
+                    if (long.TryParse(Path.GetFileNameWithoutExtension(file), out var number) && number < journalNumber)
+                        TryDeleteJournal(number);
+                }
             }
 
             public override bool JournalExists(long number)
@@ -1053,6 +1067,15 @@ namespace Voron
                     return false;
                 value.Dispose();
                 return true;
+            }
+
+            public override void DeleteJournalsBelow(long journalNumber)
+            {
+                foreach (var name in _logs.Keys.ToArray())
+                {
+                    if (long.TryParse(Path.GetFileNameWithoutExtension(name), out var number) && number < journalNumber)
+                        TryDeleteJournal(number);
+                }
             }
 
             public override bool ReadValidMetadata(string filename, out MetadataFile metadata)

--- a/test/SlowTests.Issues/Issues/RavenDB-26707.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26707.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26707(ITestOutputHelper output) : RavenTestBase(output)
+{
+    // Toggle DisableSharedJournals ON -> OFF -> ON across restarts. OFF (standalone) journals survive back ON, but
+    // the returning shared journals are renumbered higher, leaving a numbering gap above them. The pre-fix recovery cleanup scanned
+    // contiguously down from LastSyncedJournal and stopped at the gap, so the synced journals below it leaked. Each phase forces the
+    // index env's sync to advance LastSyncedJournal (the background sync won't fire in a fast test). Asserts no journal below
+    // LastSyncedJournal survives after recovery.
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Indexes)]
+    public async Task Standalone_era_journals_must_be_cleaned_after_returning_to_shared_mode()
+    {
+        var disableKey = RavenConfiguration.GetKey(x => x.Indexing.DisableSharedJournals);
+        var maxJournalKey = RavenConfiguration.GetKey(x => x.Storage.MaxJournalFileSize);
+        const string dbName = nameof(Standalone_era_journals_must_be_cleaned_after_returning_to_shared_mode);
+        string dataDirectory;
+        string indexDataPath = null;
+
+        var sharedOn = new Dictionary<string, string> { [disableKey] = "false", [maxJournalKey] = "4" };
+        var sharedOff = new Dictionary<string, string> { [disableKey] = "true", [maxJournalKey] = "4" };
+
+        // Phase 1 (ON): seed + index a Lucene index, then force the index env's sync.
+        using (var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, DeletePrevious = false, CustomSettings = sharedOn }))
+        {
+            using var store = new DocumentStore { Urls = new[] { server.WebUrl }, Database = dbName }.Initialize();
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new Raven.Client.ServerWide.DatabaseRecord(dbName)));
+            await new ByName().ExecuteAsync(store);
+            await StoreDocs(store, 0, 5_000);
+            Indexes.WaitForIndexing(store, databaseName: dbName);
+            await ForceIndexSync(server, store, dbName);
+
+            dataDirectory = server.Configuration.Core.DataDirectory.FullPath;
+            indexDataPath = Path.Combine(dataDirectory, "Databases", dbName, "Indexes", nameof(ByName));
+            Output.WriteLine($"P1 (ON):  {await DescribeBranch(server, store, dbName, indexDataPath)}");
+        }
+
+        // Phase 2 (OFF, standalone): write the index's own journals; capture them.
+        long[] standaloneEra;
+        using (var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, DeletePrevious = false, DataDirectory = dataDirectory, CustomSettings = sharedOff }))
+        {
+            using var store = new DocumentStore { Urls = new[] { server.WebUrl }, Database = dbName }.Initialize();
+            await WaitForDatabaseStatsAsync(store, TimeSpan.FromMinutes(21));
+            await StoreDocs(store, 5_000, 12_000);
+            Indexes.WaitForIndexing(store, databaseName: dbName);
+            await ForceIndexSync(server, store, dbName);
+            standaloneEra = ListJournalNumbers(indexDataPath);
+            Output.WriteLine($"P2 (OFF): {await DescribeBranch(server, store, dbName, indexDataPath)}");
+        }
+        Output.WriteLine($"standalone-era journals captured: [{string.Join(",", standaloneEra)}]");
+
+        // Phase 3 (ON, branch): standalone-era journals survive; the returning shared journals are renumbered higher, opening a
+        // numbering gap above them - the synced journals below that gap are what must be reclaimed.
+        using (var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, DeletePrevious = false, DataDirectory = dataDirectory, CustomSettings = sharedOn }))
+        {
+            using var store = new DocumentStore { Urls = new[] { server.WebUrl }, Database = dbName }.Initialize();
+            await WaitForDatabaseStatsAsync(store, TimeSpan.FromMinutes(21));
+            await StoreDocs(store, 12_000, 30_000);
+            Indexes.WaitForIndexing(store, databaseName: dbName);
+            await ForceIndexSync(server, store, dbName);
+            Output.WriteLine($"P3 (ON):  {await DescribeBranch(server, store, dbName, indexDataPath)}");
+
+            // P3 in-run: standalone-era journals are now below LastSyncedJournal; they must be retired at runtime, not left for P4.
+            var p3OnDisk = ListJournalNumbers(indexDataPath);
+            var p3Survivors = standaloneEra.Where(p3OnDisk.Contains).ToArray();
+            Assert.True(p3Survivors.Length == 0,
+                $"standalone-era journals must be retired at runtime; survivors: [{string.Join(",", p3Survivors)}] (onDisk=[{string.Join(",", p3OnDisk)}])");
+        }
+
+        // Phase 4 (restart ON): branch recovery must reclaim every journal below LastSyncedJournal.
+        using (var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, DeletePrevious = false, DataDirectory = dataDirectory, CustomSettings = sharedOn }))
+        {
+            using var store = new DocumentStore { Urls = new[] { server.WebUrl }, Database = dbName }.Initialize();
+            await WaitForDatabaseStatsAsync(store, TimeSpan.FromMinutes(21));
+            Indexes.WaitForIndexing(store, databaseName: dbName);
+
+            var branchEnv = await GetIndexEnv(server, store, dbName);
+            var lsj = branchEnv.Journal.GetCurrentJournalInfo().LastSyncedJournal;
+            var onDisk = ListJournalNumbers(indexDataPath);
+            var belowLsj = onDisk.Where(n => n < lsj).ToArray();
+            var standaloneSurvivors = standaloneEra.Where(onDisk.Contains).ToArray();
+
+            var diag = $"reopenLsj={lsj}, onDisk=[{string.Join(",", onDisk)}], standaloneEra=[{string.Join(",", standaloneEra)}], " +
+                       $"belowLsj=[{string.Join(",", belowLsj)}], standaloneSurvivors=[{string.Join(",", standaloneSurvivors)}]";
+            Output.WriteLine("P4 (ON):  " + diag);
+
+            Assert.True(belowLsj.Length == 0,
+                "branch recovery must reclaim every synced journal (below LastSyncedJournal); survivors below a gap: " + diag);
+        }
+    }
+
+    private static async Task StoreDocs(IDocumentStore store, int from, int to)
+    {
+        using var bulk = store.BulkInsert();
+        for (int i = from; i < to; i++)
+            await bulk.StoreAsync(new Item { Id = $"items/{i}", Name = $"name-{i % 50}" });
+    }
+
+    private async Task<StorageEnvironment> GetIndexEnv(RavenServer server, IDocumentStore store, string dbName)
+    {
+        var database = await Databases.GetDocumentDatabaseInstanceFor(server, store, dbName);
+        return database.IndexStore.GetIndex(nameof(ByName))._environment;
+    }
+
+    // Index envs aren't ManualFlushing, so FlushLogToDataFile() is unavailable. The background flusher applies
+    // the journal; ForceSyncDataFile() then syncs + advances LastSyncedJournal. Poll until it advances.
+    private async Task ForceIndexSync(RavenServer server, IDocumentStore store, string dbName)
+    {
+        var env = await GetIndexEnv(server, store, dbName);
+        var before = env.Journal.GetCurrentJournalInfo().LastSyncedJournal;
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(30))
+        {
+            env.ForceSyncDataFile();
+            await Task.Delay(250);
+            if (env.Journal.GetCurrentJournalInfo().LastSyncedJournal > before)
+                return;
+        }
+        // LSJ did not advance within the budget - leave it; diagnostics will show the resulting layout.
+    }
+
+    private async Task<string> DescribeBranch(RavenServer server, IDocumentStore store, string dbName, string indexDataPath)
+    {
+        long lsj = -2;
+        try { lsj = (await GetIndexEnv(server, store, dbName)).Journal.GetCurrentJournalInfo().LastSyncedJournal; }
+        catch { /* ignore */ }
+        return $"LSJ={lsj}, journals=[{string.Join(",", ListJournalNumbers(indexDataPath))}]";
+    }
+
+    private static long[] ListJournalNumbers(string indexDataPath)
+    {
+        var jdir = Path.Combine(indexDataPath, "Journals");
+        if (Directory.Exists(jdir) == false)
+            return Array.Empty<long>();
+        return Directory.EnumerateFiles(jdir, "*.journal")
+            .Select(p => long.Parse(Path.GetFileNameWithoutExtension(p)))
+            .OrderBy(n => n)
+            .ToArray();
+    }
+
+    private static async Task<DatabaseStatistics> WaitForDatabaseStatsAsync(IDocumentStore store, TimeSpan timeout)
+    {
+        var sw = Stopwatch.StartNew();
+        Exception lastError = null;
+        while (sw.Elapsed < timeout)
+        {
+            try { return await store.Maintenance.SendAsync(new GetStatisticsOperation()); }
+            catch (Exception e) { lastError = e; }
+            await Task.Delay(500);
+        }
+        throw new TimeoutException($"Database did not respond within {timeout}. Last: {lastError?.GetType().Name}: {lastError?.Message}");
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class ByName : AbstractIndexCreationTask<Item>
+    {
+        public ByName()
+        {
+            Map = items => from i in items select new { i.Name };
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Lucene;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26707

### Additional description

- Delete every journal below `LastSyncedJournal` gap-tolerantly (`DeleteJournalsBelow`) instead of stopping at the first missing number. Switching the shared-journals mode renumbers can open a numbering gap on already processed journal, so the previous contiguous-downward scan left already-synced (durable, never-replayed) journals behind. 
- Also track non-hard-linked journals during recovery so that, after switching back to shared-journals mode, these standalone-era leftovers are retired through the normal flush/sync path instead of leaking.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
