### PR TITLE
RavenDB-26416: HandleDatabaseRecordChange can shut down an AiWorker while another thread is still adding new work to it.

### DIFF
--- a/src/Raven.Server/Documents/AI/Embeddings/CompletableQueue.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/CompletableQueue.cs
@@ -1,0 +1,67 @@
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Sparrow.Server;
+
+namespace Raven.Server.Documents.AI.Embeddings;
+
+internal sealed class CompletableQueue<T>
+{
+    private readonly ConcurrentQueue<T> _queue = new();
+    private readonly AsyncManualResetEvent _hasWork = new();
+    private readonly object _lock = new();
+    private bool _completed;
+
+    // Intentionally does not wake readers.
+    // ETL relies on enqueueing multiple items and waking once from WaitForGenerationAsync.
+    // Call Wake() explicitly after enqueue when immediate processing is required.
+    public bool TryEnqueue(T item)
+    {
+        lock (_lock)
+        {
+            if (_completed)
+                return false;
+
+            _queue.Enqueue(item);
+            return true;
+        }
+    }
+
+    public void Wake() => _hasWork.Set();
+
+    public void Complete()
+    {
+        lock (_lock)
+        {
+            _completed = true;
+        }
+
+        _hasWork.Set();
+    }
+
+    public bool TryDequeue(out T item) => _queue.TryDequeue(out item);
+
+    public async ValueTask<bool> WaitToReadAsync(CancellationToken token = default)
+    {
+        while (true)
+        {
+            lock (_lock)
+            {
+                if (_completed)
+                    return _queue.IsEmpty == false;
+            }
+
+            await _hasWork.WaitAsync(token);
+            _hasWork.Reset();
+
+            lock (_lock)
+            {
+                if (_completed)
+                    return _queue.IsEmpty == false;
+
+                if (_queue.IsEmpty == false)
+                    return true;
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/AI/Embeddings/CompletableQueue.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/CompletableQueue.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
@@ -5,21 +6,24 @@ using Sparrow.Server;
 
 namespace Raven.Server.Documents.AI.Embeddings;
 
-internal sealed class CompletableQueue<T>
+internal sealed class CompletableQueue<T> : IDisposable
 {
     private readonly ConcurrentQueue<T> _queue = new();
-    private readonly AsyncManualResetEvent _hasWork = new();
+    private readonly AsyncManualResetEvent _hasWork;
     private readonly object _lock = new();
-    private bool _completed;
+    private readonly CancellationTokenSource _completed;
 
-    // Intentionally does not wake readers.
-    // ETL relies on enqueueing multiple items and waking once from WaitForGenerationAsync.
-    // Call Wake() explicitly after enqueue when immediate processing is required.
+    public CompletableQueue()
+    {
+        _completed = new CancellationTokenSource();
+        _hasWork = new AsyncManualResetEvent(_completed.Token);
+    }
+
     public bool TryEnqueue(T item)
     {
         lock (_lock)
         {
-            if (_completed)
+            if (_completed.IsCancellationRequested)
                 return false;
 
             _queue.Enqueue(item);
@@ -33,7 +37,10 @@ internal sealed class CompletableQueue<T>
     {
         lock (_lock)
         {
-            _completed = true;
+            if (_completed.IsCancellationRequested)
+                return;
+
+            _completed.Cancel();
         }
 
         _hasWork.Set();
@@ -45,23 +52,35 @@ internal sealed class CompletableQueue<T>
     {
         while (true)
         {
-            lock (_lock)
+            if (IsCompleted())
+                return _queue.IsEmpty == false;
+
+            try
             {
-                if (_completed)
-                    return _queue.IsEmpty == false;
+                await _hasWork.WaitAsync(token);
             }
 
-            await _hasWork.WaitAsync(token);
+            catch (OperationCanceledException) when (IsCompleted())
+            {
+                return _queue.IsEmpty == false;
+            }
+
             _hasWork.Reset();
 
-            lock (_lock)
-            {
-                if (_completed)
-                    return _queue.IsEmpty == false;
-
-                if (_queue.IsEmpty == false)
-                    return true;
-            }
+            if (_queue.IsEmpty == false)
+                return true;
         }
+    }
+
+    private bool IsCompleted()
+    {
+        // ReSharper disable once InconsistentlySynchronizedField
+        return _completed.IsCancellationRequested;
+    }
+
+    public void Dispose()
+    {
+        _hasWork.Dispose();
+        _completed.Dispose();
     }
 }

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -329,6 +329,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
             }
             finally
             {
+                _work.Dispose();
                 _taskIsRunning = 0; // only needed for debugging                
             }
         }
@@ -544,6 +545,8 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
             {
                 CancelWork(o);
             }
+
+            _work.Dispose();
         }
     }
 

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
 using Microsoft.IdentityModel.Protocols.Configuration;
 using Microsoft.SemanticKernel;
-using Nito.AsyncEx;
 using Raven.Client;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Indexes.Vector;
@@ -40,8 +39,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
     private const string EmbeddingAttachmentContentType = "application/octet-stream";
     private readonly Mode _mode = mode;
     private readonly ConcurrentDictionary<EmbeddingsGenerationTaskIdentifier, AiWorker> _workers = [];
-    private readonly ConcurrentQueue<IEmbeddingsCommand> _work = new();
-    private readonly AsyncManualResetEvent _hasWork = new();
+    private readonly CompletableQueue<IEmbeddingsCommand> _work = new();
     private readonly RavenLogger _logger = logger;
     private readonly DocumentDatabase _database = database;
 
@@ -86,8 +84,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
         private readonly AiConnectionString _connectionString;
         private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerationService;
         private readonly CancellationToken _cancellationToken;
-        private readonly AsyncManualResetEvent _hasWork = new();
-        private readonly ConcurrentQueue<GenerateEmbeddings> _work = new();
+        private readonly CompletableQueue<GenerateEmbeddings> _work = new();
         private readonly ConcurrentDictionary<string, GenerateEmbeddings> _inFlightCache = new(StringComparer.OrdinalIgnoreCase);
         private readonly SizeLimitedConcurrentDictionary<string, int> _prefixTokenCounts = new(PrefixTokenCountsCacheSize, StringComparer.Ordinal);
         private readonly Task[] _tasks;
@@ -235,7 +232,11 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
             var inCacheGen = _inFlightCache.GetOrAdd(value, newGen);
             if (newGen == inCacheGen)
             {
-                _work.Enqueue(newGen);
+                if (_work.TryEnqueue(newGen) == false)
+                {
+                    RemoveFromCache(value);
+                    newGen.TaskCompletionSource.TrySetCanceled(_cancellationToken);
+                }
             }
             return inCacheGen;
         }
@@ -244,6 +245,8 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
         {
             _inFlightCache.TryRemove(value, out _);   
         }
+
+        public void Wake() => _work.Wake();
         
         private bool TryGetFromCache(DocumentsOperationContext documentsContext, string text,
             TimeSpan cacheDuration, ref List<(string, string)> expirationRefresh, out ReadOnlyMemory<byte> result)
@@ -302,12 +305,20 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
         public async Task ShutdownAsync()
         {
             _shutdown.Cancel(false);
+            _work.Complete();
             try
             {
                 while (_work.TryDequeue(out var work))
                 {
-                    work.TaskCompletionSource.SetCanceled(_shutdown.Token);
+                    work.TaskCompletionSource.TrySetCanceled(_shutdown.Token);
                 }
+
+                foreach (var c in _inFlightCache)
+                {
+                    c.Value.TaskCompletionSource.TrySetCanceled(_shutdown.Token);
+                }
+
+                _inFlightCache.Clear();
 
                 await Task.WhenAll(_tasks);
             }
@@ -327,43 +338,46 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
             if (Interlocked.Increment(ref _taskIsRunning) != 1)
                 return; // we may race to start it, so we skip the next one
 
-            while (_cancellationToken.IsCancellationRequested == false)
+            try
             {
-                await _hasWork.WaitAsync(_cancellationToken);
-                _hasWork.Reset();
-
-                List<string> batch = [];
-                List<List<ReadOnlyMemory<byte>>> embeddings = [];
-                List<GenerateEmbeddings> works = [];
-
-                while (_work.TryDequeue(out var work))
+                while (await _work.WaitToReadAsync(_cancellationToken))
                 {
-                    for (int i = 0; i < work.Values.Count; i++)
+                    List<string> batch = [];
+                    List<List<ReadOnlyMemory<byte>>> embeddings = [];
+                    List<GenerateEmbeddings> works = [];
+
+                    while (_work.TryDequeue(out var work))
                     {
-                        batch.Add(work.Values[i]);
-                        // we add the embedding list multiple times, to make it
-                        // easier to track which results list each value belongs to
-                        embeddings.Add(work.Embeddings);
+                        for (int i = 0; i < work.Values.Count; i++)
+                        {
+                            batch.Add(work.Values[i]);
+                            // we add the embedding list multiple times, to make it
+                            // easier to track which results list each value belongs to
+                            embeddings.Add(work.Embeddings);
+                        }
+
+                        works.Add(work);
+                        if (batch.Count >= _maxBatchSize)
+                        {
+                            _work.Wake();
+                            break;
+                        }
                     }
 
-                    works.Add(work);
-                    if (batch.Count >= _maxBatchSize)
-                    {
-                        Wake();
-                        break;
-                    }
+                    if (works.Count is 0)
+                        continue;
+
+                    // GetAvailableTaskIndexAsync is ensuring that we aren't running
+                    // too many concurrent tasks, while the actual batch itself
+                    // is running in the background
+                    int index = await GetAvailableTaskIndexAsync();
+                    _tasks[index] = FlushBatchAsync(batch, embeddings, works);
                 }
-
-                if (works.Count is 0)
-                    continue;
-
-                // GetAvailableTaskIndexAsync is ensuring that we aren't running
-                // too many concurrent tasks, while the actual batch itself
-                // is running in the background
-                int index = await GetAvailableTaskIndexAsync();
-                _tasks[index] = FlushBatchAsync(batch, embeddings, works);
             }
-        } 
+            catch (OperationCanceledException)
+            {
+            }
+        }
         private async Task FlushBatchAsync(List<string> batch, List<List<ReadOnlyMemory<byte>>> embeddings, List<GenerateEmbeddings> works)
         {
             try
@@ -372,6 +386,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
 
                 try
                 {
+                    _parent._forTestingPurposes?.OnGenerateBatch?.Invoke(batch.Count);
                     allEmbeddings = await _embeddingGenerationService.GenerateAsync(batch, cancellationToken: _cancellationToken);
                 }
                 catch (HttpOperationException httpOperationException) when (httpOperationException.StatusCode == HttpStatusCode.TooManyRequests)
@@ -429,16 +444,36 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                    _connectionString.Compare(updateConnectionString) != AiSettingsCompareDifferences.None;
         }
 
-        public void Wake()
-        {
-            _hasWork.Set();
-        }
     }
     
