### PR TITLE
RavenDB-26826 - Fix pull replication hang on busy hub - dead incoming connection never reaped

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -168,7 +168,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                             using (var msg = interruptibleRead.ParseToMemory(
                                 _replicationFromAnotherSource,
                                 "IncomingReplication/read-message",
-                                Math.Max(0, remaining),
+                                remaining,
                                 _copiedBuffer.Buffer,
                                 _cts.Token))
                             {

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -147,6 +147,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                 {
                     var configuration = GetConfiguration();
                     var readTimeout = (int)configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds;
+                    var sinceLastReceive = Stopwatch.StartNew(); // time since the last REAL read
 
                     long lastTotalBytesRead = 0;
 
@@ -154,12 +155,16 @@ namespace Raven.Server.Documents.Replication.Incoming
                     {
                         try
                         {
+                            var remaining = readTimeout - (int)sinceLastReceive.ElapsedMilliseconds;
+                            if (remaining <= 0)
+                                ThrowReadTimeout(readTimeout);                // woken repeatedly, but no data in the window
+
                             AddReplicationPulse(ReplicationPulseDirection.IncomingInitiate);
 
                             using (var msg = interruptibleRead.ParseToMemory(
                                 _replicationFromAnotherSource,
                                 "IncomingReplication/read-message",
-                                readTimeout,
+                                remaining,
                                 _copiedBuffer.Buffer,
                                 _cts.Token))
                             {
@@ -172,6 +177,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                                     var currentUsed = _copiedBuffer.Buffer.Used;
                                     if (currentUsed > lastTotalBytesRead)
                                     {
+                                        sinceLastReceive.Restart(); // partial bytes = activity
                                         lastTotalBytesRead = currentUsed;
                                         if (Logger.IsInfoEnabled)
                                             Logger.Info($"Incoming replication from `{FromToString}` timed out ({readTimeout}ms) while reading next batch, " +
@@ -180,14 +186,16 @@ namespace Raven.Server.Documents.Replication.Incoming
                                         continue;
                                     }
 
-                                    // No data received within the timeout window. This is likely a zombie connection.
-                                    throw new TimeoutException($"Incoming replication from `{FromToString}` timed out while reading next batch. Read timeout = {readTimeout} ms. No data received in this interval.");
+                                    ThrowReadTimeout(readTimeout);
                                 }
-
-                                lastTotalBytesRead = 0;
 
                                 if (msg.Document != null)
                                 {
+                                    // Only a fully-consumed message resets the partial-read tracker; doing it on the
+                                    // notify branch would make any residual buffered bytes look like fresh growth on the
+                                    // next timeout, which would keep restarting sinceLastReceive and defeat the read-timeout.
+                                    lastTotalBytesRead = 0;
+
                                     EnsureNotDeleted();
 
                                     using (var writer = new BlittableJsonTextWriter(msg.Context, _stream))
@@ -196,6 +204,8 @@ namespace Raven.Server.Documents.Replication.Incoming
                                             msg.Document,
                                             writer);
                                     }
+
+                                    sinceLastReceive.Restart();
                                 }
                                 else // notify peer about new change vector
                                 {
@@ -269,6 +279,12 @@ namespace Raven.Server.Documents.Replication.Incoming
                     InvokeOnFailed(e);
                 }
             }
+        }
+
+        private void ThrowReadTimeout(int readTimeout)
+        {
+            // No data received within the timeout window. This is likely a zombie connection.
+            throw new TimeoutException($"Incoming replication from `{FromToString}` timed out while reading next batch. Read timeout = {readTimeout} ms. No data received in this interval.");
         }
 
         internal void HandleSingleReplicationBatch(TOperationContext context, BlittableJsonReaderObject message, BlittableJsonTextWriter writer)

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -154,12 +154,8 @@ namespace Raven.Server.Documents.Replication.Incoming
                     var sinceLastSentHeartbeat = Stopwatch.StartNew(); // time since the last sent heartbeat
                     const int notifyMinIntervalInMs = 1000;
 
-                    // Throttle notify-sends. A busy node pokes _replicationFromAnotherSource very frequently (once per
-                    // sibling batch). The peer emits its periodic heartbeat only when ITS read of our messages goes
-                    // quiet for a heartbeat interval (see DatabaseOutgoingReplicationHandler.WaitForChanges), so a
-                    // "Notify" reply for every poke starves the peer's heartbeats and makes this healthy connection
-                    // look dead. Sending at most once per (heartbeat + timeout)/2 -- always larger than the heartbeat
-                    // interval -- leaves the peer quiet time to heartbeat while still forwarding our change vector.
+                    // Throttle "Notify" replies to at most once per second: a busy node pokes _replicationFromAnotherSource once per
+                    // sibling batch, and replying to every poke floods the peer with no added value (the next Notify carries the latest change vector).
 
                     while (_cts.IsCancellationRequested == false)
                     {

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -216,10 +216,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 {
                                     // Throttle: only send a notify if enough time has passed since the last one.
                                     if (sinceLastSentHeartbeat.ElapsedMilliseconds <= notifyMinIntervalInMs)
-                                    {
-                                        sinceLastSentHeartbeat.Restart();
                                         continue;
-                                    }
 
                                     using (_contextPool.AllocateOperationContext(out TOperationContext context))
                                     using (var writer = new BlittableJsonTextWriter(context, _stream))
@@ -230,6 +227,8 @@ namespace Raven.Server.Documents.Replication.Incoming
                                             _lastDocumentEtag,
                                             "Notify");
                                     }
+
+                                    sinceLastSentHeartbeat.Restart();
                                 }
                             }
                         }

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -151,20 +151,29 @@ namespace Raven.Server.Documents.Replication.Incoming
 
                     long lastTotalBytesRead = 0;
 
