### PR TITLE
RavenDB-26295 Sink tombstone retention used per-node state instead of the shared cluster cursor, causing inconsistent cleanup

### DIFF
--- a/src/Raven.Server/Documents/OngoingTasks/AbstractOngoingTasks.cs
+++ b/src/Raven.Server/Documents/OngoingTasks/AbstractOngoingTasks.cs
@@ -624,8 +624,8 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
             AccessName = sinkReplication.AccessName,
             AllowedHubToSinkPaths = sinkReplication.AllowedHubToSinkPaths,
             AllowedSinkToHubPaths = sinkReplication.AllowedSinkToHubPaths,
-            HubCursor = ReplicationUtils.ReadCursorFromClusterFor(_server, databaseRecord.DatabaseName, sinkReplication.TaskId, ExternalReplicationState.ReplicationStateType.HubCursor, context),
-            SinkCursor = ReplicationUtils.ReadCursorFromClusterFor(_server, databaseRecord.DatabaseName, sinkReplication.TaskId, ExternalReplicationState.ReplicationStateType.SinkCursor, context),
+            HubCursor = ReplicationUtils.ReadCursorFromClusterFor(context, _server, databaseRecord.DatabaseName, sinkReplication.TaskId, ExternalReplicationState.ReplicationStateType.HubCursor),
+            SinkCursor = ReplicationUtils.ReadCursorFromClusterFor(context, _server, databaseRecord.DatabaseName, sinkReplication.TaskId, ExternalReplicationState.ReplicationStateType.SinkCursor),
             Error = error
         };
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -123,7 +123,7 @@ namespace Raven.Server.Documents.Replication
             DatabaseTopology topology;
             long minEtag = long.MaxValue;
 
-            using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            using (_server.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
                 var dbRecord = _server.Cluster.ReadRawDatabaseRecord(ctx, Database.Name);
@@ -133,10 +133,22 @@ namespace Raven.Server.Documents.Replication
                 {
                     foreach (var external in externals)
                     {
-                        var state = GetExternalReplicationState(_server, Database.Name, external.TaskId, ctx);
+                        var state = GetExternalReplicationState(ctx, _server, Database.Name, external.TaskId);
                         var myEtag = ChangeVectorUtils.GetEtagById(state.SourceChangeVector, Database.DbBase64Id);
                         minEtag = Math.Min(myEtag, minEtag);
                         AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, external.Name, myEtag, ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication);
+                    }
+                }
+
+                var sinkPullReplications = dbRecord.SinkPullReplications;
+                if (sinkPullReplications != null)
+                {
+                    foreach (var sink in sinkPullReplications)
+                    {
+                        var sinkCursor = ReplicationUtils.ReadCursorFromClusterFor(ctx, _server, Database.Name, sink.TaskId, ExternalReplicationState.ReplicationStateType.SinkCursor);
+                        var myEtag = ChangeVectorUtils.GetEtagById(sinkCursor, Database.DbBase64Id);
+                        minEtag = Math.Min(myEtag, minEtag);
+                        AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, sink.Name, myEtag, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsSink);
                     }
                 }
             }
