### PR TITLE
RavenDB-26837 Preserve WhereToken subtypes through from-alias rewrite

### DIFF
--- a/src/Raven.Client/Documents/Session/Tokens/MoreLikeThisToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/MoreLikeThisToken.cs
@@ -16,6 +16,8 @@ namespace Raven.Client.Documents.Session.Tokens
             WhereTokens = new LinkedList<QueryToken>();
         }
 
+        public override WhereToken AddAlias(string alias) => this;
+
         public override void WriteTo(StringBuilder writer)
         {
             writer.Append("moreLikeThis(");

--- a/src/Raven.Client/Documents/Session/Tokens/VectorSearchToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/VectorSearchToken.cs
@@ -38,7 +38,29 @@ public sealed class VectorSearchToken : WhereToken
         
         PortableExceptions.ThrowIf<InvalidOperationException>(embeddingsGenerationTaskIdentifier != null && embeddingsGenerationTaskIdentifierByValue != null, $"Embeddings generation task identifier set in value factory cannot be used with field factory. It solely purpose to use already generated embeddings.");
     }
-    
+
+    public override WhereToken AddAlias(string alias)
+    {
+        if (FieldName == Constants.Documents.Indexing.Fields.DocumentIdFieldName)
+            return this;
+
+        var token = new VectorSearchToken(
+            fieldName: alias + "." + FieldName,
+            parameterName: ParameterName,
+            sourceQuantizationType: _sourceQuantizationType,
+            targetQuantizationType: _targetQuantizationType,
+            similarityThreshold: _similarityThreshold,
+            numberOfCandidatesForQuerying: _numberOfCandidatesForQuerying,
+            isExact: Options.Exact,
+            isDocumentId: _isDocumentId,
+            embeddingsGenerationTaskIdentifier: _embeddingsGenerationTaskIdentifier,
+            embeddingsGenerationTaskIdentifierByValue: _embeddingsGenerationTaskIdentifierByValue);
+
+        token.Options = Options;
+        token.WhereOperator = WhereOperator;
+        return token;
+    }
+
     public override void WriteTo(StringBuilder writer)
     {
         if (Options.Boost.HasValue)

--- a/src/Raven.Client/Documents/Session/Tokens/WhereToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/WhereToken.cs
@@ -80,7 +80,7 @@ namespace Raven.Client.Documents.Session.Tokens
         }
 
         public string FieldName { get; protected set; }
-        public WhereOperator WhereOperator { get; private set; }
+        public WhereOperator WhereOperator { get; protected set; }
         public string ParameterName { get; protected set; }
         public WhereOptions Options;
         
@@ -95,7 +95,7 @@ namespace Raven.Client.Documents.Session.Tokens
             };
         }
 
