### PR TITLE
RavenDB-26218 Address review on the read_ahead_kb alert

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -808,7 +808,7 @@ namespace Raven.Server.ServerWide
                             "High read_ahead_kb Detected",
                             $"One or more block devices have read_ahead_kb set above {thresholdKb.Value} KB: {deviceList}. " +
                             "This can cause excessive I/O during random-access workloads. " +
-                            "Consider lowering it. Please follow the documentation for guidance.",
+                            "Check the device(s) backing RavenDB's data and consider lowering it there. Please follow the documentation for guidance.",
                             AlertType.HighReadAheadKb,
                             NotificationSeverity.Warning);
                         if (NotificationCenter.IsInitialized)
@@ -825,7 +825,7 @@ namespace Raven.Server.ServerWide
             catch (Exception e)
             {
                 if (Logger.IsInfoEnabled)
-                    Logger.Info("An error occurred while trying to check read_ahead_kb values for block devices", e);
+                    Logger.Info("An error occurred while raising the high read_ahead_kb alert", e);
             }
 
             options.SchemaVersion = SchemaUpgrader.CurrentVersion.ServerVersion;


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-...

### Additional description

Addressing comments from https://github.com/ravendb/ravendb/pull/22676

- Point the alert message at the device(s) backing RavenDB's data instead of implying every scanned disk should be retuned.
- Fix the catch message to reflect it guards raising the alert (reading the values is already handled in GetBlockDevicesWithHighReadAhead).


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