@@ -1138,14 +1150,14 @@ namespace Raven.Server.Documents.Replication
         
         public static ExternalReplicationState GetExternalReplicationState(ServerStore server, string database, long taskId)
         {
-            using (server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (server.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
-                return GetExternalReplicationState(server, database, taskId, context);
+                return GetExternalReplicationState(context, server, database, taskId);
             }
         }
 
-        private static ExternalReplicationState GetExternalReplicationState(ServerStore server, string database, long taskId, TransactionOperationContext context)
+        private static ExternalReplicationState GetExternalReplicationState(ClusterOperationContext context, ServerStore server, string database, long taskId)
         {
             var stateBlittable = server.Cluster.Read(context, ExternalReplicationState.GenerateItemName(database, taskId));
 

--- a/src/Raven.Server/Utils/ReplicationUtils.cs
+++ b/src/Raven.Server/Utils/ReplicationUtils.cs
@@ -86,11 +86,11 @@ namespace Raven.Server.Utils
             using (serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
-                return ReadCursorFromClusterFor(serverStore, databaseName, taskId, type, context);
+                return ReadCursorFromClusterFor(context, serverStore, databaseName, taskId, type);
             }
         }
 
-        public static string ReadCursorFromClusterFor(ServerStore serverStore, string databaseName, long taskId, ExternalReplicationState.ReplicationStateType type, ClusterOperationContext context)
+        public static string ReadCursorFromClusterFor(ClusterOperationContext context, ServerStore serverStore, string databaseName, long taskId, ExternalReplicationState.ReplicationStateType type)
         {
             var key = ExternalReplicationState.GenerateItemName(databaseName, taskId, type);
             var stateBlittable = serverStore.Cluster.Read(context, key);

--- a/test/SlowTests.Issues/Issues/RavenDB-26295/FilteredPullDualClusterTestBase.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26295/FilteredPullDualClusterTestBase.cs
@@ -166,10 +166,20 @@ public abstract class FilteredPullDualClusterTestBase : ReplicationTestBase
     protected async Task<DualClusterLab> CreateDualClusterLabAsync(
         Options options,
         ClusterSide? filteredPassReceiveSide = null,
-        string itemName = null)
+        string itemName = null,
+        int hubNodeCount = 3,
+        int sinkNodeCount = 3)
     {
-        var hubCluster = await CreateTaggedClusterAsync(nodeTags: ["HA", "HB", "HC"]);
-        var sinkCluster = await CreateTaggedClusterAsync(nodeTags: ["SA", "SB", "SC"]);
+        if (hubNodeCount < 1 || hubNodeCount > NodesOnEachClusterSide.Length)
+            throw new ArgumentOutOfRangeException(nameof(hubNodeCount), hubNodeCount, $"Hub node count must be between 1 and {NodesOnEachClusterSide.Length}.");
+        if (sinkNodeCount < 1 || sinkNodeCount > NodesOnEachClusterSide.Length)
+            throw new ArgumentOutOfRangeException(nameof(sinkNodeCount), sinkNodeCount, $"Sink node count must be between 1 and {NodesOnEachClusterSide.Length}.");
+
+        var hubLabNodes = NodesOnEachClusterSide.Take(hubNodeCount).ToArray();
+        var sinkLabNodes = NodesOnEachClusterSide.Take(sinkNodeCount).ToArray();
+
+        var hubCluster = await CreateTaggedClusterAsync(hubLabNodes.Select(node => NodeTag(ClusterSide.Hub, node)).ToArray());
+        var sinkCluster = await CreateTaggedClusterAsync(sinkLabNodes.Select(node => NodeTag(ClusterSide.Sink, node)).ToArray());
         var hubAdminCertificate = RegisterClusterAdminCertificate(hubCluster);
         var sinkAdminCertificate = RegisterClusterAdminCertificate(sinkCluster);
 
@@ -178,11 +188,11 @@ public abstract class FilteredPullDualClusterTestBase : ReplicationTestBase
 
         var hubRecord = new DatabaseRecord(hubDatabaseName);
         DisableResolveToLatest(hubRecord);
-        await CreateDatabaseInCluster(hubRecord, replicationFactor: 3, leadersUrl: hubCluster.Leader.WebUrl, certificate: hubAdminCertificate);
+        await CreateDatabaseInCluster(hubRecord, replicationFactor: hubNodeCount, leadersUrl: hubCluster.Leader.WebUrl, certificate: hubAdminCertificate);
 
         var sinkRecord = new DatabaseRecord(sinkDatabaseName);
         DisableResolveToLatest(sinkRecord);
-        await CreateDatabaseInCluster(sinkRecord, replicationFactor: 3, leadersUrl: sinkCluster.Leader.WebUrl, certificate: sinkAdminCertificate);
+        await CreateDatabaseInCluster(sinkRecord, replicationFactor: sinkNodeCount, leadersUrl: sinkCluster.Leader.WebUrl, certificate: sinkAdminCertificate);
 
         var hubStores = Cluster.GetDocumentStores(
             hubCluster.Nodes,
@@ -198,16 +208,19 @@ public abstract class FilteredPullDualClusterTestBase : ReplicationTestBase
 
         var pullCertificate = Convert.ToBase64String(hubCluster.Certificates.ClientCertificate2.Value.Export(X509ContentType.Pfx));
 
-        var lab = new DualClusterLab(hubCluster, sinkCluster, hubDatabaseName, pullCertificate, filteredPassReceiveSide, itemName);
+        var lab = new DualClusterLab(hubCluster, sinkCluster, hubDatabaseName, sinkDatabaseName, pullCertificate, filteredPassReceiveSide, itemName);
 
-        foreach (var node in NodesOnEachClusterSide)
+        foreach (var node in hubLabNodes)
         {
             var hubServer = hubCluster.Nodes.Single(x => string.Equals(x.ServerStore.NodeTag, NodeTag(ClusterSide.Hub, node), StringComparison.OrdinalIgnoreCase));
-            var hubStore = hubStores[node switch { LabNode.A => 0, LabNode.B => 1, _ => 2 }];
+            var hubStore = hubStores[(int)node];
             lab.AddNode(ClusterSide.Hub, node, hubServer, hubStore, await GetDocumentDatabaseInstanceForAsync(hubDatabaseName, hubServer));
+        }
 
+        foreach (var node in sinkLabNodes)
+        {
             var sinkServer = sinkCluster.Nodes.Single(x => string.Equals(x.ServerStore.NodeTag, NodeTag(ClusterSide.Sink, node), StringComparison.OrdinalIgnoreCase));
-            var sinkStore = sinkStores[node switch { LabNode.A => 0, LabNode.B => 1, _ => 2 }];
+            var sinkStore = sinkStores[(int)node];
             lab.AddNode(ClusterSide.Sink, node, sinkServer, sinkStore, await GetDocumentDatabaseInstanceForAsync(sinkDatabaseName, sinkServer));
         }
 

--- a/test/SlowTests.Issues/Issues/RavenDB-26295/FilteredPullSinkClusterTombstoneTests.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26295/FilteredPullSinkClusterTombstoneTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Replication;
+using SlowTests.Issues.RavenDB_26295.Tools;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues.RavenDB_26295;
+
+public class FilteredPullSinkClusterTombstoneTests : FilteredPullDualClusterTestBase
+{
+    public FilteredPullSinkClusterTombstoneTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private const int TicketCount = 5;
+
+    [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Cluster | RavenTestCategory.Certificates)]
+    public async Task SinkClusterTombstones_ShouldStayIdentical_WhenSinkToHubChannelIsBroken()
+    {
+        // 1 hub node, 3 sink nodes. Sink->hub filtered replication pinned to sink node A.
+        await using var lab = await CreateDualClusterLabAsync(new Options(), hubNodeCount: 1, sinkNodeCount: 3);
+        await ConfigureSinkToHubReplicationAsync(lab, sinkOwner: LabNode.A, hubNode: LabNode.A);
+
+        var sinkNodes = NodesOnEachClusterSide; // A, B, C
+
+        // Store tickets on the sink owner and confirm the sink->hub channel works (docs reach the hub and every sink node).
+        for (var i = 0; i < TicketCount; i++)
+            await lab.StoreTicketAsync(ClusterSide.Sink, LabNode.A, $"tickets/{i}", $"ticket-{i}");
+
+        for (var i = 0; i < TicketCount; i++)
+        {
+            await lab.WaitForTicketAsync(ClusterSide.Hub, LabNode.A, $"tickets/{i}", $"ticket-{i}");
+            foreach (var node in sinkNodes)
+                await lab.WaitForTicketAsync(ClusterSide.Sink, node, $"tickets/{i}", $"ticket-{i}");
+        }
+
+        // Break the sink->hub channel by freezing the owning sink node's replication.
+        using var sinkToHubBreak = await BreakReplication(lab.GetServer(ClusterSide.Sink, LabNode.A).ServerStore, lab.SinkDatabaseName);
+
+        // Delete the documents on a different sink node so the tombstones spread cluster-wide through internal replication.
+        for (var i = 0; i < TicketCount; i++)
+            await lab.DeleteDocumentAsync(ClusterSide.Sink, LabNode.B, $"tickets/{i}");
+
+        // Wait until each sink node observes all tombstones (internal replication completed and was confirmed).
+        foreach (var node in sinkNodes)
+        {
+            var reached = await WaitForValueAsync(() => lab.GetNumberOfDocumentTombstones(ClusterSide.Sink, node), TicketCount, timeout: 30_000, interval: 100);
+            Assert.Equal(TicketCount, (int)reached);
+        }
+
+        // ---- Phase 1: channel broken -> every sink node retains the SAME, non-zero set ----
+        // The cleaner must not delete tombstones the hub has not confirmed yet - and that must hold on every node,
+        // not only the one that personally runs the outgoing sink->hub handler.
+        foreach (var node in sinkNodes)
+            await lab.RunTombstoneCleanupAsync(ClusterSide.Sink, node);
+
+        foreach (var node in sinkNodes)
+        {
+            var count = lab.GetNumberOfDocumentTombstones(ClusterSide.Sink, node);
+            Assert.True(
+                count == TicketCount,
+                $"While the sink->hub channel is broken every sink node must retain all {TicketCount} tombstones, " +
+                $"but {NodeTag(ClusterSide.Sink, node)} has {count}. Per-node: {SinkTombstoneReport(lab)}.");
+        }
+
+        // ---- Phase 2: mend the channel and let replication move forward -> tombstones get cleaned everywhere ----
+        sinkToHubBreak.Mend();
+
+        // Author a fresh ticket on every sink node and confirm it reaches the hub and all sinks. This advances each
+        // node's component in the sink cursor past the tombstone etags, which is what lets the cleaner release them.
+        foreach (var node in sinkNodes)
+            await lab.StoreTicketAsync(ClusterSide.Sink, node, $"tickets/after-mend-{node}", $"after-mend-{node}");
+
+        foreach (var authored in sinkNodes)
+        {
+            await lab.WaitForTicketAsync(ClusterSide.Hub, LabNode.A, $"tickets/after-mend-{authored}", $"after-mend-{authored}");
+            foreach (var node in sinkNodes)
+                await lab.WaitForTicketAsync(ClusterSide.Sink, node, $"tickets/after-mend-{authored}", $"after-mend-{authored}");
+        }
+
+        // Every sink node must now release the tombstones (the originals only - the fresh docs are live).
+        foreach (var node in sinkNodes)
+        {
+            long remaining = -1;
+            for (var attempt = 0; attempt < 30 && remaining != 0; attempt++)
+            {
+                await lab.RunTombstoneCleanupAsync(ClusterSide.Sink, node);
+                remaining = lab.GetNumberOfDocumentTombstones(ClusterSide.Sink, node);
+                if (remaining != 0)
+                    await Task.Delay(200);
+            }
+
+            Assert.True(
+                remaining == 0,
+                $"Once replication moved forward, {NodeTag(ClusterSide.Sink, node)} should clean its tombstones but still has {remaining}. " +
+                $"Per-node: {SinkTombstoneReport(lab)}.");
+        }
+    }
+
+    private static string SinkTombstoneReport(DualClusterLab lab) =>
+        string.Join(", ", NodesOnEachClusterSide.Select(node => $"{NodeTag(ClusterSide.Sink, node)}={lab.GetNumberOfDocumentTombstones(ClusterSide.Sink, node)}"));
+
+    // Scenario-specific wiring: a sink->hub-only filtered pull task pinned to one sink node, built from the lab's
+    // general connection inputs (stores, hub database, hub URLs, pull certificate).
+    private async Task ConfigureSinkToHubReplicationAsync(DualClusterLab lab, LabNode sinkOwner, LabNode hubNode)
+    {
+        var sinkStore = lab.GetStore(ClusterSide.Sink, sinkOwner);
+        var connectionStringName = $"sink-to-hub-{Guid.NewGuid():N}";
+
+        await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+        {
+            Name = connectionStringName,
+            Database = lab.HubDatabaseName,
+            TopologyDiscoveryUrls = [lab.GetServer(ClusterSide.Hub, hubNode).WebUrl]
+        }));
+
+        await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+        {
+            Name = connectionStringName,
+            ConnectionStringName = connectionStringName,
+            Mode = PullReplicationMode.SinkToHub,
+            HubName = HubName(hubNode),
+            AccessName = HubAccessName,
+            CertificateWithPrivateKey = lab.PullCertificate,
+            PinToMentorNode = true,
+            MentorNode = NodeTag(ClusterSide.Sink, sinkOwner),
+            AllowedSinkToHubPaths = ["tickets/*"]
+        }));
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB-26295/Tools/DualClusterLab.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26295/Tools/DualClusterLab.cs
@@ -34,6 +34,8 @@ public sealed class DualClusterLab : IAsyncDisposable
     private readonly Dictionary<string, IDocumentStore> _stores;
     private readonly Dictionary<string, RavenServer> _servers;
     private readonly Dictionary<string, DocumentDatabase> _databases;