-        public WhereToken AddAlias(string alias)
+        public virtual WhereToken AddAlias(string alias)
         {
             if (FieldName == Constants.Documents.Indexing.Fields.DocumentIdFieldName)
                 return this;

--- a/test/FastTests/Client/MoreLikeThisTokenAliasTests.cs
+++ b/test/FastTests/Client/MoreLikeThisTokenAliasTests.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Queries.MoreLikeThis;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Client;
+
+public class MoreLikeThisTokenAliasTests(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class Article
+    {
+        public string Id { get; set; }
+        public string Body { get; set; }
+    }
+
+    private class ArticleResult
+    {
+        public string Id { get; set; }
+        public string Body { get; set; }
+        public object Meta { get; set; }
+    }
+
+    private class ArticleIndex : AbstractIndexCreationTask<Article>
+    {
+        public ArticleIndex()
+        {
+            Map = articles => from a in articles select new { a.Body };
+            Indexes.Add(a => a.Body, FieldIndexing.Search);
+            TermVectors.Add(a => a.Body, FieldTermVector.Yes);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void MoreLikeThisTokenSurvivesFromAliasWhenProjectionIsJsObject()
+    {
+        using var store = GetDocumentStore();
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Article { Body = "test test test" });
+            session.Store(new Article { Body = "cake is great" });
+            session.SaveChanges();
+        }
+
+        new ArticleIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using var session2 = store.OpenSession();
+
+        var query = session2.Query<Article, ArticleIndex>()
+            .MoreLikeThis(f => f.UsingDocument(@"{""Body"":""test""}").WithOptions(new MoreLikeThisOptions
+            {
+                MinimumTermFrequency = 1,
+                MinimumDocumentFrequency = 1,
+                MinimumWordLength = 0
+            }))
+            .Select(d => new ArticleResult
+            {
+                Id = d.Id,
+                Body = d.Body,
+                Meta = RavenQuery.Metadata(d)[Constants.Documents.Metadata.LastModified]
+            });
+
+        string rql = query.ToString();
+
+        Assert.Contains("moreLikeThis(", rql);
+
+        var results = query.ToList();
+
+        Assert.Single(results);
+        Assert.Equal("test test test", results[0].Body);
+        Assert.NotNull(results[0].Meta);
+    }
+}

--- a/test/FastTests/Corax/Vectors/VectorSearchTokenAliasTests.cs
+++ b/test/FastTests/Corax/Vectors/VectorSearchTokenAliasTests.cs
@@ -1,0 +1,124 @@
+using System.Linq;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax.Vectors;
+
+public class VectorSearchTokenAliasTests(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class VecDoc
+    {
+        public string Id { get; set; }
+        public float[] Vector { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class VecResult
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public double Score { get; set; }
+    }
+
+    private class VecIndex : AbstractIndexCreationTask<VecDoc>
+    {
+        public VecIndex()
+        {
+            Map = docs => from doc in docs
+                select new Entry
+                {
+                    Vector = CreateVector(doc.Vector),
+                    Name = doc.Name
+                };
+
+            VectorIndexes.Add(x => ((Entry)(object)x).Vector,
+                new VectorOptions { SourceEmbeddingType = VectorEmbeddingType.Single });
+        }
+
+        public class Entry
+        {
+            public object Vector { get; set; }
+            public string Name { get; set; }
+        }
+    }
+
+    private void SeedDocs(IDocumentStore store)
+    {
+        using var session = store.OpenSession();
+        session.Store(new VecDoc { Vector = new float[] { 0.1f, 0.2f }, Name = "match" });
+        session.Store(new VecDoc { Vector = new float[] { -0.9f, -0.9f }, Name = "nomatch" });
+        session.SaveChanges();
+
+        new VecIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void VectorSearchTokenSurvivesFromAliasWhenProjectionIsJsObject()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax, includeScoresAndDistances: true));
+        SeedDocs(store);
+
+        using var session = store.OpenSession();
+
+        var query = session.Query<VecIndex.Entry, VecIndex>()
+            .VectorSearch(f => f.WithField(e => e.Vector), v => v.ByEmbedding(new float[] { 0.1f, 0.2f }), minimumSimilarity: 0.5f)
+            .OrderByScore()
+            .OfType<VecDoc>()
+            .Select(d => new VecResult
+            {
+                Id = d.Id,
+                Name = d.Name,
+                Score = (double)RavenQuery.Metadata(d)[Constants.Documents.Metadata.IndexScore]
+            });
+
+        string rql = query.ToString();
+
+        Assert.Contains("vector.search(d.Vector,", rql);
+        Assert.DoesNotContain("d.Vector = ", rql);
+
+        var results = query.ToList();
+
+        Assert.Single(results);
+        Assert.Equal("match", results[0].Name);
+        Assert.True(results[0].Score > 0);
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void ExactVectorSearchTokenSurvivesFromAliasWhenProjectionIsJsObject()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax, includeScoresAndDistances: true));
+        SeedDocs(store);
+
+        using var session = store.OpenSession();
+
+        var query = session.Query<VecIndex.Entry, VecIndex>()
+            .VectorSearch(f => f.WithField(e => e.Vector), v => v.ByEmbedding(new float[] { 0.1f, 0.2f }), minimumSimilarity: 0.5f, isExact: true)
+            .OrderByScore()
+            .OfType<VecDoc>()
+            .Select(d => new VecResult
+            {
+                Id = d.Id,
+                Name = d.Name,
+                Score = (double)RavenQuery.Metadata(d)[Constants.Documents.Metadata.IndexScore]
+            });
+
+        string rql = query.ToString();
+
+        Assert.Contains("exact(vector.search(d.Vector,", rql);
+        Assert.DoesNotContain("d.Vector = ", rql);
+
+        var results = query.ToList();
+
+        Assert.Single(results);
+        Assert.Equal("match", results[0].Name);
+        Assert.True(results[0].Score > 0);
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26837

### Additional description

When a query uses `VectorSearch` or `MoreLikeThis` and the projection contains a
computed expression (anything that forces a JS-object projection, e.g.
`RavenQuery.Metadata(d)["@index-score"]`), the query is rewritten into the
`from index 'X' as x` aliased form and the special where-token is lost. The cause
is `WhereToken.AddAlias`, which builds a new base `WhereToken` to apply the alias
and discards the concrete subtype (and its `WriteTo`). It runs for every where-token
via `AbstractDocumentQuery.AddFromAliasToTokens` once a projection introduces a
from-alias. The result is two failures: `VectorSearch` silently degrades to a scalar
field equality (no error), and `MoreLikeThis` throws `NullReferenceException` during
RQL generation (rebuilt token has `Options == null`, dereferenced in `WriteTo`).

For the vector case the generated RQL changes from a vector search to a plain
equality once a computed binding is added:

    // plain projection — correct
    from index 'X' where exact(vector.search(Vector, $p0, 0, 10000)) select Name
    // computed binding added — vector search is gone
    from index 'X' as x where exact(x.Vector = $p0) select { Name : x.Name, Score : getMetadata(x)["@index-score"] }

The fix:
- make `WhereToken.AddAlias` virtual (and widen the `WhereOperator` setter to `protected`)
- override it on `VectorSearchToken` to rebuild itself with the alias-prefixed field, keeping the full `Options` reference and the operator
- override it on `MoreLikeThisToken` to return itself unchanged — its `WriteTo` emits `moreLikeThis($param, ...)` and never uses `FieldName`, so no alias applies

Added FastTests regression tests covering vector search (exact and non-exact) and
more-like-this combined with a JS-object projection; there were no existing tests
for a special where-token plus a computed projection. Boosting a vector search is
intentionally unsupported (`BoostingMatch` throws, RavenDB-23524), so that path is
not tested; the override still preserves the full `Options` reference, so it will be
correct if that limitation is lifted.

Related GitHub issue: https://github.com/ravendb/ravendb/issues/22990

### Type of change
- [x] Bug fix

### How risky is the change?
- [x] Low

### Backward compatibility
No breaking change. Queries that previously returned wrong results or threw now
generate the correct RQL; no API or serialization change.

### Is it platform specific issue?
No.

### Documentation update
Not required.

### Testing by Contributor
Added and ran the new FastTests regression tests (all green); `Raven.Client` builds clean.

### Testing by RavenDB QA team
Recommended.

### Is there any existing behavior change of other features due to this change?
No — the change only affects how special where-tokens are carried through the
from-alias rewrite.

### UI work
N/A.