-    private void ProcessInBackground(IEmbeddingsCommand works)
+    private void ProcessInBackground(IEmbeddingsCommand work)
     {
-        _work.Enqueue(works);
-        _hasWork.Set();
+        if (_work.TryEnqueue(work))
+        {
+            _work.Wake();
+            return;
+        }
+
+        CancelWork(work);
+    }
+
+    private static void CancelWork(IEmbeddingsCommand work)
+    {
+        switch (work)
+        {
+            case StoreEmbeddingCacheDocuments se:
+                foreach (GenerateEmbeddings ge in se.GeneratedEmbeddings)
+                {
+                    ge.TaskCompletionSource.TrySetCanceled();
+                    ge.Owner.RemoveFromCache(ge.CacheKey);
+                }
+                break;
+            case BatchGenerator bg:
+                bg.DocumentEmbeddingsStorageTcs.TrySetCanceled();
+                break;
+            case RefreshCache:
+                break;
+        }
     }
 
     private AiWorker CreateAiWorker(DatabaseRecord record, EmbeddingsGenerationConfiguration configuration)
@@ -478,10 +513,8 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
     {
         try
         {
-            while (CancellationToken.IsCancellationRequested == false)
+            while (await _work.WaitToReadAsync(CancellationToken))
             {
-                await _hasWork.WaitAsync(CancellationToken);
-                _hasWork.Reset();
                 await SubmitAndWaitForWorkAsync(GetBatch());
             }
         }
@@ -504,15 +537,12 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                 // we don't care about an error here
             }
             