+    private readonly List<LabNode> _hubNodes;
+    private readonly List<LabNode> _sinkNodes;
     private readonly List<LogicalInternalReplicationBlocker> _internalReplicationBlockers;
     private readonly List<IDisposable> _testingHookScopes;
     private Func<ClusterSide, LabNode, Task> _waitForExpectedFilteredRoundTripItemAsync;
@@ -46,6 +48,7 @@ public sealed class DualClusterLab : IAsyncDisposable
         TaggedCluster hubCluster,
         TaggedCluster sinkCluster,
         string hubDatabaseName,
+        string sinkDatabaseName,
         string pullCertificate,
         ClusterSide? filteredPassReceiveSide,
         string itemName)
@@ -53,6 +56,7 @@ public sealed class DualClusterLab : IAsyncDisposable
         HubCluster = hubCluster;
         SinkCluster = sinkCluster;
         HubDatabaseName = hubDatabaseName;
+        SinkDatabaseName = sinkDatabaseName;
         PullCertificate = pullCertificate;
         FilteredPassReceiveSide = filteredPassReceiveSide;
         FilteredRoundTripItemName = itemName;
@@ -82,6 +86,8 @@ public sealed class DualClusterLab : IAsyncDisposable
         _stores = new Dictionary<string, IDocumentStore>(StringComparer.OrdinalIgnoreCase);
         _servers = new Dictionary<string, RavenServer>(StringComparer.OrdinalIgnoreCase);
         _databases = new Dictionary<string, DocumentDatabase>(StringComparer.OrdinalIgnoreCase);
