### PR TITLE
RavenDB-26846 - Advanced.HasChanges is always true after loading an entity with a ulong property holding a large value

### DIFF
--- a/src/Sparrow/Json/ManualBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/ManualBlittableJsonDocumentBuilder.cs
@@ -424,6 +424,17 @@ namespace Sparrow.Json
 
         public void WriteValue(ulong value)
         {
+            // values that fit in Int64 must be written as an Integer token (the same way the JSON
+            // parser tokenizes them when reading a document back from the server). Otherwise the
+            // write path (LazyNumber) and the read path (Integer) disagree, and change tracking
+            // bridges the two through a double - losing precision above 2^53 and reporting a
+            // spurious change (RavenDB-26846). Only values that don't fit in Int64 need LazyNumber.
+            if (value <= long.MaxValue)
+            {
+                WriteValue((long)value);
+                return;
+            }
+
             var currentState = _continuationState.Pop();
             var valuePos = _writer.WriteValue(value);
             _writeToken = new WriteToken

--- a/test/SlowTests.Issues/Issues/RavenDB_26846.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26846.cs
@@ -1,0 +1,90 @@
+using System.Threading.Tasks;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26846 : RavenTestBase
+{
+    public RavenDB_26846(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.ClientApi)]
+    [InlineData(0UL)]
+    [InlineData(5UL)]
+    [InlineData(9007199254740992UL)] // 2^53 - largest integer exactly representable as a double
+    [InlineData(9007199254740993UL)] // 2^53 + 1 - first ulong that loses precision when bridged through a double
+    [InlineData(1419814379775459300UL)] // the value from the bug report
+    [InlineData(9223372036854775807UL)] // long.MaxValue - largest value parsed back as an Integer token
+    [InlineData(9223372036854775808UL)] // long.MaxValue + 1 - first value that must be stored as a LazyNumber
+    [InlineData(ulong.MaxValue)] // 18446744073709551615
+    public async Task HasChanges_ShouldBeFalse_AfterLoadingEntityWithULongProperty(ulong value)
+    {
+        using var store = GetDocumentStore();
+
+        const string id = "data/1";
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new DataWithULong { Id = id, Value = value });
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var loaded = await session.LoadAsync<DataWithULong>(id);
+
+            Assert.NotNull(loaded);
+            Assert.Equal(value, loaded.Value);
+
+            // loading an unmodified entity must leave the session clean
+            Assert.Empty(session.Advanced.WhatChangedFor(loaded));
+            Assert.False(session.Advanced.HasChanges);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task HasChanges_ShouldStillDetectModification_ForULongProperty()
+    {
+        using var store = GetDocumentStore();
+
+        const string id = "data/1";
+        const ulong original = 1419814379775459300UL;
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new DataWithULong { Id = id, Value = original });
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var loaded = await session.LoadAsync<DataWithULong>(id);
+            Assert.False(session.Advanced.HasChanges);
+
+            loaded.Value = original + 1;
+
+            Assert.True(session.Advanced.HasChanges);
+            Assert.NotEmpty(session.Advanced.WhatChangedFor(loaded));
+
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var loaded = await session.LoadAsync<DataWithULong>(id);
+
+            Assert.Equal(original + 1, loaded.Value);
+            Assert.False(session.Advanced.HasChanges);
+        }
+    }
+
+    private class DataWithULong
+    {
+        public string Id { get; set; }
+
+        public ulong Value { get; set; }
+    }
+}


### PR DESCRIPTION
Write ulong values that fit in Int64 as an Integer token (matching how the JSON parser tokenizes them when reading a document back from the server) instead of always emitting a LazyNumber. The previous asymmetry made change tracking bridge the two representations through a double, losing precision above 2^53 and reporting a spurious change on load.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26846

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
