### PR TITLE
RavenDB-26630 Agent test panel and UI adjustments

### DIFF
--- a/src/Raven.AiAppliance.Web/src/api/api.ts
+++ b/src/Raven.AiAppliance.Web/src/api/api.ts
@@ -1,6 +1,7 @@
 import { createApiClient, type ApiClient, type ApiClientOptions } from "@/api/http-client";
 import { createServerApi, type ServerApi } from "@/api/generated/server-api";
 import { createChatService } from "@/api/custom-services/chat-service";
+import { createAgentTestService } from "@/api/custom-services/agent-test-service";
 import { createAppsQueries } from "@/api/queries/apps-queries";
 import { createAgentsQueries } from "@/api/queries/agents-queries";
 import { createChannelsQueries } from "@/api/queries/channels-queries";
@@ -11,6 +12,7 @@ import { createAiConnectionStringsQueries } from "@/api/queries/ai-connection-st
 
 export type ApiServices = Omit<ServerApi, "chat"> & {
     chat: ReturnType<typeof createChatService>;
+    agentTest: ReturnType<typeof createAgentTestService>;
 };
 
 export type ApiQueries = {
@@ -35,6 +37,7 @@ export function createApi(options?: ApiClientOptions): Api {
     const services = {
         ...generatedServices,
         chat: createChatService(client),
+        agentTest: createAgentTestService(client),
     };
 
     return {

--- a/src/Raven.AiAppliance.Web/src/api/custom-services/agent-stream.ts
+++ b/src/Raven.AiAppliance.Web/src/api/custom-services/agent-stream.ts
@@ -1,6 +1,21 @@
 import { z } from "zod";
 import type { ApiClient } from "@/api/http-client";
 
+// One query tool the agent invoked during the turn, reconstructed server-side from the
+// conversation transcript: the configured RQL + description, the parameters the model filled
+// in, and the content the query returned. Present on the wizard's "Test agent" stream (which
+// supports query tools only); the chat/embed streams don't send tool calls.
+const agentToolCallSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().nullish(),
+    query: z.string().nullish(),
+    arguments: z.string().nullish(),
+    result: z.string().nullish(),
+});
+
+export type AgentToolCall = z.infer<typeof agentToolCallSchema>;
+
 // Shared NDJSON streaming for the agent endpoints (chat + wizard "Test agent"). Both stream
 // the same frame shape: incremental `chunk`s, a terminal `done` (with the full answer), or an
 // `error`.
@@ -15,6 +30,9 @@ const agentStreamEventSchema = z.discriminatedUnion("type", [
         // The full structured model output (every declared field). Present on the wizard's
         // "Test agent" stream; absent on the chat/embed streams, which only send `answer`.
         fullAnswer: z.unknown().optional(),
+        // The query tools the agent ran this turn. Present (possibly empty) on the wizard's
+        // "Test agent" stream; absent on the chat/embed streams.
+        toolCalls: z.array(agentToolCallSchema).optional(),
         conversationId: z.string(),
     }),
     z.object({

--- a/src/Raven.AiAppliance.Web/src/api/custom-services/agent-stream.ts
+++ b/src/Raven.AiAppliance.Web/src/api/custom-services/agent-stream.ts
@@ -44,13 +44,15 @@ const agentStreamEventSchema = z.discriminatedUnion("type", [
 export type AgentStreamEvent = z.infer<typeof agentStreamEventSchema>;
 
 /** POSTs `body` to `path` and yields the NDJSON frames the server streams back. Non-2xx
- * responses (e.g. a pre-stream 400/404) throw an ApiError before the first frame. */
+ * responses (e.g. a pre-stream 400/404) throw an ApiError before the first frame. Pass a
+ * `signal` to cancel the request (the caller aborts it when the panel unmounts mid-stream). */
 export async function* streamAgentNdjson(
     client: ApiClient,
     path: string,
     body: unknown,
+    signal?: AbortSignal,
 ): AsyncGenerator<AgentStreamEvent> {
-    const response = await client.post<Response>(path, body, { responseType: "response" });
+    const response = await client.post<Response>(path, body, { responseType: "response", signal });
 
     if (!response.body) {
         return;
@@ -81,7 +83,10 @@ export async function* streamAgentNdjson(
             yield parseAgentStreamEvent(buffer);
         }
     } finally {
-        reader.releaseLock();
+        // Cancel the body so an aborted or abandoned generator stops the request streaming in the
+        // background instead of only releasing the lock. cancel() also releases the reader; it
+        // rejects on an already-errored stream (e.g. after an abort), which is safe to ignore.
+        await reader.cancel().catch(() => {});
     }
 }
 

--- a/src/Raven.AiAppliance.Web/src/api/custom-services/agent-stream.ts
+++ b/src/Raven.AiAppliance.Web/src/api/custom-services/agent-stream.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { ApiClient } from "@/api/http-client";
+
+// Shared NDJSON streaming for the agent endpoints (chat + wizard "Test agent"). Both stream
+// the same frame shape: incremental `chunk`s, a terminal `done` (with the full answer), or an
+// `error`.
+const agentStreamEventSchema = z.discriminatedUnion("type", [
+    z.object({
+        type: z.literal("chunk"),
+        text: z.string(),
+    }),
+    z.object({
+        type: z.literal("done"),
+        answer: z.unknown(),
+        // The full structured model output (every declared field). Present on the wizard's
+        // "Test agent" stream; absent on the chat/embed streams, which only send `answer`.
+        fullAnswer: z.unknown().optional(),
+        conversationId: z.string(),
+    }),
+    z.object({
+        type: z.literal("error"),
+        message: z.string(),
+    }),
+]);
+
+export type AgentStreamEvent = z.infer<typeof agentStreamEventSchema>;
+
+/** POSTs `body` to `path` and yields the NDJSON frames the server streams back. Non-2xx
+ * responses (e.g. a pre-stream 400/404) throw an ApiError before the first frame. */
+export async function* streamAgentNdjson(
+    client: ApiClient,
+    path: string,
+    body: unknown,
+): AsyncGenerator<AgentStreamEvent> {
+    const response = await client.post<Response>(path, body, { responseType: "response" });
+
+    if (!response.body) {
+        return;
+    }
+
+    const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+    let buffer = "";
+
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+                break;
+            }
+
+            buffer += value;
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
+
+            for (const line of lines) {
+                if (line.trim()) {
+                    yield parseAgentStreamEvent(line);
+                }
+            }
+        }
+
+        if (buffer.trim()) {
+            yield parseAgentStreamEvent(buffer);
+        }
+    } finally {
+        reader.releaseLock();
+    }
+}
+
+function parseAgentStreamEvent(line: string): AgentStreamEvent {
+    const result = agentStreamEventSchema.safeParse(JSON.parse(line) as unknown);
+
+    if (!result.success) {
+        throw new Error("Received an invalid agent stream event.");
+    }
+
+    return result.data;
+}

--- a/src/Raven.AiAppliance.Web/src/api/custom-services/agent-test-service.ts
+++ b/src/Raven.AiAppliance.Web/src/api/custom-services/agent-test-service.ts
@@ -1,0 +1,16 @@
+import { API_ENDPOINTS } from "@/api/generated/server-api";
+import type { SetupTryRequest } from "@/api/generated/server-api";
+import type { ApiClient } from "@/api/http-client";
+import { streamAgentNdjson, type AgentStreamEvent } from "@/api/custom-services/agent-stream";
+
+// Streams a single "Test agent" turn against the wizard's draft configuration via
+// /api/apps/{slug}/setup/try. The generated client types this endpoint as `void` (it streams
+// NDJSON rather than a JSON body), so the wizard uses this custom streaming service instead.
+export function createAgentTestService(client: ApiClient) {
+    return {
+        stream: (slug: string, request: SetupTryRequest): AsyncGenerator<AgentStreamEvent> =>
+            streamAgentNdjson(client, API_ENDPOINTS.apps.setupTry(slug), request),
+    };
+}
+
+export type AgentTestService = ReturnType<typeof createAgentTestService>;

--- a/src/Raven.AiAppliance.Web/src/api/custom-services/agent-test-service.ts
+++ b/src/Raven.AiAppliance.Web/src/api/custom-services/agent-test-service.ts
@@ -8,8 +8,8 @@ import { streamAgentNdjson, type AgentStreamEvent } from "@/api/custom-services/
 // NDJSON rather than a JSON body), so the wizard uses this custom streaming service instead.
 export function createAgentTestService(client: ApiClient) {
     return {
-        stream: (slug: string, request: SetupTryRequest): AsyncGenerator<AgentStreamEvent> =>
-            streamAgentNdjson(client, API_ENDPOINTS.apps.setupTry(slug), request),
+        stream: (slug: string, request: SetupTryRequest, signal?: AbortSignal): AsyncGenerator<AgentStreamEvent> =>
+            streamAgentNdjson(client, API_ENDPOINTS.apps.setupTry(slug), request, signal),
     };
 }
 

--- a/src/Raven.AiAppliance.Web/src/api/custom-services/chat-service.ts
+++ b/src/Raven.AiAppliance.Web/src/api/custom-services/chat-service.ts
@@ -3,12 +3,16 @@ import type { ChatRequest } from "@/api/generated/server-api";
 import type { ApiClient } from "@/api/http-client";
 import { streamAgentNdjson, type AgentStreamEvent } from "@/api/custom-services/agent-stream";
 
-export type ChatStreamEvent = AgentStreamEvent;
+// The chat/embed streams never send the wizard-only `fullAnswer`/`toolCalls` fields, so narrow
+// the shared agent stream to the frames chat actually receives (its `done` carries `answer` only).
+export type ChatStreamEvent =
+    | Extract<AgentStreamEvent, { type: "chunk" | "error" }>
+    | Omit<Extract<AgentStreamEvent, { type: "done" }>, "fullAnswer" | "toolCalls">;
 
 export function createChatService(client: ApiClient) {
     return {
-        stream: (request: ChatRequest): AsyncGenerator<ChatStreamEvent> =>
-            streamAgentNdjson(client, API_ENDPOINTS.chat.stream, request),
+        stream: (request: ChatRequest, signal?: AbortSignal): AsyncGenerator<ChatStreamEvent> =>
+            streamAgentNdjson(client, API_ENDPOINTS.chat.stream, request, signal),
     };
 }
 

--- a/src/Raven.AiAppliance.Web/src/api/custom-services/chat-service.ts
+++ b/src/Raven.AiAppliance.Web/src/api/custom-services/chat-service.ts
@@ -1,76 +1,15 @@
-import { z } from "zod";
 import { API_ENDPOINTS } from "@/api/generated/server-api";
 import type { ChatRequest } from "@/api/generated/server-api";
 import type { ApiClient } from "@/api/http-client";
+import { streamAgentNdjson, type AgentStreamEvent } from "@/api/custom-services/agent-stream";
 
-const chatStreamEventSchema = z.discriminatedUnion("type", [
-    z.object({
-        type: z.literal("chunk"),
-        text: z.string(),
-    }),
-    z.object({
-        type: z.literal("done"),
-        answer: z.unknown(),
-        conversationId: z.string(),
-    }),
-    z.object({
-        type: z.literal("error"),
-        message: z.string(),
-    }),
-]);
-
-export type ChatStreamEvent = z.infer<typeof chatStreamEventSchema>;
+export type ChatStreamEvent = AgentStreamEvent;
 
 export function createChatService(client: ApiClient) {
     return {
-        stream: async function* (request: ChatRequest): AsyncGenerator<ChatStreamEvent> {
-            const response = await client.post<Response>(API_ENDPOINTS.chat.stream, request, {
-                responseType: "response",
-            });
-
-            if (!response.body) {
-                return;
-            }
-
-            const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
-            let buffer = "";
-
-            try {
-                while (true) {
-                    const { done, value } = await reader.read();
-                    if (done) {
-                        break;
-                    }
-
-                    buffer += value;
-                    const lines = buffer.split("\n");
-                    buffer = lines.pop() ?? "";
-
-                    for (const line of lines) {
-                        if (line.trim()) {
-                            yield parseChatStreamEvent(line);
-                        }
-                    }
-                }
-
-                if (buffer.trim()) {
-                    yield parseChatStreamEvent(buffer);
-                }
-            } finally {
-                reader.releaseLock();
-            }
-        },
+        stream: (request: ChatRequest): AsyncGenerator<ChatStreamEvent> =>
+            streamAgentNdjson(client, API_ENDPOINTS.chat.stream, request),
     };
 }
 
 export type ChatService = ReturnType<typeof createChatService>;
-
-function parseChatStreamEvent(line: string) {
-    const result = chatStreamEventSchema.safeParse(JSON.parse(line) as unknown);
-
-    if (!result.success) {
-        throw new Error("Received an invalid chat stream event.");
-    }
-
-    return result.data;
-}

--- a/src/Raven.AiAppliance.Web/src/api/generated/server-api.ts
+++ b/src/Raven.AiAppliance.Web/src/api/generated/server-api.ts
@@ -770,7 +770,11 @@ export interface components {
         };
         SetupTryRequest: {
             prompt: string;
-            agentId: string;
+            configuration: components["schemas"]["AiAgentConfiguration"];
+            parameters: null | {
+                [key: string]: string;
+            };
+            streamField?: null | string;
         };
         SuggestAgentRequest: {
             intentPrompt: null | string;

--- a/src/Raven.AiAppliance.Web/src/api/generated/server-api.ts
+++ b/src/Raven.AiAppliance.Web/src/api/generated/server-api.ts
@@ -671,6 +671,7 @@ export interface components {
             /** Format: int32 */
             embeddingsMaxConcurrentBatches?: null | number;
         };
+        JsonElement: unknown;
         MapRequest: {
             /** Format: int64 */
             taskId?: null | number;
@@ -768,11 +769,15 @@ export interface components {
         RedeemLicenseRequest: {
             licenseKey: string;
         };
+        SetupTryParameter: {
+            value: null | components["schemas"]["JsonElement"];
+            sendToModel: boolean;
+        };
         SetupTryRequest: {
             prompt: string;
             configuration: components["schemas"]["AiAgentConfiguration"];
             parameters: null | {
-                [key: string]: string;
+                [key: string]: components["schemas"]["SetupTryParameter"];
             };
             streamField?: null | string;
         };
@@ -1846,6 +1851,7 @@ export type EmbedLinkSummaryResponse = components["schemas"]["EmbedLinkSummaryRe
 export type GoogleAIVersion = components["schemas"]["GoogleAIVersion"];
 export type GoogleSettings = components["schemas"]["GoogleSettings"];
 export type HuggingFaceSettings = components["schemas"]["HuggingFaceSettings"];
+export type JsonElement = components["schemas"]["JsonElement"];
 export type MapRequest = components["schemas"]["MapRequest"];
 export type MintEmbedLinkRequest = components["schemas"]["MintEmbedLinkRequest"];
 export type MintEmbedLinkResponse = components["schemas"]["MintEmbedLinkResponse"];
@@ -1860,6 +1866,7 @@ export type ProvisionChannelResponse = components["schemas"]["ProvisionChannelRe
 export type ProvisionRequest = components["schemas"]["ProvisionRequest"];
 export type ProvisionResponse = components["schemas"]["ProvisionResponse"];
 export type RedeemLicenseRequest = components["schemas"]["RedeemLicenseRequest"];
+export type SetupTryParameter = components["schemas"]["SetupTryParameter"];
 export type SetupTryRequest = components["schemas"]["SetupTryRequest"];
 export type SuggestAgentRequest = components["schemas"]["SuggestAgentRequest"];
 export type SuggestAgentResponse = components["schemas"]["SuggestAgentResponse"];

--- a/src/Raven.AiAppliance.Web/src/components/data/status-indicator.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/data/status-indicator.tsx
@@ -1,23 +1,14 @@
-import { cn } from "@/lib/utils";
+import { CircleCheckIcon } from "lucide-react";
+
+import { Badge } from "@/components/shadcn/ui/badge";
 
 export function StatusIndicator({ tone, label }: { tone: "positive" | "muted"; label: string }) {
+    const isPositive = tone === "positive";
+
     return (
-        <span
-            className={cn(
-                "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium",
-                tone === "positive"
-                    ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-                    : "bg-muted text-muted-foreground",
-            )}
-        >
-            <span
-                className={cn(
-                    "size-1.5 rounded-full",
-                    tone === "positive" ? "bg-emerald-500" : "bg-muted-foreground/50",
-                )}
-                aria-hidden="true"
-            />
+        <Badge variant={isPositive ? "success" : "secondary"}>
+            {isPositive && <CircleCheckIcon aria-hidden="true" />}
             {label}
-        </span>
+        </Badge>
     );
 }

--- a/src/Raven.AiAppliance.Web/src/components/form/form-radio-cards.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/form/form-radio-cards.tsx
@@ -1,0 +1,100 @@
+import { type ReactNode } from "react";
+import { type FieldPath, type FieldValues, type UseControllerProps, useController } from "react-hook-form";
+import { FieldDescription } from "@/components/shadcn/ui/field";
+import { cn } from "@/lib/utils";
+
+/**
+ * Active state shared by every selectable card across the wizards: brand border,
+ * a subtle brand gradient fill, and a soft ring. Cards with bespoke layouts that
+ * can't use FormRadioCards still reuse this so the selected look stays consistent.
+ */
+export const SELECTED_CARD_CLASSES =
+    "border-primary bg-linear-to-br from-primary/15 to-transparent ring-2 ring-ring/25";
+
+export type RadioCardOption<TValue extends string = string> = {
+    value: TValue;
+    label: ReactNode;
+    description?: ReactNode;
+    icon?: ReactNode;
+    disabled?: boolean;
+    /**
+     * Extra content rendered inside the card, below the header (e.g. an input).
+     * Receives `select` so interactive content can select the card on focus.
+     */
+    content?: (helpers: { isSelected: boolean; select: () => void }) => ReactNode;
+};
+
+type FormRadioCardsProps<
+    TFieldValues extends FieldValues,
+    TName extends FieldPath<TFieldValues>,
+    TValue extends string,
+> = UseControllerProps<TFieldValues, TName> & {
+    options: ReadonlyArray<RadioCardOption<TValue>>;
+    className?: string;
+    disabled?: boolean;
+};
+
+export function FormRadioCards<
+    TFieldValues extends FieldValues,
+    TName extends FieldPath<TFieldValues>,
+    TValue extends string,
+>({ className, control, defaultValue, disabled, name, options }: FormRadioCardsProps<TFieldValues, TName, TValue>) {
+    const {
+        field: { onChange, value },
+        fieldState: { error, invalid },
+        formState,
+    } = useController({
+        control,
+        defaultValue,
+        name,
+    });
+
+    return (
+        <div className="grid gap-2">
+            <div role="radiogroup" aria-invalid={invalid || undefined} className={cn("grid gap-3", className)}>
+                {options.map((option) => {
+                    const isSelected = option.value === value;
+                    const isDisabled = disabled || formState.isSubmitting || option.disabled;
+                    const select = () => onChange(option.value);
+
+                    return (
+                        <div
+                            key={option.value}
+                            className={cn(
+                                "rounded-lg border bg-background transition-colors",
+                                isSelected && SELECTED_CARD_CLASSES,
+                                !isSelected && !isDisabled && "hover:bg-accent hover:text-accent-foreground",
+                                isDisabled && "cursor-not-allowed opacity-55",
+                            )}
+                        >
+                            <button
+                                type="button"
+                                role="radio"
+                                aria-checked={isSelected}
+                                disabled={isDisabled}
+                                onClick={select}
+                                className={cn(
+                                    "block w-full p-4 text-left",
+                                    option.content ? "rounded-t-lg" : "rounded-lg",
+                                    isDisabled && "cursor-not-allowed",
+                                )}
+                            >
+                                {option.icon && <span className="mb-3 block">{option.icon}</span>}
+                                <span className="block text-sm font-semibold">{option.label}</span>
+                                {option.description && (
+                                    <span className="mt-2 block text-xs leading-5 text-muted-foreground">
+                                        {option.description}
+                                    </span>
+                                )}
+                            </button>
+                            {option.content && (
+                                <div className="px-4 pb-4">{option.content({ isSelected, select })}</div>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+            {error?.message && <FieldDescription className="text-destructive">{error.message}</FieldDescription>}
+        </div>
+    );
+}

--- a/src/Raven.AiAppliance.Web/src/components/form/wizard/form-wizard.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/form/wizard/form-wizard.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import {
     useFormContext,
     useWatch,
@@ -13,12 +13,20 @@ import { Alert } from "@/components/shadcn/ui/alert";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { cn } from "@/lib/utils";
 
-export type WizardBeforeNext = () => void | Promise<void>;
+export type WizardAction = () => void | Promise<void>;
 export type WizardStepPosition = "first" | "middle" | "last";
 export type WizardValidationTarget<Values extends FieldValues> = Path<Values> | readonly Path<Values>[] | false;
 
+export type WizardCompletion =
+    | { type: "submit"; label?: ReactNode }
+    | { type: "action"; label?: ReactNode; onComplete: WizardAction };
+
 export type WizardBodyComponentProps<StepId extends string = string> = {
     currentStepId: StepId;
+    isBusy: boolean;
+};
+
+export type WizardFooterComponentProps = {
     isBusy: boolean;
 };
 
@@ -43,10 +51,11 @@ export type WizardStep<StepId extends string, Values extends FieldValues = Field
     description?: ReactNode;
     bodyComponent: (props: WizardBodyComponentProps<StepId>) => ReactNode;
     validate: WizardValidationTarget<Values>;
-    beforeNext?: WizardBeforeNext;
-    // Optional step-specific action rendered in the footer (e.g. the review step's "Test
-    // agent" button). Renders alongside the wizard's Back/Next/Submit controls.
-    footerComponent?: () => ReactNode;
+    beforeNext?: WizardAction;
+    nextLabel?: ReactNode;
+    canCancel?: boolean;
+    canGoBack?: boolean;
+    footerComponent?: (props: WizardFooterComponentProps) => ReactNode;
 } & WizardStepBadge<Values>;
 
 export type WizardSteps<StepId extends string, Values extends FieldValues = FieldValues> = Record<
@@ -59,15 +68,15 @@ type FormWizardProps<StepId extends string, Values extends FieldValues> = {
     flow: StepId[];
     initialStep?: StepId;
     cancel: () => void;
-    submitLabel?: ReactNode;
+    completion?: WizardCompletion;
 };
 
 export function FormWizard<StepId extends string, Values extends FieldValues>({
     steps,
     flow,
     initialStep,
-    submitLabel,
     cancel,
+    completion = { type: "submit" },
 }: FormWizardProps<StepId, Values>) {
     const { trigger, control, getValues, formState } = useFormContext<Values>();
 
@@ -80,6 +89,7 @@ export function FormWizard<StepId extends string, Values extends FieldValues>({
     const [lastKnownIndex, setLastKnownIndex] = useState(() => Math.max(flow.indexOf(initialStepId), 0));
     const [isAdvancing, setIsAdvancing] = useState(false);
     const [advanceError, setAdvanceError] = useState<Error | null>(null);
+    const isAdvancingRef = useRef(false);
 
     const currentIndexInFlow = flow.indexOf(currentStepId);
     const currentIndex = currentIndexInFlow >= 0 ? currentIndexInFlow : Math.min(lastKnownIndex, flow.length - 1);
@@ -104,11 +114,7 @@ export function FormWizard<StepId extends string, Values extends FieldValues>({
         setActiveStepIndex(currentIndex - 1);
     };
 
-    const handleNext = async () => {
-        if (currentIndex >= flow.length - 1) {
-            return;
-        }
-
+    const validateCurrentStep = async () => {
         if (currentStep.validate !== false) {
             // The trigger only works correctly when passing an array
             const isValid = await trigger(
@@ -116,24 +122,62 @@ export function FormWizard<StepId extends string, Values extends FieldValues>({
             );
 
             if (!isValid) {
-                return;
+                return false;
             }
         }
 
+        return true;
+    };
+
+    const runAction = async (action: () => Promise<void>) => {
+        // A ref closes the gap before React commits the disabled state, including the time spent
+        // in async RHF validation.
+        if (isAdvancingRef.current) {
+            return;
+        }
+
+        isAdvancingRef.current = true;
         setIsAdvancing(true);
         setAdvanceError(null);
 
         try {
-            if (currentStep.beforeNext) {
-                await currentStep.beforeNext();
-            }
-
-            setActiveStepIndex(currentIndex + 1);
+            await action();
         } catch (error) {
             setAdvanceError(error instanceof Error ? error : new Error(String(error)));
         } finally {
+            isAdvancingRef.current = false;
             setIsAdvancing(false);
         }
+    };
+
+    const handleNext = async () => {
+        if (currentIndex >= flow.length - 1) {
+            return;
+        }
+
+        await runAction(async () => {
+            if (!(await validateCurrentStep())) {
+                return;
+            }
+
+            await currentStep.beforeNext?.();
+            setActiveStepIndex(currentIndex + 1);
+        });
+    };
+
+    const handleComplete = async () => {
+        if (completion.type !== "action") {
+            return;
+        }
+
+        await runAction(async () => {
+            if (!(await validateCurrentStep())) {
+                return;
+            }
+
+            await currentStep.beforeNext?.();
+            await completion.onComplete();
+        });
     };
 
     return (
@@ -163,9 +207,13 @@ export function FormWizard<StepId extends string, Values extends FieldValues>({
                         cancel={cancel}
                         goPrev={goPrev}
                         handleNext={handleNext}
+                        handleComplete={handleComplete}
                         isBusy={isBusy}
                         currentStepId={currentStepIdInFlow}
-                        submitLabel={submitLabel}
+                        nextLabel={currentStep.nextLabel}
+                        canCancel={currentStep.canCancel !== false}
+                        canGoBack={currentStep.canGoBack !== false}
+                        completion={completion}
                         footerComponent={currentStep.footerComponent}
                     />
                 </div>
@@ -207,7 +255,7 @@ function WizardStepper<StepId extends string, Values extends FieldValues>({
                 const isComplete = index < currentIndex;
 
                 return (
-                    <li key={stepId} className="flex items-start gap-3">
+                    <li key={stepId} className="flex items-start gap-3" aria-current={isCurrent ? "step" : undefined}>
                         <StepIndicator isComplete={isComplete} isCurrent={isCurrent} />
                         <div className="grid gap-1.5">
                             <span
@@ -289,9 +337,13 @@ type WizardFooterProps<StepId extends string> = {
     cancel: () => void;
     goPrev: () => void;
     handleNext: () => Promise<void>;
+    handleComplete: () => Promise<void>;
     isBusy: boolean;
-    submitLabel?: ReactNode;
-    footerComponent?: () => ReactNode;
+    nextLabel?: ReactNode;
+    canCancel: boolean;
+    canGoBack: boolean;
+    completion: WizardCompletion;
+    footerComponent?: (props: WizardFooterComponentProps) => ReactNode;
 };
 
 function WizardFooter<StepId extends string>({
@@ -300,17 +352,25 @@ function WizardFooter<StepId extends string>({
     cancel,
     goPrev,
     handleNext,
+    handleComplete,
     isBusy,
-    submitLabel,
+    nextLabel,
+    canCancel,
+    canGoBack,
+    completion,
     footerComponent: FooterComponent,
 }: WizardFooterProps<StepId>) {
+    const isLast = stepPosition === "last";
+
     return (
         <div className="flex items-center border-t px-4 py-2">
             <div className="flex gap-2">
-                <Button onClick={cancel} variant="outline">
-                    Cancel
-                </Button>
-                {stepPosition !== "first" && (
+                {canCancel && (
+                    <Button onClick={cancel} variant="outline" disabled={isBusy}>
+                        Cancel
+                    </Button>
+                )}
+                {stepPosition !== "first" && canGoBack && (
                     <Button onClick={goPrev} variant="secondary" disabled={isBusy}>
                         Back
                     </Button>
@@ -318,16 +378,21 @@ function WizardFooter<StepId extends string>({
             </div>
 
             <div className="ml-auto flex items-center gap-2">
-                {FooterComponent && <FooterComponent />}
-                {stepPosition === "last" ? (
+                {FooterComponent && <FooterComponent isBusy={isBusy} />}
+                {isLast && completion.type === "action" ? (
+                    <Button type="button" onClick={handleComplete} disabled={isBusy} key={`${currentStepId}:complete`}>
+                        {isBusy && <Spinner />}
+                        {completion.label ?? "Finish"}
+                    </Button>
+                ) : isLast ? (
                     <Button type="submit" disabled={isBusy} key={`${currentStepId}:submit`}>
                         {isBusy && <Spinner />}
-                        {submitLabel ?? "Submit"}
+                        {completion.label ?? "Submit"}
                     </Button>
                 ) : (
                     <Button onClick={handleNext} disabled={isBusy} key={`${currentStepId}:next`}>
                         {isBusy && <Spinner />}
-                        Next
+                        {nextLabel ?? "Next"}
                     </Button>
                 )}
             </div>

--- a/src/Raven.AiAppliance.Web/src/components/form/wizard/form-wizard.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/form/wizard/form-wizard.tsx
@@ -43,7 +43,7 @@ type WizardStepBadge<Values extends FieldValues> =
       }
     | {
           badge: (context: WizardBadgeContext<Values>) => ReactNode;
-          badgeFields: readonly Path<Values>[];
+          badgeFields?: readonly Path<Values>[];
       };
 
 export type WizardStep<StepId extends string, Values extends FieldValues = FieldValues> = {
@@ -286,7 +286,7 @@ function WizardStepper<StepId extends string, Values extends FieldValues>({
 type WizardStepBadgeProps<StepId extends string, Values extends FieldValues> = {
     step: WizardStep<StepId, Values> & {
         badge: (context: WizardBadgeContext<Values>) => ReactNode;
-        badgeFields: readonly Path<Values>[];
+        badgeFields?: readonly Path<Values>[];
     };
     isComplete: boolean;
     isCurrent: boolean;
@@ -301,7 +301,8 @@ function WizardStepBadge<StepId extends string, Values extends FieldValues>({
     control,
     getValues,
 }: WizardStepBadgeProps<StepId, Values>) {
-    useWatch({ control, name: step.badgeFields });
+    // An empty name array subscribes to nothing, so steps with a static badge can omit badgeFields.
+    useWatch({ control, name: step.badgeFields ?? [] });
     const badge = step.badge({ values: getValues(), isComplete, isCurrent });
 
     if (!badge) {

--- a/src/Raven.AiAppliance.Web/src/components/form/wizard/form-wizard.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/form/wizard/form-wizard.tsx
@@ -44,6 +44,9 @@ export type WizardStep<StepId extends string, Values extends FieldValues = Field
     bodyComponent: (props: WizardBodyComponentProps<StepId>) => ReactNode;
     validate: WizardValidationTarget<Values>;
     beforeNext?: WizardBeforeNext;
+    // Optional step-specific action rendered in the footer (e.g. the review step's "Test
+    // agent" button). Renders alongside the wizard's Back/Next/Submit controls.
+    footerComponent?: () => ReactNode;
 } & WizardStepBadge<Values>;
 
 export type WizardSteps<StepId extends string, Values extends FieldValues = FieldValues> = Record<
@@ -163,6 +166,7 @@ export function FormWizard<StepId extends string, Values extends FieldValues>({
                         isBusy={isBusy}
                         currentStepId={currentStepIdInFlow}
                         submitLabel={submitLabel}
+                        footerComponent={currentStep.footerComponent}
                     />
                 </div>
 
@@ -287,6 +291,7 @@ type WizardFooterProps<StepId extends string> = {
     handleNext: () => Promise<void>;
     isBusy: boolean;
     submitLabel?: ReactNode;
+    footerComponent?: () => ReactNode;
 };
 
 function WizardFooter<StepId extends string>({
@@ -297,9 +302,10 @@ function WizardFooter<StepId extends string>({
     handleNext,
     isBusy,
     submitLabel,
+    footerComponent: FooterComponent,
 }: WizardFooterProps<StepId>) {
     return (
-        <div className="flex border-t px-4 py-2">
+        <div className="flex items-center border-t px-4 py-2">
             <div className="flex gap-2">
                 <Button onClick={cancel} variant="outline">
                     Cancel
@@ -311,17 +317,20 @@ function WizardFooter<StepId extends string>({
                 )}
             </div>
 
-            {stepPosition === "last" ? (
-                <Button type="submit" className="ml-auto" disabled={isBusy} key={`${currentStepId}:submit`}>
-                    {isBusy && <Spinner />}
-                    {submitLabel ?? "Submit"}
-                </Button>
-            ) : (
-                <Button onClick={handleNext} className="ml-auto" disabled={isBusy} key={`${currentStepId}:next`}>
-                    {isBusy && <Spinner />}
-                    Next
-                </Button>
-            )}
+            <div className="ml-auto flex items-center gap-2">
+                {FooterComponent && <FooterComponent />}
+                {stepPosition === "last" ? (
+                    <Button type="submit" disabled={isBusy} key={`${currentStepId}:submit`}>
+                        {isBusy && <Spinner />}
+                        {submitLabel ?? "Submit"}
+                    </Button>
+                ) : (
+                    <Button onClick={handleNext} disabled={isBusy} key={`${currentStepId}:next`}>
+                        {isBusy && <Spinner />}
+                        Next
+                    </Button>
+                )}
+            </div>
         </div>
     );
 }

--- a/src/Raven.AiAppliance.Web/src/components/shadcn/ui/badge.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/shadcn/ui/badge.tsx
@@ -11,7 +11,8 @@ const badgeVariants = cva(
         variants: {
             variant: {
                 default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-                success: "border-transparent bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+                primary: "border-badge-default-border bg-badge-default-bg text-badge-default-fg",
+                success: "border-badge-success-border bg-badge-success-bg text-badge-success-fg",
                 secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
                 destructive:
                     "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",

--- a/src/Raven.AiAppliance.Web/src/components/shadcn/ui/badge.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/shadcn/ui/badge.tsx
@@ -13,9 +13,10 @@ const badgeVariants = cva(
                 default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
                 primary: "border-badge-default-border bg-badge-default-bg text-badge-default-fg",
                 success: "border-badge-success-border bg-badge-success-bg text-badge-success-fg",
-                secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
-                destructive:
-                    "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+                warning: "border-badge-warning-border bg-badge-warning-bg text-badge-warning-fg",
+                info: "border-badge-info-border bg-badge-info-bg text-badge-info-fg",
+                secondary: "border-badge-secondary-border bg-secondary text-secondary-foreground",
+                destructive: "border-badge-destructive-border bg-badge-destructive-bg text-badge-destructive-fg",
                 outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
                 ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
                 link: "text-primary underline-offset-4 hover:underline",

--- a/src/Raven.AiAppliance.Web/src/components/shadcn/ui/sonner.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/shadcn/ui/sonner.tsx
@@ -8,6 +8,10 @@ const Toaster = ({ ...props }: ToasterProps) => {
     return (
         <Sonner
             theme={theme as ToasterProps["theme"]}
+            position="top-center"
+            offset={{ top: "4rem" }}
+            mobileOffset={{ top: "4rem" }}
+            richColors
             className="toaster group"
             icons={{
                 success: <CircleCheckIcon className="size-4" />,
@@ -22,6 +26,10 @@ const Toaster = ({ ...props }: ToasterProps) => {
                     "--normal-text": "var(--popover-foreground)",
                     "--normal-border": "var(--border)",
                     "--border-radius": "var(--radius)",
+                    "--success-border": "var(--success)",
+                    "--info-border": "var(--info)",
+                    "--error-border": "var(--destructive)",
+                    "--warning-border": "var(--warning)",
                 } as React.CSSProperties
             }
             toastOptions={{

--- a/src/Raven.AiAppliance.Web/src/components/shadcn/ui/table.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/shadcn/ui/table.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
     return (
-        <div data-slot="table-container" className="relative w-full overflow-x-auto">
+        <div data-slot="table-container" className="relative w-full overflow-x-auto bg-card">
             <table data-slot="table" className={cn("w-full caption-bottom text-sm", className)} {...props} />
         </div>
     );

--- a/src/Raven.AiAppliance.Web/src/lib/form-utils.ts
+++ b/src/Raven.AiAppliance.Web/src/lib/form-utils.ts
@@ -19,9 +19,9 @@ export function withNestedSubmit<T>(action: (...args: T[]) => void) {
 }
 
 export function getOptionLabel<TValue extends string>(
-    options: ReadonlyArray<{ value: TValue; label: string }>,
+    options: ReadonlyArray<{ value: TValue; label: React.ReactNode }>,
     value: TValue | null | undefined,
-): string | undefined {
+): React.ReactNode {
     return options.find((option) => option.value === value)?.label;
 }
 

--- a/src/Raven.AiAppliance.Web/src/mocks/apps-mocks.ts
+++ b/src/Raven.AiAppliance.Web/src/mocks/apps-mocks.ts
@@ -94,6 +94,22 @@ export const sampleAgentTestEvents: AgentStreamEvent[] = [
             reply: "Sure! Based on the demo data, I can help you find products and check orders.",
             relatedProducts: ["Wireless Mouse", "USB-C Hub", "Laptop Stand"],
         },
+        // The query tools the agent ran this turn (server's `toolCalls`): the RQL, the parameters
+        // the model filled in, and the rows the query returned.
+        toolCalls: [
+            {
+                id: "call_1",
+                name: "search-products",
+                description: "Search products by name.",
+                query: "from Products where search(Name, $searchTerm)",
+                arguments: JSON.stringify({ searchTerm: "mouse" }),
+                result: JSON.stringify([
+                    { Name: "Wireless Mouse", Price: 24.99 },
+                    { Name: "USB-C Hub", Price: 39.0 },
+                    { Name: "Laptop Stand", Price: 29.5 },
+                ]),
+            },
+        ],
         conversationId: "chats/test",
     },
 ];

--- a/src/Raven.AiAppliance.Web/src/mocks/apps-mocks.ts
+++ b/src/Raven.AiAppliance.Web/src/mocks/apps-mocks.ts
@@ -1,4 +1,6 @@
+import { delay, http, HttpResponse } from "msw";
 import type { AppResponse, ProvisionAgentResponse, SuggestAgentResponse } from "@/api/generated/server-api";
+import type { AgentStreamEvent } from "@/api/custom-services/agent-stream";
 import { apiHttp } from "./api-http";
 
 export const appsMocks = {
@@ -10,7 +12,24 @@ export const appsMocks = {
         }),
     provisionAgent: (result: ProvisionAgentResponse = { agentId: "agents/sales" }) =>
         apiHttp.post("/api/apps/{slug}/setup/agent", ({ response }) => response(200).json(result)),
-    setupTry: () => apiHttp.post("/api/apps/{slug}/setup/try", ({ response }) => response(200).empty()),
+    // setup/try streams newline-delimited JSON events (not described by the OpenAPI
+    // contract), so this mock uses plain msw instead of `apiHttp` — mirroring chatMocks.
+    setupTry: (events: AgentStreamEvent[] = sampleAgentTestEvents, chunkDelayMs = 150) =>
+        http.post("/api/apps/:slug/setup/try", () => {
+            const encoder = new TextEncoder();
+            const stream = new ReadableStream<Uint8Array>({
+                async start(controller) {
+                    for (const event of events) {
+                        await delay(chunkDelayMs);
+                        controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+                    }
+
+                    controller.close();
+                },
+            });
+
+            return new HttpResponse(stream, { headers: { "Content-Type": "application/x-ndjson" } });
+        }),
     suggestAgent: (suggestion: SuggestAgentResponse = sampleAgentSuggestion) =>
         apiHttp.post("/api/apps/{slug}/suggest/agent", ({ response }) => response(200).json(suggestion)),
 };
@@ -41,6 +60,14 @@ export const sampleAgentSuggestion: SuggestAgentResponse = {
             name: "Sales assistant",
             connectionStringName: "openai-chat",
             systemPrompt: "You help customers of the Demo Shop find products and check their orders.",
+            sampleObject: JSON.stringify(
+                {
+                    reply: "A helpful answer to the customer's question.",
+                    relatedProducts: "Up to three product names worth suggesting.",
+                },
+                null,
+                4,
+            ),
             queries: [
                 {
                     name: "search-products",
@@ -54,3 +81,19 @@ export const sampleAgentSuggestion: SuggestAgentResponse = {
     rationale: ["The database contains products and orders, so a shopping assistant fits well."],
     status: "Success",
 };
+
+export const sampleAgentTestEvents: AgentStreamEvent[] = [
+    { type: "chunk", text: "Sure! " },
+    { type: "chunk", text: "Based on the demo data, " },
+    { type: "chunk", text: "I can help you find products and check orders." },
+    {
+        type: "done",
+        answer: { reply: "Sure! Based on the demo data, I can help you find products and check orders." },
+        // The full structured model output the wizard renders as JSON (server's `fullAnswer`).
+        fullAnswer: {
+            reply: "Sure! Based on the demo data, I can help you find products and check orders.",
+            relatedProducts: ["Wireless Mouse", "USB-C Hub", "Laptop Stand"],
+        },
+        conversationId: "chats/test",
+    },
+];

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-overview.stories.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-overview.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { agentsMocks } from "@/mocks/agents-mocks";
+import { channelsMocks } from "@/mocks/channels-mocks";
 import { AppOverview } from "./app-overview";
 
 const meta = {
@@ -15,3 +17,16 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+// Fresh app: no agents or channels yet, so the welcome panel shows the remaining
+// steps as numbered (incomplete) call-to-actions.
+export const Onboarding: Story = {
+    parameters: {
+        msw: {
+            handlers: {
+                agents: [agentsMocks.list([])],
+                channels: [channelsMocks.list([])],
+            },
+        },
+    },
+};

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-overview.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-overview.tsx
@@ -1,12 +1,14 @@
 import { useParams } from "react-router";
 import { AgentsSection } from "@/pages/apps/agents-section";
 import { ChannelsSection } from "@/pages/apps/channels-section";
+import { WelcomePanel } from "@/pages/apps/welcome-panel";
 
 export function AppOverview() {
     const { slug = "" } = useParams();
 
     return (
         <div className="space-y-5">
+            <WelcomePanel slug={slug} />
             <AgentsSection slug={slug} />
             <ChannelsSection slug={slug} />
         </div>

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/add-channel-menu.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/add-channel-menu.tsx
@@ -8,7 +8,7 @@ import {
     DropdownMenuTrigger,
 } from "@/components/shadcn/ui/dropdown-menu";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/shadcn/ui/sheet";
-import { WebWidgetChannelForm } from "@/pages/apps/channels/web-widget-channel-form";
+import { WebWidgetChannelForm, type FixedAgent } from "@/pages/apps/channels/web-widget-channel-form";
 
 type ChannelOption = {
     id: string;
@@ -50,7 +50,7 @@ const CHANNEL_OPTIONS: ChannelOption[] = [
     },
 ];
 
-export function AddChannelMenu({ slug }: { slug: string }) {
+export function AddChannelMenu({ slug, agent }: { slug: string; agent?: FixedAgent }) {
     const [isSheetOpen, setIsSheetOpen] = useState(false);
 
     return (
@@ -84,9 +84,13 @@ export function AddChannelMenu({ slug }: { slug: string }) {
                 <SheetContent className="w-full gap-0 sm:max-w-lg data-[side=right]:sm:max-w-lg">
                     <SheetHeader className="border-b">
                         <SheetTitle>New web widget channel</SheetTitle>
-                        <SheetDescription>Embed a chat widget on your site and route it to an agent.</SheetDescription>
+                        <SheetDescription>
+                            {agent
+                                ? `Embed a chat widget on your site, routed to “${agent.name}”.`
+                                : "Embed a chat widget on your site and route it to an agent."}
+                        </SheetDescription>
                     </SheetHeader>
-                    <WebWidgetChannelForm slug={slug} onCreated={() => setIsSheetOpen(false)} />
+                    <WebWidgetChannelForm slug={slug} agent={agent} onCreated={() => setIsSheetOpen(false)} />
                 </SheetContent>
             </Sheet>
         </>

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/web-widget-channel-form.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/web-widget-channel-form.tsx
@@ -28,14 +28,27 @@ const DEFAULT_VALUES: WebWidgetChannelFormData = {
     allowedOrigins: [],
 };
 
-export function WebWidgetChannelForm({ slug, onCreated }: { slug: string; onCreated: () => void }) {
+// The agent the channel routes to, when the caller has already chosen it (e.g. the capability
+// wizard just created it). When omitted, the operator picks from the app's agents.
+export type FixedAgent = { agentId: string; name: string };
+
+export function WebWidgetChannelForm({
+    slug,
+    agent,
+    onCreated,
+}: {
+    slug: string;
+    agent?: FixedAgent;
+    onCreated: () => void;
+}) {
     const queryClient = useQueryClient();
-    const agentsQuery = useQuery(api.queries.agents.list(slug));
+    // With a fixed agent there's nothing to pick, so skip loading the list.
+    const agentsQuery = useQuery({ ...api.queries.agents.list(slug), enabled: !agent });
 
     const form = useForm<WebWidgetChannelFormData>({
         mode: "onChange",
         resolver: zodResolver(webWidgetChannelSchema),
-        defaultValues: DEFAULT_VALUES,
+        defaultValues: { ...DEFAULT_VALUES, agentId: agent?.agentId ?? "" },
     });
 
     const createMutation = useMutation({
@@ -58,10 +71,12 @@ export function WebWidgetChannelForm({ slug, onCreated }: { slug: string; onCrea
     });
 
     const agents = agentsQuery.data ?? [];
-    const agentOptions: FormSelectOption<string>[] = agents.map((agent) => ({
-        value: agent.agentId,
-        label: agent.name,
+    const agentOptions: FormSelectOption<string>[] = agents.map((option) => ({
+        value: option.agentId,
+        label: option.name,
     }));
+    // A fixed agent always gives a target; otherwise the operator needs at least one to pick.
+    const hasAgentTarget = Boolean(agent?.agentId) || agents.length > 0;
 
     return (
         <form
@@ -70,26 +85,30 @@ export function WebWidgetChannelForm({ slug, onCreated }: { slug: string; onCrea
         >
             <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
                 <ApiState
-                    isLoading={agentsQuery.isPending}
-                    isError={agentsQuery.isError}
+                    isLoading={!agent && agentsQuery.isPending}
+                    isError={!agent && agentsQuery.isError}
                     errorTitle="Could not load agents"
                     onRetry={() => void agentsQuery.refetch()}
                     loadingLabel="Loading agents..."
                 >
-                    {agents.length === 0 ? (
+                    {!hasAgentTarget ? (
                         <Alert>
                             Create an agent first — a channel routes conversations to one of the app&apos;s agents.
                         </Alert>
                     ) : (
                         <>
-                            <FormSelect
-                                control={form.control}
-                                name="agentId"
-                                label="Agent"
-                                placeholder="Select an agent"
-                                options={agentOptions}
-                                description="Conversations from this widget are answered by this agent."
-                            />
+                            {/* When the agent is fixed it's bound via the form's defaults; only show the
+                                picker when the operator still needs to choose one. */}
+                            {!agent && (
+                                <FormSelect
+                                    control={form.control}
+                                    name="agentId"
+                                    label="Agent"
+                                    placeholder="Select an agent"
+                                    options={agentOptions}
+                                    description="Conversations from this widget are answered by this agent."
+                                />
+                            )}
                             <FormInput
                                 control={form.control}
                                 name="displayName"
@@ -114,7 +133,7 @@ export function WebWidgetChannelForm({ slug, onCreated }: { slug: string; onCrea
                     {createMutation.isError && (
                         <Alert variant="destructive">
                             {createMutation.error instanceof Error
-                                ? createMutation.error.message
+                                ? createMutation.error.message.split("\n")[0]
                                 : "Could not create channel."}
                         </Alert>
                     )}
@@ -127,7 +146,7 @@ export function WebWidgetChannelForm({ slug, onCreated }: { slug: string; onCrea
                         Cancel
                     </Button>
                 </SheetClose>
-                <Button type="submit" disabled={createMutation.isPending || agents.length === 0}>
+                <Button type="submit" disabled={createMutation.isPending || !hasAgentTarget}>
                     {createMutation.isPending && <Spinner />}
                     Create channel
                 </Button>

--- a/src/Raven.AiAppliance.Web/src/pages/apps/welcome-panel.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/welcome-panel.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { Link } from "react-router";
+import { Check, ExternalLink, X } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/api";
+import { Button } from "@/components/shadcn/ui/button";
+import { appRoutes } from "@/lib/app-routes";
+import { cn } from "@/lib/utils";
+
+const QUICKSTART_GUIDE_URL = "https://docs.ravendb.net/";
+const DISMISSED_STORAGE_KEY_PREFIX = "quill-welcome-dismissed:";
+
+function dismissedStorageKey(slug: string) {
+    return `${DISMISSED_STORAGE_KEY_PREFIX}${slug}`;
+}
+
+function readDismissed(slug: string) {
+    return localStorage.getItem(dismissedStorageKey(slug)) === "true";
+}
+
+export function WelcomePanel({ slug }: { slug: string }) {
+    const appQuery = useQuery(api.queries.apps.detail(slug));
+    const agentsQuery = useQuery(api.queries.agents.list(slug));
+    const channelsQuery = useQuery(api.queries.channels.list(slug));
+
+    // Dismissal lives in localStorage per app. Re-read it when the route switches
+    // to a different app without remounting (mirrors the sidebar pattern in app.tsx).
+    const [dismissedSlug, setDismissedSlug] = useState(slug);
+    const [isDismissed, setIsDismissed] = useState(() => readDismissed(slug));
+    if (slug !== dismissedSlug) {
+        setDismissedSlug(slug);
+        setIsDismissed(readDismissed(slug));
+    }
+
+    if (isDismissed) {
+        return null;
+    }
+
+    const dismiss = () => {
+        localStorage.setItem(dismissedStorageKey(slug), "true");
+        setIsDismissed(true);
+    };
+
+    const steps = [
+        { label: "Connect a data source", isComplete: Boolean(appQuery.data?.database) },
+        {
+            label: "Create the first AI agent",
+            isComplete: (agentsQuery.data?.length ?? 0) > 0,
+            to: appRoutes.addCapability(slug, "agent"),
+        },
+        {
+            label: "Connect a channel",
+            isComplete: (channelsQuery.data?.length ?? 0) > 0,
+            to: appRoutes.app(slug, "channels"),
+        },
+    ];
+
+    return (
+        <section className="rounded-lg border bg-card p-4">
+            <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                    <h2 className="text-sm font-semibold">Welcome to Quill</h2>
+                    <p className="text-sm text-muted-foreground">
+                        Three steps to get your first agent answering questions in production.
+                    </p>
+                </div>
+                <div className="flex items-center gap-1">
+                    <Button asChild size="sm" variant="outline">
+                        <a href={QUICKSTART_GUIDE_URL} target="_blank" rel="noreferrer">
+                            <ExternalLink className="size-3.5" aria-hidden="true" />
+                            Quickstart Guide
+                        </a>
+                    </Button>
+                    <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={dismiss}>
+                        Dismiss
+                        <X className="size-3.5" aria-hidden="true" />
+                    </Button>
+                </div>
+            </div>
+
+            <ol className="flex flex-wrap items-center gap-x-8 gap-y-3">
+                {steps.map((step, index) => (
+                    <li key={step.label}>
+                        <WelcomeStep position={index + 1} {...step} />
+                    </li>
+                ))}
+            </ol>
+        </section>
+    );
+}
+
+type WelcomeStepProps = {
+    position: number;
+    label: string;
+    isComplete: boolean;
+    to?: string;
+};
+
+function WelcomeStep({ position, label, isComplete, to }: WelcomeStepProps) {
+    if (!to) {
+        return (
+            <span className="flex items-center gap-2">
+                <Indicator isComplete={isComplete} position={position} />
+                <span className="text-sm font-medium">{label}</span>
+            </span>
+        );
+    }
+
+    return (
+        <Link to={to} className="group flex items-center gap-2 transition-colors hover:text-primary">
+            <Indicator isComplete={isComplete} position={position} />
+            <span className="text-sm font-medium group-hover:underline">{label}</span>
+        </Link>
+    );
+}
+
+function Indicator({ isComplete, position }: Pick<WelcomeStepProps, "isComplete" | "position">) {
+    return (
+        <span
+            className={cn(
+                "flex size-5 shrink-0 items-center justify-center rounded-full text-xs font-medium",
+                isComplete ? "bg-emerald-500 text-white" : "border border-border bg-muted text-muted-foreground",
+            )}
+            aria-hidden="true"
+        >
+            {isComplete ? <Check className="size-3" /> : position}
+        </span>
+    );
+}

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/add-app-wizard.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/add-app-wizard.tsx
@@ -42,7 +42,7 @@ export function AddAppWizard() {
         onSuccess: async (result) => {
             await queryClient.invalidateQueries({ queryKey: api.queries.apps.list().queryKey });
             toast.success(`App ${result.slug} created`);
-            navigate(appRoutes.app(result.slug));
+            navigate(appRoutes.addCapability(result.slug, "agent"));
         },
         onError: (error) => {
             const message = error instanceof Error ? error.message.split("\n")[0] : "Could not create app.";
@@ -53,7 +53,7 @@ export function AddAppWizard() {
     return (
         <FormProvider {...form}>
             <form
-                onSubmit={form.handleSubmit((x) => provisionMutation.mutateAsync(x))}
+                onSubmit={form.handleSubmit((values) => provisionMutation.mutate(values))}
                 onKeyDown={preventEnterKeySubmission}
                 className="h-full"
             >

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/app-wizard-flow.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/app-wizard-flow.tsx
@@ -31,9 +31,7 @@ export const useAppSteps = (): WizardSteps<AppStepId, AppFormData> => {
                 if (!isComplete) {
                     return null;
                 }
-                return (
-                    <Badge variant="secondary">{getOptionLabel(DATA_SOURCE_OPTIONS, values.dataSource.source)}</Badge>
-                );
+                return <Badge variant="primary">{getOptionLabel(DATA_SOURCE_OPTIONS, values.dataSource.source)}</Badge>;
             },
         },
         externalConnection: {
@@ -61,9 +59,13 @@ export const useAppSteps = (): WizardSteps<AppStepId, AppFormData> => {
             validate: "map",
             beforeNext: mapSchemaBeforeNext,
             badgeFields: ["map.source"],
-            badge: ({ values }) => (
-                <Badge variant="secondary">{getOptionLabel(MAP_SOURCE_OPTIONS, values.map?.source)}</Badge>
-            ),
+            badge: ({ isComplete, values }) => {
+                if (!isComplete) {
+                    return null;
+                }
+
+                return <Badge variant="primary">{getOptionLabel(MAP_SOURCE_OPTIONS, values.map?.source)}</Badge>;
+            },
         },
         mapTables: {
             title: "Map schema",

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
@@ -1,4 +1,5 @@
 import { useController, useFormContext } from "react-hook-form";
+import { SELECTED_CARD_CLASSES } from "@/components/form/form-radio-cards";
 import { FormInput } from "@/components/form/form-input";
 import { FormTextarea } from "@/components/form/form-textarea";
 import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
@@ -38,9 +39,9 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
                                 disabled={isBusy}
                                 className={cn(
                                     "flex min-h-28 flex-col items-center justify-center gap-3 rounded-lg border bg-background p-4 transition-colors",
-                                    "hover:bg-accent hover:text-accent-foreground",
-                                    isSelected && "border-foreground bg-accent text-accent-foreground",
-                                    isBusy && "cursor-not-allowed opacity-55 hover:bg-background hover:text-foreground",
+                                    isSelected && SELECTED_CARD_CLASSES,
+                                    !isSelected && !isBusy && "hover:bg-accent hover:text-accent-foreground",
+                                    isBusy && "cursor-not-allowed opacity-55",
                                 )}
                             >
                                 {option.icon}

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/data-source/choose-data-source-step.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/data-source/choose-data-source-step.tsx
@@ -1,39 +1,17 @@
-import { cn } from "@/lib/utils";
+import { useFormContext } from "react-hook-form";
+import { FormRadioCards } from "@/components/form/form-radio-cards";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { DATA_SOURCE_OPTIONS } from "@/pages/setup/add-app-wizard/steps/data-source/data-source-options";
-import { useFormContext, useWatch } from "react-hook-form";
 
 export function ChooseDataSourceStep() {
     const { control } = useFormContext<AppFormData>();
-    const source = useWatch({
-        control,
-        name: "dataSource.source",
-    });
 
     return (
-        <div className="grid gap-3 md:grid-cols-2">
-            {DATA_SOURCE_OPTIONS.map((option) => {
-                const isSelected = option.value === source;
-
-                return (
-                    <button
-                        key={option.value}
-                        type="button"
-                        disabled={option.isDisabled}
-                        aria-pressed={isSelected}
-                        className={cn(
-                            "min-h-28 rounded-lg border bg-background p-4 text-left transition-colors",
-                            "hover:bg-accent hover:text-accent-foreground",
-                            isSelected && "border-foreground bg-accent text-accent-foreground",
-                            option.isDisabled && "cursor-not-allowed opacity-55 hover:bg-background",
-                        )}
-                    >
-                        {option.icon}
-                        <span className="block text-sm font-semibold">{option.label}</span>
-                        <span className="mt-2 block text-xs leading-5 text-muted-foreground">{option.description}</span>
-                    </button>
-                );
-            })}
-        </div>
+        <FormRadioCards
+            control={control}
+            name="dataSource.source"
+            options={DATA_SOURCE_OPTIONS}
+            className="md:grid-cols-2"
+        />
     );
 }

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/data-source/data-source-options.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/data-source/data-source-options.tsx
@@ -1,26 +1,19 @@
 import { Database, DatabaseZap } from "lucide-react";
+import type { RadioCardOption } from "@/components/form/form-radio-cards";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 
-type DataSourceOption = {
-    value: AppFormData["dataSource"]["source"];
-    label: string;
-    description: string;
-    icon: React.ReactNode;
-    isDisabled?: boolean;
-};
-
-export const DATA_SOURCE_OPTIONS: DataSourceOption[] = [
+export const DATA_SOURCE_OPTIONS: RadioCardOption<AppFormData["dataSource"]["source"]>[] = [
     {
         value: "external",
         label: "External database",
         description: "Mirror data from PostgreSQL, SQL Server, or MySQL via Change Data Capture.",
-        icon: <Database className="mb-5 size-5" />,
+        icon: <Database className="size-5" />,
     },
     {
         value: "ravendb",
         label: "RavenDB database",
         description: "Connect to an existing database on your RavenDB server.",
-        isDisabled: true,
-        icon: <DatabaseZap className="mb-5 size-5" />,
+        disabled: true,
+        icon: <DatabaseZap className="size-5" />,
     },
 ];

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/map/map-schema-step.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/map/map-schema-step.tsx
@@ -1,72 +1,44 @@
 import { Sparkles } from "lucide-react";
-import { useFormContext, useWatch } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
+import { FormRadioCards } from "@/components/form/form-radio-cards";
 import { FormTextarea } from "@/components/form/form-textarea";
 import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
-import { cn } from "@/lib/utils";
 import { type AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { AI_SUGGEST_OPTION, MANUAL_OPTION } from "@/pages/setup/add-app-wizard/steps/map/map-source-options";
 
 export function MapSchemaStep({ isBusy }: WizardBodyComponentProps) {
-    const { control, setValue } = useFormContext<AppFormData>();
-
-    const mapSource = useWatch({
-        control,
-        name: "map.source",
-    });
-
-    const isAiSelected = mapSource === "ai-suggested";
-    const isManualSelected = mapSource === "manual";
+    const { control } = useFormContext<AppFormData>();
 
     return (
-        <div className="grid gap-4">
-            <div
-                className={cn(
-                    "rounded-lg border bg-background transition-colors",
-                    isAiSelected && "border-foreground bg-accent text-accent-foreground",
-                    !isAiSelected && "hover:bg-accent hover:text-accent-foreground",
-                )}
-            >
-                <button
-                    type="button"
-                    aria-pressed={isAiSelected}
-                    disabled={isBusy}
-                    onClick={() => setValue("map.source", "ai-suggested")}
-                    className={cn("block w-full rounded-t-lg p-4 text-left", isBusy && "cursor-not-allowed")}
-                >
-                    <Sparkles className="mb-4 size-5" aria-hidden="true" />
-                    <span className="block text-sm font-semibold">{AI_SUGGEST_OPTION.label}</span>
-                    <span className="mt-2 block text-xs leading-5 text-muted-foreground">
-                        {AI_SUGGEST_OPTION.description}
-                    </span>
-                </button>
-                <div className="px-4 pb-4">
-                    <FormTextarea
-                        control={control}
-                        name="map.aiPrompt"
-                        label="Intent prompt"
-                        placeholder='e.g. "Embed line items in each order, link customers by id, flatten addresses."'
-                        rows={4}
-                        disabled={isBusy}
-                        onFocus={() => setValue("map.source", "ai-suggested")}
-                    />
-                </div>
-            </div>
-
-            <button
-                type="button"
-                aria-pressed={isManualSelected}
-                disabled={isBusy}
-                onClick={() => setValue("map.source", "manual")}
-                className={cn(
-                    "min-h-24 rounded-lg border bg-background p-4 text-left transition-colors",
-                    isManualSelected && "border-foreground bg-accent text-accent-foreground",
-                    !isManualSelected && "hover:bg-accent hover:text-accent-foreground",
-                    isBusy && "cursor-not-allowed",
-                )}
-            >
-                <span className="block text-sm font-semibold">{MANUAL_OPTION.label}</span>
-                <span className="mt-2 block text-xs leading-5 text-muted-foreground">{MANUAL_OPTION.description}</span>
-            </button>
-        </div>
+        <FormRadioCards
+            control={control}
+            name="map.source"
+            disabled={isBusy}
+            className="gap-4"
+            options={[
+                {
+                    value: AI_SUGGEST_OPTION.value,
+                    label: AI_SUGGEST_OPTION.label,
+                    description: AI_SUGGEST_OPTION.description,
+                    icon: <Sparkles className="size-5" aria-hidden="true" />,
+                    content: ({ select }) => (
+                        <FormTextarea
+                            control={control}
+                            name="map.aiPrompt"
+                            label="Intent prompt"
+                            placeholder='e.g. "Embed line items in each order, link customers by id, flatten addresses."'
+                            rows={4}
+                            disabled={isBusy}
+                            onFocus={select}
+                        />
+                    ),
+                },
+                {
+                    value: MANUAL_OPTION.value,
+                    label: MANUAL_OPTION.label,
+                    description: MANUAL_OPTION.description,
+                },
+            ]}
+        />
     );
 }

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/add-capability-wizard.stories.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/add-capability-wizard.stories.tsx
@@ -5,6 +5,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { FormWizard } from "@/components/form/wizard/form-wizard";
 import { preventEnterKeySubmission } from "@/lib/form-utils";
 import { sampleAgentSuggestion } from "@/mocks/apps-mocks";
+import { channelsMocks } from "@/mocks/channels-mocks";
 import { AddCapabilityWizard } from "./add-capability-wizard";
 import { suggestionToAgentConfiguration } from "./agent-config-form";
 import { CAPABILITY_FLOW, useCapabilitySteps } from "./capability-wizard-flow";
@@ -45,7 +46,15 @@ const SEED: AgentFormData = {
 // suggestions from the store, so seed them before those steps first render (Default's
 // AddCapabilityWizard resets the store on mount, so this never leaks).
 function CapabilityWizardAtStep({ initialStep }: { initialStep: AgentStepId }) {
-    useState(() => useCapabilityWizardStore.setState({ suggestions: sampleAgentSuggestion.configurations }));
+    // Seed the store so any step renders with realistic data. The channels step is entered
+    // directly (no provisioning runs first), so seed its created agent; other steps provision
+    // on the way in and must start without one so "Save agent" actually creates the agent.
+    useState(() =>
+        useCapabilityWizardStore.setState({
+            suggestions: sampleAgentSuggestion.configurations,
+            createdAgent: initialStep === "channels" ? { agentId: "agents/sales", name: "Sales assistant" } : null,
+        }),
+    );
 
     const form = useForm<AgentFormData>({
         mode: "onChange",
@@ -72,7 +81,7 @@ function CapabilityWizardStepBody({ initialStep }: { initialStep: AgentStepId })
             flow={CAPABILITY_FLOW}
             initialStep={initialStep}
             cancel={() => {}}
-            submitLabel="Save agent"
+            completion={{ type: "action", label: "Finish", onComplete: () => {} }}
         />
     );
 }
@@ -91,4 +100,13 @@ export const CreateAgent: Story = {
 
 export const ReviewAgent: Story = {
     render: () => <CapabilityWizardAtStep initialStep="review" />,
+};
+
+export const Channels: Story = {
+    render: () => <CapabilityWizardAtStep initialStep="channels" />,
+};
+
+export const ChannelsEmpty: Story = {
+    render: () => <CapabilityWizardAtStep initialStep="channels" />,
+    parameters: { msw: { handlers: { channels: [channelsMocks.list([])] } } },
 };

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/add-capability-wizard.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/add-capability-wizard.tsx
@@ -2,26 +2,16 @@ import { useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FormProvider, useForm } from "react-hook-form";
 import { useNavigate, useParams, useSearchParams } from "react-router";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import { api } from "@/api/api";
-import type { AiAgentConfiguration } from "@/api/generated/server-api";
 import { appRoutes } from "@/lib/app-routes";
 import { FormWizard } from "@/components/form/wizard/form-wizard";
 import { agentSchema, type AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
-import {
-    buildAgentConfigurationPayload,
-    emptyAgentConfiguration,
-} from "@/pages/setup/add-capability-wizard/agent-config-form";
+import { emptyAgentConfiguration } from "@/pages/setup/add-capability-wizard/agent-config-form";
 import { CAPABILITY_FLOW, useCapabilitySteps } from "@/pages/setup/add-capability-wizard/capability-wizard-flow";
 import { useCapabilityWizardStore } from "@/pages/setup/add-capability-wizard/capability-wizard-store";
 import { preventEnterKeySubmission } from "@/lib/form-utils";
 
 export function AddCapabilityWizard() {
-    const { slug = "" } = useParams();
-    const navigate = useNavigate();
     const resetStore = useCapabilityWizardStore((state) => state.reset);
-    const queryClient = useQueryClient();
 
     const form = useForm<AgentFormData>({
         mode: "onChange",
@@ -34,43 +24,12 @@ export function AddCapabilityWizard() {
         return resetStore;
     }, [resetStore]);
 
-    const provisionMutation = useMutation({
-        mutationFn: async (values: AgentFormData) => {
-            // The base carries fields the form does not edit (e.g. chatTrimming) from the AI
-            // candidate; manual setup has none. Everything editable is overridden below.
-            const base = resolveAgentBase(values);
-
-            const config: AiAgentConfiguration = {
-                ...base,
-                ...buildAgentConfigurationPayload(values),
-            };
-
-            await api.services.apps.provisionAgent(slug, config);
-            return config.name;
-        },
-        onSuccess: async (name) => {
-            await queryClient.invalidateQueries({ queryKey: api.queries.agents.list(slug).queryKey });
-            toast.success(`Agent "${name}" created`);
-            navigate(appRoutes.app(slug));
-        },
-        onError: (error) => {
-            // Backend rejections can carry a full stack trace; show only the first line.
-            const message = error instanceof Error ? error.message.split("\n")[0] : "Could not create agent.";
-            toast.error(message);
-        },
-    });
-
     return (
         <FormProvider {...form}>
-            <form
-                onSubmit={form.handleSubmit(async (values) => {
-                    // Errors surface via the mutation's onError toast; swallow so the rejected
-                    // promise doesn't bubble out of handleSubmit.
-                    await provisionMutation.mutateAsync(values).catch(() => {});
-                })}
-                onKeyDown={preventEnterKeySubmission}
-                className="h-full"
-            >
+            {/* The agent is provisioned in the review step's beforeNext (so the wizard can advance
+                to the optional channels step), not on form submit. The form element just provides
+                the RHF context and swallows stray Enter-key submits. */}
+            <form onSubmit={(event) => event.preventDefault()} onKeyDown={preventEnterKeySubmission} className="h-full">
                 <AddCapabilityWizardBody />
             </form>
         </FormProvider>
@@ -93,34 +52,13 @@ function AddCapabilityWizardBody() {
             flow={CAPABILITY_FLOW}
             initialStep={isAgentPreselected ? "connection" : undefined}
             cancel={() => navigate(appRoutes.app(slug))}
-            submitLabel="Save agent"
+            completion={{
+                type: "action",
+                label: "Finish",
+                onComplete: () => navigate(appRoutes.app(slug)),
+            }}
         />
     );
-}
-
-// The AI candidate a provisioned agent builds on: the selected data suggestion ("ai"), the
-// prompt-generated config ("prompt"), or none ("manual"). Throws when the expected candidate
-// is missing so we never silently provision an empty agent.
-function resolveAgentBase(values: AgentFormData): AiAgentConfiguration | undefined {
-    const store = useCapabilityWizardStore.getState();
-
-    if (values.create.mode === "ai") {
-        const base = store.suggestions[values.create.selectedIndex];
-        if (!base) {
-            throw new Error("No agent suggestion selected.");
-        }
-        return base;
-    }
-
-    if (values.create.mode === "prompt") {
-        const base = store.promptResult?.config;
-        if (!base) {
-            throw new Error("No generated agent. Go back and generate one from your prompt.");
-        }
-        return base;
-    }
-
-    return undefined;
 }
 
 function getDefaultValues(): AgentFormData {

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/capability-wizard-flow.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/capability-wizard-flow.tsx
@@ -6,6 +6,7 @@ import { useConnectProviderStep } from "@/pages/setup/add-capability-wizard/step
 import { CreateAgentStep } from "@/pages/setup/add-capability-wizard/steps/create/create-agent-step";
 import { useCreateAgentStep } from "@/pages/setup/add-capability-wizard/steps/create/use-create-agent-step";
 import { ReviewAgentStep } from "@/pages/setup/add-capability-wizard/steps/review/review-agent-step";
+import { ReviewTestAgentButton } from "@/pages/setup/add-capability-wizard/steps/review/test-agent-sheet";
 import { CAPABILITY_OPTIONS } from "@/pages/setup/add-capability-wizard/steps/capability/capability-options";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { getOptionLabel } from "@/lib/form-utils";
@@ -55,6 +56,7 @@ export const useCapabilitySteps = (): WizardSteps<AgentStepId, AgentFormData> =>
             title: "Review & edit your agent",
             bodyComponent: ReviewAgentStep,
             validate: "review",
+            footerComponent: ReviewTestAgentButton,
         },
     };
 };

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/capability-wizard-flow.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/capability-wizard-flow.tsx
@@ -30,7 +30,7 @@ export const useCapabilitySteps = (): WizardSteps<AgentStepId, AgentFormData> =>
                 if (!isComplete) {
                     return null;
                 }
-                return <Badge variant="secondary">{getOptionLabel(CAPABILITY_OPTIONS, values.capability.type)}</Badge>;
+                return <Badge variant="primary">{getOptionLabel(CAPABILITY_OPTIONS, values.capability.type)}</Badge>;
             },
         },
         connection: {
@@ -39,7 +39,6 @@ export const useCapabilitySteps = (): WizardSteps<AgentStepId, AgentFormData> =>
             bodyComponent: ConnectProviderStep,
             validate: "connection",
             beforeNext: connectProviderBeforeNext,
-            badgeFields: ["connection.connectionStringName"],
             badge: ({ isComplete }: WizardBadgeContext<AgentFormData>) => {
                 if (!isComplete) {
                     return null;
@@ -64,6 +63,12 @@ export const useCapabilitySteps = (): WizardSteps<AgentStepId, AgentFormData> =>
             beforeNext: provisionAgentBeforeNext,
             nextLabel: "Save agent",
             footerComponent: ReviewTestAgentButton,
+            badge: ({ isComplete }: WizardBadgeContext<AgentFormData>) => {
+                if (!isComplete) {
+                    return null;
+                }
+                return <Badge variant="success">Agent created</Badge>;
+            },
         },
         channels: {
             title: "Add a channel",

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/capability-wizard-flow.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/capability-wizard-flow.tsx
@@ -7,15 +7,18 @@ import { CreateAgentStep } from "@/pages/setup/add-capability-wizard/steps/creat
 import { useCreateAgentStep } from "@/pages/setup/add-capability-wizard/steps/create/use-create-agent-step";
 import { ReviewAgentStep } from "@/pages/setup/add-capability-wizard/steps/review/review-agent-step";
 import { ReviewTestAgentButton } from "@/pages/setup/add-capability-wizard/steps/review/test-agent-sheet";
+import { useProvisionAgentStep } from "@/pages/setup/add-capability-wizard/steps/review/use-provision-agent-step";
+import { ChannelsStep } from "@/pages/setup/add-capability-wizard/steps/channels/channels-step";
 import { CAPABILITY_OPTIONS } from "@/pages/setup/add-capability-wizard/steps/capability/capability-options";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { getOptionLabel } from "@/lib/form-utils";
 
-export const CAPABILITY_FLOW: AgentStepId[] = ["capability", "connection", "create", "review"];
+export const CAPABILITY_FLOW: AgentStepId[] = ["capability", "connection", "create", "review", "channels"];
 
 export const useCapabilitySteps = (): WizardSteps<AgentStepId, AgentFormData> => {
     const connectProviderBeforeNext = useConnectProviderStep();
     const createAgentBeforeNext = useCreateAgentStep();
+    const provisionAgentBeforeNext = useProvisionAgentStep();
 
     return {
         capability: {
@@ -56,7 +59,23 @@ export const useCapabilitySteps = (): WizardSteps<AgentStepId, AgentFormData> =>
             title: "Review & edit your agent",
             bodyComponent: ReviewAgentStep,
             validate: "review",
+            // Provisions the agent on the way out, then the wizard advances to the optional
+            // channels step.
+            beforeNext: provisionAgentBeforeNext,
+            nextLabel: "Save agent",
             footerComponent: ReviewTestAgentButton,
+        },
+        channels: {
+            title: "Add a channel",
+            description:
+                "Your agent is ready. Connect a channel so people can reach it — or finish and add channels later.",
+            bodyComponent: ChannelsStep,
+            // Channels are created through their own API, not via the wizard form.
+            validate: false,
+            // The agent was already committed on the review step. Do not offer navigation that
+            // could provision it a second time or imply that cancelling would undo it.
+            canCancel: false,
+            canGoBack: false,
         },
     };
 };

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/capability-wizard-store.ts
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/capability-wizard-store.ts
@@ -10,6 +10,11 @@ export type PromptResult = {
     config: AiAgentConfiguration;
 };
 
+export type CreatedAgent = {
+    agentId: string;
+    name: string;
+};
+
 export type CapabilityWizardState = {
     // AI-suggested agent candidates returned by the suggest/agent endpoint. Held here (not in
     // the form) because they are read-only source data the create/review steps select from.
@@ -18,17 +23,21 @@ export type CapabilityWizardState = {
     // The latest agent generated from a custom prompt (see PromptResult).
     promptResult: PromptResult | null;
     setPromptResult: (result: PromptResult) => void;
+    createdAgent: CreatedAgent | null;
+    setCreatedAgent: (agent: CreatedAgent) => void;
     reset: () => void;
 };
 
-const initialState: Pick<CapabilityWizardState, "suggestions" | "promptResult"> = {
+const initialState: Pick<CapabilityWizardState, "suggestions" | "promptResult" | "createdAgent"> = {
     suggestions: [],
     promptResult: null,
+    createdAgent: null,
 };
 
 export const useCapabilityWizardStore = create<CapabilityWizardState>((set) => ({
     ...initialState,
     setSuggestions: (suggestions) => set({ suggestions }),
     setPromptResult: (promptResult) => set({ promptResult }),
+    setCreatedAgent: (createdAgent) => set({ createdAgent }),
     reset: () => set(initialState),
 }));

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/capability-wizard-validation.ts
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/capability-wizard-validation.ts
@@ -111,4 +111,6 @@ export type AgentConfigurationFormData = AgentFormData["review"];
 export type AgentParameterFormData = AgentConfigurationFormData["parameters"][number];
 export type AgentQueryToolFormData = AgentConfigurationFormData["queries"][number];
 
-export type AgentStepId = keyof AgentFormData;
+// "channels" has no form fields of its own (channels are created through their own API);
+// it is an optional step shown after the agent is provisioned.
+export type AgentStepId = keyof AgentFormData | "channels";

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/capability/capability-options.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/capability/capability-options.tsx
@@ -1,33 +1,26 @@
 import { MessageSquare, ScanText, Sparkle } from "lucide-react";
+import type { RadioCardOption } from "@/components/form/form-radio-cards";
 
-type CapabilityOption = {
-    value: "agent" | "embeddings" | "genai";
-    label: string;
-    description: string;
-    icon: React.ReactNode;
-    isDisabled?: boolean;
-};
-
-export const CAPABILITY_OPTIONS: CapabilityOption[] = [
+export const CAPABILITY_OPTIONS: RadioCardOption<"agent" | "embeddings" | "genai">[] = [
     {
         value: "agent",
         label: "AI Agent",
         description:
             "Conversational agent grounded in live CDC data. System prompt + RQL tools. Deploy your agent to chosen channels.",
-        icon: <MessageSquare className="mb-5 size-5" />,
+        icon: <MessageSquare className="size-5" />,
     },
     {
         value: "embeddings",
         label: "Embeddings generation",
         description: "Vector index over CDC data. Collection + field selection for vectorisation.",
-        isDisabled: true,
-        icon: <ScanText className="mb-5 size-5" />,
+        disabled: true,
+        icon: <ScanText className="size-5" />,
     },
     {
         value: "genai",
         label: "GenAI",
         description: "Conversational agent grounded in live CDC data. System prompt + RQL tools.",
-        isDisabled: true,
-        icon: <Sparkle className="mb-5 size-5" />,
+        disabled: true,
+        icon: <Sparkle className="size-5" />,
     },
 ];

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/capability/choose-capability-step.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/capability/choose-capability-step.tsx
@@ -1,37 +1,17 @@
-import { useFormContext, useWatch } from "react-hook-form";
-import { cn } from "@/lib/utils";
+import { useFormContext } from "react-hook-form";
+import { FormRadioCards } from "@/components/form/form-radio-cards";
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
 import { CAPABILITY_OPTIONS } from "@/pages/setup/add-capability-wizard/steps/capability/capability-options";
 
 export function ChooseCapabilityStep() {
-    const { control, setValue } = useFormContext<AgentFormData>();
-    const selected = useWatch({ control, name: "capability.type" });
+    const { control } = useFormContext<AgentFormData>();
 
     return (
-        <div className="grid gap-3 md:grid-cols-3">
-            {CAPABILITY_OPTIONS.map((option) => {
-                const isSelected = option.value === selected;
-
-                return (
-                    <button
-                        key={option.value}
-                        type="button"
-                        disabled={option.isDisabled}
-                        aria-pressed={isSelected}
-                        onClick={() => option.value === "agent" && setValue("capability.type", "agent")}
-                        className={cn(
-                            "min-h-28 rounded-lg border bg-background p-4 text-left transition-colors",
-                            "hover:bg-accent hover:text-accent-foreground",
-                            isSelected && "border-foreground bg-accent text-accent-foreground",
-                            option.isDisabled && "cursor-not-allowed opacity-55 hover:bg-background",
-                        )}
-                    >
-                        {option.icon}
-                        <span className="block text-sm font-semibold">{option.label}</span>
-                        <span className="mt-2 block text-xs leading-5 text-muted-foreground">{option.description}</span>
-                    </button>
-                );
-            })}
-        </div>
+        <FormRadioCards
+            control={control}
+            name="capability.type"
+            options={CAPABILITY_OPTIONS}
+            className="md:grid-cols-3"
+        />
     );
 }

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/channels/channels-step.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/channels/channels-step.tsx
@@ -1,0 +1,84 @@
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router";
+import { MessageSquarePlus } from "lucide-react";
+import { api } from "@/api/api";
+import { Alert } from "@/components/shadcn/ui/alert";
+import { ApiState } from "@/components/data/api-state";
+import { StatusIndicator } from "@/components/data/status-indicator";
+import { TableCell, TableRow } from "@/components/shadcn/ui/table";
+import { CHANNEL_TYPE_LABELS } from "@/lib/channel-type-labels";
+import { AddChannelMenu } from "@/pages/apps/channels/add-channel-menu";
+import { SectionCard, SectionTable } from "@/pages/apps/section-card";
+import { useCapabilityWizardStore } from "@/pages/setup/add-capability-wizard/capability-wizard-store";
+
+// The wizard's final, optional step. Reached only after the agent is provisioned; lets the
+// operator attach channels to the new agent or finish and do it later.
+export function ChannelsStep() {
+    const { slug = "" } = useParams();
+    const createdAgent = useCapabilityWizardStore((state) => state.createdAgent);
+    const channelsQuery = useQuery({
+        ...api.queries.channels.list(slug),
+        enabled: Boolean(createdAgent),
+    });
+
+    // The flow only advances here after provisioning succeeds, so createdAgent is set; guard
+    // defensively in case the step is rendered out of order.
+    if (!createdAgent) {
+        return <Alert>Create the agent first to add channels.</Alert>;
+    }
+
+    const channels = (channelsQuery.data ?? []).filter((channel) => channel.agentId === createdAgent.agentId);
+
+    return (
+        <div className="max-w-3xl">
+            <ApiState
+                isLoading={channelsQuery.isPending}
+                isError={channelsQuery.isError}
+                errorTitle="Could not load channels"
+                onRetry={() => void channelsQuery.refetch()}
+                loadingLabel="Loading channels..."
+            >
+                {channels.length === 0 ? (
+                    // The first-run case for a brand-new agent: lead with the action so connecting a
+                    // channel — not the "Finish" skip below — reads as the obvious next step.
+                    <div className="flex flex-col items-center gap-4 rounded-lg border border-dashed px-6 py-12 text-center">
+                        <span className="flex size-11 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                            <MessageSquarePlus className="size-5" aria-hidden="true" />
+                        </span>
+                        <div className="grid gap-1">
+                            <p className="text-sm font-medium">No channels connected yet</p>
+                            <p className="text-sm text-muted-foreground">
+                                Connect one so people can start chatting with “{createdAgent.name}”.
+                            </p>
+                        </div>
+                        <AddChannelMenu slug={slug} agent={createdAgent} />
+                    </div>
+                ) : (
+                    <SectionCard
+                        title={`Channels for “${createdAgent.name}”`}
+                        action={<AddChannelMenu slug={slug} agent={createdAgent} />}
+                    >
+                        <SectionTable
+                            headers={["Channel name", "Status", "Type"]}
+                            isEmpty={false}
+                            emptyMessage="No channels yet."
+                        >
+                            {channels.map((channel) => (
+                                <TableRow key={channel.widgetId}>
+                                    <TableCell className="font-medium">{channel.displayName}</TableCell>
+                                    <TableCell>
+                                        <StatusIndicator
+                                            tone={channel.enabled ? "positive" : "muted"}
+                                            label={channel.enabled ? "Connected" : "Disabled"}
+                                        />
+                                    </TableCell>
+                                    <TableCell>{channel.type ? CHANNEL_TYPE_LABELS[channel.type] : "—"}</TableCell>
+                                </TableRow>
+                            ))}
+                        </SectionTable>
+                    </SectionCard>
+                )}
+            </ApiState>
+        </div>
+    );
+}

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx
@@ -1,5 +1,6 @@
 import { useFormContext, useWatch } from "react-hook-form";
 import { cn } from "@/lib/utils";
+import { SELECTED_CARD_CLASSES } from "@/components/form/form-radio-cards";
 import { FormTextarea } from "@/components/form/form-textarea";
 import { Alert } from "@/components/shadcn/ui/alert";
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
@@ -42,7 +43,7 @@ export function CreateAgentStep() {
             <div
                 className={cn(
                     "grid gap-3 rounded-lg border bg-background p-4 transition-colors",
-                    mode === "prompt" && "border-foreground",
+                    mode === "prompt" && SELECTED_CARD_CLASSES,
                 )}
             >
                 <FormTextarea
@@ -64,8 +65,8 @@ export function CreateAgentStep() {
                     onClick={chooseManualSetup}
                     className={cn(
                         "min-h-16 rounded-lg border bg-background p-4 text-left transition-colors",
-                        "hover:bg-accent hover:text-accent-foreground",
-                        mode === "manual" && "border-foreground bg-accent text-accent-foreground",
+                        mode !== "manual" && "hover:bg-accent hover:text-accent-foreground",
+                        mode === "manual" && SELECTED_CARD_CLASSES,
                     )}
                 >
                     <span className="block text-sm font-semibold">Setup manually</span>

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { type Control, useFieldArray, useForm, useFormContext, useWatch } from "react-hook-form";
 import { useParams } from "react-router";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -23,7 +23,6 @@ import { FormSelect, type FormSelectOption } from "@/components/form/form-select
 import { FormTextarea } from "@/components/form/form-textarea";
 import AceEditor from "@/components/ace-editor/ace-editor";
 import { TestQueryToolCall } from "@/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call";
-import { withNestedSubmit } from "@/lib/form-utils";
 
 // Footer action for the wizard's Review step: opens a sheet to chat with the draft agent.
 // The button stays disabled until the draft has the minimum a test needs (name, system
@@ -66,6 +65,12 @@ export function ReviewTestAgentButton() {
     );
 }
 
+let messageIdCounter = 0;
+function nextMessageId(): string {
+    messageIdCounter += 1;
+    return `agent-test-message-${messageIdCounter}`;
+}
+
 // Agent answers always render as JSON: `json` holds the live answer (the sample response
 // shape with the streamed field filling in) and is swapped for the full structured answer
 // once the turn finishes. `toolCalls` are the query tools the agent ran (filled on `done`).
@@ -82,7 +87,24 @@ const testFormSchema = z.object({
     prompt: z.string(),
     // Which output field streams token-by-token; empty lets the server pick the first field.
     streamField: z.string(),
-    parameters: z.array(z.object({ name: z.string(), value: z.string().trim().min(1, "Value is required") })),
+    parameters: z
+        .array(
+            z.object({
+                name: z.string(),
+                value: z.string(),
+                // A value is required only when the model isn't allowed to generate one
+                // (ForbidModelGeneration). Parameters the model can fill stay optional for a
+                // one-off test run, so the operator needn't invent a value.
+                isRequired: z.boolean(),
+            }),
+        )
+        .superRefine((parameters, ctx) => {
+            parameters.forEach((parameter, index) => {
+                if (parameter.isRequired && parameter.value.trim().length === 0) {
+                    ctx.addIssue({ code: "custom", message: "Value is required", path: [index, "value"] });
+                }
+            });
+        }),
 });
 
 type TestFormData = z.infer<typeof testFormSchema>;
@@ -94,22 +116,34 @@ function TestAgentPanel() {
     const [isStreaming, setIsStreaming] = useState(false);
     const [areParametersCollapsed, setAreParametersCollapsed] = useState(false);
 
-    // The draft's declared output fields (sample object first, schema as fallback) — the
-    // options for the "Streamed field" select. Read once from the wizard form on open.
-    const [streamFieldOptions] = useState(() =>
-        getOutputFieldNames(wizardForm.getValues("review.sampleObject"), wizardForm.getValues("review.outputSchema")),
-    );
+    // Re-read the draft's output shape live from the wizard form (it stays mounted behind the
+    // sheet), so the "Streamed field" options and the streaming preview track edits to the
+    // sample object / schema instead of a stale open-time snapshot.
+    const [sampleObject, outputSchema] = useWatch({
+        control: wizardForm.control,
+        name: ["review.sampleObject", "review.outputSchema"],
+    });
+    const answerShape = getOutputShape(sampleObject, outputSchema);
+    // Only string-typed fields can stream as text, so they alone populate the select.
+    const streamFieldOptions = getStreamableFieldNames(answerShape);
+
+    // Aborts the in-flight stream when the panel unmounts (the sheet closes) so the request stops
+    // and no state update fires afterwards.
+    const abortControllerRef = useRef<AbortController | null>(null);
+    useEffect(() => () => abortControllerRef.current?.abort(), []);
 
     const form = useForm<TestFormData>({
         resolver: zodResolver(testFormSchema),
         defaultValues: {
             prompt: "",
-            // Default to the first declared field — the server's own convention when unset.
+            // Default to the first streamable field — the server's own convention when unset.
             streamField: streamFieldOptions[0] ?? "",
-            // The agent's declared parameters, ready for the operator to fill in values.
+            // The agent's declared parameters, ready for the operator to fill in values. A value
+            // is required only for parameters the model may not generate (ForbidModelGeneration).
             parameters: wizardForm.getValues("review.parameters").map((parameter) => ({
                 name: parameter.name,
                 value: "",
+                isRequired: parameter.policy === "ForbidModelGeneration",
             })),
         },
     });
@@ -126,33 +160,42 @@ function TestAgentPanel() {
             return;
         }
 
-        // Re-read the wizard form so the test always runs the latest draft.
+        // Re-read the wizard form so the test always runs the latest draft. The streamed field
+        // fills into `answerShape` (derived above from the same live form values), so the live
+        // answer reads as a real JSON object while it streams in.
         const wizardValues = wizardForm.getValues();
         const configuration = buildAgentConfigurationPayload(wizardValues);
         const parameters = toParameterRecord(values.parameters);
-        // The streamed field fills into this declared answer shape, so the live answer reads
-        // as a real JSON object while it streams in. The shape comes from the sample response
-        // object, or the Response JSON schema when only that is provided.
-        const answerShape = getOutputShape(wizardValues.review.sampleObject, wizardValues.review.outputSchema);
-        const { streamField } = values;
+        // An edit to the sample/schema may have dropped the selected field; fall back to the
+        // first streamable one so the value sent matches the current options.
+        const streamField = streamFieldOptions.includes(values.streamField)
+            ? values.streamField
+            : (streamFieldOptions[0] ?? "");
 
-        const agentMessageId = crypto.randomUUID();
+        const agentMessageId = nextMessageId();
         setMessages((previous) => [
             ...previous,
-            { id: crypto.randomUUID(), role: "user", text: trimmedPrompt },
+            { id: nextMessageId(), role: "user", text: trimmedPrompt },
             { id: agentMessageId, role: "agent", text: "", json: buildStreamingJson(answerShape, streamField, "") },
         ]);
         form.setValue("prompt", "");
         setIsStreaming(true);
 
+        const abortController = new AbortController();
+        abortControllerRef.current = abortController;
+
         let streamedText = "";
         try {
-            for await (const event of api.services.agentTest.stream(slug, {
-                prompt: trimmedPrompt,
-                configuration,
-                parameters,
-                streamField: streamField || null,
-            })) {
+            for await (const event of api.services.agentTest.stream(
+                slug,
+                {
+                    prompt: trimmedPrompt,
+                    configuration,
+                    parameters,
+                    streamField: streamField || null,
+                },
+                abortController.signal,
+            )) {
                 if (event.type === "chunk") {
                     streamedText += event.text;
                     const json = buildStreamingJson(answerShape, streamField, streamedText);
@@ -185,11 +228,18 @@ function TestAgentPanel() {
                 }
             }
         } catch (error) {
+            // The panel closed mid-stream (the unmount cleanup aborted) — the component is gone,
+            // so there's nothing to surface.
+            if (abortController.signal.aborted) {
+                return;
+            }
+
             const message = error instanceof Error ? error.message : "Agent test failed.";
             setMessages((previous) =>
                 replaceMessage(previous, agentMessageId, () => ({ id: agentMessageId, role: "error", text: message })),
             );
         } finally {
+            abortControllerRef.current = null;
             setIsStreaming(false);
         }
     }
@@ -199,9 +249,12 @@ function TestAgentPanel() {
         form.setValue("prompt", "");
     }
 
-    // Reveal the parameters when a send is blocked by a missing value, so the validation
-    // errors are never hidden behind a collapsed section.
-    const handleSend = form.handleSubmit(send, () => setAreParametersCollapsed(false));
+    // Build and run the submit handler at event time (not during render), so `send` — which
+    // manages the abort-controller ref — isn't treated as a render-time ref access. On a blocked
+    // send, reveal the parameters so the validation errors aren't hidden behind a collapsed section.
+    function handleSend() {
+        return form.handleSubmit(send, () => setAreParametersCollapsed(false))();
+    }
 
     return (
         <div className="flex min-h-0 flex-1 flex-col">
@@ -247,7 +300,16 @@ function TestAgentPanel() {
                 )}
             </div>
 
-            <form className="border-t p-4" onSubmit={withNestedSubmit(handleSend)}>
+            <form
+                className="border-t p-4"
+                // Inlined (rather than withNestedSubmit) so the ref-touching handleSend stays in an
+                // event handler. stopPropagation keeps this nested submit off the outer wizard form.
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    handleSend();
+                }}
+            >
                 <FormTextarea
                     control={form.control}
                     name="prompt"
@@ -258,7 +320,7 @@ function TestAgentPanel() {
                         if (event.key === "Enter" && !event.shiftKey) {
                             event.preventDefault();
                             event.stopPropagation();
-                            void handleSend();
+                            handleSend();
                         }
                     }}
                 />
@@ -282,8 +344,9 @@ function TestAgentPanel() {
     );
 }
 
-// Operator-supplied values for the agent's declared parameters. Each value is required;
-// the section can be collapsed to a one-line summary once filled to free up chat space.
+// Operator-supplied values for the agent's declared parameters. Only parameters the model may
+// not generate require a value; the section can be collapsed to a one-line summary once filled
+// to free up chat space.
 function TestParametersSection({
     control,
     fields,
@@ -292,7 +355,7 @@ function TestParametersSection({
     disabled,
 }: {
     control: Control<TestFormData>;
-    fields: { id: string; name: string }[];
+    fields: { id: string; name: string; isRequired: boolean }[];
     isCollapsed: boolean;
     onToggleCollapsed: () => void;
     disabled: boolean;
@@ -329,7 +392,14 @@ function TestParametersSection({
                             key={field.id}
                             control={control}
                             name={`parameters.${index}.value`}
-                            label={field.name}
+                            label={
+                                <span className="flex items-center gap-1.5">
+                                    {field.name}
+                                    {!field.isRequired && (
+                                        <span className="text-xs font-normal text-muted-foreground">(optional)</span>
+                                    )}
+                                </span>
+                            }
                             placeholder={`Value for ${field.name}`}
                             disabled={disabled}
                         />
@@ -388,6 +458,8 @@ function replaceMessage(messages: ChatMessage[], id: string, update: (message: C
     return messages.map((message) => (message.id === id ? update(message) : message));
 }
 
+// Builds the parameter map sent to the server, dropping blanks: optional parameters the operator
+// left empty are omitted so the model/server applies its own value rather than receiving "".
 function toParameterRecord(parameters: TestFormData["parameters"]): Record<string, string> | null {
     const entries = parameters
         .map((parameter) => [parameter.name, parameter.value] as const)
@@ -406,10 +478,16 @@ function buildStreamingJson(
     streamedText: string,
 ): string {
     const answer: Record<string, unknown> = { ...(answerShape ?? {}) };
-    const field = streamField || Object.keys(answer)[0] || "reply";
+    // Prefer the chosen field, then the first string-typed field (a non-string slot can't hold
+    // streamed text), then any field, then a single "reply" key when the draft declares no shape.
+    const field = streamField || firstStringKey(answer) || Object.keys(answer)[0] || "reply";
     answer[field] = streamedText;
 
     return JSON.stringify(answer, null, 4);
+}
+
+function firstStringKey(answer: Record<string, unknown>): string | undefined {
+    return Object.keys(answer).find((key) => typeof answer[key] === "string");
 }
 
 // Pretty-prints the structured answer for the JSON editor; null when there is nothing to show.
@@ -421,11 +499,12 @@ function toAnswerJson(answer: unknown): string | null {
     return null;
 }
 
-// The agent's declared output fields — the keys of the resolved output shape (see
-// getOutputShape). Empty when the draft declares neither a sample nor a schema, which hides
-// the "Streamed field" select and lets the server pick the default.
-function getOutputFieldNames(sampleObject: string, outputSchema: string): string[] {
-    return objectKeys(getOutputShape(sampleObject, outputSchema));
+// The output fields that can stream as text: the string-typed keys of the resolved output shape
+// (see getOutputShape). A non-string field (array/object/number) can't hold a streamed string, so
+// it's excluded from the "Streamed field" select and never used as the default. Empty when the
+// draft declares no string output field, which hides the select and lets the server pick.
+function getStreamableFieldNames(shape: Record<string, unknown> | null): string[] {
+    return shape ? Object.keys(shape).filter((key) => typeof shape[key] === "string") : [];
 }
 
 // The declared output shape used to skeleton the live answer: the sample response object when
@@ -488,8 +567,4 @@ function parseJsonObject(json: string | null | undefined): Record<string, unknow
     } catch {
         return null;
     }
-}
-
-function objectKeys(value: Record<string, unknown> | null): string[] {
-    return value ? Object.keys(value) : [];
 }

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
@@ -6,7 +6,10 @@ import { z } from "zod";
 import { Bot, ChevronDown, ChevronUp, FlaskConical, MessageSquare, Send, Settings2, Trash2 } from "lucide-react";
 import { api } from "@/api/api";
 import type { AgentToolCall } from "@/api/custom-services/agent-stream";
-import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
+import {
+    AGENT_PARAMETER_TYPES,
+    type AgentFormData,
+} from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
 import type { WizardFooterComponentProps } from "@/components/form/wizard/form-wizard";
 import { buildAgentConfigurationPayload } from "@/pages/setup/add-capability-wizard/agent-config-form";
 import { Button } from "@/components/shadcn/ui/button";
@@ -21,6 +24,7 @@ import {
 } from "@/components/shadcn/ui/sheet";
 import { FormInput } from "@/components/form/form-input";
 import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
+import { FormSwitch } from "@/components/form/form-switch";
 import { FormTextarea } from "@/components/form/form-textarea";
 import AceEditor from "@/components/ace-editor/ace-editor";
 import { TestQueryToolCall } from "@/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call";
@@ -84,28 +88,38 @@ type ChatMessage = {
     toolCalls?: AgentToolCall[];
 };
 
+const testParameterSchema = z
+    .object({
+        name: z.string(),
+        value: z.string(),
+        type: z.enum(AGENT_PARAMETER_TYPES),
+        isSendToModel: z.boolean(),
+    })
+    .superRefine((parameter, ctx) => {
+        const value = parameter.value.trim();
+        if (parameter.type === "Null") {
+            return;
+        }
+
+        if (!value) {
+            ctx.addIssue({ code: "custom", message: "Value is required", path: ["value"] });
+            return;
+        }
+
+        if (parameter.type === "Number" && !Number.isFinite(Number(value))) {
+            ctx.addIssue({ code: "custom", message: "Enter a valid number", path: ["value"] });
+        } else if (parameter.type === "Boolean" && !isBooleanToken(value)) {
+            ctx.addIssue({ code: "custom", message: "Select true or false", path: ["value"] });
+        } else if (parameter.type.startsWith("ArrayOf") && !isValidParameterArray(value, parameter.type)) {
+            ctx.addIssue({ code: "custom", message: `Enter a valid ${parameter.type} JSON array`, path: ["value"] });
+        }
+    });
+
 const testFormSchema = z.object({
     prompt: z.string(),
     // Which output field streams token-by-token; empty lets the server pick the first field.
     streamField: z.string(),
-    parameters: z
-        .array(
-            z.object({
-                name: z.string(),
-                value: z.string(),
-                // A value is required only when the model isn't allowed to generate one
-                // (ForbidModelGeneration). Parameters the model can fill stay optional for a
-                // one-off test run, so the operator needn't invent a value.
-                isRequired: z.boolean(),
-            }),
-        )
-        .superRefine((parameters, ctx) => {
-            parameters.forEach((parameter, index) => {
-                if (parameter.isRequired && parameter.value.trim().length === 0) {
-                    ctx.addIssue({ code: "custom", message: "Value is required", path: [index, "value"] });
-                }
-            });
-        }),
+    parameters: z.array(testParameterSchema),
 });
 
 type TestFormData = z.infer<typeof testFormSchema>;
@@ -139,12 +153,14 @@ function TestAgentPanel() {
             prompt: "",
             // Default to the first streamable field — the server's own convention when unset.
             streamField: streamFieldOptions[0] ?? "",
-            // The agent's declared parameters, ready for the operator to fill in values. A value
-            // is required only for parameters the model may not generate (ForbidModelGeneration).
+            // The agent's declared parameters, ready for the operator to fill in values. RavenDB
+            // requires every declared parameter value for a top-level conversation; policy only
+            // controls parameter generation when this agent is used as a sub-agent.
             parameters: wizardForm.getValues("review.parameters").map((parameter) => ({
                 name: parameter.name,
                 value: "",
-                isRequired: parameter.policy === "ForbidModelGeneration",
+                type: parameter.type,
+                isSendToModel: parameter.isSendToModel,
             })),
         },
     });
@@ -271,7 +287,7 @@ function TestAgentPanel() {
                     />
                 )}
 
-                {parameterFields.fields.length > 0 && (
+                {parameterFields.fields.some((field) => field.type !== "Null") && (
                     <TestParametersSection
                         control={form.control}
                         fields={parameterFields.fields}
@@ -345,9 +361,9 @@ function TestAgentPanel() {
     );
 }
 
-// Operator-supplied values for the agent's declared parameters. Only parameters the model may
-// not generate require a value; the section can be collapsed to a one-line summary once filled
-// to free up chat space.
+// Operator-supplied values for the agent's declared parameters. Null parameters have no editable
+// value; all others are required for a top-level test conversation. The section can be collapsed
+// to a one-line summary once filled to free up chat space.
 function TestParametersSection({
     control,
     fields,
@@ -356,13 +372,14 @@ function TestParametersSection({
     disabled,
 }: {
     control: Control<TestFormData>;
-    fields: { id: string; name: string; isRequired: boolean }[];
+    fields: { id: string; name: string; type: TestFormData["parameters"][number]["type"] }[];
     isCollapsed: boolean;
     onToggleCollapsed: () => void;
     disabled: boolean;
 }) {
     const values = useWatch({ control, name: "parameters" });
     const summary = (values ?? [])
+        .filter((parameter) => parameter.type !== "Null")
         .map((parameter) => `${parameter.name}: ${parameter.value?.trim() || "—"}`)
         .join(", ");
 
@@ -388,23 +405,46 @@ function TestParametersSection({
                 <p className="truncate text-xs text-muted-foreground">{summary}</p>
             ) : (
                 <div className="grid gap-2">
-                    {fields.map((field, index) => (
-                        <FormInput
-                            key={field.id}
-                            control={control}
-                            name={`parameters.${index}.value`}
-                            label={
-                                <span className="flex items-center gap-1.5">
-                                    {field.name}
-                                    {!field.isRequired && (
-                                        <span className="text-xs font-normal text-muted-foreground">(optional)</span>
-                                    )}
-                                </span>
-                            }
-                            placeholder={`Value for ${field.name}`}
-                            disabled={disabled}
-                        />
-                    ))}
+                    {fields.map((field, index) => {
+                        if (field.type === "Null") {
+                            return null;
+                        }
+
+                        return (
+                            <div key={field.id} className="grid gap-2 rounded-md border p-3">
+                                <div className="flex items-center justify-between gap-3">
+                                    <span className="truncate text-sm font-medium" title={field.name}>
+                                        {field.name}
+                                    </span>
+                                    <FormSwitch
+                                        control={control}
+                                        name={`parameters.${index}.isSendToModel`}
+                                        label="Send to model"
+                                        disabled={disabled}
+                                    />
+                                </div>
+                                {field.type === "Boolean" ? (
+                                    <FormSelect
+                                        control={control}
+                                        name={`parameters.${index}.value`}
+                                        label="Value"
+                                        placeholder="Select true or false"
+                                        options={BOOLEAN_PARAMETER_OPTIONS}
+                                        disabled={disabled}
+                                    />
+                                ) : (
+                                    <FormInput
+                                        control={control}
+                                        name={`parameters.${index}.value`}
+                                        label="Value"
+                                        placeholder={getParameterPlaceholder(field.name, field.type)}
+                                        inputMode={field.type === "Number" ? "decimal" : undefined}
+                                        disabled={disabled}
+                                    />
+                                )}
+                            </div>
+                        );
+                    })}
                 </div>
             )}
         </div>
@@ -459,14 +499,111 @@ function replaceMessage(messages: ChatMessage[], id: string, update: (message: C
     return messages.map((message) => (message.id === id ? update(message) : message));
 }
 
-// Builds the parameter map sent to the server, dropping blanks: optional parameters the operator
-// left empty are omitted so the model/server applies its own value rather than receiving "".
-function toParameterRecord(parameters: TestFormData["parameters"]): Record<string, string> | null {
+const BOOLEAN_PARAMETER_OPTIONS: FormSelectOption<string>[] = [
+    { value: "true", label: "True" },
+    { value: "false", label: "False" },
+];
+
+// Mirrors RavenDB Studio's createParametersDto: convert the form text to the parameter's declared
+// JSON type and send the per-test SendToModel value alongside it.
+function toParameterRecord(
+    parameters: TestFormData["parameters"],
+): Record<string, { value: unknown; sendToModel: boolean }> | null {
     const entries = parameters
-        .map((parameter) => [parameter.name, parameter.value] as const)
-        .filter(([name, value]) => name && value.trim() !== "");
+        .filter((parameter) => parameter.name)
+        .map(
+            (parameter) =>
+                [
+                    parameter.name,
+                    {
+                        value: mapParameterValueToType(parameter.value, parameter.type),
+                        sendToModel: parameter.isSendToModel,
+                    },
+                ] as const,
+        );
 
     return entries.length > 0 ? Object.fromEntries(entries) : null;
+}
+
+function mapParameterValueToType(value: string, type: TestFormData["parameters"][number]["type"]): unknown {
+    switch (type) {
+        case "Number":
+            return Number(value);
+        case "Boolean":
+            return value.trim().toLowerCase() === "true";
+        case "ArrayOfString":
+            return requireParameterArray(value);
+        case "ArrayOfNumber":
+            return requireParameterArray(value).map((item) => Number(item));
+        case "ArrayOfBoolean":
+            return requireParameterArray(value).map((item) =>
+                typeof item === "boolean" ? item : String(item).trim().toLowerCase() === "true",
+            );
+        case "Null":
+            return null;
+        case "Default":
+        case "String":
+            return value;
+    }
+}
+
+function requireParameterArray(value: string): unknown[] {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+        throw new Error("Expected an agent parameter value in JSON array format.");
+    }
+    return parsed;
+}
+
+function isBooleanToken(value: string): boolean {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "false";
+}
+
+function isValidParameterArray(value: string, type: TestFormData["parameters"][number]["type"]): boolean {
+    try {
+        const parsed: unknown = JSON.parse(value);
+        if (!Array.isArray(parsed)) {
+            return false;
+        }
+
+        switch (type) {
+            case "ArrayOfString":
+                return parsed.every((item) => typeof item === "string");
+            case "ArrayOfNumber":
+                return parsed.every(isFiniteNumberToken);
+            case "ArrayOfBoolean":
+                return parsed.every(
+                    (item) => typeof item === "boolean" || (typeof item === "string" && isBooleanToken(item)),
+                );
+            default:
+                return false;
+        }
+    } catch {
+        return false;
+    }
+}
+
+function isFiniteNumberToken(value: unknown): boolean {
+    if (typeof value === "number") {
+        return Number.isFinite(value);
+    }
+    return typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value));
+}
+
+function getParameterPlaceholder(name: string, type: TestFormData["parameters"][number]["type"]): string {
+    switch (type) {
+        case "ArrayOfString":
+            return `["value1", "value2"] for ${name}`;
+        case "ArrayOfNumber":
+            return `[1, 2] for ${name}`;
+        case "ArrayOfBoolean":
+            return `[true, false] for ${name}`;
+        case "Number":
+            return `Number for ${name}`;
+        default:
+            return `Value for ${name}`;
+    }
 }
 
 // Builds the JSON shown while a single field streams in: the declared answer shape with the

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { Bot, ChevronDown, ChevronUp, FlaskConical, MessageSquare, Send, Settings2, Trash2 } from "lucide-react";
 import { api } from "@/api/api";
+import type { AgentToolCall } from "@/api/custom-services/agent-stream";
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
 import { buildAgentConfigurationPayload } from "@/pages/setup/add-capability-wizard/agent-config-form";
 import { Button } from "@/components/shadcn/ui/button";
@@ -21,6 +22,7 @@ import { FormInput } from "@/components/form/form-input";
 import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
 import { FormTextarea } from "@/components/form/form-textarea";
 import AceEditor from "@/components/ace-editor/ace-editor";
+import { TestQueryToolCall } from "@/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call";
 import { withNestedSubmit } from "@/lib/form-utils";
 
 // Footer action for the wizard's Review step: opens a sheet to chat with the draft agent.
@@ -66,8 +68,15 @@ export function ReviewTestAgentButton() {
 
 // Agent answers always render as JSON: `json` holds the live answer (the sample response
 // shape with the streamed field filling in) and is swapped for the full structured answer
-// once the turn finishes. `text` carries plain user prompts and error messages.
-type ChatMessage = { id: string; role: "user" | "agent" | "error"; text: string; json?: string };
+// once the turn finishes. `toolCalls` are the query tools the agent ran (filled on `done`).
+// `text` carries plain user prompts and error messages.
+type ChatMessage = {
+    id: string;
+    role: "user" | "agent" | "error";
+    text: string;
+    json?: string;
+    toolCalls?: AgentToolCall[];
+};
 
 const testFormSchema = z.object({
     prompt: z.string(),
@@ -156,12 +165,14 @@ function TestAgentPanel() {
                     );
                 } else if (event.type === "done") {
                     // Swap the live answer for the full structured output, keeping the streamed
-                    // JSON if the server returned no structured answer.
+                    // JSON if the server returned no structured answer. Attach the query tools the
+                    // agent ran so the transcript can show them above the answer.
                     const json =
                         toAnswerJson(event.fullAnswer ?? event.answer) ??
                         buildStreamingJson(answerShape, streamField, streamedText);
+                    const toolCalls = event.toolCalls ?? [];
                     setMessages((previous) =>
-                        replaceMessage(previous, agentMessageId, (message) => ({ ...message, json })),
+                        replaceMessage(previous, agentMessageId, (message) => ({ ...message, json, toolCalls })),
                     );
                 } else if (event.type === "error") {
                     setMessages((previous) =>
@@ -356,6 +367,13 @@ function TestMessage({ message, isLoading }: { message: ChatMessage; isLoading: 
                     <div className="mb-1.5 flex items-center gap-2 text-xs text-muted-foreground">
                         <Spinner className="size-3" />
                         <span>Generating response…</span>
+                    </div>
+                )}
+                {message.toolCalls && message.toolCalls.length > 0 && (
+                    <div className="mb-2 grid gap-2">
+                        {message.toolCalls.map((toolCall, index) => (
+                            <TestQueryToolCall key={toolCall.id || index} toolCall={toolCall} />
+                        ))}
                     </div>
                 )}
                 <div className="overflow-hidden rounded-lg border">

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
@@ -1,0 +1,477 @@
+import { useState } from "react";
+import { type Control, useFieldArray, useForm, useFormContext, useWatch } from "react-hook-form";
+import { useParams } from "react-router";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Bot, ChevronDown, ChevronUp, FlaskConical, MessageSquare, Send, Settings2, Trash2 } from "lucide-react";
+import { api } from "@/api/api";
+import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
+import { buildAgentConfigurationPayload } from "@/pages/setup/add-capability-wizard/agent-config-form";
+import { Button } from "@/components/shadcn/ui/button";
+import { Spinner } from "@/components/shadcn/ui/spinner";
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+    SheetTrigger,
+} from "@/components/shadcn/ui/sheet";
+import { FormInput } from "@/components/form/form-input";
+import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
+import { FormTextarea } from "@/components/form/form-textarea";
+import AceEditor from "@/components/ace-editor/ace-editor";
+import { withNestedSubmit } from "@/lib/form-utils";
+
+// Footer action for the wizard's Review step: opens a sheet to chat with the draft agent.
+// The button stays disabled until the draft has the minimum a test needs (name, system
+// prompt, and an AI provider connection).
+export function ReviewTestAgentButton() {
+    const { control } = useFormContext<AgentFormData>();
+    const [name, systemPrompt, connectionStringName] = useWatch({
+        control,
+        name: ["review.name", "review.systemPrompt", "connection.connectionStringName"],
+    });
+    const [isOpen, setIsOpen] = useState(false);
+
+    const isReady = Boolean(name?.trim() && systemPrompt?.trim() && connectionStringName);
+
+    return (
+        <Sheet open={isOpen} onOpenChange={setIsOpen}>
+            <SheetTrigger asChild>
+                <Button
+                    type="button"
+                    variant="outline"
+                    disabled={!isReady}
+                    title={
+                        isReady ? undefined : "Add a name, system prompt, and AI provider connection before testing."
+                    }
+                >
+                    <FlaskConical className="size-4" aria-hidden />
+                    Test agent
+                </Button>
+            </SheetTrigger>
+            <SheetContent className="flex w-full flex-col gap-0 sm:max-w-lg data-[side=right]:sm:max-w-lg">
+                <SheetHeader className="border-b">
+                    <SheetTitle>Test agent</SheetTitle>
+                    <SheetDescription>
+                        Chat with the draft agent to check its answers. Each message runs a fresh, unsaved turn.
+                    </SheetDescription>
+                </SheetHeader>
+                <TestAgentPanel />
+            </SheetContent>
+        </Sheet>
+    );
+}
+
+// Agent answers always render as JSON: `json` holds the live answer (the sample response
+// shape with the streamed field filling in) and is swapped for the full structured answer
+// once the turn finishes. `text` carries plain user prompts and error messages.
+type ChatMessage = { id: string; role: "user" | "agent" | "error"; text: string; json?: string };
+
+const testFormSchema = z.object({
+    prompt: z.string(),
+    // Which output field streams token-by-token; empty lets the server pick the first field.
+    streamField: z.string(),
+    parameters: z.array(z.object({ name: z.string(), value: z.string().trim().min(1, "Value is required") })),
+});
+
+type TestFormData = z.infer<typeof testFormSchema>;
+
+function TestAgentPanel() {
+    const { slug = "" } = useParams();
+    const wizardForm = useFormContext<AgentFormData>();
+    const [messages, setMessages] = useState<ChatMessage[]>([]);
+    const [isStreaming, setIsStreaming] = useState(false);
+    const [areParametersCollapsed, setAreParametersCollapsed] = useState(false);
+
+    // The draft's declared output fields (sample object first, schema as fallback) — the
+    // options for the "Streamed field" select. Read once from the wizard form on open.
+    const [streamFieldOptions] = useState(() =>
+        getOutputFieldNames(wizardForm.getValues("review.sampleObject"), wizardForm.getValues("review.outputSchema")),
+    );
+
+    const form = useForm<TestFormData>({
+        resolver: zodResolver(testFormSchema),
+        defaultValues: {
+            prompt: "",
+            // Default to the first declared field — the server's own convention when unset.
+            streamField: streamFieldOptions[0] ?? "",
+            // The agent's declared parameters, ready for the operator to fill in values.
+            parameters: wizardForm.getValues("review.parameters").map((parameter) => ({
+                name: parameter.name,
+                value: "",
+            })),
+        },
+    });
+    const parameterFields = useFieldArray({ control: form.control, name: "parameters" });
+    const prompt = useWatch({ control: form.control, name: "prompt" });
+    const streamFieldSelectOptions: FormSelectOption<string>[] = streamFieldOptions.map((name) => ({
+        value: name,
+        label: name,
+    }));
+
+    async function send(values: TestFormData) {
+        const trimmedPrompt = values.prompt.trim();
+        if (!trimmedPrompt || isStreaming) {
+            return;
+        }
+
+        // Re-read the wizard form so the test always runs the latest draft.
+        const wizardValues = wizardForm.getValues();
+        const configuration = buildAgentConfigurationPayload(wizardValues);
+        const parameters = toParameterRecord(values.parameters);
+        // The streamed field fills into this declared answer shape, so the live answer reads
+        // as a real JSON object while it streams in. The shape comes from the sample response
+        // object, or the Response JSON schema when only that is provided.
+        const answerShape = getOutputShape(wizardValues.review.sampleObject, wizardValues.review.outputSchema);
+        const { streamField } = values;
+
+        const agentMessageId = crypto.randomUUID();
+        setMessages((previous) => [
+            ...previous,
+            { id: crypto.randomUUID(), role: "user", text: trimmedPrompt },
+            { id: agentMessageId, role: "agent", text: "", json: buildStreamingJson(answerShape, streamField, "") },
+        ]);
+        form.setValue("prompt", "");
+        setIsStreaming(true);
+
+        let streamedText = "";
+        try {
+            for await (const event of api.services.agentTest.stream(slug, {
+                prompt: trimmedPrompt,
+                configuration,
+                parameters,
+                streamField: streamField || null,
+            })) {
+                if (event.type === "chunk") {
+                    streamedText += event.text;
+                    const json = buildStreamingJson(answerShape, streamField, streamedText);
+                    setMessages((previous) =>
+                        replaceMessage(previous, agentMessageId, (message) => ({
+                            ...message,
+                            text: streamedText,
+                            json,
+                        })),
+                    );
+                } else if (event.type === "done") {
+                    // Swap the live answer for the full structured output, keeping the streamed
+                    // JSON if the server returned no structured answer.
+                    const json =
+                        toAnswerJson(event.fullAnswer ?? event.answer) ??
+                        buildStreamingJson(answerShape, streamField, streamedText);
+                    setMessages((previous) =>
+                        replaceMessage(previous, agentMessageId, (message) => ({ ...message, json })),
+                    );
+                } else if (event.type === "error") {
+                    setMessages((previous) =>
+                        replaceMessage(previous, agentMessageId, () => ({
+                            id: agentMessageId,
+                            role: "error",
+                            text: event.message,
+                        })),
+                    );
+                }
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Agent test failed.";
+            setMessages((previous) =>
+                replaceMessage(previous, agentMessageId, () => ({ id: agentMessageId, role: "error", text: message })),
+            );
+        } finally {
+            setIsStreaming(false);
+        }
+    }
+
+    function clearChat() {
+        setMessages([]);
+        form.setValue("prompt", "");
+    }
+
+    // Reveal the parameters when a send is blocked by a missing value, so the validation
+    // errors are never hidden behind a collapsed section.
+    const handleSend = form.handleSubmit(send, () => setAreParametersCollapsed(false));
+
+    return (
+        <div className="flex min-h-0 flex-1 flex-col">
+            <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
+                {streamFieldSelectOptions.length > 1 && (
+                    <FormSelect
+                        control={form.control}
+                        name="streamField"
+                        label="Streamed field"
+                        description="Which response field streams token-by-token. The full answer is shown once the turn finishes."
+                        options={streamFieldSelectOptions}
+                        disabled={isStreaming}
+                    />
+                )}
+
+                {parameterFields.fields.length > 0 && (
+                    <TestParametersSection
+                        control={form.control}
+                        fields={parameterFields.fields}
+                        isCollapsed={areParametersCollapsed}
+                        onToggleCollapsed={() => setAreParametersCollapsed((collapsed) => !collapsed)}
+                        disabled={isStreaming}
+                    />
+                )}
+
+                {messages.length === 0 ? (
+                    <div className="flex flex-1 flex-col items-center justify-center gap-2 py-8 text-center text-muted-foreground">
+                        <MessageSquare className="size-8" aria-hidden />
+                        <p className="text-sm">Ask the agent anything to see how it responds.</p>
+                    </div>
+                ) : (
+                    <div className="flex flex-col gap-3">
+                        {messages.map((message, index) => (
+                            <TestMessage
+                                key={message.id}
+                                message={message}
+                                // Only the in-flight agent turn (always the last message) shows the
+                                // "generating" indicator above its answer.
+                                isLoading={isStreaming && message.role === "agent" && index === messages.length - 1}
+                            />
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            <form className="border-t p-4" onSubmit={withNestedSubmit(handleSend)}>
+                <FormTextarea
+                    control={form.control}
+                    name="prompt"
+                    placeholder="Ask the agent anything"
+                    rows={3}
+                    disabled={isStreaming}
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter" && !event.shiftKey) {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            void handleSend();
+                        }
+                    }}
+                />
+                <div className="mt-2 flex justify-end gap-2">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={clearChat}
+                        disabled={isStreaming || messages.length === 0}
+                    >
+                        <Trash2 className="size-4" aria-hidden />
+                        Clear
+                    </Button>
+                    <Button type="submit" disabled={isStreaming || !prompt.trim()}>
+                        {isStreaming ? <Spinner /> : <Send className="size-4" aria-hidden />}
+                        Send
+                    </Button>
+                </div>
+            </form>
+        </div>
+    );
+}
+
+// Operator-supplied values for the agent's declared parameters. Each value is required;
+// the section can be collapsed to a one-line summary once filled to free up chat space.
+function TestParametersSection({
+    control,
+    fields,
+    isCollapsed,
+    onToggleCollapsed,
+    disabled,
+}: {
+    control: Control<TestFormData>;
+    fields: { id: string; name: string }[];
+    isCollapsed: boolean;
+    onToggleCollapsed: () => void;
+    disabled: boolean;
+}) {
+    const values = useWatch({ control, name: "parameters" });
+    const summary = (values ?? [])
+        .map((parameter) => `${parameter.name}: ${parameter.value?.trim() || "—"}`)
+        .join(", ");
+
+    return (
+        <div className="grid gap-2 rounded-lg border bg-background p-3">
+            <button
+                type="button"
+                className="flex w-full items-center justify-between gap-2 text-left"
+                aria-expanded={!isCollapsed}
+                onClick={onToggleCollapsed}
+            >
+                <span className="flex items-center gap-2 text-sm font-medium">
+                    <Settings2 className="size-4 text-muted-foreground" aria-hidden />
+                    Parameters
+                </span>
+                {isCollapsed ? (
+                    <ChevronDown className="size-4 text-muted-foreground" aria-hidden />
+                ) : (
+                    <ChevronUp className="size-4 text-muted-foreground" aria-hidden />
+                )}
+            </button>
+            {isCollapsed ? (
+                <p className="truncate text-xs text-muted-foreground">{summary}</p>
+            ) : (
+                <div className="grid gap-2">
+                    {fields.map((field, index) => (
+                        <FormInput
+                            key={field.id}
+                            control={control}
+                            name={`parameters.${index}.value`}
+                            label={field.name}
+                            placeholder={`Value for ${field.name}`}
+                            disabled={disabled}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function TestMessage({ message, isLoading }: { message: ChatMessage; isLoading: boolean }) {
+    if (message.role === "user") {
+        return (
+            <div className="ml-auto max-w-[85%] rounded-lg bg-primary px-3 py-2 text-sm whitespace-pre-wrap text-primary-foreground">
+                {message.text}
+            </div>
+        );
+    }
+
+    if (message.role === "error") {
+        return (
+            <div className="mr-auto max-w-[85%] rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {message.text}
+            </div>
+        );
+    }
+
+    // Agent answers are always JSON, rendered in the read-only editor: live while the field
+    // streams in, then the full structured answer once the turn finishes.
+    return (
+        <div className="mr-auto flex w-full gap-2">
+            <Bot className="mt-2 size-4 shrink-0 text-muted-foreground" aria-hidden />
+            <div className="min-w-0 flex-1">
+                {isLoading && (
+                    <div className="mb-1.5 flex items-center gap-2 text-xs text-muted-foreground">
+                        <Spinner className="size-3" />
+                        <span>Generating response…</span>
+                    </div>
+                )}
+                <div className="overflow-hidden rounded-lg border">
+                    <AceEditor mode="json" value={message.json ?? ""} readOnly height="160px" maxHeight={400} />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function replaceMessage(messages: ChatMessage[], id: string, update: (message: ChatMessage) => ChatMessage) {
+    return messages.map((message) => (message.id === id ? update(message) : message));
+}
+
+function toParameterRecord(parameters: TestFormData["parameters"]): Record<string, string> | null {
+    const entries = parameters
+        .map((parameter) => [parameter.name, parameter.value] as const)
+        .filter(([name, value]) => name && value.trim() !== "");
+
+    return entries.length > 0 ? Object.fromEntries(entries) : null;
+}
+
+// Builds the JSON shown while a single field streams in: the declared answer shape with the
+// streamed field replaced by the text received so far, so the live answer reads as a real
+// JSON object instead of a bare string. Falls back to a single-field object when the draft
+// declares no output shape at all.
+function buildStreamingJson(
+    answerShape: Record<string, unknown> | null,
+    streamField: string,
+    streamedText: string,
+): string {
+    const answer: Record<string, unknown> = { ...(answerShape ?? {}) };
+    const field = streamField || Object.keys(answer)[0] || "reply";
+    answer[field] = streamedText;
+
+    return JSON.stringify(answer, null, 4);
+}
+
+// Pretty-prints the structured answer for the JSON editor; null when there is nothing to show.
+function toAnswerJson(answer: unknown): string | null {
+    if (answer && typeof answer === "object" && Object.keys(answer).length > 0) {
+        return JSON.stringify(answer, null, 4);
+    }
+
+    return null;
+}
+
+// The agent's declared output fields — the keys of the resolved output shape (see
+// getOutputShape). Empty when the draft declares neither a sample nor a schema, which hides
+// the "Streamed field" select and lets the server pick the default.
+function getOutputFieldNames(sampleObject: string, outputSchema: string): string[] {
+    return objectKeys(getOutputShape(sampleObject, outputSchema));
+}
+
+// The declared output shape used to skeleton the live answer: the sample response object when
+// present (its instruction strings double as placeholders), otherwise a skeleton built from
+// the Response JSON schema's `properties`. Null when the draft declares neither. The streamed
+// field overwrites its slot, and the real answer replaces the whole thing once the turn ends.
+function getOutputShape(sampleObject: string, outputSchema: string): Record<string, unknown> | null {
+    const sample = parseJsonObject(sampleObject);
+    if (sample && Object.keys(sample).length > 0) {
+        return sample;
+    }
+
+    return schemaPropertiesToShape(parseJsonObject(outputSchema)?.properties);
+}
+
+// Turns a JSON schema's `properties` map into a placeholder object, one type-appropriate empty
+// value per declared field (e.g. "" for strings, [] for arrays), so the streaming preview
+// resembles the real response shape.
+function schemaPropertiesToShape(properties: unknown): Record<string, unknown> | null {
+    if (!properties || typeof properties !== "object" || Array.isArray(properties)) {
+        return null;
+    }
+
+    const shape: Record<string, unknown> = {};
+    for (const [field, definition] of Object.entries(properties as Record<string, unknown>)) {
+        shape[field] = schemaTypePlaceholder(definition);
+    }
+
+    return Object.keys(shape).length > 0 ? shape : null;
+}
+
+function schemaTypePlaceholder(definition: unknown): unknown {
+    const type = definition && typeof definition === "object" ? (definition as { type?: unknown }).type : undefined;
+
+    switch (type) {
+        case "array":
+            return [];
+        case "object":
+            return {};
+        case "number":
+        case "integer":
+            return 0;
+        case "boolean":
+            return false;
+        default:
+            return "";
+    }
+}
+
+function parseJsonObject(json: string | null | undefined): Record<string, unknown> | null {
+    if (!json || !json.trim()) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(json);
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+function objectKeys(value: Record<string, unknown> | null): string[] {
+    return value ? Object.keys(value) : [];
+}

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
@@ -7,6 +7,7 @@ import { Bot, ChevronDown, ChevronUp, FlaskConical, MessageSquare, Send, Setting
 import { api } from "@/api/api";
 import type { AgentToolCall } from "@/api/custom-services/agent-stream";
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
+import type { WizardFooterComponentProps } from "@/components/form/wizard/form-wizard";
 import { buildAgentConfigurationPayload } from "@/pages/setup/add-capability-wizard/agent-config-form";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
@@ -27,7 +28,7 @@ import { TestQueryToolCall } from "@/pages/setup/add-capability-wizard/steps/rev
 // Footer action for the wizard's Review step: opens a sheet to chat with the draft agent.
 // The button stays disabled until the draft has the minimum a test needs (name, system
 // prompt, and an AI provider connection).
-export function ReviewTestAgentButton() {
+export function ReviewTestAgentButton({ isBusy }: WizardFooterComponentProps) {
     const { control } = useFormContext<AgentFormData>();
     const [name, systemPrompt, connectionStringName] = useWatch({
         control,
@@ -43,7 +44,7 @@ export function ReviewTestAgentButton() {
                 <Button
                     type="button"
                     variant="outline"
-                    disabled={!isReady}
+                    disabled={isBusy || !isReady}
                     title={
                         isReady ? undefined : "Add a name, system prompt, and AI provider connection before testing."
                     }

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Database } from "lucide-react";
+import type { AgentToolCall } from "@/api/custom-services/agent-stream";
+import AceEditor from "@/components/ace-editor/ace-editor";
+import type { AceEditorMode } from "@/components/ace-editor/ace-editor-types";
+
+// A collapsed transcript of one query tool the agent ran this turn: the RQL it executed, the
+// parameters the model filled in, and the content the query returned. Mirrors Studio's query
+// tool transcript; the appliance supports query tools only, so there's no action/sub-agent variant.
+export function TestQueryToolCall({ toolCall }: { toolCall: AgentToolCall }) {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    return (
+        <div className="rounded-lg border bg-background text-sm">
+            <button
+                type="button"
+                className="flex w-full items-center justify-between gap-2 p-2 text-left"
+                aria-expanded={isExpanded}
+                onClick={() => setIsExpanded((expanded) => !expanded)}
+            >
+                <span className="flex min-w-0 items-center gap-2 font-medium">
+                    <Database className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                    <span className="truncate">Query tool: {toolCall.name}</span>
+                </span>
+                {isExpanded ? (
+                    <ChevronUp className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                ) : (
+                    <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                )}
+            </button>
+
+            {isExpanded && (
+                <div className="grid gap-3 border-t p-2">
+                    {toolCall.description && <p className="text-xs text-muted-foreground">{toolCall.description}</p>}
+                    {toolCall.query && <CodeField label="Query" value={toolCall.query} mode="sql" height="80px" />}
+                    <CodeField
+                        label="Parameters filled by the model"
+                        value={prettifyJson(toolCall.arguments)}
+                        mode="json"
+                        height="60px"
+                    />
+                    {toolCall.result != null && <ResultField result={toolCall.result} />}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function ResultField({ result }: { result: string }) {
+    // The query result is usually a JSON document set, but a tool can return plain text — render
+    // JSON prettified, falling back to a plain-text editor when it isn't parseable.
+    const parsed = tryParseJson(result);
+
+    return parsed === undefined ? (
+        <CodeField label="Result" value={result} mode="text" height="120px" />
+    ) : (
+        <CodeField label="Result" value={JSON.stringify(parsed, null, 4)} mode="json" height="120px" />
+    );
+}
+
+function CodeField({
+    label,
+    value,
+    mode,
+    height,
+}: {
+    label: string;
+    value: string;
+    mode: AceEditorMode;
+    height: string;
+}) {
+    return (
+        <div className="grid gap-1">
+            <span className="text-xs text-muted-foreground">{label}</span>
+            <div className="overflow-hidden rounded-md border">
+                <AceEditor mode={mode} value={value} readOnly height={height} maxHeight={300} />
+            </div>
+        </div>
+    );
+}
+
+// Pretty-prints a JSON string for display, leaving it untouched when it isn't valid JSON (e.g. an
+// empty or partial arguments string).
+function prettifyJson(value: string | null | undefined): string {
+    if (!value) {
+        return "";
+    }
+
+    const parsed = tryParseJson(value);
+    return parsed === undefined ? value : JSON.stringify(parsed, null, 4);
+}
+
+function tryParseJson(value: string): unknown {
+    try {
+        return JSON.parse(value);
+    } catch {
+        return undefined;
+    }
+}

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call.tsx
@@ -39,7 +39,7 @@ export function TestQueryToolCall({ toolCall }: { toolCall: AgentToolCall }) {
                         mode="json"
                         height="60px"
                     />
-                    {toolCall.result != null && <ResultField result={toolCall.result} />}
+                    {toolCall.result?.trim() && <ResultField result={toolCall.result} />}
                 </div>
             )}
         </div>

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/use-provision-agent-step.ts
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/use-provision-agent-step.ts
@@ -1,0 +1,77 @@
+import { useFormContext } from "react-hook-form";
+import { useParams } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api } from "@/api/api";
+import type { AiAgentConfiguration } from "@/api/generated/server-api";
+import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
+import { buildAgentConfigurationPayload } from "@/pages/setup/add-capability-wizard/agent-config-form";
+import { useCapabilityWizardStore } from "@/pages/setup/add-capability-wizard/capability-wizard-store";
+
+// Runs on "Save agent" from the review step: provisions the agent, then lets the wizard
+// advance to the optional channels step. The new agent id is stored so that step can attach
+// channels to it. Success shows a toast; failure throws so the wizard surfaces it inline via
+// its advance error.
+export function useProvisionAgentStep() {
+    const { slug = "" } = useParams();
+    const { getValues } = useFormContext<AgentFormData>();
+    const queryClient = useQueryClient();
+    const setCreatedAgent = useCapabilityWizardStore((state) => state.setCreatedAgent);
+
+    return async () => {
+        // Provisioning is create-only. The channels step has no Back, so this guards only the
+        // defensive case — never create a second agent for the same wizard run.
+        if (useCapabilityWizardStore.getState().createdAgent) {
+            return;
+        }
+
+        const values = getValues();
+        const base = resolveAgentBase(values);
+        const config: AiAgentConfiguration = {
+            ...base,
+            ...buildAgentConfigurationPayload(values),
+        };
+        const name = values.review.name.trim();
+
+        let agentId: string;
+        try {
+            const result = await api.services.apps.provisionAgent(slug, config);
+            agentId = result.agentId;
+        } catch (error) {
+            // Backend rejections can carry a full stack trace; surface only the first line.
+            const message = error instanceof Error ? error.message.split("\n")[0] : "Could not create agent.";
+            throw new Error(message, { cause: error });
+        }
+
+        // Record the irreversible write before non-critical cache work. If invalidation ever
+        // fails, the wizard must still know not to provision the same agent again.
+        setCreatedAgent({ agentId, name });
+        void queryClient.invalidateQueries({ queryKey: api.queries.agents.list(slug).queryKey });
+        toast.success(`Agent "${name}" created`);
+    };
+}
+
+// The AI candidate a provisioned agent builds on: the selected data suggestion ("ai"), the
+// prompt-generated config ("prompt"), or none ("manual"). Throws when the expected candidate
+// is missing so we never silently provision an empty agent.
+function resolveAgentBase(values: AgentFormData): AiAgentConfiguration | undefined {
+    const store = useCapabilityWizardStore.getState();
+
+    if (values.create.mode === "ai") {
+        const base = store.suggestions[values.create.selectedIndex];
+        if (!base) {
+            throw new Error("No agent suggestion selected.");
+        }
+        return base;
+    }
+
+    if (values.create.mode === "prompt") {
+        const base = store.promptResult?.config;
+        if (!base) {
+            throw new Error("No generated agent. Go back and generate one from your prompt.");
+        }
+        return base;
+    }
+
+    return undefined;
+}

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/suggestion-picker.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/suggestion-picker.tsx
@@ -1,5 +1,6 @@
 import { useFormContext, useWatch } from "react-hook-form";
 import { cn } from "@/lib/utils";
+import { SELECTED_CARD_CLASSES } from "@/components/form/form-radio-cards";
 import type { AiAgentConfiguration } from "@/api/generated/server-api";
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
 import { applySuggestionToForm } from "@/pages/setup/add-capability-wizard/agent-config-form";
@@ -32,8 +33,8 @@ export function SuggestionPicker() {
                         }}
                         className={cn(
                             "min-h-28 rounded-lg border bg-background p-4 text-left transition-colors",
-                            "hover:bg-accent hover:text-accent-foreground",
-                            isSelected && "border-foreground bg-accent text-accent-foreground",
+                            !isSelected && "hover:bg-accent hover:text-accent-foreground",
+                            isSelected && SELECTED_CARD_CLASSES,
                         )}
                     >
                         <span className="block text-sm font-semibold">{config.name}</span>

--- a/src/Raven.AiAppliance/Agents/AgentTestParameterValue.cs
+++ b/src/Raven.AiAppliance/Agents/AgentTestParameterValue.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.AiAppliance.Agents;
+
+/// <summary>
+/// Converts a System.Text.Json value from the appliance request to the blittable-compatible value
+/// RavenDB's agent endpoint expects.
+/// </summary>
+public static class AgentTestParameterValue
+{
+    public static object? Convert(JsonElement? value) => value is null ? null : ToRavenJsonValue(value.Value);
+
+    private static object? ToRavenJsonValue(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Null:
+            case JsonValueKind.Undefined:
+                return null;
+            case JsonValueKind.String:
+                return element.GetString();
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                return element.GetBoolean();
+            case JsonValueKind.Number:
+                if (element.TryGetInt64(out var integer))
+                    return integer;
+                if (element.TryGetDecimal(out var decimalValue))
+                    return decimalValue;
+                return element.GetDouble();
+            case JsonValueKind.Array:
+                var array = new DynamicJsonArray();
+                foreach (var item in element.EnumerateArray())
+                    array.Add(ToRavenJsonValue(item));
+                return array;
+            case JsonValueKind.Object:
+                var result = new DynamicJsonValue();
+                foreach (var property in element.EnumerateObject())
+                    result[property.Name] = ToRavenJsonValue(property.Value);
+                return result;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(element), element.ValueKind, "Unsupported JSON value kind.");
+        }
+    }
+}

--- a/src/Raven.AiAppliance/Agents/AgentTestTranscript.cs
+++ b/src/Raven.AiAppliance/Agents/AgentTestTranscript.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Raven.Client.Documents.Operations.AI.Agents;
+
+namespace Raven.AiAppliance.Agents;
+
+/// <summary>
+/// One query tool the model invoked during a test turn, reconstructed from the conversation
+/// transcript: the configured query (RQL + description), the parameters the model filled in,
+/// and the content the query returned. The appliance only supports query tools, so action and
+/// sub-agent calls are intentionally not surfaced.
+/// </summary>
+/// <param name="Id">The tool-call id (ties the call to its result message).</param>
+/// <param name="Name">The configured query tool's name (the function the model invoked).</param>
+/// <param name="Description">The tool's configured description, if any.</param>
+/// <param name="Query">The tool's configured RQL.</param>
+/// <param name="Arguments">The JSON arguments the model filled in for the call.</param>
+/// <param name="Result">The content the query returned; null when no matching result message.</param>
+public sealed record AgentQueryToolCall(
+    string Id,
+    string Name,
+    string? Description,
+    string? Query,
+    string Arguments,
+    string? Result);
+
+/// <summary>
+/// Reconstructs the query tool calls from a draft agent test run so the wizard's "Test agent"
+/// panel can show what the agent did, mirroring Studio's transcript view (query tools only).
+///
+/// RavenDB's <c>ai/agent/test</c> endpoint returns the (non-persisted) conversation document(s)
+/// under <c>Documents</c>; each holds the OpenAI-style message list (<c>Messages</c>). A tool
+/// invocation spans two messages: an <c>assistant</c> message carrying <c>tool_calls</c>
+/// (id + function name + JSON arguments) and a later <c>tool</c> message whose
+/// <c>tool_call_id</c> ties the returned <c>content</c> back to the call. We pair them up and
+/// keep only calls whose name matches a configured query tool.
+/// </summary>
+public static class AgentTestTranscript
+{
+    // The result object's document map (PascalCase); each value is a conversation document.
+    private const string DocumentsField = "Documents";
+
+    // The conversation document's OpenAI-style message list (PascalCase, per ConversationDocument.ToJson).
+    private const string MessagesField = "Messages";
+
+    // OpenAI message / tool-call field names (lowercase on the wire).
+    private const string RoleField = "role";
+    private const string ContentField = "content";
+    private const string ToolCallsField = "tool_calls";
+    private const string ToolCallIdField = "tool_call_id";
+    private const string FunctionField = "function";
+    private const string IdField = "id";
+    private const string NameField = "name";
+    private const string ArgumentsField = "arguments";
+    private const string ToolRole = "tool";
+
+    /// <summary>
+    /// Extracts the query tool calls from the test endpoint's final result object
+    /// (<paramref name="root"/>), enriched with the matching query config from
+    /// <paramref name="configuration"/>. Returns an empty list when the run invoked no query
+    /// tool or the configuration declares none.
+    /// </summary>
+    public static IReadOnlyList<AgentQueryToolCall> ExtractQueryToolCalls(JsonElement root, AiAgentConfiguration configuration)
+    {
+        var toolCalls = new List<AgentQueryToolCall>();
+
+        if (root.ValueKind != JsonValueKind.Object ||
+            root.TryGetProperty(DocumentsField, out var documents) == false ||
+            documents.ValueKind != JsonValueKind.Object)
+        {
+            return toolCalls;
+        }
+
+        // The appliance only supports query tools; index them by name to filter the calls and
+        // to enrich each with its RQL + description.
+        var queriesByName = new Dictionary<string, AiAgentToolQuery>(StringComparer.Ordinal);
+        foreach (var query in configuration.Queries ?? [])
+        {
+            if (string.IsNullOrEmpty(query.Name) == false)
+                queriesByName[query.Name] = query;
+        }
+
+        if (queriesByName.Count == 0)
+            return toolCalls;
+
+        foreach (var document in documents.EnumerateObject())
+        {
+            if (document.Value.ValueKind != JsonValueKind.Object ||
+                document.Value.TryGetProperty(MessagesField, out var messages) == false ||
+                messages.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            // First pass: tool_call_id -> returned content (the "tool" role messages).
+            var resultsByCallId = new Dictionary<string, string?>(StringComparer.Ordinal);
+            foreach (var message in messages.EnumerateArray())
+            {
+                if (GetString(message, RoleField) != ToolRole)
+                    continue;
+
+                var callId = GetString(message, ToolCallIdField);
+                if (string.IsNullOrEmpty(callId) == false)
+                    resultsByCallId[callId] = GetString(message, ContentField);
+            }
+
+            // Second pass: each assistant tool_call that names a configured query tool.
+            foreach (var message in messages.EnumerateArray())
+            {
+                if (message.TryGetProperty(ToolCallsField, out var calls) == false || calls.ValueKind != JsonValueKind.Array)
+                    continue;
+
+                foreach (var call in calls.EnumerateArray())
+                {
+                    if (call.ValueKind != JsonValueKind.Object ||
+                        call.TryGetProperty(FunctionField, out var function) == false ||
+                        function.ValueKind != JsonValueKind.Object)
+                    {
+                        continue;
+                    }
+
+                    var name = GetString(function, NameField);
+                    if (name is null || queriesByName.TryGetValue(name, out var query) == false)
+                        continue; // not a (known) query tool — actions/sub-agents aren't surfaced
+
+                    var id = GetString(call, IdField) ?? "";
+                    var arguments = GetString(function, ArgumentsField) ?? "";
+                    resultsByCallId.TryGetValue(id, out var result);
+
+                    toolCalls.Add(new AgentQueryToolCall(id, name, query.Description, query.Query, arguments, result));
+                }
+            }
+        }
+
+        return toolCalls;
+    }
+
+    private static string? GetString(JsonElement element, string property) =>
+        element.ValueKind == JsonValueKind.Object &&
+        element.TryGetProperty(property, out var value) &&
+        value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/src/Raven.AiAppliance/Agents/AgentTestTranscript.cs
+++ b/src/Raven.AiAppliance/Agents/AgentTestTranscript.cs
@@ -54,6 +54,7 @@ public static class AgentTestTranscript
     private const string NameField = "name";
     private const string ArgumentsField = "arguments";
     private const string ToolRole = "tool";
+    private const string AssistantRole = "assistant";
 
     /// <summary>
     /// Extracts the query tool calls from the test endpoint's final result object
@@ -105,9 +106,14 @@ public static class AgentTestTranscript
                     resultsByCallId[callId] = GetString(message, ContentField);
             }
 
-            // Second pass: each assistant tool_call that names a configured query tool.
+            // Second pass: each assistant tool_call that names a configured query tool. Only
+            // assistant messages carry the calls the model made; tool_calls on any other role
+            // aren't the model's invocations, so skip them.
             foreach (var message in messages.EnumerateArray())
             {
+                if (GetString(message, RoleField) != AssistantRole)
+                    continue;
+
                 if (message.TryGetProperty(ToolCallsField, out var calls) == false || calls.ValueKind != JsonValueKind.Array)
                     continue;
 

--- a/src/Raven.AiAppliance/Agents/RunDraftAgentTestOperation.cs
+++ b/src/Raven.AiAppliance/Agents/RunDraftAgentTestOperation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
@@ -34,23 +35,26 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
     private readonly IReadOnlyDictionary<string, string>? _parameters;
     private readonly string _streamField;
     private readonly Func<string, Task> _onChunk;
+    private readonly CancellationToken _token;
 
     public RunDraftAgentTestOperation(
         AiAgentConfiguration configuration,
         string prompt,
         IReadOnlyDictionary<string, string>? parameters,
         string streamField,
-        Func<string, Task> onChunk)
+        Func<string, Task> onChunk,
+        CancellationToken token)
     {
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _prompt = prompt ?? throw new ArgumentNullException(nameof(prompt));
         _parameters = parameters;
         _streamField = streamField ?? throw new ArgumentNullException(nameof(streamField));
         _onChunk = onChunk ?? throw new ArgumentNullException(nameof(onChunk));
+        _token = token;
     }
 
     public RavenCommand<Result> GetCommand(DocumentConventions conventions, JsonOperationContext ctx) =>
-        new Command(_configuration, _prompt, _parameters, _streamField, _onChunk, conventions);
+        new Command(_configuration, _prompt, _parameters, _streamField, _onChunk, conventions, _token);
 
     public sealed class Result
     {
@@ -78,6 +82,7 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
         private readonly string _replyField;
         private readonly Func<string, Task> _onChunk;
         private readonly DocumentConventions _conventions;
+        private readonly CancellationToken _token;
 
         public Command(
             AiAgentConfiguration configuration,
@@ -85,7 +90,8 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
             IReadOnlyDictionary<string, string>? parameters,
             string replyField,
             Func<string, Task> onChunk,
-            DocumentConventions conventions)
+            DocumentConventions conventions,
+            CancellationToken token)
         {
             _configuration = configuration;
             _prompt = prompt;
@@ -93,6 +99,7 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
             _replyField = replyField;
             _onChunk = onChunk;
             _conventions = conventions;
+            _token = token;
 
             // The server streams the reply property as text/event-stream; read it raw so we can
             // relay chunks as they arrive instead of buffering the whole turn.
@@ -158,7 +165,9 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
             using var reader = new StreamReader(stream);
             while (true)
             {
-                var line = await reader.ReadLineAsync().ConfigureAwait(false);
+                // Pass the request token so a client disconnect is observed promptly mid-read,
+                // rather than only when the next chunk write to the browser fails.
+                var line = await reader.ReadLineAsync(_token).ConfigureAwait(false);
                 if (line is null)
                     break;
 

--- a/src/Raven.AiAppliance/Agents/RunDraftAgentTestOperation.cs
+++ b/src/Raven.AiAppliance/Agents/RunDraftAgentTestOperation.cs
@@ -62,6 +62,11 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
         // produced no structured response object.
         public JsonElement? Answer { get; set; }
 
+        // The query tools the agent invoked during the turn (with their RQL, the parameters the
+        // model filled in, and the returned content), so the wizard can show the transcript.
+        // Empty when the turn called no query tool.
+        public IReadOnlyList<AgentQueryToolCall> ToolCalls { get; set; } = [];
+
         public string ConversationId { get; set; } = "";
     }
 
@@ -194,6 +199,11 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
                 Result.Answer = answer.Clone();
                 Result.Reply = ExtractReply(answer);
             }
+
+            // Reconstruct the query tool calls from the returned conversation transcript so the
+            // wizard can show what the agent did. The extracted strings are copied out of the
+            // JsonDocument here, so they outlive its disposal.
+            Result.ToolCalls = AgentTestTranscript.ExtractQueryToolCalls(root, _configuration);
         }
 
         // The model answer wraps the reply under the configured reply field; fall back to the

--- a/src/Raven.AiAppliance/Agents/RunDraftAgentTestOperation.cs
+++ b/src/Raven.AiAppliance/Agents/RunDraftAgentTestOperation.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.AiAppliance.Contracts;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI.Agents;
@@ -32,7 +33,7 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
 {
     private readonly AiAgentConfiguration _configuration;
     private readonly string _prompt;
-    private readonly IReadOnlyDictionary<string, string>? _parameters;
+    private readonly IReadOnlyDictionary<string, SetupTryParameter>? _parameters;
     private readonly string _streamField;
     private readonly Func<string, Task> _onChunk;
     private readonly CancellationToken _token;
@@ -40,7 +41,7 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
     public RunDraftAgentTestOperation(
         AiAgentConfiguration configuration,
         string prompt,
-        IReadOnlyDictionary<string, string>? parameters,
+        IReadOnlyDictionary<string, SetupTryParameter>? parameters,
         string streamField,
         Func<string, Task> onChunk,
         CancellationToken token)
@@ -78,7 +79,7 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
     {
         private readonly AiAgentConfiguration _configuration;
         private readonly string _prompt;
-        private readonly IReadOnlyDictionary<string, string>? _parameters;
+        private readonly IReadOnlyDictionary<string, SetupTryParameter>? _parameters;
         private readonly string _replyField;
         private readonly Func<string, Task> _onChunk;
         private readonly DocumentConventions _conventions;
@@ -87,7 +88,7 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
         public Command(
             AiAgentConfiguration configuration,
             string prompt,
-            IReadOnlyDictionary<string, string>? parameters,
+            IReadOnlyDictionary<string, SetupTryParameter>? parameters,
             string replyField,
             Func<string, Task> onChunk,
             DocumentConventions conventions,
@@ -119,15 +120,14 @@ internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraf
             if (_parameters is { Count: > 0 })
             {
                 var values = new DynamicJsonValue();
-                foreach (var (key, value) in _parameters)
+                foreach (var (key, parameter) in _parameters)
                 {
-                    // Mirror AiConversationParameter so the server binds it like a normal
-                    // conversation parameter; SendToModel mirrors the appliance router's
-                    // string-parameter convention (always exposed to the model).
+                    // Mirror AiConversationParameter so the server binds the already-typed JSON
+                    // value exactly like RavenDB Studio's agent test panel.
                     values[key] = new DynamicJsonValue
                     {
-                        ["Value"] = value,
-                        ["SendToModel"] = true,
+                        ["Value"] = AgentTestParameterValue.Convert(parameter?.Value),
+                        ["SendToModel"] = parameter?.SendToModel ?? true,
                     };
                 }
 

--- a/src/Raven.AiAppliance/Agents/RunDraftAgentTestOperation.cs
+++ b/src/Raven.AiAppliance/Agents/RunDraftAgentTestOperation.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.AiAppliance.Agents;
+
+/// <summary>
+/// Runs a single, non-persisted conversation turn against a <em>draft</em>
+/// <see cref="AiAgentConfiguration"/> via RavenDB's <c>POST /databases/{db}/ai/agent/test</c>
+/// endpoint — the same endpoint Studio's agent test panel uses — and streams the reply.
+/// This lets the wizard smoke-test the configuration an operator is still editing in the
+/// Review step, before it is provisioned (so there is no persisted agent to bind to via
+/// <see cref="AgentRouter"/>). The endpoint streams the reply property (resolved via
+/// <see cref="AgentOutputShape.ResolveReplyField"/>) as <c>text/event-stream</c>: each line is
+/// a JSON-encoded chunk, then a trailing JSON object with the full result. We relay chunks to
+/// <paramref name="onChunk"/> as they arrive (mirroring <c>RunConversationOperation</c>) and
+/// read the reply / conversation id from the final object. The endpoint does not persist the
+/// conversation, so the turn is stateless.
+/// </summary>
+internal sealed class RunDraftAgentTestOperation : IMaintenanceOperation<RunDraftAgentTestOperation.Result>
+{
+    private readonly AiAgentConfiguration _configuration;
+    private readonly string _prompt;
+    private readonly IReadOnlyDictionary<string, string>? _parameters;
+    private readonly string _streamField;
+    private readonly Func<string, Task> _onChunk;
+
+    public RunDraftAgentTestOperation(
+        AiAgentConfiguration configuration,
+        string prompt,
+        IReadOnlyDictionary<string, string>? parameters,
+        string streamField,
+        Func<string, Task> onChunk)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _prompt = prompt ?? throw new ArgumentNullException(nameof(prompt));
+        _parameters = parameters;
+        _streamField = streamField ?? throw new ArgumentNullException(nameof(streamField));
+        _onChunk = onChunk ?? throw new ArgumentNullException(nameof(onChunk));
+    }
+
+    public RavenCommand<Result> GetCommand(DocumentConventions conventions, JsonOperationContext ctx) =>
+        new Command(_configuration, _prompt, _parameters, _streamField, _onChunk, conventions);
+
+    public sealed class Result
+    {
+        // The streamed field's text — used as the chat fallback when nothing streamed.
+        public string Reply { get; set; } = "";
+
+        // The full model output object (every declared field), so the caller can surface the
+        // whole structured answer rather than only the streamed reply. Null when the turn
+        // produced no structured response object.
+        public JsonElement? Answer { get; set; }
+
+        public string ConversationId { get; set; } = "";
+    }
+
+    private sealed class Command : RavenCommand<Result>
+    {
+        private readonly AiAgentConfiguration _configuration;
+        private readonly string _prompt;
+        private readonly IReadOnlyDictionary<string, string>? _parameters;
+        private readonly string _replyField;
+        private readonly Func<string, Task> _onChunk;
+        private readonly DocumentConventions _conventions;
+
+        public Command(
+            AiAgentConfiguration configuration,
+            string prompt,
+            IReadOnlyDictionary<string, string>? parameters,
+            string replyField,
+            Func<string, Task> onChunk,
+            DocumentConventions conventions)
+        {
+            _configuration = configuration;
+            _prompt = prompt;
+            _parameters = parameters;
+            _replyField = replyField;
+            _onChunk = onChunk;
+            _conventions = conventions;
+
+            // The server streams the reply property as text/event-stream; read it raw so we can
+            // relay chunks as they arrive instead of buffering the whole turn.
+            ResponseType = RavenCommandResponseType.Raw;
+        }
+
+        // The test endpoint runs the model but writes no cluster state — it is registered as a
+        // read endpoint server-side, so route it like one.
+        public override bool IsReadRequest => true;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/ai/agent/test" +
+                  $"?streaming=true&streamPropertyPath={Uri.EscapeDataString(_replyField)}";
+
+            var creationOptions = new DynamicJsonValue();
+            if (_parameters is { Count: > 0 })
+            {
+                var values = new DynamicJsonValue();
+                foreach (var (key, value) in _parameters)
+                {
+                    // Mirror AiConversationParameter so the server binds it like a normal
+                    // conversation parameter; SendToModel mirrors the appliance router's
+                    // string-parameter convention (always exposed to the model).
+                    values[key] = new DynamicJsonValue
+                    {
+                        ["Value"] = value,
+                        ["SendToModel"] = true,
+                    };
+                }
+
+                creationOptions["Parameters"] = values;
+            }
+
+            // Serialize the configuration through the same converter AddOrUpdateAiAgentOperation
+            // uses, so the draft binds to AiAgentConfiguration server-side exactly as a
+            // provisioned one would.
+            var body = new DynamicJsonValue
+            {
+                ["Configuration"] = _conventions.Serialization.DefaultConverter.ToBlittable(_configuration, ctx),
+                ["UserPrompt"] = _prompt,
+                ["CreationOptions"] = creationOptions,
+            };
+
+            var payload = ctx.ReadObject(body, "ai-agent-test");
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, payload).ConfigureAwait(false), _conventions),
+            };
+        }
+
+        // Raw streamed response (mirrors RunConversationOperation): each non-"{" line is a
+        // JSON-encoded chunk of the reply property; the trailing "{" line is the final result
+        // object. We relay chunks to the caller and read the reply / conversation id from the
+        // final object (a fallback used when nothing streamed). Parsed with System.Text.Json —
+        // RavenDB's blittable sync reader (context.Sync) is internal to the client assembly.
+        public override async Task SetResponseRawAsync(HttpResponseMessage response, Stream stream, JsonOperationContext context)
+        {
+            Result = new Result();
+
+            using var reader = new StreamReader(stream);
+            while (true)
+            {
+                var line = await reader.ReadLineAsync().ConfigureAwait(false);
+                if (line is null)
+                    break;
+
+                if (line.StartsWith('{'))
+                {
+                    PopulateResult(line);
+                    break;
+                }
+
+                if (string.IsNullOrEmpty(line))
+                    continue;
+
+                var chunk = JsonSerializer.Deserialize<string>(line);
+                if (string.IsNullOrEmpty(chunk) == false)
+                    await _onChunk(chunk).ConfigureAwait(false);
+            }
+        }
+
+        // Not used on the streaming (Raw) path, but RavenCommand requires it.
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            Result ??= new Result();
+        }
+
+        private void PopulateResult(string finalLine)
+        {
+            using var doc = JsonDocument.Parse(finalLine);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return;
+
+            if (root.TryGetProperty("ConversationId", out var conversationId) && conversationId.ValueKind == JsonValueKind.String)
+                Result.ConversationId = conversationId.GetString() ?? "";
+
+            if (root.TryGetProperty("Response", out var answer) && answer.ValueKind == JsonValueKind.Object)
+            {
+                // Clone so the element outlives this method's JsonDocument (disposed on return).
+                Result.Answer = answer.Clone();
+                Result.Reply = ExtractReply(answer);
+            }
+        }
+
+        // The model answer wraps the reply under the configured reply field; fall back to the
+        // first non-empty string property so a custom output shape still surfaces something.
+        private string ExtractReply(JsonElement answer)
+        {
+            if (answer.TryGetProperty(_replyField, out var preferred) &&
+                preferred.ValueKind == JsonValueKind.String &&
+                preferred.GetString() is { Length: > 0 } text)
+            {
+                return text;
+            }
+
+            foreach (var property in answer.EnumerateObject())
+            {
+                if (property.Value.ValueKind == JsonValueKind.String &&
+                    property.Value.GetString() is { Length: > 0 } value)
+                {
+                    return value;
+                }
+            }
+
+            return "";
+        }
+    }
+}

--- a/src/Raven.AiAppliance/Contracts/SetupTryRequest.cs
+++ b/src/Raven.AiAppliance/Contracts/SetupTryRequest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using Raven.Client.Documents.Operations.AI.Agents;
 
 namespace Raven.AiAppliance.Contracts;
@@ -20,5 +21,12 @@ namespace Raven.AiAppliance.Contracts;
 public sealed record SetupTryRequest(
     string Prompt,
     AiAgentConfiguration Configuration,
-    Dictionary<string, string>? Parameters,
+    Dictionary<string, SetupTryParameter>? Parameters,
     string? StreamField = null);
+
+/// <summary>
+/// One operator-supplied conversation parameter, matching RavenDB's
+/// <see cref="Raven.Client.Documents.AI.AiConversationParameter"/> wire shape. The value keeps
+/// its JSON type and <see cref="SendToModel"/> can be overridden for an individual test run.
+/// </summary>
+public sealed record SetupTryParameter(JsonElement? Value, bool SendToModel);

--- a/src/Raven.AiAppliance/Contracts/SetupTryRequest.cs
+++ b/src/Raven.AiAppliance/Contracts/SetupTryRequest.cs
@@ -1,13 +1,24 @@
+using System.Collections.Generic;
+using Raven.Client.Documents.Operations.AI.Agents;
+
 namespace Raven.AiAppliance.Contracts;
 
 /// <summary>
-/// Wizard "Try the agent" smoke-test input (design §1.3 Stage C.2 step 12).
-/// Streams a single turn against the per-app agent so the operator can confirm
-/// it answers before wiring a channel to it.
+/// Wizard "Test agent" input (design §1.3 Stage C.2 step 12). The operator tests the
+/// <em>draft</em> configuration being edited in the Review step — before it is
+/// provisioned — so the request carries the full <see cref="AiAgentConfiguration"/>
+/// rather than a persisted agent id (which does not exist yet). Runs one
+/// non-persisted turn against RavenDB's agent test endpoint.
 /// </summary>
 /// <param name="Prompt">The test prompt to send the agent.</param>
-/// <param name="AgentId">The agent identifier to run — required (the operator
-/// picks which agent to smoke-test).</param>
+/// <param name="Configuration">The draft agent configuration to run the turn against.</param>
+/// <param name="Parameters">Conversation-level parameter values the operator supplies
+/// for the run (name -> value); optional.</param>
+/// <param name="StreamField">Which output property streams token-by-token (the wizard's
+/// "Streamed field" select). Optional — when unset, the conventional first-declared output
+/// field is used (see <see cref="Raven.AiAppliance.Agents.AgentOutputShape.ResolveReplyField"/>).</param>
 public sealed record SetupTryRequest(
     string Prompt,
-    string AgentId);
+    AiAgentConfiguration Configuration,
+    Dictionary<string, string>? Parameters,
+    string? StreamField = null);

--- a/src/Raven.AiAppliance/Endpoints/AppsEndpoints.cs
+++ b/src/Raven.AiAppliance/Endpoints/AppsEndpoints.cs
@@ -325,7 +325,8 @@ public static class AppsEndpoints
                 body.Prompt,
                 body.Parameters,
                 streamField,
-                async chunk => await NdjsonStream.WriteLineAsync(ctx, new { type = "chunk", text = chunk }));
+                async chunk => await NdjsonStream.WriteLineAsync(ctx, new { type = "chunk", text = chunk }),
+                ct);
 
             var result = await store.Maintenance.ForDatabase(app.Database).SendAsync(operation, ct);
 

--- a/src/Raven.AiAppliance/Endpoints/AppsEndpoints.cs
+++ b/src/Raven.AiAppliance/Endpoints/AppsEndpoints.cs
@@ -337,6 +337,9 @@ public static class AppsEndpoints
                 // Full structured model output, so the wizard can render the whole JSON answer
                 // (not just the streamed field). Omitted when the turn produced no object.
                 fullAnswer = result.Answer,
+                // The query tools the agent ran this turn (RQL, model-filled parameters, and the
+                // returned content), so the wizard can show the transcript. Empty when none ran.
+                toolCalls = result.ToolCalls,
                 conversationId = result.ConversationId,
             });
         }

--- a/src/Raven.AiAppliance/Endpoints/AppsEndpoints.cs
+++ b/src/Raven.AiAppliance/Endpoints/AppsEndpoints.cs
@@ -41,7 +41,7 @@ public static class AppsEndpoints
         group.MapPost("/{slug}/setup/try", SetupTryAsync)
             .WithName("apps.setupTry")
             .Accepts<SetupTryRequest>("application/json")
-            // Streams NDJSON frames, not a single string — declare the status +
+            // Streams NDJSON frames (chunk/done/error), not a single body — declare the status +
             // content type only, without a (misleading) string body schema.
             .Produces(StatusCodes.Status200OK, contentType: "application/x-ndjson")
             .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest)
@@ -275,25 +275,26 @@ public static class AppsEndpoints
     }
 
     /// <summary>
-    /// "Try the agent" smoke test (design §1.3 Stage C.2 step 12 /
-    /// RavenDB-26629 carryover). Streams one turn against the per-app agent via
-    /// <see cref="IAgentRouter"/> as NDJSON, so the operator can confirm the
-    /// agent answers before wiring a channel to it.
+    /// "Test agent" smoke test (design §1.3 Stage C.2 step 12 / RavenDB-26629
+    /// carryover). Streams a single turn against the <em>draft</em> configuration the
+    /// operator is editing in the wizard's Review step — before it is provisioned — via
+    /// <see cref="RunDraftAgentTestOperation"/> (RavenDB's agent test endpoint), relaying
+    /// the reply chunks as NDJSON so the operator can confirm it answers before saving.
+    /// The conversation is not persisted, so each turn is independent.
     /// </summary>
     private static async Task SetupTryAsync(
         string slug,
         SetupTryRequest body,
         IDocumentStore store,
-        IAgentRouter router,
         ILogger<AppsLogger> logger,
         HttpContext ctx)
     {
         var ct = ctx.RequestAborted;
 
-        if (body is null || string.IsNullOrWhiteSpace(body.Prompt) || string.IsNullOrWhiteSpace(body.AgentId))
+        if (body is null || string.IsNullOrWhiteSpace(body.Prompt) || body.Configuration is null)
         {
             ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
-            await ctx.Response.WriteAsJsonAsync(new ApiErrorResponse("prompt and agentId are required"), ct);
+            await ctx.Response.WriteAsJsonAsync(new ApiErrorResponse("prompt and configuration are required"), ct);
             return;
         }
 
@@ -306,34 +307,36 @@ public static class AppsEndpoints
             return;
         }
 
-        // Validate the agent id against the per-app database up front (mirrors
-        // ProvisionIFrameAsync). Without this an unknown id surfaces as a 200 +
-        // NDJSON error frame after the headers flush; a miss is a client error, so
-        // return a clean 400 before the stream starts — and adopt the persisted
-        // agent's canonical casing for the run.
-        var config = await AgentLookup.FindAsync(store, app.Database, body.AgentId, ct);
-        if (config is null)
-        {
-            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
-            await ctx.Response.WriteAsJsonAsync(new ApiErrorResponse($"unknown agentId '{body.AgentId}'"), ct);
-            return;
-        }
+        // Give the smallest draft (name + prompt + connection string) the same default output
+        // shape provisioning applies, so RavenDB's agent validation accepts it.
+        AiAgentRegistrar.EnsureDefaultOutputShape(body.Configuration);
 
-        var agentId = config.Identifier;
+        // The operator can pick which output field streams token-by-token (the wizard's
+        // "Streamed field" select); fall back to the conventional first-declared field when unset.
+        var streamField = string.IsNullOrWhiteSpace(body.StreamField)
+            ? AgentOutputShape.ResolveReplyField(body.Configuration)
+            : body.StreamField.Trim();
 
         NdjsonStream.SetHeaders(ctx);
         try
         {
-            var result = await router.RunAsync(
-                new AgentRequest(app.Database, agentId, ConversationId: null, body.Prompt, Parameters: null),
-                async chunk => await NdjsonStream.WriteLineAsync(ctx, new { type = "chunk", text = chunk }),
-                ct,
-                resolved: config);
+            var operation = new RunDraftAgentTestOperation(
+                body.Configuration,
+                body.Prompt,
+                body.Parameters,
+                streamField,
+                async chunk => await NdjsonStream.WriteLineAsync(ctx, new { type = "chunk", text = chunk }));
+
+            var result = await store.Maintenance.ForDatabase(app.Database).SendAsync(operation, ct);
 
             await NdjsonStream.WriteLineAsync(ctx, new
             {
                 type = "done",
-                answer = result.Answer,
+                // Normalized single reply (casing-safe) — the no-stream fallback for the chat bubble.
+                answer = new { reply = result.Reply },
+                // Full structured model output, so the wizard can render the whole JSON answer
+                // (not just the streamed field). Omitted when the turn produced no object.
+                fullAnswer = result.Answer,
                 conversationId = result.ConversationId,
             });
         }
@@ -343,12 +346,13 @@ public static class AppsEndpoints
         }
         catch (Exception e)
         {
-            // Log full detail server-side; surface only a generic message — raw
-            // exceptions can leak DB names / connection strings / file paths.
-            logger.LogError(e, "setup/try failed for slug={Slug} agentId={AgentId}", slug, agentId);
+            // Both an invalid draft (RavenDB validation) and a model/provider failure surface
+            // here. Log full detail server-side; emit a generic error frame — raw exceptions can
+            // leak DB names / connection strings / file paths.
+            logger.LogError(e, "setup/try failed for slug={Slug}", slug);
             try
             {
-                await NdjsonStream.WriteLineAsync(ctx, new { type = "error", message = "Agent run failed. See server logs for details." });
+                await NdjsonStream.WriteLineAsync(ctx, new { type = "error", message = "Agent test failed. See server logs for details." });
             }
             catch
             {

--- a/src/Raven.AiAppliance/Raven/AiAgentRegistrar.cs
+++ b/src/Raven.AiAppliance/Raven/AiAgentRegistrar.cs
@@ -16,14 +16,24 @@ public static class AiAgentRegistrar
     // requires either OutputSchema or SampleObject to be non-empty.
     private const string DefaultSampleObject = """{"reply":""}""";
 
+    /// <summary>
+    /// Applies the minimal default output shape when the configuration declares neither a
+    /// sample object nor an output schema. Both provisioning and the draft "Test agent" turn
+    /// go through RavenDB's agent validation, which requires one — so both call this first.
+    /// </summary>
+    public static void EnsureDefaultOutputShape(AiAgentConfiguration config)
+    {
+        if (string.IsNullOrWhiteSpace(config.SampleObject) && string.IsNullOrWhiteSpace(config.OutputSchema))
+            config.SampleObject = DefaultSampleObject;
+    }
+
     public static async Task<RegisterResult> RegisterAsync(
         IDocumentStore store,
         AiAgentConfiguration config,
         string targetDatabase,
         CancellationToken ct = default)
     {
-        if (string.IsNullOrWhiteSpace(config.SampleObject) && string.IsNullOrWhiteSpace(config.OutputSchema))
-            config.SampleObject = DefaultSampleObject;
+        EnsureDefaultOutputShape(config);
 
         var result = await store.AI.ForDatabase(targetDatabase).CreateAgentAsync(config, ct);
         return new RegisterResult(result.Identifier);

--- a/test/AiApplianceTests/AgentTestParameterValueTests.cs
+++ b/test/AiApplianceTests/AgentTestParameterValueTests.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using FastTests;
+using Raven.AiAppliance.Agents;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace AiApplianceTests;
+
+public class AgentTestParameterValueTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public void Converts_typed_json_parameter_values_for_raven()
+    {
+        Assert.Equal("42", Convert("\"42\""));
+        Assert.Equal(42L, Convert("42"));
+        Assert.Equal(true, Convert("true"));
+        Assert.Null(Convert("null"));
+
+        var strings = Assert.IsType<DynamicJsonArray>(Convert("[\"one\",\"two\"]"));
+        Assert.Equal("one", strings.Items[0]);
+        Assert.Equal("two", strings.Items[1]);
+
+        var numbers = Assert.IsType<DynamicJsonArray>(Convert("[1,2.5]"));
+        Assert.Equal(1L, numbers.Items[0]);
+        Assert.Equal(2.5m, numbers.Items[1]);
+
+        var booleans = Assert.IsType<DynamicJsonArray>(Convert("[true,false]"));
+        Assert.Equal(true, booleans.Items[0]);
+        Assert.Equal(false, booleans.Items[1]);
+    }
+
+    private static object? Convert(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return AgentTestParameterValue.Convert(document.RootElement);
+    }
+}

--- a/test/AiApplianceTests/AgentTestTranscriptTests.cs
+++ b/test/AiApplianceTests/AgentTestTranscriptTests.cs
@@ -1,0 +1,172 @@
+using System.Text.Json;
+using FastTests;
+using Raven.AiAppliance.Agents;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace AiApplianceTests;
+
+/// <summary>
+/// Fast unit tests for reconstructing the query tool-call transcript from a draft agent test
+/// run's result object (the data the wizard's "Test agent" panel renders).
+/// </summary>
+public class AgentTestTranscriptTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    private static AiAgentConfiguration ConfigWithSearchProducts() => new()
+    {
+        Queries =
+        [
+            new AiAgentToolQuery
+            {
+                Name = "search-products",
+                Description = "Search products by name.",
+                Query = "from Products where search(Name, $searchTerm)",
+            },
+        ],
+    };
+
+    private static IReadOnlyList<AgentQueryToolCall> Extract(string json, AiAgentConfiguration configuration)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return AgentTestTranscript.ExtractQueryToolCalls(doc.RootElement, configuration);
+    }
+
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public void Pairs_assistant_call_with_its_tool_result_and_query_config()
+    {
+        const string json = """
+        {
+            "ConversationId": "TestConversation",
+            "Response": { "reply": "Found one." },
+            "Documents": {
+                "TestConversation": {
+                    "Agent": "agents/sales",
+                    "Messages": [
+                        { "role": "system", "content": "You help shoppers." },
+                        { "role": "assistant", "tool_calls": [
+                            { "id": "call_1", "type": "function", "function": { "name": "search-products", "arguments": "{\"searchTerm\":\"mouse\"}" } }
+                        ] },
+                        { "role": "tool", "tool_call_id": "call_1", "content": "[{\"Name\":\"Wireless Mouse\"}]" },
+                        { "role": "assistant", "content": "{\"reply\":\"Found one.\"}" }
+                    ]
+                }
+            }
+        }
+        """;
+
+        var toolCalls = Extract(json, ConfigWithSearchProducts());
+
+        var call = Assert.Single(toolCalls);
+        Assert.Equal("call_1", call.Id);
+        Assert.Equal("search-products", call.Name);
+        Assert.Equal("Search products by name.", call.Description);
+        Assert.Equal("from Products where search(Name, $searchTerm)", call.Query);
+        Assert.Equal("{\"searchTerm\":\"mouse\"}", call.Arguments);
+        Assert.Equal("[{\"Name\":\"Wireless Mouse\"}]", call.Result);
+    }
+
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public void Keeps_the_call_even_when_no_result_message_is_present()
+    {
+        const string json = """
+        {
+            "Documents": {
+                "TestConversation": {
+                    "Messages": [
+                        { "role": "assistant", "tool_calls": [
+                            { "id": "call_1", "type": "function", "function": { "name": "search-products", "arguments": "{}" } }
+                        ] }
+                    ]
+                }
+            }
+        }
+        """;
+
+        var call = Assert.Single(Extract(json, ConfigWithSearchProducts()));
+        Assert.Equal("search-products", call.Name);
+        Assert.Equal("{}", call.Arguments);
+        Assert.Null(call.Result);
+    }
+
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public void Skips_calls_that_do_not_match_a_configured_query_tool()
+    {
+        // The model invoked some other tool name (e.g. an action) — the appliance only surfaces
+        // query tools, so it is dropped.
+        const string json = """
+        {
+            "Documents": {
+                "TestConversation": {
+                    "Messages": [
+                        { "role": "assistant", "tool_calls": [
+                            { "id": "call_1", "type": "function", "function": { "name": "escalate-to-human", "arguments": "{}" } }
+                        ] },
+                        { "role": "tool", "tool_call_id": "call_1", "content": "ok" }
+                    ]
+                }
+            }
+        }
+        """;
+
+        Assert.Empty(Extract(json, ConfigWithSearchProducts()));
+    }
+
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public void Returns_empty_when_the_result_has_no_documents()
+    {
+        const string json = """{ "ConversationId": "TestConversation", "Response": { "reply": "Hi." } }""";
+        Assert.Empty(Extract(json, ConfigWithSearchProducts()));
+    }
+
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public void Returns_empty_when_the_configuration_declares_no_query_tools()
+    {
+        const string json = """
+        {
+            "Documents": {
+                "TestConversation": {
+                    "Messages": [
+                        { "role": "assistant", "tool_calls": [
+                            { "id": "call_1", "type": "function", "function": { "name": "search-products", "arguments": "{}" } }
+                        ] }
+                    ]
+                }
+            }
+        }
+        """;
+
+        Assert.Empty(Extract(json, new AiAgentConfiguration()));
+    }
+
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public void Extracts_multiple_calls_in_conversation_order()
+    {
+        const string json = """
+        {
+            "Documents": {
+                "TestConversation": {
+                    "Messages": [
+                        { "role": "assistant", "tool_calls": [
+                            { "id": "call_1", "type": "function", "function": { "name": "search-products", "arguments": "{\"searchTerm\":\"mouse\"}" } }
+                        ] },
+                        { "role": "tool", "tool_call_id": "call_1", "content": "[1]" },
+                        { "role": "assistant", "tool_calls": [
+                            { "id": "call_2", "type": "function", "function": { "name": "search-products", "arguments": "{\"searchTerm\":\"hub\"}" } }
+                        ] },
+                        { "role": "tool", "tool_call_id": "call_2", "content": "[2]" }
+                    ]
+                }
+            }
+        }
+        """;
+
+        var toolCalls = Extract(json, ConfigWithSearchProducts());
+
+        Assert.Equal(2, toolCalls.Count);
+        Assert.Equal("call_1", toolCalls[0].Id);
+        Assert.Equal("[1]", toolCalls[0].Result);
+        Assert.Equal("call_2", toolCalls[1].Id);
+        Assert.Equal("[2]", toolCalls[1].Result);
+    }
+}

--- a/test/AiApplianceTests/AgentTestTranscriptTests.cs
+++ b/test/AiApplianceTests/AgentTestTranscriptTests.cs
@@ -113,6 +113,28 @@ public class AgentTestTranscriptTests(ITestOutputHelper output) : NoDisposalNeed
     }
 
     [RavenFact(RavenTestCategory.AiAppliance)]
+    public void Skips_tool_calls_that_are_not_on_an_assistant_message()
+    {
+        // Only assistant messages carry the model's tool invocations; tool_calls riding on any
+        // other role (here a "tool" message) are not the model's calls and must be ignored.
+        const string json = """
+        {
+            "Documents": {
+                "TestConversation": {
+                    "Messages": [
+                        { "role": "tool", "tool_call_id": "call_1", "content": "[]", "tool_calls": [
+                            { "id": "call_1", "type": "function", "function": { "name": "search-products", "arguments": "{}" } }
+                        ] }
+                    ]
+                }
+            }
+        }
+        """;
+
+        Assert.Empty(Extract(json, ConfigWithSearchProducts()));
+    }
+
+    [RavenFact(RavenTestCategory.AiAppliance)]
     public void Returns_empty_when_the_result_has_no_documents()
     {
         const string json = """{ "ConversationId": "TestConversation", "Response": { "reply": "Hi." } }""";

--- a/test/AiApplianceTests/ChannelLifecycleEndpointsTests.cs
+++ b/test/AiApplianceTests/ChannelLifecycleEndpointsTests.cs
@@ -17,12 +17,12 @@ namespace AiApplianceTests;
 /// <summary>
 /// RavenDB-26700 (T-6) channel lifecycle + wizard read-side coverage:
 /// list / edit / delete channels, the <c>/cdc/progress</c> WebSocket, and the
-/// <c>/setup/try</c> smoke stream, plus the two channel-adjacent embed gates
-/// (CSP header + agent-deleted 404). The minted-token embed lifecycle lives in
-/// <see cref="EmbedLinksTests"/> (RavenDB-26775). The real-LLM reply path is
-/// asserted in the E2E (<see cref="E2E.ApplianceFullFlowTests"/> T14); here we
-/// only prove the stream wiring opens with valid NDJSON, so these run without a
-/// live LLM.
+/// <c>/setup/try</c> draft "Test agent" smoke stream, plus the two channel-adjacent
+/// embed gates (CSP header + agent-deleted 404). The minted-token embed lifecycle
+/// lives in <see cref="EmbedLinksTests"/> (RavenDB-26775). The real-LLM reply path
+/// is asserted in the E2E (<see cref="E2E.ApplianceFullFlowTests"/> T14); here we
+/// only prove the stream wiring opens with valid NDJSON against the draft, so these
+/// run without a live LLM.
 /// </summary>
 public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : RavenTestBase(output)
 {
@@ -408,7 +408,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : RavenTes
     // ---- setup/try ----
 
     [RavenFact(RavenTestCategory.AiAppliance)]
-    public async Task SetupTry_opens_an_ndjson_stream()
+    public async Task SetupTry_streams_ndjson_for_the_draft()
     {
         var store = GetDocumentStore();
         var (perAppDb, cleanup) = await CreatePerAppDatabaseAsync(store);
@@ -418,19 +418,31 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : RavenTes
         using var factory = NewApplianceFactory(store);
         var client = factory.CreateClient();
 
+        // Seed the connection string the draft references (this also provisions a throwaway
+        // agent, which the draft test ignores — it runs the posted configuration, not a
+        // persisted agent).
         await ApplianceTestSeed.SeedMockAgentAsync(client, "my-app", "demo-agent");
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var req = new HttpRequestMessage(HttpMethod.Post, "/api/apps/my-app/setup/try")
         {
-            Content = JsonContent.Create(new { prompt = "hello", agentId = "demo-agent" }),
+            Content = JsonContent.Create(new
+            {
+                prompt = "hello",
+                configuration = new
+                {
+                    name = "Draft Agent",
+                    systemPrompt = "You are a placeholder draft agent.",
+                    connectionStringName = "demo-llm",
+                },
+            }),
         };
         var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token);
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Contains("application/x-ndjson", resp.Content.Headers.ContentType?.ToString() ?? "");
 
-        // No live LLM in this unit test, so the wiring surfaces a valid NDJSON
-        // frame (chunk/done if an LLM happened to be reachable, otherwise error).
+        // No live LLM in this unit test, so the wiring surfaces a valid NDJSON frame: chunk/done
+        // if a model happened to be reachable, otherwise an error frame.
         var line = await ReadFirstLineAsync(resp, l => string.IsNullOrWhiteSpace(l) == false, cts.Token);
         Assert.NotNull(line);
         using var doc = JsonDocument.Parse(line!);
@@ -439,7 +451,24 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : RavenTes
     }
 
     [RavenFact(RavenTestCategory.AiAppliance)]
-    public async Task SetupTry_returns_400_when_agentId_missing()
+    public async Task SetupTry_returns_400_when_prompt_missing()
+    {
+        var store = GetDocumentStore();
+        var (perAppDb, cleanup) = await CreatePerAppDatabaseAsync(store);
+        using var _db = cleanup;
+        await SeedAppAsync(store, slug: "my-app", database: perAppDb);
+
+        using var factory = NewApplianceFactory(store);
+        var client = factory.CreateClient();
+
+        var resp = await client.PostAsJsonAsync(
+            "/api/apps/my-app/setup/try",
+            new { configuration = new { name = "Draft", systemPrompt = "p", connectionStringName = "demo-llm" } });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public async Task SetupTry_returns_400_when_configuration_missing()
     {
         var store = GetDocumentStore();
         var (perAppDb, cleanup) = await CreatePerAppDatabaseAsync(store);
@@ -454,34 +483,19 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : RavenTes
     }
 
     [RavenFact(RavenTestCategory.AiAppliance)]
-    public async Task SetupTry_returns_400_for_unknown_agentId()
-    {
-        // A non-empty but unknown agentId is a client error, so the handler
-        // validates it against the per-app database and returns 400 before
-        // opening the NDJSON stream (rather than a 200 + error frame after the
-        // headers flush).
-        var store = GetDocumentStore();
-        var (perAppDb, cleanup) = await CreatePerAppDatabaseAsync(store);
-        using var _db = cleanup;
-        await SeedAppAsync(store, slug: "my-app", database: perAppDb);
-
-        using var factory = NewApplianceFactory(store);
-        var client = factory.CreateClient();
-
-        var resp = await client.PostAsJsonAsync(
-            "/api/apps/my-app/setup/try",
-            new { prompt = "hi", agentId = "does-not-exist" });
-        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
-    }
-
-    [RavenFact(RavenTestCategory.AiAppliance)]
     public async Task SetupTry_returns_404_for_unknown_slug()
     {
         var store = GetDocumentStore();
         using var factory = NewApplianceFactory(store);
         var client = factory.CreateClient();
 
-        var resp = await client.PostAsJsonAsync("/api/apps/nonexistent/setup/try", new { prompt = "hi", agentId = "demo-agent" });
+        var resp = await client.PostAsJsonAsync(
+            "/api/apps/nonexistent/setup/try",
+            new
+            {
+                prompt = "hi",
+                configuration = new { name = "Draft", systemPrompt = "p", connectionStringName = "demo-llm" },
+            });
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
@@ -510,7 +524,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : RavenTes
     /// <summary>Reads the streamed response line by line and returns the first
     /// line satisfying <paramref name="match"/>, or null on end-of-stream /
     /// cancellation. Cancellation comes from the caller's CTS so the test never
-    /// hangs on the open-ended SSE / NDJSON stream.</summary>
+    /// hangs on the open-ended NDJSON stream.</summary>
     private static async Task<string?> ReadFirstLineAsync(HttpResponseMessage resp, Func<string, bool> match, CancellationToken ct)
     {
         try


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26630

### Additional description

Adds the ability to test a draft AI agent before provisioning, plus several UX refinements to the app/capability setup wizards.

What's included

- Agent test panel — new "test agent" sheet in the wizard review step, backed by a streaming RunDraftAgentTestOperation endpoint. Lets users chat with a draft agent before it's provisioned.
- Tool call handling — the test transcript now renders agent tool calls (AgentTestTranscript), with streaming support on the client and matching server-side tests.
- Welcome panel — added to the app overview to guide users into setup.
- FormRadioCards — reusable radio-card form component, adopted across the data-source, capability, and channel selection steps to replace ad-hoc markup.
- Wizard flow adjustments — reworked form-wizard, added a channels step (incl. web widget channel form), and extracted a useProvisionAgentStep hook for the provisioning logic.

Tests

- Added AgentTestTranscriptTests and extended ChannelLifecycleEndpointsTests.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