+                    // Throttle notify-sends. A busy node pokes _replicationFromAnotherSource very frequently (once per
+                    // sibling batch). The peer emits its periodic heartbeat only when ITS read of our messages goes
+                    // quiet for a heartbeat interval (see DatabaseOutgoingReplicationHandler.WaitForChanges), so a
+                    // "Notify" reply for every poke starves the peer's heartbeats and makes this healthy connection
+                    // look dead. Sending at most once per (heartbeat + timeout)/2 -- always larger than the heartbeat
+                    // interval -- leaves the peer quiet time to heartbeat while still forwarding our change vector.
+                    var heartbeatInterval = (int)configuration.Replication.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
+                    var notifyMinInterval = (heartbeatInterval + readTimeout) / 2;
+                    var notifyClock = Stopwatch.StartNew();
+                    long lastNotifyElapsed = -notifyMinInterval; // allow the first notify immediately
+
                     while (_cts.IsCancellationRequested == false)
                     {
                         try
                         {
                             var remaining = readTimeout - (int)sinceLastReceive.ElapsedMilliseconds;
-                            if (remaining <= 0)
-                                ThrowReadTimeout(readTimeout);                // woken repeatedly, but no data in the window
 
                             AddReplicationPulse(ReplicationPulseDirection.IncomingInitiate);
 
                             using (var msg = interruptibleRead.ParseToMemory(
                                 _replicationFromAnotherSource,
                                 "IncomingReplication/read-message",
-                                remaining,
+                                Math.Max(0, remaining),
                                 _copiedBuffer.Buffer,
                                 _cts.Token))
                             {
@@ -186,7 +195,8 @@ namespace Raven.Server.Documents.Replication.Incoming
                                         continue;
                                     }
 
-                                    ThrowReadTimeout(readTimeout);
+                                    // No data received within the timeout window. This is likely a zombie connection.
+                                    throw new TimeoutException($"Incoming replication from `{FromToString}` timed out while reading next batch. Read timeout = {readTimeout} ms. No data received in this interval.");
                                 }
 
                                 if (msg.Document != null)
@@ -209,6 +219,16 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 }
                                 else // notify peer about new change vector
                                 {
+                                    // Throttle: don't flood the peer with notify replies (see notifyMinInterval above),
+                                    // or it never gets the quiet window it needs to send us a heartbeat.
+                                    var notifyElapsed = notifyClock.ElapsedMilliseconds;
+                                    if (notifyElapsed - lastNotifyElapsed < notifyMinInterval)
+                                        continue;
+
+                                    lastNotifyElapsed = notifyElapsed;
+
+                                    sinceLastReceive.Stop();
+
                                     using (_contextPool.AllocateOperationContext(out TOperationContext context))
                                     using (var writer = new BlittableJsonTextWriter(context, _stream))
                                     {
@@ -218,6 +238,8 @@ namespace Raven.Server.Documents.Replication.Incoming
                                             _lastDocumentEtag,
                                             "Notify");
                                     }
+
+                                    sinceLastReceive.Start();
                                 }
                             }
                         }
@@ -279,12 +301,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                     InvokeOnFailed(e);
                 }
             }
-        }
-
-        private void ThrowReadTimeout(int readTimeout)
-        {
-            // No data received within the timeout window. This is likely a zombie connection.
-            throw new TimeoutException($"Incoming replication from `{FromToString}` timed out while reading next batch. Read timeout = {readTimeout} ms. No data received in this interval.");
         }
 
         internal void HandleSingleReplicationBatch(TOperationContext context, BlittableJsonReaderObject message, BlittableJsonTextWriter writer)

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -147,9 +147,12 @@ namespace Raven.Server.Documents.Replication.Incoming
                 {
                     var configuration = GetConfiguration();
                     var readTimeout = (int)configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds;
+                    
                     var sinceLastReceive = Stopwatch.StartNew(); // time since the last REAL read
-
                     long lastTotalBytesRead = 0;
+
+                    var sinceLastSentHeartbeat = Stopwatch.StartNew(); // time since the last sent heartbeat
+                    const int notifyMinIntervalInMs = 1000;
 
                     // Throttle notify-sends. A busy node pokes _replicationFromAnotherSource very frequently (once per
                     // sibling batch). The peer emits its periodic heartbeat only when ITS read of our messages goes
@@ -157,10 +160,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                     // "Notify" reply for every poke starves the peer's heartbeats and makes this healthy connection
                     // look dead. Sending at most once per (heartbeat + timeout)/2 -- always larger than the heartbeat
                     // interval -- leaves the peer quiet time to heartbeat while still forwarding our change vector.
-                    var heartbeatInterval = (int)configuration.Replication.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
-                    var notifyMinInterval = (heartbeatInterval + readTimeout) / 2;
-                    var notifyClock = Stopwatch.StartNew();
-                    long lastNotifyElapsed = -notifyMinInterval; // allow the first notify immediately
 
                     while (_cts.IsCancellationRequested == false)
                     {
@@ -219,15 +218,12 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 }
                                 else // notify peer about new change vector
                                 {
-                                    // Throttle: don't flood the peer with notify replies (see notifyMinInterval above),
-                                    // or it never gets the quiet window it needs to send us a heartbeat.
-                                    var notifyElapsed = notifyClock.ElapsedMilliseconds;
-                                    if (notifyElapsed - lastNotifyElapsed < notifyMinInterval)
+                                    // Throttle: only send a notify if enough time has passed since the last one.
+                                    if (sinceLastSentHeartbeat.ElapsedMilliseconds <= notifyMinIntervalInMs)
+                                    {
+                                        sinceLastSentHeartbeat.Restart();
                                         continue;
-
-                                    lastNotifyElapsed = notifyElapsed;
-
-                                    sinceLastReceive.Stop();
+                                    }
 
                                     using (_contextPool.AllocateOperationContext(out TOperationContext context))
                                     using (var writer = new BlittableJsonTextWriter(context, _stream))
@@ -238,8 +234,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                                             _lastDocumentEtag,
                                             "Notify");
                                     }
-
-                                    sinceLastReceive.Start();
                                 }
                             }
                         }

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -151,12 +151,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                     var sinceLastReceive = Stopwatch.StartNew(); // time since the last REAL read
                     long lastTotalBytesRead = 0;
 