+        _hubNodes = [];
+        _sinkNodes = [];
         _internalReplicationBlockers = [];
         _testingHookScopes = [];
     }
@@ -94,9 +100,11 @@ public sealed class DualClusterLab : IAsyncDisposable
 
     private TestCertificatesHolder SinkCertificates => SinkCluster.Certificates;
 
-    private string HubDatabaseName { get; }
+    public string HubDatabaseName { get; }
 
-    private string PullCertificate { get; }
+    public string SinkDatabaseName { get; }
+
+    public string PullCertificate { get; }
 
     private ClusterSide? FilteredPassReceiveSide { get; }
 
@@ -134,9 +142,14 @@ public sealed class DualClusterLab : IAsyncDisposable
         _servers[key] = server;
         _stores[key] = store;
         _databases[key] = database;
+        (side == ClusterSide.Hub ? _hubNodes : _sinkNodes).Add(node);
     }
 
     private IDocumentStore Store(ClusterSide side, LabNode node) => _stores[Key(side, node)];
+
+    public IDocumentStore GetStore(ClusterSide side, LabNode node) => Store(side, node);
+
+    private IReadOnlyList<LabNode> NodesOf(ClusterSide side) => side == ClusterSide.Hub ? _hubNodes : _sinkNodes;
 
     public async Task SeedInternalReplicationAsync()
     {
@@ -146,7 +159,8 @@ public sealed class DualClusterLab : IAsyncDisposable
 
     private async Task SeedInternalReplicationAsync(ClusterSide side)
     {
-        foreach (var node in NodesOnEachClusterSide)
+        var nodes = NodesOf(side);
+        foreach (var node in nodes)
         {
             var nodeTag = NodeTagLower(side, node);
             var documentId = $"tickets/internal-replication-seed/from-{nodeTag}";
@@ -154,7 +168,7 @@ public sealed class DualClusterLab : IAsyncDisposable
 
             await StoreTicketAsync(side, node, documentId, name);
 
-            foreach (var other in NodesOnEachClusterSide.Where(x => x != node))
+            foreach (var other in nodes.Where(x => x != node))
                 await WaitForDocumentNameByIdAsync(side, other, documentId, name, DefaultReplicationWaitTimeout);
         }
     }
@@ -167,11 +181,12 @@ public sealed class DualClusterLab : IAsyncDisposable
 
     private async Task WaitForInternalHandlersAsync(ClusterSide side)
     {
-        foreach (var node in NodesOnEachClusterSide)
+        var nodes = NodesOf(side);
+        foreach (var node in nodes)
         {
             var ready = await WaitForValueAsync(
                 () => Database(side, node).ReplicationLoader.OutgoingHandlers
-                    .Count(x => x.Destination is InternalReplication) >= 2,
+                    .Count(x => x.Destination is InternalReplication) >= nodes.Count - 1,
                 expectedVal: true,
                 timeout: (int)DefaultReplicationWaitTimeout.TotalMilliseconds,
                 interval: 100);
@@ -198,7 +213,7 @@ public sealed class DualClusterLab : IAsyncDisposable
 
     public async Task ConfigurePerNodeHubDefinitionsAsync()
     {
-        foreach (var node in NodesOnEachClusterSide)
+        foreach (var node in NodesOf(ClusterSide.Hub))
         {
             var hubDefinition = new PullReplicationDefinition
             {
@@ -224,6 +239,8 @@ public sealed class DualClusterLab : IAsyncDisposable
     }
 
     private RavenServer Server(ClusterSide side, LabNode node) => _servers[Key(side, node)];
+
+    public RavenServer GetServer(ClusterSide side, LabNode node) => Server(side, node);
 
     private DocumentDatabase Database(ClusterSide side, LabNode node) => _databases[Key(side, node)];
 
@@ -752,12 +769,33 @@ public sealed class DualClusterLab : IAsyncDisposable
         _allowedTicketThenFilteredOutUserStored = true;
     }
 
-    private async Task StoreTicketAsync(ClusterSide side, LabNode node, string documentId, string name)
+    public async Task StoreTicketAsync(ClusterSide side, LabNode node, string documentId, string name)
     {
         using var session = Store(side, node).OpenAsyncSession();
         await session.StoreAsync(new Ticket { Name = name }, documentId);
         await session.SaveChangesAsync();
     }
+
+    public async Task DeleteDocumentAsync(ClusterSide side, LabNode node, string documentId)
+    {
+        using var session = Store(side, node).OpenAsyncSession();
+        session.Delete(documentId);
+        await session.SaveChangesAsync();
+    }
+
+    public Task WaitForTicketAsync(ClusterSide side, LabNode node, string documentId, string expectedName, TimeSpan? timeout = null) =>
+        WaitForDocumentNameByIdAsync(side, node, documentId, expectedName, timeout);
+
+    public long GetNumberOfDocumentTombstones(ClusterSide side, LabNode node)
+    {
+        var database = Database(side, node);
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        using (context.OpenReadTransaction())
+            return database.DocumentsStorage.GetNumberOfTombstones(context);
+    }
+
+    public Task RunTombstoneCleanupAsync(ClusterSide side, LabNode node) =>
+        Database(side, node).TombstoneCleaner.ExecuteCleanup();
 
     private async Task StoreUserAsync(ClusterSide side, LabNode node, string documentId, string name)
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26295

### Additional description

In a filtered hub-sink cluster, tombstone retention for the sink→hub channel relied on per-node in-memory state (`_lastSendEtagPerDestination`), which only exists on the node running the outgoing handler. When the channel broke, that node held its tombstones while the other sink nodes' cleaner deleted theirs — leaving tombstone counts diverging across the cluster.

Fix: `ReplicationLoader.GetMinimalEtagForReplication` now also reads the cluster-persisted `SinkCursor` change vector for each sink task, so every node holds tombstones back consistently and releases them together once replication catches up.

Added a cluster test (1 hub + 3 sink) covering broken-channel retention and post-recovery cleanup; made the existing `DualClusterLab` topology configurable to support it.

### Type of change

- [x] Bug fix

### How risky is the change?

- [x] Low

### Backward compatibility

- [x] Non breaking change

### Is it platform specific issue?

- [x] No

### Documentation update

- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] No

### UI work

- [x] No UI work is needed