### PR TITLE
RavenDB-26809: Fix use-after-free in parallel HNSW node placement

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -150,6 +150,15 @@ public partial class Hnsw
             private readonly List<int> _indexes = [];
             private readonly List<int> _requiresEdgeFiltering = [];
             private readonly List<UnmanagedSpan> _vectors = [];
+
+            // Per-task, point-in-time copy of the current (node, level) edge indexes. Filled on the
+            // LLT thread in PrepareEdgesOnLLT and read by the worker in PopulateWorkListsOnWorker.
+            // This decouples the worker from the shared, growable EdgesIndexesPerLevel native buffer,
+            // whose backing store the LLT thread can free/realloc in a later dispatch round while the
+            // worker still runs (the PopulateWorkListsOnWorker use-after-free, RavenDB-26809). One
+            // WorkItem per task is in flight at a time (WorkItem.Execute re-enqueues the iterator only
+            // after the worker finishes), so this buffer is safe to clear+refill on every dispatch.
+            private readonly List<int> _edgeIndexSnapshot = [];
             private readonly PriorityQueue<int, float> _candidatesQ = new();
             private readonly PriorityQueue<int, float> _nearestEdgesQ = new();
             private ulong[] _visitedBitmap = [];
@@ -648,6 +657,14 @@ public partial class Hnsw
                     }
                 }
 
+                // Snapshot the now-in-sync edge indexes into the per-task buffer ON THE LLT THREAD.
+                // The worker reads this private copy in PopulateWorkListsOnWorker instead of the shared
+                // EdgesIndexesPerLevel native buffer, so the LLT thread is free to grow/realloc that
+                // buffer in later rounds without racing the worker (RavenDB-26809). The copy is a
+                // consistent point-in-time view, so the worker never observes a torn read.
+                _edgeIndexSnapshot.Clear();
+                _edgeIndexSnapshot.AddRange(edgesIndexes.ToSpan());
+
                 return true; // always dispatch; worker decides via _indexes.Count after fill
             }
 
@@ -676,8 +693,11 @@ public partial class Hnsw
                     _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
                 }
 