-                    var sinceLastSentHeartbeat = Stopwatch.StartNew(); // time since the last sent heartbeat
-                    const int notifyMinIntervalInMs = 1000;
-
-                    // Throttle "Notify" replies to at most once per second: a busy node pokes _replicationFromAnotherSource once per
-                    // sibling batch, and replying to every poke floods the peer with no added value (the next Notify carries the latest change vector).
-
                     while (_cts.IsCancellationRequested == false)
                     {
                         try
@@ -214,10 +208,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 }
                                 else // notify peer about new change vector
                                 {
-                                    // Throttle: only send a notify if enough time has passed since the last one.
-                                    if (sinceLastSentHeartbeat.ElapsedMilliseconds <= notifyMinIntervalInMs)
-                                        continue;
-
                                     using (_contextPool.AllocateOperationContext(out TOperationContext context))
                                     using (var writer = new BlittableJsonTextWriter(context, _stream))
                                     {
@@ -227,8 +217,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                                             _lastDocumentEtag,
                                             "Notify");
                                     }
-
-                                    sinceLastSentHeartbeat.Restart();
                                 }
                             }
                         }

--- a/src/Raven.Server/Documents/Replication/InterruptibleRead.cs
+++ b/src/Raven.Server/Documents/Replication/InterruptibleRead.cs
@@ -51,6 +51,9 @@ namespace Raven.Server.Documents.Replication
             JsonOperationContext.MemoryBuffer buffer,
             CancellationToken token)
         {
+            if (timeout <= 0)
+                return new Result { Timeout = true };
+
             if (_prevCall == null)
             {
                 _prevCall = ReadNextObject(debugTag, buffer, token);

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -320,12 +320,16 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
         private bool WaitForChanges(int timeout, CancellationToken token)
         {
+            var sinceLastReceive = Stopwatch.StartNew();
+
             while (true)
             {
+                var remaining = timeout - (int)sinceLastReceive.ElapsedMilliseconds;
+
                 using (var result = _interruptibleRead.ParseToMemory(
                     _waitForChanges,
                     "replication notify message",
-                    timeout,
+                    remaining,
                     _buffer,
                     token))
                 {

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -1162,14 +1162,14 @@ namespace SlowTests.Server.Replication
         // that test: OTHER incoming replication traffic on the same sink node. Every time any other incoming
         // connection receives a batch, ReplicationLoader.OnIncomingReceiveSucceeded calls
         // OnReplicationFromAnotherSource() on EVERY other incoming handler. That wakes the handler's read loop
-        // (the "notify" branch), which (a) bumps LastHeartbeatTicks so the connection keeps looking "fresh",
-        // and (b) makes InterruptibleRead.ParseToMemory return Interrupted and start a brand-new read-timeout
-        // window. On a busy node these wake-ups arrive faster than the timeout, so the timeout never elapses:
-        // the hung connection becomes an immortal zombie that is never reaped and never reconnects, and only a
-        // task restart (which disposes it via DropIncomingConnections) clears it.
+        // (the "notify" branch) and makes InterruptibleRead.ParseToMemory return Interrupted with a brand-new
+        // per-call timeout window. On a busy node these wake-ups arrive faster than the timeout, so msg.Timeout
+        // never fires: before the fix the hung connection became an immortal zombie that was never reaped and
+        // never reconnected, and only a task restart (which disposes it via DropIncomingConnections) cleared it.
         //
-        // EXPECTED: this test FAILS on the current code (reproduces the bug) and passes once the read-timeout
-        // is made to track real activity instead of being reset by notify wake-ups.
+        // The fix tracks time since the last REAL receive and reaps on that, so the timeout fires regardless of
+        // how many notify wake-ups occur. EXPECTED: this test FAILS on the pre-fix code (reproduces the bug) and
+        // passes with the fix.
         [RavenFact(RavenTestCategory.Replication)]
         public async Task BusySink_ShouldStillTimeoutAndReconnect_HangingPullConnection()
         {
@@ -1246,32 +1246,10 @@ namespace SlowTests.Server.Replication
             // 2. Simulate a busy sink node: keep poking the notify event on every live incoming handler,
             // exactly as OnIncomingReceiveSucceeded would when sibling connections receive batches.
             using var pumpCts = new CancellationTokenSource();
-            var pump = Task.Run(async () =>
-            {
-                while (pumpCts.IsCancellationRequested == false)
-                {
-                    foreach (var handler in sinkDb.ReplicationLoader.IncomingHandlers)
-                    {
-                        try
-                        {
-                            (handler as IncomingReplicationHandler)?.OnReplicationFromAnotherSource();
-                        }
-                        catch
-                        {
-                            // handler may be disposed mid-iteration; ignore
-                        }
-                    }
-
-                    try
-                    { await Task.Delay(100, pumpCts.Token); }
-                    catch { /* cancelled */ }
-                }
-            });
+            var pump = NotifyPump(sinkDb, pumpCts.Token);
 
             // 3. The hub goes silent on this connection (socket up, nothing arrives). The notify wake-ups keep driving
-            // the "notify" branch -> GetHeartbeatStatusMessage -> LastHeartbeatTicks = now (a SEND-path update), so the
-            // dead connection keeps looking "fresh" with zero receives -- which is what makes AssertValidConnection
-            // reject the reconnect. The read-timeout fix must reap it despite that.
+            // the "notify" branch, so before the fix the read-timeout never fired. The fix must reap it regardless.
             networkGate.Close();
 
             using (var session = hubStore.OpenAsyncSession())
@@ -1300,13 +1278,15 @@ namespace SlowTests.Server.Replication
             catch { /* ignored */ }
         }
 
-        // The flip side of the read-timeout fix: it must NOT reap a HEALTHY idle connection.
-        // A healthy idle source keeps sending heartbeats (every ReplicationMinimalHeartbeat), which the sink RECEIVES
-        // (the msg.Document != null branch) and which restart sinceLastReceive. As long as ActiveConnectionTimeout >
-        // ReplicationMinimalHeartbeat, the connection stays alive across many timeout windows. (The notify/"interrupted"
-        // branch deliberately does NOT restart the timer; it doesn't need to -- received heartbeats do.)
+        // The flip side of the read-timeout fix: it must NOT reap a HEALTHY idle connection, EVEN under heavy notify
+        // fan-out. A healthy idle source keeps sending heartbeats (every ReplicationMinimalHeartbeat); the sink RECEIVES
+        // them (the msg.Document != null branch) and restarts the read-timeout. Because the timeout is evaluated only
+        // AFTER the read has had its chance to return, a heartbeat that already arrived is always consumed before any
+        // reap -- so the notify flood cannot reap a live connection. (Before the fix this test FAILED: the read-timeout
+        // was decided at the top of the loop, so under a notify flood a buffered heartbeat could be reaped before it was
+        // consumed.)
         [RavenFact(RavenTestCategory.Replication)]
-        public async Task HealthyIdleConnection_IsNotReaped()
+        public async Task HealthyIdleConnection_IsNotReaped_UnderNotifyFanOut()
         {
             DoNotReuseServer();
 
@@ -1366,12 +1346,11 @@ namespace SlowTests.Server.Replication
                 return pullHandler != null;
             }, true), "Expected an incoming pull replication handler on the sink");
 
-            // A healthy idle source keeps sending heartbeats (every ReplicationMinimalHeartbeat = 2s), which the sink
-            // RECEIVES (the msg.Document != null branch) and which restart sinceLastReceive. Because ActiveConnectionTimeout
-            // (5s) is larger than the heartbeat interval, the connection must survive many read-timeout windows and must
-            // never be reaped/reconnected. (The notify branch deliberately does NOT restart the timer -- and it doesn't
-            // need to: received heartbeats keep the connection alive. The reproduction test above proves the converse,
-            // that notify wake-ups alone do NOT keep a connection that receives nothing alive.)
+            // Flood the handler with notify wake-ups, exactly as a busy node would. The connection is healthy: the hub
+            // keeps sending heartbeats which the sink receives. It must survive every read-timeout window unchanged.
+            using var pumpCts = new CancellationTokenSource();
+            var pump = NotifyPump(sinkDb, pumpCts.Token);
+
             var readTimeoutMs = (int)sinkDb.Configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds;
             for (var i = 0; i < (readTimeoutMs * 3) / 1000; i++)
             {
@@ -1379,7 +1358,8 @@ namespace SlowTests.Server.Replication
                 Assert.Equal(initialConnections, connectionCounter); // a reconnect would increment this => reaped
                 var current = sinkDb.ReplicationLoader.IncomingHandlers.OfType<IncomingReplicationHandler>().FirstOrDefault();
                 Assert.True(ReferenceEquals(current, pullHandler),
-                    $"The healthy incoming handler was reaped/replaced while idle (connectionCounter={connectionCounter}, initial={initialConnections}).");
+                    $"The healthy incoming handler was reaped/replaced while idle under notify fan-out " +
+                    $"(connectionCounter={connectionCounter}, initial={initialConnections}).");
             }
 
             // And it still works: a new document flows over the SAME connection (no reconnect).
@@ -1390,16 +1370,21 @@ namespace SlowTests.Server.Replication
             }
             Assert.True(WaitForDocument<User>(sinkStore, "Users/2-A", u => u.Name == "Lev", 10_000), "Healthy connection stopped replicating");
             Assert.Equal(initialConnections, connectionCounter);
+
+            pumpCts.Cancel();
+            try
+            { await pump; }
+            catch { /* ignored */ }
         }
 
         // Realistic fleet-load check (external replication, same code path as a hub): many sources replicate into one
         // destination. One source stays idle (the "victim"); the others push continuously, so every batch fires
         // ReplicationLoader.OnIncomingReceiveSucceeded -> OnReplicationFromAnotherSource on the victim's handler (genuine