+            _forTestingPurposes?.BeforeShutdownDrain?.Invoke();
+
+            _work.Complete();
             while (_work.TryDequeue(out IEmbeddingsCommand o))
             {
-                if (o is not StoreEmbeddingCacheDocuments se) 
-                    continue;
-                
-                foreach (GenerateEmbeddings ge in se.GeneratedEmbeddings)
-                {
-                    ge.TaskCompletionSource.TrySetCanceled();
-                }
+                CancelWork(o);
             }
         }
     }
@@ -592,7 +622,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
             results.Add(o);
             if (results.Count > 128)
             {
-                _hasWork.Set();
+                _work.Wake();
                 break;
             }
         }
@@ -780,6 +810,8 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
             throw new InvalidQueryException($"Couldn't find Embeddings Generation task with '{taskId.Value}' identifier");
         }
 
+        _forTestingPurposes?.AfterWorkerResolvedForQuery?.Invoke();
+
         if (values.Length == 1)
         {
             return worker.GetEmbeddingsForQueryAsync(documentsContext, values[0]);
@@ -844,10 +876,10 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
             _results.Add(putDocumentEmbeddings);
         }
 
-        public async Task WaitForGenerationAsync()
+        public Task WaitForGenerationAsync()
         {
             _worker.Wake();
-            await Task.WhenAll(_tasks);
+            return Task.WhenAll(_tasks);
         }
 
         public Task StoreDocumentEmbeddingsAsync()
