### PR TITLE
RavenDB-26744 Add support for customizable OpenTelemetry service name and namespace configuration

### DIFF
--- a/src/Raven.Server/Config/Categories/MonitoringConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/MonitoringConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.Extensions.Configuration;
@@ -49,6 +50,20 @@ namespace Raven.Server.Config.Categories
         [ConfigurationCategory(ConfigurationCategoryType.Monitoring)]
         public sealed class OpenTelemetryConfiguration : ConfigurationCategory
         {
+            public override void Initialize(IConfigurationRoot settings, HashSet<string> settingsNames, IConfigurationRoot serverWideSettings, HashSet<string> serverWideSettingsNames, ResourceType type, string resourceName)
+            {
+                base.Initialize(settings, settingsNames, serverWideSettings, serverWideSettingsNames, type, resourceName);
+
+                if (Enabled == false)
+                    return;
+
+                if (string.IsNullOrWhiteSpace(ServiceName))
+                    throw new InvalidOperationException($"Configuration '{RavenConfiguration.GetKey(x => x.Monitoring.OpenTelemetry.ServiceName)}' cannot be null or empty.");
+
+                if (string.IsNullOrWhiteSpace(ServiceNamespace))
+                    throw new InvalidOperationException($"Configuration '{RavenConfiguration.GetKey(x => x.Monitoring.OpenTelemetry.ServiceNamespace)}' cannot be null or empty.");
+            }
+            
             [Description("Indicates if OpenTelemetry is enabled or not. Default: false")]
             [DefaultValue(false)]
             [ConfigurationEntry("Monitoring.OpenTelemetry.Enabled", ConfigurationEntryScope.ServerWideOnly)]
@@ -58,6 +73,16 @@ namespace Raven.Server.Config.Categories
             [DefaultValue(null)]
             [ConfigurationEntry("Monitoring.OpenTelemetry.ServiceInstanceId", ConfigurationEntryScope.ServerWideOnly)]
             public string ServiceInstanceId { get; set; }
+            
+            [Description("Sets the OpenTelemetry service name.")]
+            [DefaultValue("server")]
+            [ConfigurationEntry("Monitoring.OpenTelemetry.ServiceName", ConfigurationEntryScope.ServerWideOnly)]
+            public string ServiceName { get; set; }
+
+            [Description("Sets the OpenTelemetry service namespace.")]
+            [DefaultValue("ravendb")]
+            [ConfigurationEntry("Monitoring.OpenTelemetry.ServiceNamespace", ConfigurationEntryScope.ServerWideOnly)]
+            public string ServiceNamespace { get; set; }
             
             [Description("Indicates if RavenDB's OpenTelemetry metrics are enabled or not. Default: true")]
             [DefaultValue(true)]

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -526,9 +526,11 @@ namespace Raven.Server
             void ConfigureMetrics(MeterProviderBuilder builder)
             {
                 var configuration = Configuration.Monitoring.OpenTelemetry;
+                var serviceName = configuration.ServiceName;
+                var serviceNamespace = configuration.ServiceNamespace;
                 builder.SetResourceBuilder(
                     ResourceBuilder.CreateDefault()
-                        .AddService("server", "ravendb", serviceInstanceId: serviceInstanceId));
+                        .AddService(serviceName, serviceNamespace, serviceInstanceId: serviceInstanceId));
                 if (configuration.AspNetCoreInstrumentationMetersEnabled)
                     builder.AddAspNetCoreInstrumentation();
                 if (configuration.RuntimeInstrumentationMetersEnabled)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26744

### Additional description

Names should be set via RavenDB configuration instead of OpenTelemetry's environment variables.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