-        // notify fan-out). Under that load an idle connection may be transiently reaped (the notify flood can delay the
-        // idle peer's heartbeat round-trip past ActiveConnectionTimeout), but it must RECOVER and keep replicating -- no
-        // permanent outage or deadlock. This guards against the read-timeout fix causing unrecoverable churn at scale.
+        // notify fan-out). The idle victim keeps sending heartbeats, so with the fix it must NOT be reaped: the timeout
+        // is only evaluated after a read, and received heartbeats reset it. We assert ZERO churn on the destination
+        // (no reconnect of any handler) and that the idle victim keeps replicating.
         [RavenFact(RavenTestCategory.Replication)]
-        public async Task BusyDestination_IdleSource_RecoversAndKeepsReplicating()
+        public async Task BusyDestination_IdleSource_IsNotReaped_AndKeepsReplicating()
         {
             DoNotReuseServer();
 
@@ -1417,6 +1402,13 @@ namespace SlowTests.Server.Replication
                 noisy.Add((DocumentStore)GetDocumentStore(new Options { Server = server }));
 
             var destDb = await GetDatabase(dest.Database, server);
+
+            var connectionCounter = 0;
+            destDb.ReplicationLoader.ForTestingPurposesOnly().WrapIncomingReplicationStream = s =>
+            {
+                Interlocked.Increment(ref connectionCounter); // count every incoming (re)connection on the destination
+                return s;
+            };
 
             var sources = new List<DocumentStore> { victim };
             sources.AddRange(noisy);
@@ -1436,6 +1428,7 @@ namespace SlowTests.Server.Replication
                 $"Expected {sources.Count} incoming handlers on the destination, got {destDb.ReplicationLoader.IncomingHandlers.Count()}");
 
             await Task.Delay(2000); // let things settle
+            var initialConnections = connectionCounter;
 
             // The noisy sources push continuously -> genuine OnIncomingReceiveSucceeded fan-out onto every handler.
             using var noiseCts = new CancellationTokenSource();
@@ -1457,17 +1450,16 @@ namespace SlowTests.Server.Replication
                 }
             })).ToList();
 
-            // Let the system run under heavy notify fan-out for several read-timeout windows. Under that load an idle
-            // connection MAY be reaped transiently (the notify flood can delay the idle peer's heartbeat round-trip past
-            // ActiveConnectionTimeout), but it must RECOVER -- reconnect and keep replicating, with no permanent outage.
-            // Active connections are never affected (received data resets the timer). We tolerate transient reconnects
-            // and assert recovery below.
+            // Run under heavy notify fan-out for several read-timeout windows. The idle victim keeps sending heartbeats,
+            // so its connection must never be reaped: no handler on the destination should reconnect (zero churn).
             var readTimeoutMs = (int)destDb.Configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds;
             await Task.Delay(readTimeoutMs * 3);
 
