### PR TITLE
RavenDB-26746 Moving long runing cases to Stresstests. Keeping random seed in SlowTests since they run much more frequently.

### DIFF
--- a/test/SlowTests/Voron/Issues/RavenDB_26746.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26746.cs
@@ -29,12 +29,10 @@ namespace SlowTests.Voron.Issues
         // The workload mimics the original scenario: tombstone-like keys (short ids mixed with ~1.5 KB
         // change-vector suffixes, so branch pages hold only a few nodes), waves of sorted inserts
         // followed by mass deletes.
+        // Fixed-seed variants run in StressTests.Voron.RavenDB_26746.
+        // Here we keep a single random-seed case so every PR run fuzzes it.
         [RavenTheory(RavenTestCategory.Voron)]
-        [InlineData(15, 4)]
-        [InlineData(15, 5)]
-        [InlineData(15, 10)]
-        [InlineData(50, 3)] // on unfixed code this seed failed with the search-misroute symptom (out-of-order separators)
-        [InlineDataWithRandomSeed(20)]
+        [InlineDataWithRandomSeed(-1)] // maxCycles -1 -> pick a random 15..20 below
         public void Rebalancing_must_not_corrupt_tree_when_separator_readd_splits_ancestors(int maxCycles, int seed)
         {
             using (var tx = Env.WriteTransaction())
@@ -44,6 +42,8 @@ namespace SlowTests.Voron.Issues
             }
 
             var rng = new Random(seed);
+            if (maxCycles < 0)
+                maxCycles = rng.Next(15, 21); // 15..20, derived from the seed so a failure stays reproducible
             var generations = new Dictionary<long, int>();
             var live = new HashSet<string>(StringComparer.Ordinal);
 

--- a/test/StressTests/Voron/RavenDB_26746.cs
+++ b/test/StressTests/Voron/RavenDB_26746.cs
@@ -1,0 +1,26 @@
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Voron
+{
+    public class RavenDB_26746 : NoDisposalNoOutputNeeded
+    {
+        public RavenDB_26746(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(15, 4)]
+        [InlineData(15, 5)]
+        [InlineData(15, 10)]
+        [InlineData(50, 3)] // on unfixed code this seed failed with the search-misroute symptom (out-of-order separators)
+        public void Rebalancing_must_not_corrupt_tree_when_separator_readd_splits_ancestors(int maxCycles, int seed)
+        {
+            using (var test = new SlowTests.Voron.Issues.RavenDB_26746(Output))
+            {
+                test.Rebalancing_must_not_corrupt_tree_when_separator_readd_splits_ancestors(maxCycles, seed);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26746

### Additional description

Tests were added in https://github.com/ravendb/ravendb/pull/22959

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