-                ref var edgesIndexes = ref n.EdgesIndexesPerLevel[level];
-                foreach (var idx in edgesIndexes)
+                // Read the per-task snapshot captured on the LLT thread in PrepareEdgesOnLLT, NOT the
+                // shared EdgesIndexesPerLevel native buffer: that buffer's storage can be freed and
+                // reallocated by the LLT thread in a later round while this worker is still running
+                // (use-after-free, RavenDB-26809).
+                foreach (var idx in _edgeIndexSnapshot)
                 {
                     if (MarkVisited(idx) is false)
                         continue;
@@ -737,14 +757,6 @@ public partial class Hnsw
                 _mainCts = CancellationTokenSource.CreateLinkedTokenSource(token, _errorCts.Token);
                 _activeTasksCount = activeTasksCount;
                 _searchState = parent._searchState;
-
-                // Pre-size SearchState._nodes so that AllocateNodeIndex calls during the
-                // build never reallocate the underlying ByteString. Workers in
-                // PopulateWorkListsOnWorker hold ref Node values into that storage across
-                // LLT-side dispatch; a Grow → Release between dispatch and worker access
-                // would invalidate those refs. Headroom of 16 K covers edge nodes that get
-                // lazily loaded on top of CreatedNodes.
-                _searchState.EnsureNodesCapacity(_searchState.CreatedNodes + 16 * 1024);
 
                 for (int i = 0; i < activeTasksCount; i++)
                 {

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -693,6 +693,7 @@ public partial class Hnsw
                     _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
                 }
 
+                parent._forTestingPurposes?.OnWorkerCapturedEdgeListRef(_searchState, currentNodeIndex, level);
                 // Read the per-task snapshot captured on the LLT thread in PrepareEdgesOnLLT, NOT the
                 // shared EdgesIndexesPerLevel native buffer: that buffer's storage can be freed and
                 // reallocated by the LLT thread in a later round while this worker is still running
@@ -730,6 +731,7 @@ public partial class Hnsw
             private readonly CancellationTokenSource _mainCts;
             private readonly List<Exception> _errors = [];
             private readonly LinkedList<int> _inFlightIndexes = [];
+            private readonly Registration.TestingStuff _forTestingPurposes;
 
             // Latches to true once an iteration completes with nothing left to preload, meaning
             // every node touched so far is resident. From that point we skip the RegisterForPreloading
@@ -758,6 +760,10 @@ public partial class Hnsw
                 _activeTasksCount = activeTasksCount;
                 _searchState = parent._searchState;
 
+                _forTestingPurposes = parent._forTestingPurposes;
+                if (_forTestingPurposes is { SimulateConcurrentRealloc: true })
+                    _forTestingPurposes.WakeLltLoop = () => _ready.Set();
+
                 for (int i = 0; i < activeTasksCount; i++)
                 {
                     Enqueue(new NodePlacement(parent, this).Process().GetEnumerator());
@@ -772,7 +778,9 @@ public partial class Hnsw
                 {
                     _ready.Wait();
                     _ready.Reset();
-                    
+
+                    _forTestingPurposes?.OnLltRunRound(_searchState);
+
                     while(_placementTasks.TryDequeue(out var it))
                     {
                         if (it.MoveNext())

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -171,6 +171,24 @@ public unsafe partial class Hnsw
             return (nint)_nodes.RawItems != before;
         }
 
+        // Test-only: grow the node array, then claim a buffer of the vacated capacity and fill it with a
+        // poison pattern. If the grow freed the old buffer (the RavenDB-26809 bug) the allocator reuses
+        // that same memory and a dangling reader sees poison; if it was retained (the fix) the reader is
+        // unaffected. The poison buffer is retained so it occupies the region past the reader's resume.
+        internal bool GrowNodesAndPoisonVacatedForTesting()
+        {
+            var before = (nint)_nodes.RawItems;
+            int vacatedCapacity = _nodes.Capacity;
+            GrowNodesRetainingOldBuffer();
+
+            var poison = new NativeList<Node>();
+            poison.Initialize(Llt.Allocator, vacatedCapacity);
+            poison.ToFullCapacitySpan().Fill(new Node { NodeId = -1, VectorId = -1 });
+            (_retiredNodeStores ??= []).Add(poison);
+
+            return (nint)_nodes.RawItems != before;
+        }
+
         // Number of grown-from node buffers kept alive (un-disposed) until dispose.
         internal int RetiredNodeStorageCountForTesting => _retiredNodeStores?.Count ?? 0;
 
@@ -954,6 +972,91 @@ public unsafe partial class Hnsw
         public int AmountOfModifiedVectorsInTransaction => _vectorHashCache.Count;
 
         public Options Options => _searchState.Options;
+
+        internal TestingStuff _forTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly() => _forTestingPurposes ??= new TestingStuff();
+
+        // Deterministically reproduces the RavenDB-26809 interleaving for tests: parks a placement worker
+        // while it holds a reference into a node's edges, then has the LLT thread move both that edge
+        // buffer and the node array before the worker resumes. With the fix in place the worker reads a
+        // private edge snapshot and the grown-from node buffer is retained, so the build completes and the
+        // graph stays queryable; reverting either guard turns this into a use-after-free.
+        internal sealed class TestingStuff
+        {
+            internal bool SimulateConcurrentRealloc;
+
+            // Latched once the matching buffer was actually moved while the worker was parked, so a test
+            // can fail loudly if the race window was never exercised.
+            internal volatile bool VictimSelected;
+            internal volatile bool InnerEdgeBufferMovedWhileWorkerParked;
+            internal volatile bool NodesArrayMovedWhileWorkerParked;
+
+            // False if a node reference captured before the move read poisoned/freed data after it — i.e.
+            // the node array was not retained across the grow (the RavenDB-26809 bug).
+            internal volatile bool StaleNodeReferenceStillValid = true;
+
+            // Set by the runner so the parked worker can wake the dispatch loop; without it the loop may
+            // not iterate again when the only outstanding work is the parked worker itself.
+            internal Action WakeLltLoop;
+
+            private int _victim = -1;
+            private int _victimLevel;
+            private nint _victimEdgeBufferBeforeMove;
+            private nint _victimNodePtr;
+            private long _victimNodeIdExpected;
+            private readonly ManualResetEventSlim _workerParked = new(false);
+            private readonly ManualResetEventSlim _lltMoved = new(false);
+
+            // Worker thread: the first worker about to consume a node's edges at a level with real storage
+            // parks here until the LLT thread has moved that storage and the node array.
+            internal void OnWorkerCapturedEdgeListRef(SearchState searchState, int nodeIndex, int level)
+            {
+                if (SimulateConcurrentRealloc == false || Volatile.Read(ref _victim) >= 0)
+                    return;
+
+                ref var candidate = ref searchState.GetNodeByIndex(nodeIndex);
+                if (candidate.EdgesIndexesPerLevel.Count <= level || candidate.EdgesIndexesPerLevel[level].Count == 0)
+                    return;
+                if (Interlocked.CompareExchange(ref _victim, nodeIndex, -1) != -1)
+                    return;
+
+                _victimLevel = level;
+                _victimEdgeBufferBeforeMove = (nint)candidate.EdgesIndexesPerLevel[level].RawItems;
+                _victimNodePtr = (nint)Unsafe.AsPointer(ref candidate);
+                _victimNodeIdExpected = candidate.NodeId;
+                VictimSelected = true;
+                _workerParked.Set();
+                WakeLltLoop?.Invoke();
+                _lltMoved.Wait(TimeSpan.FromMinutes(2));
+
+                // Read through the reference captured before the move, exactly as a racing worker would.
+                // Retaining the grown-from buffer keeps this valid; freeing it (the bug) reads poison.
+                if (((Node*)_victimNodePtr)->NodeId != _victimNodeIdExpected)
+                    StaleNodeReferenceStillValid = false;
+            }
+
+            // LLT thread, at the top of each dispatch round: once the victim worker has parked, move its
+            // edge buffer (restoring contents) and the node array, then release the worker.
+            internal void OnLltRunRound(SearchState searchState)
+            {
+                if (SimulateConcurrentRealloc == false || _lltMoved.IsSet || _workerParked.IsSet == false)
+                    return;
+
+                ref var inner = ref searchState.GetNodeByIndex(_victim).EdgesIndexesPerLevel[_victimLevel];
+                var saved = inner.ToSpan().ToArray();
+                inner.ResetAndEnsureCapacity(searchState.Llt.Allocator, Math.Max(inner.Capacity * 2, saved.Length + 1));
+                foreach (var v in saved)
+                    inner.AddUnsafe(v);
+                if ((nint)inner.RawItems != _victimEdgeBufferBeforeMove)
+                    InnerEdgeBufferMovedWhileWorkerParked = true;
+
+                if (searchState.GrowNodesAndPoisonVacatedForTesting())
+                    NodesArrayMovedWhileWorkerParked = true;
+
+                _lltMoved.Set();
+            }
+        }
 
         public Registration(LowLevelTransaction llt, Slice name, Random random = null)
         {

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -146,19 +146,33 @@ public unsafe partial class Hnsw
 
         public int CreatedNodes => _newNodes.Count;
 
-        /// <summary>
-        /// Pre-size the underlying <see cref="_nodes"/> NativeList so that no
-        /// AllocateNodeIndex call during the build can trigger a Grow → Release of
-        /// the old storage. Needed by the parallel placement runner when worker
-        /// threads hold <c>ref Node</c> values into <see cref="_nodes"/> across
-        /// LLT-side dispatch — without this, a Grow would invalidate those refs.
-        /// </summary>
-        public void EnsureNodesCapacity(int totalCapacity)
+        private List<NativeList<Node>> _retiredNodeStores;
+
+        // Grow the node array by copying into a fresh buffer and keeping the old one alive (released on
+        // dispose) instead of freeing it, so a parallel-placement worker dereferencing a ref into the
+        // array never observes a buffer freed by a grow mid-dispatch (RavenDB-26809).
+        private void GrowNodesRetainingOldBuffer()
         {
-            if (_nodes.Capacity >= totalCapacity)
-                return;
-            _nodes.EnsureCapacityFor(Llt.Allocator, totalCapacity - _nodes.Count);
+            var grown = new NativeList<Node>();
+            grown.Initialize(Llt.Allocator, Math.Max(InitialNodesCapacityWithCache, _nodes.Capacity * 2));
+            grown.AddRangeUnsafe(_nodes.ToSpan());
+            (_retiredNodeStores ??= []).Add(_nodes);
+            // Publish the copied buffer before the new pointer becomes observable, so a concurrent
+            // reader that sees the new pointer also sees the copied contents (weak-memory archs).
+            Thread.MemoryBarrier();
+            _nodes = grown;
         }
+
+        // Force a grow of the node array backing store; returns true if the buffer moved. Test-only.
+        internal bool ForceGrowNodesForTesting()
+        {
+            var before = (nint)_nodes.RawItems;
+            GrowNodesRetainingOldBuffer();
+            return (nint)_nodes.RawItems != before;
+        }
+
+        // Number of grown-from node buffers kept alive (un-disposed) until dispose.
+        internal int RetiredNodeStorageCountForTesting => _retiredNodeStores?.Count ?? 0;
 
         public int GetCreatedNodeIndex(int index) => _newNodes[index];
 
@@ -293,8 +307,10 @@ public unsafe partial class Hnsw
 
         private int AllocateNodeIndex(long nodeId)
         {
+            if (_nodes.HasCapacityFor(1) == false)
+                GrowNodesRetainingOldBuffer();
             int nodeIndex = _nodes.Count;
-            _nodes.Add(Llt.Allocator, new Node { NodeId = nodeId });
+            _nodes.AddUnsafe(new Node { NodeId = nodeId });
             return nodeIndex;
         }
 
@@ -892,6 +908,15 @@ public unsafe partial class Hnsw
            _newNodes.Dispose(Llt.Allocator);
 
            _nodes.Dispose(Llt.Allocator);
+
+           if (_retiredNodeStores is not null)
+           {
+               foreach (var store in _retiredNodeStores)
+               {
+                   var retired = store;
+                   retired.Dispose(Llt.Allocator);
+               }
+           }
 
            if (_queryNormalizationScope is { } scope)
            {

--- a/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
+++ b/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
@@ -175,6 +175,29 @@ public unsafe class HnswIndexCacheTests(ITestOutputHelper output) : StorageTest(
         }
     }
 
+    // RavenDB-26809: under parallel placement a worker dereferences a pointer into the node array while
+    // the LLT thread may grow it. Growth must retain the grown-from buffer instead of freeing it, so the
+    // worker never reads freed memory. Copy-correctness of the moved contents is covered by the
+    // build+query tests above.
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void GrowingNodeArrayRetainsGrownFromBuffer()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        using (var tx = Env.WriteTransaction())
+        {
+            Hnsw.Create(tx.LowLevelTransaction, treeName, VectorSizeInBytes, numberOfEdges: 12,
+                numberOfCandidates: 16, VectorEmbeddingType.Single);
+            tx.Commit();
+        }
+
+        using var rtx = Env.ReadTransaction();
+        using var state = new Hnsw.SearchState(rtx.LowLevelTransaction, treeName);
+
+        Assert.True(state.ForceGrowNodesForTesting(), "node array did not move");
+        Assert.True(state.ForceGrowNodesForTesting(), "node array did not move");
+        Assert.Equal(2, state.RetiredNodeStorageCountForTesting);
+    }
+
     private void BuildGraph(Slice treeName, int vectorCount, int seed)
     {
         var random = new Random(seed);

--- a/test/SlowTests/Voron/Graphs/HnswParallelPlacementRaceTests.cs
+++ b/test/SlowTests/Voron/Graphs/HnswParallelPlacementRaceTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Graphs;
+using Xunit;
+using VectorEmbeddingType = Voron.Data.Graphs.VectorEmbeddingType;
+
+namespace SlowTests.Voron.Graphs;
+
+public unsafe class HnswParallelPlacementRaceTests(ITestOutputHelper output) : StorageTest(output)
+{
+    private const string TreeName = "test";
+    private const int VectorDimensions = 16;
+    private const int VectorSizeInBytes = VectorDimensions * sizeof(float);
+
+    // RavenDB-26809: reproduces the actual use-after-free. A placement worker is parked while it holds a
+    // reference into a node's edges, then the LLT thread moves both that edge buffer and the node array
+    // before the worker resumes. With the fix (per-task edge snapshot + retained node buffer) the build
+    // completes and the graph stays queryable; reverting either guard crashes here under the parked read.
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void ParallelPlacementSurvivesEdgeAndNodeReallocUnderParkedWorker()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        // Enough vectors that several placement tasks run concurrently, so the parked victim is never the
+        // only outstanding work and the runner keeps looping.
+        const int vectorCount = 4000;
+        var random = new Random(42);
+
+        using (var tx = Env.WriteTransaction())
+        {
+            Hnsw.Create(tx.LowLevelTransaction, treeName, VectorSizeInBytes, numberOfEdges: 12,
+                numberOfCandidates: 16, VectorEmbeddingType.Single);
+
+            using var registration = Hnsw.RegistrationFor(tx.LowLevelTransaction, treeName, random);
+            registration.ForTestingPurposesOnly().SimulateConcurrentRealloc = true;
+
+            for (int i = 1; i <= vectorCount; i++)
+                registration.Register(i, MemoryMarshal.Cast<float, byte>(RandomVector(random)));
+
+            registration.Commit(CancellationToken.None);
+            tx.Commit();
+
+            var testing = registration.ForTestingPurposesOnly();
+            Assert.True(testing.VictimSelected,
+                "no worker parked on a non-empty edge buffer — the race window was never exercised; adjust count/seed");
+            Assert.True(testing.InnerEdgeBufferMovedWhileWorkerParked,
+                "the edge buffer was not moved while the worker was parked — edge use-after-free window not exercised");
+            Assert.True(testing.NodesArrayMovedWhileWorkerParked,
+                "the node array was not moved while the worker was parked — node use-after-free window not exercised");
+            Assert.True(testing.StaleNodeReferenceStillValid,
+                "a node reference captured before the grow read freed/poisoned memory — node array was not retained");
+        }
+
+        float[] query = RandomVector(new Random(123));
+        var queryBytes = new byte[Hnsw.TensorSizeBytes<float>(query.Length)];
+        Hnsw.WriteNormalizedTensor(query, queryBytes);
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var state = new Hnsw.SearchState(tx.LowLevelTransaction, treeName);
+            using var retriever = Hnsw.ApproximateNearest(state, numberOfCandidates: 32, queryBytes, minimumSimilarity: 0f);
+
+            var scores = new float[32];
+            var docs = new long[32];
+            int total = 0, read;
+            do
+            {
+                read = retriever.Fill(docs, scores, filter: null);
+                total += read;
+            } while (read != 0);
+
+            Assert.True(total > 0, "post-build query returned no results — the graph was corrupted by the forced realloc");
+        }
+    }
+
+    private static float[] RandomVector(Random random)
+    {
+        var v = new float[VectorDimensions];
+        float sumSq = 0;
+        for (int i = 0; i < VectorDimensions; i++)
+        {
+            v[i] = (float)(random.NextDouble() * 2 - 1);
+            sumSq += v[i] * v[i];
+        }
+        var norm = MathF.Sqrt(sumSq);
+        if (norm > 0)
+        {
+            for (int i = 0; i < VectorDimensions; i++)
+                v[i] /= norm;
+        }
+        return v;
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26809

### Additional description

During parallel HNSW graph construction, worker threads could encounter freed memory when accessing shared native buffers (`EdgesIndexesPerLevel` and `_nodes`).

To prevent this:
- Edge indexes are now snapshotted into a per-task buffer on the LLT thread, decoupling workers from the shared, growable `EdgesIndexesPerLevel` buffer.
- When `_nodes` needs to grow while workers hold references into it, the old buffer is retained until `SearchState` disposal instead of being immediately freed.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