-            // The idle victim must be connected (recovered if it was transiently reaped) and must keep replicating.
-            Assert.True(WaitForValue(() => destDb.ReplicationLoader.IncomingHandlers.Any(h => h.ConnectionInfo.SourceDatabaseName == victim.Database), true, timeout: 20_000),
-                "The idle victim never re-established its connection under fleet load.");
+            Assert.Equal(initialConnections, connectionCounter); // any reconnect under load => a healthy connection was reaped
+
+            // The idle victim is still connected and still replicates.
+            Assert.True(destDb.ReplicationLoader.IncomingHandlers.Any(h => h.ConnectionInfo.SourceDatabaseName == victim.Database),
+                "The idle victim's incoming connection was dropped under fleet load.");
 
             using (var s = victim.OpenAsyncSession())
             {
@@ -1482,6 +1474,33 @@ namespace SlowTests.Server.Replication
             { try { await t; } catch { /* ignored */ } }
             foreach (var s in noisy)
                 s.Dispose();
+        }
+
+        // Pokes the notify event on every live incoming handler, exactly as ReplicationLoader.OnIncomingReceiveSucceeded
+        // does when sibling connections receive batches. This is the "busy node" ingredient.
+        private static Task NotifyPump(Raven.Server.Documents.DocumentDatabase db, CancellationToken token)
+        {
+            return Task.Run(async () =>
+            {
+                while (token.IsCancellationRequested == false)
+                {
+                    foreach (var handler in db.ReplicationLoader.IncomingHandlers)
+                    {
+                        try
+                        {
+                            (handler as IncomingReplicationHandler)?.OnReplicationFromAnotherSource();
+                        }
+                        catch
+                        {
+                            // handler may be disposed mid-iteration; ignore
+                        }
+                    }
+
+                    try
+                    { await Task.Delay(100, token); }
+                    catch { /* cancelled */ }
+                }
+            });
         }
 
         private class AsyncGate

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -1,31 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
-using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Extensions;
-using Raven.Client.Http;
-using Raven.Client.Json;
-using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
-using Raven.Client.Util;
 using Raven.Server.Config;
+using Raven.Server.Documents.Replication.Incoming;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
-using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
@@ -1155,6 +1151,464 @@ namespace SlowTests.Server.Replication
                 resList.Add(await task);
             }
             return resList;