@@ -1012,4 +1044,27 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
     }
 
     public BatchGenerator BatchFor(EmbeddingsGenerationTaskIdentifier taskId) => new (this, taskId);
+
+    private TestingStuff _forTestingPurposes;
+
+    internal TestingStuff ForTestingPurposesOnly()
+    {
+        if (_forTestingPurposes != null)
+            return _forTestingPurposes;
+
+        return _forTestingPurposes = new TestingStuff();
+    }
+
+    internal sealed class TestingStuff
+    {
+        internal TestingStuff()
+        {
+        }
+
+        internal Action AfterWorkerResolvedForQuery;
+
+        internal Action BeforeShutdownDrain;
+
+        internal Action<int> OnGenerateBatch;
+    }
 }

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_26416.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_26416.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Server.Documents.AI;
+using Raven.Server.Documents.AI.Embeddings;
+using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.Embeddings;
+
+public class RavenDB_26416(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
+    public async Task QueryEmbeddings_WhenWorkerIsShutDownByRecordChangeWhileEnqueuing_ShouldNotHangForever()
+    {
+        using var store = GetDocumentStore();
+
+        var (configuration, _) = AddEmbeddingsGenerationTask(store,
+            embeddingsPaths: [new EmbeddingPathConfiguration { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
+
+        var (queriesWorkerRegistered, _) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+
+        var database = await GetDatabase(store.Database);
+        var generator = database.EmbeddingsGeneratorQueries;
+        var taskId = new EmbeddingsGenerationTaskIdentifier(configuration.Identifier);
+
+        var recordWithoutTask = database.ReadDatabaseRecord();
+        recordWithoutTask.EmbeddingsGenerations.Clear();
+
+        var alreadyFired = false;
+        generator.ForTestingPurposesOnly().AfterWorkerResolvedForQuery = () =>
+        {
+            if (alreadyFired)
+                return;
+            alreadyFired = true;
+
+            generator.HandleDatabaseRecordChange(recordWithoutTask);
+        };
+
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        using (context.OpenReadTransaction())
+        {
+            var queryTask = generator
+                .GetEmbeddingsForQueryAsync(context, taskId, "some text that is not in the embeddings cache")
+                .AsTask();
+
+            try
+            {
+                await queryTask.WaitAsync(TimeSpan.FromSeconds(15));
+                Assert.Fail("Expected OperationCanceledException: the worker was shut down before the query enqueued, " +
+                            "so the enqueue is rejected and the query must surface cancellation (RavenDB-26416).");
+            }
+            catch (OperationCanceledException)
+            {
+                // expected: the rejected enqueue cancels the query's TaskCompletionSource
+            }
+            catch (TimeoutException)
+            {
+                Assert.Fail("Querying for embeddings hung forever: HandleDatabaseRecordChange shut the worker down " +
+                            "while a query thread was still adding work to it, leaving its TaskCompletionSource never " +
+                            "completed (RavenDB-26416).");
+            }
+        }
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Etl, RavenArchitecture.AllX64)]
+    public async Task StoreDocumentEmbeddings_WhenGeneratorShutsDownWithPendingStore_ShouldNotHangForever()
+    {
+        using var store = GetDocumentStore();
+
+        var (configuration, _) = AddEmbeddingsGenerationTask(store,
+            embeddingsPaths: [new EmbeddingPathConfiguration { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
+
+        var database = await GetDatabase(store.Database);
+        var taskId = new EmbeddingsGenerationTaskIdentifier(configuration.Identifier);
+
+        using var generator = new EmbeddingsGenerator(database, database.Loggers.GetLogger<EmbeddingsGenerator>(),
+            database.DatabaseShutdown, EmbeddingsGenerator.Mode.Etl);
+
+        var storeTaskReady = new TaskCompletionSource<Task>(TaskCreationOptions.RunContinuationsAsynchronously);
+        generator.ForTestingPurposesOnly().BeforeShutdownDrain = () =>
+        {
+            var batch = generator.BatchFor(taskId);
+            storeTaskReady.TrySetResult(batch.StoreDocumentEmbeddingsAsync());
+        };
+
+        generator.Start(); // InitializeWork -> HandleDatabaseRecordChange -> creates the worker for the task
+        Assert.True(await WaitForValueAsync(() => generator.EmbeddingTaskExists(taskId), true),
+            "the embeddings worker did not register on the standalone generator");
+
+        generator.Stop(); // cancels the generator; DoWork exits and its finally fires BeforeShutdownDrain
+
+        var storeTask = await storeTaskReady.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        try
+        {
+            await storeTask.WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        catch (OperationCanceledException)
+        {
+            // expected: shutting down cancels the pending store. The point is it did not hang.
+        }
+        catch (TimeoutException)
+        {
+            Assert.Fail("StoreDocumentEmbeddingsAsync hung forever on shutdown: the generator's pending store " +
+                        "request (DocumentEmbeddingsStorageTcs) was never completed (RavenDB-26416, parent store-phase).");
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Vector)]
+    public void CompletableQueue_RejectsEnqueueAfterComplete_ButStillDrainsExistingItems()
+    {
+        var queue = new CompletableQueue<int>();
+
+        Assert.True(queue.TryEnqueue(1));
+
+        queue.Complete();
+
+        // rejected after Complete() - this is what lets a producer cancel its own awaiter instead of hanging (RavenDB-26416)
+        Assert.False(queue.TryEnqueue(2));
+
+        // an item enqueued before Complete() is still drainable; the rejected one never entered
+        Assert.True(queue.TryDequeue(out var drained));
+        Assert.Equal(1, drained);
+        Assert.False(queue.TryDequeue(out _));
+
+        // completed and drained -> WaitToReadAsync returns false, which is what makes the consumer loops exit
+        Assert.False(queue.WaitToReadAsync().AsTask().GetAwaiter().GetResult());
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Etl, RavenArchitecture.AllX64)]
+    public async Task StoreDocumentEmbeddings_WhenSubmittedAfterGeneratorShutdown_IsCancelledNotHung()
+    {
+        using var store = GetDocumentStore();
+
+        var (configuration, _) = AddEmbeddingsGenerationTask(store,
+            embeddingsPaths: [new EmbeddingPathConfiguration { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
+
+        var database = await GetDatabase(store.Database);
+        var taskId = new EmbeddingsGenerationTaskIdentifier(configuration.Identifier);
+
+        using var generator = new EmbeddingsGenerator(database, database.Loggers.GetLogger<EmbeddingsGenerator>(),
+            database.DatabaseShutdown, EmbeddingsGenerator.Mode.Etl);
+
+        generator.Start();
+        Assert.True(await WaitForValueAsync(() => generator.EmbeddingTaskExists(taskId), true),
+            "the embeddings worker did not register on the standalone generator");
+
+        generator.Stop(); // DoWork's finally Complete()s the parent queue and drains it
+
+        var storeTask = generator.BatchFor(taskId).StoreDocumentEmbeddingsAsync();
+
+        try
+        {
+            await storeTask.WaitAsync(TimeSpan.FromSeconds(15));
+            Assert.Fail("Expected OperationCanceledException: a store request submitted after shutdown must be cancelled (RavenDB-26416).");
+        }
+        catch (OperationCanceledException)
+        {
+            // expected
+        }
+        catch (TimeoutException)
+        {
+            Assert.Fail("StoreDocumentEmbeddingsAsync hung after the generator was stopped (RavenDB-26416, parent store-phase).");
+        }
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Etl, RavenArchitecture.AllX64)]
+    public async Task EtlBatch_WithMultipleNewEmbeddings_IsGeneratedInOneModelCall()
+    {
+        using var store = GetDocumentStore();
+
+        var database = await GetDatabase(store.Database);
+        var batchSizes = new ConcurrentBag<int>();
+        database.EmbeddingsGeneratorEtl.ForTestingPurposesOnly().OnGenerateBatch = count => batchSizes.Add(count);
+
+        const int docs = 3;
+        using (var session = store.OpenSession())
+        {
+            for (int i = 0; i < docs; i++)
+                session.Store(new EmbeddingsBatchDoc { TextualValue = $"value-{i}" });
+            session.SaveChanges();
+        }
+
+        AddEmbeddingsGenerationTask(store,
+            embeddingsPaths: [new EmbeddingPathConfiguration { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }],
+            collectionName: "EmbeddingsBatchDocs");
+
+        // the whole ETL batch is one work unit -> a single GenerateAsync call (RavenDB-26416)
+        Assert.Equal(docs, await WaitForValueAsync(() => batchSizes.Sum(), docs, timeout: (int)DefaultEtlTimeout.TotalMilliseconds));
+        Assert.Equal(1, batchSizes.Count);
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Etl, RavenArchitecture.AllX64)]
+    public async Task EtlBatch_LargerThanMaxBatchSize_IsSplitIntoCeilingNumberOfCalls()
+    {
+        using var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record => record.Settings["Ai.Embeddings.MaxBatchSize"] = "2"
+        });
+
+        var database = await GetDatabase(store.Database);
+        var batchSizes = new ConcurrentBag<int>();
+        database.EmbeddingsGeneratorEtl.ForTestingPurposesOnly().OnGenerateBatch = count => batchSizes.Add(count);
+
+        const int docs = 5;
+        using (var session = store.OpenSession())
+        {
+            for (int i = 0; i < docs; i++)
+                session.Store(new EmbeddingsBatchDoc { TextualValue = $"value-{i}" });
+            session.SaveChanges();
+        }
+
+        AddEmbeddingsGenerationTask(store,
+            embeddingsPaths: [new EmbeddingPathConfiguration { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }],
+            collectionName: "EmbeddingsBatchDocs");
+
+        // each doc is a single chunk, so the cap (a per-work-item threshold) splits the 5 into ceil(5/2) = 3 calls
+        Assert.Equal(docs, await WaitForValueAsync(() => batchSizes.Sum(), docs, timeout: (int)DefaultEtlTimeout.TotalMilliseconds));
+        Assert.Equal(3, batchSizes.Count);
+        Assert.True(batchSizes.All(size => size <= 2), "with single-chunk work items every call stays within maxBatchSize");
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Etl, RavenArchitecture.AllX64)]
+    public async Task SingleEmbeddingWithMoreChunksThanMaxBatchSize_IsSentAtomicallyInOneCall()
+    {
+        // maxBatchSize is a per-work-item threshold (existing v7.2 behavior), not a strict cap on input values:
+        // one source value's chunks are always sent in a single GenerateAsync call, even when they exceed the cap.
+        var chunking = new ChunkingOptions { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 1 };
+        var manyLines = string.Join("\n", Enumerable.Range(0, 12).Select(i => $"distinctword{i:D3}value"));
+        var expectedChunks = TextChunker.Chunk(manyLines, chunking).Count(c => string.IsNullOrWhiteSpace(c) == false);
+        Assert.True(expectedChunks > 2, $"test setup must produce more chunks than maxBatchSize; got {expectedChunks}");
+
+        using var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record => record.Settings["Ai.Embeddings.MaxBatchSize"] = "2"
+        });
+
+        var database = await GetDatabase(store.Database);
+        var batchSizes = new ConcurrentBag<int>();
+        database.EmbeddingsGeneratorEtl.ForTestingPurposesOnly().OnGenerateBatch = count => batchSizes.Add(count);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new EmbeddingsBatchDoc { TextualValue = manyLines });
+            session.SaveChanges();
+        }
+
+        AddEmbeddingsGenerationTask(store,
+            embeddingsPaths: [new EmbeddingPathConfiguration { Path = "TextualValue", ChunkingOptions = chunking }],
+            collectionName: "EmbeddingsBatchDocs");
+
+        // one field = one GenerateEmbeddings of all its chunks -> a single atomic call that exceeds the cap, never split
+        Assert.Equal(expectedChunks, await WaitForValueAsync(() => batchSizes.Sum(), expectedChunks, timeout: (int)DefaultEtlTimeout.TotalMilliseconds));
+        Assert.Equal(1, batchSizes.Count);
+        Assert.True(batchSizes.Single() > 2, $"a single work item must not be split by maxBatchSize; expected one call of {expectedChunks}");
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
+    public async Task Query_IsGeneratedEagerlyAsAUnitOfOne()
+    {
+        using var store = GetDocumentStore();
+
+        var (configuration, _) = AddEmbeddingsGenerationTask(store,
+            embeddingsPaths: [new EmbeddingPathConfiguration { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
+
+        var (queriesWorkerRegistered, _) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+
+        var database = await GetDatabase(store.Database);
+        var taskId = new EmbeddingsGenerationTaskIdentifier(configuration.Identifier);
+
+        var batchSizes = new ConcurrentBag<int>();
+        database.EmbeddingsGeneratorQueries.ForTestingPurposesOnly().OnGenerateBatch = count => batchSizes.Add(count);
+
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        using (context.OpenReadTransaction())
+        {
+            await database.EmbeddingsGeneratorQueries
+                .GetEmbeddingsForQueryAsync(context, taskId, "a query value that is not in the cache")
+                .AsTask();
+        }
+
+        Assert.Equal(1, batchSizes.Count);
+        Assert.Equal(1, batchSizes.Single());
+    }
+    private sealed class EmbeddingsBatchDoc
+    {
+        public string Id { get; set; }
+        public string TextualValue { get; set; }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_26416.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_26416.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.Documents.AI;
@@ -131,6 +132,56 @@ public class RavenDB_26416(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
         // completed and drained -> WaitToReadAsync returns false, which is what makes the consumer loops exit
         Assert.False(queue.WaitToReadAsync().AsTask().GetAwaiter().GetResult());
+    }
+
+    [RavenFact(RavenTestCategory.Vector)]
+    public async Task CompletableQueue_CompleteWhileWaiting_ReturnsQueueState_WithoutLeakingCancellation()
+    {
+        // empty queue, a reader is waiting, then Complete() -> returns false (not an OperationCanceledException)
+        var empty = new CompletableQueue<int>();
+        var waitOnEmpty = empty.WaitToReadAsync().AsTask();
+        Assert.False(waitOnEmpty.IsCompleted); // genuinely parked on the event
+
+        empty.Complete();
+        Assert.False(await waitOnEmpty.WaitAsync(TimeSpan.FromSeconds(5)));
+
+        // items still queued at Complete() -> the reader returns true and can drain them, then the next wait returns false
+        var withItem = new CompletableQueue<int>();
+        Assert.True(withItem.TryEnqueue(42));
+        withItem.Complete();
+
+        Assert.True(await withItem.WaitToReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.True(withItem.TryDequeue(out var drained));
+        Assert.Equal(42, drained);
+        Assert.False(await withItem.WaitToReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [RavenFact(RavenTestCategory.Vector)]
+    public async Task CompletableQueue_ExternalCancellation_WhenNotCompleted_Propagates()
+    {
+        var queue = new CompletableQueue<int>();
+        using var cts = new CancellationTokenSource();
+
+        var wait = queue.WaitToReadAsync(cts.Token).AsTask();
+        Assert.False(wait.IsCompleted);
+
+        // the queue is NOT completed - a caller's own cancellation must surface as OperationCanceledException,
+        // not be swallowed by the completion path
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [RavenFact(RavenTestCategory.Vector)]
+    public void CompletableQueue_StaleCallsAfterCompleteAndDispose_DoNotThrow()
+    {
+        // a stale reference to a removed/shut-down worker may still call TryEnqueue/Wake even after Dispose();
+        // those must be safe (reject / no-op), never ObjectDisposedException
+        var queue = new CompletableQueue<int>();
+        queue.Complete();
+        queue.Dispose();
+
+        Assert.False(queue.TryEnqueue(1));
+        queue.Wake();
     }
 
     [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Etl, RavenArchitecture.AllX64)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26416

### Additional description

Fixes two embeddings shutdown races that could leave callers waiting forever on an unfinished `TaskCompletionSource`.

First, a query/document producer could resolve an old worker, race with `HandleDatabaseRecordChange()` shutting that worker down, and then enqueue into a queue that had already been drained. The worker queue now uses `CompletableQueue<T>`/`Channel<T>`, so `Complete()` rejects late enqueues and the producer cancels its own awaiter and cleans in-flight state.

Second, parent/background embedding commands could be queued or submitted during generator shutdown and leave `BatchGenerator.DocumentEmbeddingsStorageTcs` unfinished. Those commands are now canceled both when drained during shutdown and when rejected after the parent queue is completed.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