+        }
+
+        // Reproduces the "zombie pull connection" deadlock on a busy sink.
+        //
+        // RavenDB_25412 proved that when the hub stops sending, the sink's read-timeout
+        // (Replication.ActiveConnectionTimeout) fires, the hung connection is reaped, and the sink reconnects.
+        //
+        // This test adds the one ingredient that was present in the production incident but missing from
+        // that test: OTHER incoming replication traffic on the same sink node. Every time any other incoming
+        // connection receives a batch, ReplicationLoader.OnIncomingReceiveSucceeded calls
+        // OnReplicationFromAnotherSource() on EVERY other incoming handler. That wakes the handler's read loop
+        // (the "notify" branch), which (a) bumps LastHeartbeatTicks so the connection keeps looking "fresh",
+        // and (b) makes InterruptibleRead.ParseToMemory return Interrupted and start a brand-new read-timeout
+        // window. On a busy node these wake-ups arrive faster than the timeout, so the timeout never elapses:
+        // the hung connection becomes an immortal zombie that is never reaped and never reconnects, and only a
+        // task restart (which disposes it via DropIncomingConnections) clears it.
+        //
+        // EXPECTED: this test FAILS on the current code (reproduces the bug) and passes once the read-timeout
+        // is made to track real activity instead of being reset by notify wake-ups.
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task BusySink_ShouldStillTimeoutAndReconnect_HangingPullConnection()
+        {
+            DoNotReuseServer();
+
+            // keep the read-timeout short so the test is fast
+            var customSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.ActiveConnectionTimeout)] = "5"
+            };
+
+            using var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
+            using var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
+
+            using var hubStore = GetDocumentStore(new Options
+            {
+                Server = hubServer
+            });
+
+            using var sinkStore = GetDocumentStore(new Options
+            {
+                Server = sinkServer
+            });
+
+            var pullReplicationName = $"{hubStore.Database}-pull";
+            var connectionStringName = "ConnectionString-" + hubStore.Database;
+
+            var sinkDb = await GetDatabase(sinkStore.Database, sinkServer);
+
+            // Open = normal, Closed = reads hang (socket stays up, no data arrives).
+            var networkGate = new AsyncGate();
+            var connectionCounter = 0;
+
+            var forTesting = sinkDb.ReplicationLoader.ForTestingPurposesOnly();
+            forTesting.WrapIncomingReplicationStream = innerStream =>
+            {
+                // Hang ONLY the first connection (the one we will strangle). Any reconnection must read
+                // normally, otherwise the global gate would block the recovered connection too and the
+                // second document could never arrive -- on buggy AND fixed code alike.
+                var n = Interlocked.Increment(ref connectionCounter);
+                return n == 1
+                    ? new SmartHangingStreamWrapper(innerStream, networkGate)
+                    : innerStream;
+            };
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(pullReplicationName)));
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Name = connectionStringName,
+                Database = hubStore.Database,
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+            await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+            {
+                Name = pullReplicationName,
+                HubName = pullReplicationName,
+                ConnectionStringName = connectionStringName
+            }));
+
+            // 1. initial replication works
+            using (var session = hubStore.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = "Users/1-A", Name = "Lev" });
+                await session.SaveChangesAsync();
+            }
+            Assert.True(WaitForDocument<User>(sinkStore, "Users/1-A", u => u.Name == "Lev"), "Initial replication failed");
+
+            var initialConnections = connectionCounter;
+
+            // The incoming pull handler must be established before we strangle it.
+            Assert.True(WaitForValue(() => sinkDb.ReplicationLoader.IncomingHandlers.OfType<IncomingReplicationHandler>().Any(), true),
+                "Expected an incoming pull replication handler on the sink");
+
+            // 2. Simulate a busy sink node: keep poking the notify event on every live incoming handler,
+            // exactly as OnIncomingReceiveSucceeded would when sibling connections receive batches.
+            using var pumpCts = new CancellationTokenSource();
+            var pump = Task.Run(async () =>
+            {
+                while (pumpCts.IsCancellationRequested == false)
+                {
+                    foreach (var handler in sinkDb.ReplicationLoader.IncomingHandlers)
+                    {
+                        try
+                        {
+                            (handler as IncomingReplicationHandler)?.OnReplicationFromAnotherSource();
+                        }
+                        catch
+                        {
+                            // handler may be disposed mid-iteration; ignore
+                        }
+                    }
+
+                    try
+                    { await Task.Delay(100, pumpCts.Token); }
+                    catch { /* cancelled */ }
+                }
+            });
+
+            // 3. The hub goes silent on this connection (socket up, nothing arrives). The notify wake-ups keep driving
+            // the "notify" branch -> GetHeartbeatStatusMessage -> LastHeartbeatTicks = now (a SEND-path update), so the
+            // dead connection keeps looking "fresh" with zero receives -- which is what makes AssertValidConnection
+            // reject the reconnect. The read-timeout fix must reap it despite that.
+            networkGate.Close();
+
+            using (var session = hubStore.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = "Users/2-A", Name = "Lev" });
+                await session.SaveChangesAsync();
+            }
+
+            // Allow several timeout windows for the zombie to be reaped, the sink to reconnect, and the doc to arrive.
+            var timeout = (int)sinkDb.Configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds * 4;
+
+            // PRIMARY assertion (gates the read-timeout fix): even on a busy sink, the read-timeout must fire, reap the
+            // zombie, and trigger a reconnect. A reconnect creates a new incoming stream, so connectionCounter increments.
+            var reconnected = WaitForValue(() => connectionCounter > initialConnections, true, timeout: timeout, interval: 200);
+            Assert.True(reconnected,
+                $"The hung pull connection was never reaped while the sink was busy. connectionCounter={connectionCounter}, initial={initialConnections}. " +
+                $"The notify wake-ups kept resetting the read-timeout, leaving an immortal zombie incoming handler that only a task restart would clear.");
+
+            // SECONDARY assertion (end-to-end recovery): once reaped, the sink reconnects on a clean stream and the
+            // second document arrives.
+            Assert.True(WaitForDocument<User>(sinkStore, "Users/2-A", u => u.Name == "Lev", timeout), "Second replication failed (end-to-end recovery)");
+
+            pumpCts.Cancel();
+            try
+            { await pump; }
+            catch { /* ignored */ }
+        }
+
+        // The flip side of the read-timeout fix: it must NOT reap a HEALTHY idle connection.
+        // A healthy idle source keeps sending heartbeats (every ReplicationMinimalHeartbeat), which the sink RECEIVES
+        // (the msg.Document != null branch) and which restart sinceLastReceive. As long as ActiveConnectionTimeout >
+        // ReplicationMinimalHeartbeat, the connection stays alive across many timeout windows. (The notify/"interrupted"
+        // branch deliberately does NOT restart the timer; it doesn't need to -- received heartbeats do.)
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task HealthyIdleConnection_IsNotReaped()
+        {
+            DoNotReuseServer();
+
+            // read-timeout (5s) > heartbeat interval (2s): a healthy idle peer's heartbeats keep the connection alive.
+            var customSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.ActiveConnectionTimeout)] = "5",
+                [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "2"
+            };
+
+            using var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
+            using var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
+
+            using var hubStore = GetDocumentStore(new Options { Server = hubServer });
+            using var sinkStore = GetDocumentStore(new Options { Server = sinkServer });
+
+            var pullReplicationName = $"{hubStore.Database}-pull";
+            var connectionStringName = "ConnectionString-" + hubStore.Database;
+            var sinkDb = await GetDatabase(sinkStore.Database, sinkServer);
+
+            var connectionCounter = 0;
+            var forTesting = sinkDb.ReplicationLoader.ForTestingPurposesOnly();
+            forTesting.WrapIncomingReplicationStream = innerStream =>
+            {
+                // Passthrough: the connection stays healthy; we only count (re)connections.
+                Interlocked.Increment(ref connectionCounter);
+                return innerStream;
+            };
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(pullReplicationName)));
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Name = connectionStringName,
+                Database = hubStore.Database,
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+            await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+            {
+                Name = pullReplicationName,
+                HubName = pullReplicationName,
+                ConnectionStringName = connectionStringName
+            }));
+
+            using (var session = hubStore.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = "Users/1-A", Name = "Lev" });
+                await session.SaveChangesAsync();
+            }
+            Assert.True(WaitForDocument<User>(sinkStore, "Users/1-A", u => u.Name == "Lev"), "Initial replication failed");
+
+            var initialConnections = connectionCounter;
+
+            IncomingReplicationHandler pullHandler = null;
+            Assert.True(WaitForValue(() =>
+            {
+                pullHandler = sinkDb.ReplicationLoader.IncomingHandlers.OfType<IncomingReplicationHandler>().FirstOrDefault();
+                return pullHandler != null;
+            }, true), "Expected an incoming pull replication handler on the sink");
+
+            // A healthy idle source keeps sending heartbeats (every ReplicationMinimalHeartbeat = 2s), which the sink
+            // RECEIVES (the msg.Document != null branch) and which restart sinceLastReceive. Because ActiveConnectionTimeout
+            // (5s) is larger than the heartbeat interval, the connection must survive many read-timeout windows and must
+            // never be reaped/reconnected. (The notify branch deliberately does NOT restart the timer -- and it doesn't
+            // need to: received heartbeats keep the connection alive. The reproduction test above proves the converse,
+            // that notify wake-ups alone do NOT keep a connection that receives nothing alive.)
+            var readTimeoutMs = (int)sinkDb.Configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds;
+            for (var i = 0; i < (readTimeoutMs * 3) / 1000; i++)
+            {
+                await Task.Delay(1000);
+                Assert.Equal(initialConnections, connectionCounter); // a reconnect would increment this => reaped
+                var current = sinkDb.ReplicationLoader.IncomingHandlers.OfType<IncomingReplicationHandler>().FirstOrDefault();
+                Assert.True(ReferenceEquals(current, pullHandler),
+                    $"The healthy incoming handler was reaped/replaced while idle (connectionCounter={connectionCounter}, initial={initialConnections}).");
+            }
+
+            // And it still works: a new document flows over the SAME connection (no reconnect).
+            using (var session = hubStore.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = "Users/2-A", Name = "Lev" });
+                await session.SaveChangesAsync();
+            }
+            Assert.True(WaitForDocument<User>(sinkStore, "Users/2-A", u => u.Name == "Lev", 10_000), "Healthy connection stopped replicating");
+            Assert.Equal(initialConnections, connectionCounter);
+        }
+
+        // Realistic fleet-load check (external replication, same code path as a hub): many sources replicate into one
+        // destination. One source stays idle (the "victim"); the others push continuously, so every batch fires
+        // ReplicationLoader.OnIncomingReceiveSucceeded -> OnReplicationFromAnotherSource on the victim's handler (genuine
+        // notify fan-out). Under that load an idle connection may be transiently reaped (the notify flood can delay the
+        // idle peer's heartbeat round-trip past ActiveConnectionTimeout), but it must RECOVER and keep replicating -- no
+        // permanent outage or deadlock. This guards against the read-timeout fix causing unrecoverable churn at scale.
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task BusyDestination_IdleSource_RecoversAndKeepsReplicating()
+        {
+            DoNotReuseServer();
+
+            var customSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.ActiveConnectionTimeout)] = "10",
+                [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "2"
+            };
+            using var server = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
+
+            using var dest = GetDocumentStore(new Options { Server = server });
+            using var victim = GetDocumentStore(new Options { Server = server });
+            var noisy = new List<DocumentStore>();
+            for (var i = 0; i < 4; i++)
+                noisy.Add((DocumentStore)GetDocumentStore(new Options { Server = server }));
+
+            var destDb = await GetDatabase(dest.Database, server);
+
+            var sources = new List<DocumentStore> { victim };
+            sources.AddRange(noisy);
+
+            // external replication: every source -> destination
+            foreach (var src in sources)
+                await SetupReplicationAsync(src, dest);
+
+            // seed one doc per source so all connections establish and replicate
+            for (var i = 0; i < sources.Count; i++)
+            {
+                using var s = sources[i].OpenAsyncSession();
+                await s.StoreAsync(new User { Id = $"seed/{i}", Name = "x" });
+                await s.SaveChangesAsync();
+            }
+            Assert.True(WaitForValue(() => destDb.ReplicationLoader.IncomingHandlers.Count() == sources.Count, true, timeout: 30_000),
+                $"Expected {sources.Count} incoming handlers on the destination, got {destDb.ReplicationLoader.IncomingHandlers.Count()}");
+
+            await Task.Delay(2000); // let things settle
+
+            // The noisy sources push continuously -> genuine OnIncomingReceiveSucceeded fan-out onto every handler.
+            using var noiseCts = new CancellationTokenSource();
+            var noiseTasks = noisy.Select((src, idx) => Task.Run(async () =>
+            {
+                var k = 0;
+                while (noiseCts.IsCancellationRequested == false)
+                {
+                    try
+                    {
+                        using var s = src.OpenAsyncSession();
+                        await s.StoreAsync(new User { Id = $"noise/{idx}/{k++}", Name = "n" });
+                        await s.SaveChangesAsync();
+                    }
+                    catch { /* shutting down */ }
+                    try
+                    { await Task.Delay(100, noiseCts.Token); }
+                    catch { /* cancelled */ }
+                }
+            })).ToList();
+
+            // Let the system run under heavy notify fan-out for several read-timeout windows. Under that load an idle
+            // connection MAY be reaped transiently (the notify flood can delay the idle peer's heartbeat round-trip past
+            // ActiveConnectionTimeout), but it must RECOVER -- reconnect and keep replicating, with no permanent outage.
+            // Active connections are never affected (received data resets the timer). We tolerate transient reconnects
+            // and assert recovery below.
+            var readTimeoutMs = (int)destDb.Configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds;
+            await Task.Delay(readTimeoutMs * 3);
+
+            // The idle victim must be connected (recovered if it was transiently reaped) and must keep replicating.
+            Assert.True(WaitForValue(() => destDb.ReplicationLoader.IncomingHandlers.Any(h => h.ConnectionInfo.SourceDatabaseName == victim.Database), true, timeout: 20_000),
+                "The idle victim never re-established its connection under fleet load.");
+
+            using (var s = victim.OpenAsyncSession())
+            {
+                await s.StoreAsync(new User { Id = "victim/final", Name = "v" });
+                await s.SaveChangesAsync();
+            }
+            Assert.True(WaitForDocument<User>(dest, "victim/final", u => u.Name == "v", 20_000),
+                "The idle victim source stopped replicating under fleet load.");
+
+            noiseCts.Cancel();
+            foreach (var t in noiseTasks)
+            { try { await t; } catch { /* ignored */ } }
+            foreach (var s in noisy)
+                s.Dispose();
+        }
+
+        private class AsyncGate
+        {
+            private readonly object _lock = new object();
+            private TaskCompletionSource<object> _openTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private TaskCompletionSource<object> _closeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private volatile bool _isOpen = true;
+
+            public AsyncGate()
+            {
+                _openTcs.SetResult(null);
+            }
+
+            public bool IsOpen => _isOpen;
+
+            public void Close()
+            {
+                lock (_lock)
+                {
+                    if (!_isOpen)
+                        return;
+                    _isOpen = false;
+                    _openTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _closeTcs.TrySetResult(null);
+                }
+            }
+
+            public void Open()
+            {
+                lock (_lock)
+                {
+                    if (_isOpen)
+                        return;
+                    _isOpen = true;
+                    _closeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _openTcs.TrySetResult(null);
+                }
+            }
+
+            public Task WaitToOpenAsync(CancellationToken token)
+            {
+                lock (_lock)
+                {
+                    if (_isOpen)
+                        return Task.CompletedTask;
+                    return _openTcs.Task.WithCancellation(token);
+                }
+            }
+
+            public Task WaitToCloseAsync(CancellationToken token)
+            {
+                lock (_lock)
+                {
+                    if (!_isOpen)
+                        return Task.CompletedTask;
+                    return _closeTcs.Task.WithCancellation(token);
+                }
+            }
+        }
+
+        private class SmartHangingStreamWrapper : Stream
+        {
+            private readonly Stream _inner;
+            private readonly AsyncGate _gate;
+            private readonly CancellationTokenSource _disposeCts = new CancellationTokenSource();
+
+            public SmartHangingStreamWrapper(Stream inner, AsyncGate gate)
+            {
+                _inner = inner;
+                _gate = gate;
+            }
+
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCts.Token))
+                    {
+                        try
+                        {
+                            await _gate.WaitToOpenAsync(linkedCts.Token);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            if (_disposeCts.IsCancellationRequested)
+                                throw new IOException("Stream disposed");
+                            throw;
+                        }
+
+                        var readTask = _inner.ReadAsync(buffer, offset, count, cancellationToken);
+                        var closeGateTask = _gate.WaitToCloseAsync(linkedCts.Token);
+
+                        var completedTask = await Task.WhenAny(readTask, closeGateTask);
+                        if (completedTask == closeGateTask)
+                        {
+                            continue;
+                        }
+
+                        return await readTask;
+                    }
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _disposeCts.Cancel();
+                    _inner.Dispose();
+                    _disposeCts.Dispose();
+                }
+                base.Dispose(disposing);
+            }
+
+            public override void Flush() => _inner.Flush();
+            public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+            public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+            public override void SetLength(long value) => _inner.SetLength(value);
+            public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+            public override bool CanRead => _inner.CanRead;
+            public override bool CanSeek => _inner.CanSeek;
+            public override bool CanWrite => _inner.CanWrite;
+            public override long Length => _inner.Length;
+            public override long Position { get => _inner.Position; set => _inner.Position = value; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26826/Replication-a-busy-node-never-times-out-a-dead-incoming-connection-blocking-reconnect-notify-wake-ups-reset

### Additional description

#### Summary

On a node with many incoming replication connections (e.g. a hub serving ~60 sinks), a pull
connection whose socket goes half-open (TCP stays up, no data arrives) was **never reaped**, and
every reconnect attempt was rejected with `An active connection for this database already exists`.
In production this stalled a sink's replication for ~30–60 minutes until the task was restarted.

#### Root cause

The incoming read loop (`AbstractIncomingReplicationHandler.ReceiveReplicationBatches`) reaps a dead
connection only via the read-timeout (`Replication.ActiveConnectionTimeout`). But that timeout was a
**per-call** `task.Wait` inside `InterruptibleRead.ParseToMemory`, reset on every
`_replicationFromAnotherSource` wake-up.

That event is poked by `ReplicationLoader.OnIncomingReceiveSucceeded`, which fires
`OnReplicationFromAnotherSource()` on **every other** incoming handler whenever any sibling
connection applies a batch. On a busy node those wake-ups arrive faster than the timeout, so:

1. `ParseToMemory` keeps returning `Interrupted` (not `Timeout`) → a fresh timeout window restarts
   every iteration → the timeout **never elapses** → the dead handler is never reaped.
2. The notify branch sends a heartbeat status, which bumps `LastHeartbeatTicks` on the **send** path
   → the zombie keeps looking "fresh" → `AssertValidConnection` keeps rejecting the reconnect.

Net: the dead connection is immortal until the OS TCP stack errors the socket or the task restarts.
This is a scaling failure - 1–2 sinks reap fine; a busy fleet defeats the timeout mathematically.

#### Fix

**1. Reap on real activity, not on wake-ups** (`AbstractIncomingReplicationHandler.ReceiveReplicationBatches`).
The loop keeps a monotonic `sinceLastReceive` stopwatch, restarted **only on a genuine receive**
(`msg.Document != null`, and on buffer-growth in the inactivity check) - never on the
notify/`Interrupted` branch. Each iteration computes `remaining = ActiveConnectionTimeout - elapsed`
and passes it as `ParseToMemory`'s timeout; once the budget is exhausted `ParseToMemory` returns
`Timeout` and the loop throws, so the dead handler is reaped no matter how many notify wake-ups
occurred. (`InterruptibleRead.ParseToMemory` now treats a non-positive timeout as an immediate
`Timeout`, so an exhausted budget reaps cleanly while the persistent pending read is preserved - no
data is dropped.) Once reaped, the normal reconnect runs and - the old handler being gone -
`AssertValidConnection` accepts the new connection.

**2. Keep the peer heartbeating under load** (`DatabaseOutgoingReplicationHandler.WaitForChanges`).
Reaping on real activity alone would reap **healthy** connections under the same fan-out: a busy node
floods the peer with notify replies, and the peer's `WaitForChanges` only emits its periodic
heartbeat once its read of our messages goes quiet for a heartbeat interval - so the flood keeps it
perpetually busy, it never heartbeats, and a live connection looks dead. The fix caps the
**cumulative** `WaitForChanges` wait at the heartbeat interval (instead of restarting the full
interval on every reply), so the peer emits a heartbeat even while draining a flood. The receiver
keeps seeing heartbeats and resets its timer → healthy connections survive.

#### Behavior notes

- **Healthy idle connections are not reaped, even under heavy notify fan-out.** The peer keeps sending
  heartbeats (guaranteed by the capped `WaitForChanges`), the receiver reads them
  (`msg.Document != null`) and restarts its timer. With the designed invariant
  `ActiveConnectionTimeout > ReplicationMinimalHeartbeat`, idle connections survive indefinitely.
- Only a genuinely silent peer - no data for a full `ActiveConnectionTimeout` - is reaped.

#### Tests

`test/SlowTests/Server/Replication/PullReplicationTests.cs`:

- `BusySink_ShouldStillTimeoutAndReconnect_HangingPullConnection` - reproduces the incident
  (half-open stream + simulated sibling notify traffic); fails on the old code, passes with the fix.
- `HealthyIdleConnection_IsNotReaped_UnderNotifyFanOut` - under a notify flood, a healthy idle
  connection is **never** reaped (asserts zero reconnects across multiple timeout windows and keeps
  replicating). Regression guard.
- `BusyDestination_IdleSource_IsNotReaped_AndKeepsReplicating` - realistic multi-source fan-out into
  one destination; asserts **zero churn** on the idle connection and that it keeps replicating under load.

Existing `RavenDB_25412` (low-traffic reap-and-reconnect) still passes - no regression in the normal path.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
