### PR TITLE
RavenDB-26636 Multi-schema correctness for CDC schema discovery

### DIFF
--- a/src/Raven.Server/Documents/CdcSink/Schema/PostgresCdcSinkSchemaDiscovery.cs
+++ b/src/Raven.Server/Documents/CdcSink/Schema/PostgresCdcSinkSchemaDiscovery.cs
@@ -131,7 +131,9 @@ namespace Raven.Server.Documents.CdcSink.Schema
             Dictionary<(string Schema, string Table), CdcSinkSourceTable> tableLookup,
             CancellationToken ct)
         {
-            var keyColumnUsage = new Dictionary<string, (string Schema, string Table, List<string> Columns)>();
+            // Key by (schema, constraint name): constraint names are unique only within a schema,
+            // so a bare-name key merges/overwrites identically-named constraints across schemas.
+            var keyColumnUsage = new Dictionary<(string Schema, string ConstraintName), (string Schema, string Table, List<string> Columns)>();
             await using (var cmd = new NpgsqlCommand(queries.SelectKeyColumnUsageQuery, conn))
             await using (var reader = await cmd.ExecuteReaderAsync(ct))
             {
@@ -142,10 +144,10 @@ namespace Raven.Server.Documents.CdcSink.Schema
                     var tableName = reader["TABLE_NAME"].ToString();
                     var columnName = reader["COLUMN_NAME"].ToString();
 
-                    if (keyColumnUsage.TryGetValue(constraintName, out var entry) == false)
+                    if (keyColumnUsage.TryGetValue((schemaName, constraintName), out var entry) == false)
                     {
                         entry = (schemaName, tableName, new List<string>());
-                        keyColumnUsage[constraintName] = entry;
+                        keyColumnUsage[(schemaName, constraintName)] = entry;
                     }
                     entry.Columns.Add(columnName);
                 }
@@ -155,12 +157,14 @@ namespace Raven.Server.Documents.CdcSink.Schema
             await using var refReader = await refCmd.ExecuteReaderAsync(ct);
             while (await refReader.ReadAsync(ct))
             {
+                var fkSchema = refReader["CONSTRAINT_SCHEMA"].ToString();
                 var fkConstraint = refReader["CONSTRAINT_NAME"].ToString();
+                var uniqueSchema = refReader["UNIQUE_CONSTRAINT_SCHEMA"].ToString();
                 var uniqueConstraint = refReader["UNIQUE_CONSTRAINT_NAME"].ToString();
 
-                if (keyColumnUsage.TryGetValue(fkConstraint, out var fkEntry) == false)
+                if (keyColumnUsage.TryGetValue((fkSchema, fkConstraint), out var fkEntry) == false)
                     continue;
-                if (keyColumnUsage.TryGetValue(uniqueConstraint, out var pkEntry) == false)
+                if (keyColumnUsage.TryGetValue((uniqueSchema, uniqueConstraint), out var pkEntry) == false)
                     continue;
                 if (tableLookup.TryGetValue((fkEntry.Schema, fkEntry.Table), out var fkTable) == false)
                     continue;

--- a/src/Raven.Server/Documents/CdcSink/Schema/PostgresCdcSinkSchemaDiscovery.cs
+++ b/src/Raven.Server/Documents/CdcSink/Schema/PostgresCdcSinkSchemaDiscovery.cs
@@ -131,8 +131,6 @@ namespace Raven.Server.Documents.CdcSink.Schema
             Dictionary<(string Schema, string Table), CdcSinkSourceTable> tableLookup,
             CancellationToken ct)
         {
-            // Key by (schema, constraint name): constraint names are unique only within a schema,
-            // so a bare-name key merges/overwrites identically-named constraints across schemas.
             var keyColumnUsage = new Dictionary<(string Schema, string ConstraintName), (string Schema, string Table, List<string> Columns)>();
             await using (var cmd = new NpgsqlCommand(queries.SelectKeyColumnUsageQuery, conn))
             await using (var reader = await cmd.ExecuteReaderAsync(ct))

--- a/src/Raven.Server/Documents/CdcSink/Schema/PostgresCdcSinkSchemaDiscovery.cs
+++ b/src/Raven.Server/Documents/CdcSink/Schema/PostgresCdcSinkSchemaDiscovery.cs
@@ -151,6 +151,8 @@ namespace Raven.Server.Documents.CdcSink.Schema
                 }
             }
 
+            // keyColumnUsage is keyed by TABLE_SCHEMA; these rows key by CONSTRAINT_SCHEMA / UNIQUE_CONSTRAINT_SCHEMA.
+            // They line up because a constraint is co-located with its table, so CONSTRAINT_SCHEMA == its TABLE_SCHEMA.
             await using var refCmd = new NpgsqlCommand(queries.SelectReferentialConstraintsQuery, conn);
             await using var refReader = await refCmd.ExecuteReaderAsync(ct);
             while (await refReader.ReadAsync(ct))

--- a/src/Raven.Server/Documents/CdcSink/Schema/SqlServerCdcSinkSchemaDiscovery.cs
+++ b/src/Raven.Server/Documents/CdcSink/Schema/SqlServerCdcSinkSchemaDiscovery.cs
@@ -170,6 +170,8 @@ namespace Raven.Server.Documents.CdcSink.Schema
                 }
             }
 
+            // keyColumnUsage is keyed by TABLE_SCHEMA; these rows key by CONSTRAINT_SCHEMA / UNIQUE_CONSTRAINT_SCHEMA.
+            // They line up because a constraint is co-located with its table, so CONSTRAINT_SCHEMA == its TABLE_SCHEMA.
             await using var refCmd = conn.CreateCommand();
             refCmd.CommandText = Queries.SelectReferentialConstraintsQuery;
             await using var refReader = await refCmd.ExecuteReaderAsync(ct);

--- a/src/Raven.Server/Documents/CdcSink/Schema/SqlServerCdcSinkSchemaDiscovery.cs
+++ b/src/Raven.Server/Documents/CdcSink/Schema/SqlServerCdcSinkSchemaDiscovery.cs
@@ -149,7 +149,9 @@ namespace Raven.Server.Documents.CdcSink.Schema
             Dictionary<(string Schema, string Table), CdcSinkSourceTable> tableLookup,
             CancellationToken ct)
         {
-            var keyColumnUsage = new Dictionary<string, (string Schema, string Table, List<string> Columns)>();
+            // Key by (schema, constraint name): constraint names are unique only within a schema,
+            // so a bare-name key merges/overwrites identically-named constraints across schemas.
+            var keyColumnUsage = new Dictionary<(string Schema, string ConstraintName), (string Schema, string Table, List<string> Columns)>();
             await using (var cmd = conn.CreateCommand())
             {
                 cmd.CommandText = Queries.SelectKeyColumnUsageQuery;
@@ -161,10 +163,10 @@ namespace Raven.Server.Documents.CdcSink.Schema
                     var tableName = reader["TABLE_NAME"].ToString();
                     var columnName = reader["COLUMN_NAME"].ToString();
 
-                    if (keyColumnUsage.TryGetValue(constraintName, out var entry) == false)
+                    if (keyColumnUsage.TryGetValue((schemaName, constraintName), out var entry) == false)
                     {
                         entry = (schemaName, tableName, new List<string>());
-                        keyColumnUsage[constraintName] = entry;
+                        keyColumnUsage[(schemaName, constraintName)] = entry;
                     }
                     entry.Columns.Add(columnName);
                 }
@@ -175,12 +177,14 @@ namespace Raven.Server.Documents.CdcSink.Schema
             await using var refReader = await refCmd.ExecuteReaderAsync(ct);
             while (await refReader.ReadAsync(ct))
             {
+                var fkSchema = refReader["CONSTRAINT_SCHEMA"].ToString();
                 var fkConstraint = refReader["CONSTRAINT_NAME"].ToString();
+                var uniqueSchema = refReader["UNIQUE_CONSTRAINT_SCHEMA"].ToString();
                 var uniqueConstraint = refReader["UNIQUE_CONSTRAINT_NAME"].ToString();
 
-                if (keyColumnUsage.TryGetValue(fkConstraint, out var fkEntry) == false)
+                if (keyColumnUsage.TryGetValue((fkSchema, fkConstraint), out var fkEntry) == false)
                     continue;
-                if (keyColumnUsage.TryGetValue(uniqueConstraint, out var pkEntry) == false)
+                if (keyColumnUsage.TryGetValue((uniqueSchema, uniqueConstraint), out var pkEntry) == false)
                     continue;
                 if (tableLookup.TryGetValue((fkEntry.Schema, fkEntry.Table), out var fkTable) == false)
                     continue;

--- a/src/Raven.Server/Documents/CdcSink/Schema/SqlServerCdcSinkSchemaDiscovery.cs
+++ b/src/Raven.Server/Documents/CdcSink/Schema/SqlServerCdcSinkSchemaDiscovery.cs
@@ -149,8 +149,6 @@ namespace Raven.Server.Documents.CdcSink.Schema
             Dictionary<(string Schema, string Table), CdcSinkSourceTable> tableLookup,
             CancellationToken ct)
         {
-            // Key by (schema, constraint name): constraint names are unique only within a schema,
-            // so a bare-name key merges/overwrites identically-named constraints across schemas.
             var keyColumnUsage = new Dictionary<(string Schema, string ConstraintName), (string Schema, string Table, List<string> Columns)>();
             await using (var cmd = conn.CreateCommand())
             {

--- a/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
+++ b/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
@@ -525,6 +525,15 @@ namespace Raven.Server.SqlMigration
 
         protected abstract string QuoteTable(string schema, string tableName);
         protected abstract string QuoteColumn(string columnName);
+
+        // Identifier quoting for the CDC test-mapping row-fetch path (BuildSelectFirstRowsQuery /
+        // BuildSelectByPrimaryKeyQuery). Defaults to QuoteTable/QuoteColumn, which already quote
+        // correctly for SQL Server ([..]) and MySQL (`..`). Postgres overrides these because its
+        // QuoteTable/QuoteColumn deliberately emit RAW identifiers for the long-standing SQL-import
+        // path; the test-mapping path needs exact-case double-quoting instead.
+        protected virtual string QuoteTableForRowFetch(string schema, string tableName) => QuoteTable(schema, tableName);
+        protected virtual string QuoteColumnForRowFetch(string columnName) => QuoteColumn(columnName);
+
         protected abstract string FactoryName { get; }
 
         protected IDataProvider<string> CreateObjectLinkDataProvider(ReferenceInformation refInfo)
@@ -786,9 +795,9 @@ namespace Raven.Server.SqlMigration
             // SQL Server rejects ORDER BY inside an un-TOP'd subquery, so ORDER BY has to live
             // at the same level as the row-limit. Build the dialect-aware shape via BuildLimitedSelectQuery.
             var orderBy = orderByColumns != null && orderByColumns.Count > 0
-                ? " order by " + string.Join(", ", orderByColumns.Select(QuoteColumn))
+                ? " order by " + string.Join(", ", orderByColumns.Select(QuoteColumnForRowFetch))
                 : string.Empty;
-            return BuildLimitedSelectQuery(QuoteTable(tableSchema, tableName), whereClause: string.Empty, orderBy, maxRows);
+            return BuildLimitedSelectQuery(QuoteTableForRowFetch(tableSchema, tableName), whereClause: string.Empty, orderBy, maxRows);
         }
 
         /// <summary>
@@ -820,7 +829,7 @@ namespace Raven.Server.SqlMigration
                 parameter.ParameterName = $"p{idx}";
                 parameter.Value = ValueAsObject(typedTableSchema, column, pkValueArray, idx) ?? DBNull.Value;
                 cmd.Parameters.Add(parameter);
-                return $"{QuoteColumn(column)} = @p{idx}";
+                return $"{QuoteColumnForRowFetch(column)} = @p{idx}";
             }));
 
             // Apply the dialect-aware row cap even though the handler only accepts maxRows=1 for
@@ -828,7 +837,7 @@ namespace Raven.Server.SqlMigration
             // on the source (mis-configured CDC task, or a source table without a true PK), in
             // which case the WHERE alone could still match multiple rows. The server-side cap
             // must hold regardless of source metadata quality.
-            return BuildLimitedSelectQuery(QuoteTable(tableSchema, tableName), whereClause, orderByClause: string.Empty, maxRows);
+            return BuildLimitedSelectQuery(QuoteTableForRowFetch(tableSchema, tableName), whereClause, orderByClause: string.Empty, maxRows);
         }
     }
 }

--- a/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
+++ b/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -596,17 +597,19 @@ namespace Raven.Server.SqlMigration
         {
             // Case-insensitive column lookup: source identifiers can differ in case from the configured mapping.
             var columnSchema = tableSchema.Columns.Find(x => string.Equals(x.Name, column, StringComparison.OrdinalIgnoreCase));
+            if (columnSchema == null)
+                throw new InvalidOperationException($"Primary key column '{column}' was not found in the schema of table '{tableSchema.Schema}.{tableSchema.TableName}'.");
+
             var raw = primaryKeyValue[index];
 
-            if (columnSchema?.Type != ColumnType.Number)
+            if (columnSchema.Type != ColumnType.Number)
                 return raw;
 
-            // Widen the numeric parse: integer keys may be bigint (beyond int range), so try long first,
-            // then decimal for fixed-point/scaled keys. Leave the original value if it isn't numeric.
-            var text = raw?.ToString();
-            if (long.TryParse(text, out var asLong))
+            // Widen the numeric parse with invariant culture: integer keys may be bigint (beyond int range), so try
+            // long first, then decimal for fixed-point/scaled keys. Leave the original value if it isn't numeric.
+            if (long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var asLong))
                 return asLong;
-            if (decimal.TryParse(text, out var asDecimal))
+            if (decimal.TryParse(raw, NumberStyles.Number, CultureInfo.InvariantCulture, out var asDecimal))
                 return asDecimal;
             return raw;
         }

--- a/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
+++ b/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
@@ -594,10 +594,22 @@ namespace Raven.Server.SqlMigration
 
         public object ValueAsObject(SqlTableSchema tableSchema, string column, string[] primaryKeyValue, int index)
         {
-            var type = tableSchema.Columns.Find(x => x.Name == column).Type;
-            var value = type == ColumnType.Number ? (object)int.Parse(primaryKeyValue[index].ToString()) : primaryKeyValue[index];
+            // Case-insensitive column lookup: source identifiers can differ in case from the configured
+            // mapping; an exact-case Find missed them and then NRE'd on .Type.
+            var columnSchema = tableSchema.Columns.Find(x => string.Equals(x.Name, column, StringComparison.OrdinalIgnoreCase));
+            var raw = primaryKeyValue[index];
 
-            return value;
+            if (columnSchema?.Type != ColumnType.Number)
+                return raw;
+
+            // Widen the numeric parse: integer keys may be bigint (beyond int range), so try long first,
+            // then decimal for fixed-point/scaled keys. Leave the original value if it isn't numeric.
+            var text = raw?.ToString();
+            if (long.TryParse(text, out var asLong))
+                return asLong;
+            if (decimal.TryParse(text, out var asDecimal))
+                return asDecimal;
+            return raw;
         }
 
         protected IEnumerable<SqlMigrationDocument> EnumerateTable(string tableQuery, Dictionary<string, string> documentPropertiesMapping, 

--- a/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
+++ b/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
@@ -595,7 +595,8 @@ namespace Raven.Server.SqlMigration
 
         public object ValueAsObject(SqlTableSchema tableSchema, string column, string[] primaryKeyValue, int index)
         {
-            // Case-insensitive column lookup: source identifiers can differ in case from the configured mapping.
+            // Case-insensitive match resolves the column type only; the emitted identifier keeps the configured
+            // casing (case-sensitive in Postgres once quoted).
             var columnSchema = tableSchema.Columns.Find(x => string.Equals(x.Name, column, StringComparison.OrdinalIgnoreCase));
             if (columnSchema == null)
                 throw new InvalidOperationException($"Primary key column '{column}' was not found in the schema of table '{tableSchema.Schema}.{tableSchema.TableName}'.");
@@ -606,12 +607,13 @@ namespace Raven.Server.SqlMigration
                 return raw;
 
             // Widen the numeric parse with invariant culture: integer keys may be bigint (beyond int range), so try
-            // long first, then decimal for fixed-point/scaled keys. Leave the original value if it isn't numeric.
+            // long first, then decimal for fixed-point/scaled keys.
             if (long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var asLong))
                 return asLong;
             if (decimal.TryParse(raw, NumberStyles.Number, CultureInfo.InvariantCulture, out var asDecimal))
                 return asDecimal;
-            return raw;
+
+            throw new InvalidOperationException($"Primary key value '{raw}' for numeric column '{column}' of table '{tableSchema.Schema}.{tableSchema.TableName}' is not a valid number.");
         }
 
         protected IEnumerable<SqlMigrationDocument> EnumerateTable(string tableQuery, Dictionary<string, string> documentPropertiesMapping, 

--- a/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
+++ b/src/Raven.Server/SqlMigration/GenericDatabaseMigrator.cs
@@ -594,8 +594,7 @@ namespace Raven.Server.SqlMigration
 
         public object ValueAsObject(SqlTableSchema tableSchema, string column, string[] primaryKeyValue, int index)
         {
-            // Case-insensitive column lookup: source identifiers can differ in case from the configured
-            // mapping; an exact-case Find missed them and then NRE'd on .Type.
+            // Case-insensitive column lookup: source identifiers can differ in case from the configured mapping.
             var columnSchema = tableSchema.Columns.Find(x => string.Equals(x.Name, column, StringComparison.OrdinalIgnoreCase));
             var raw = primaryKeyValue[index];
 

--- a/src/Raven.Server/SqlMigration/MsSQL/MsSqlSchemaQueries.cs
+++ b/src/Raven.Server/SqlMigration/MsSQL/MsSqlSchemaQueries.cs
@@ -25,9 +25,8 @@ namespace Raven.Server.SqlMigration.MsSQL
             "SELECT TC.TABLE_SCHEMA, TC.TABLE_NAME, COLUMN_NAME " +
             "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC " +
             "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KU " +
-            // SQL Server constraint names are not database-wide unique; joining on CONSTRAINT_NAME
-            // alone cross-joins identically-named PKs across schemas and attaches the wrong PK columns.
-            // Qualify by schema + table.
+            // SQL Server constraint names are not database-wide unique, so qualify the PK-constraint
+            // join by schema + table.
             "ON TC.CONSTRAINT_TYPE = 'PRIMARY KEY' " +
             "AND TC.CONSTRAINT_NAME = KU.CONSTRAINT_NAME " +
             "AND TC.CONSTRAINT_SCHEMA = KU.CONSTRAINT_SCHEMA " +

--- a/src/Raven.Server/SqlMigration/MsSQL/MsSqlSchemaQueries.cs
+++ b/src/Raven.Server/SqlMigration/MsSQL/MsSqlSchemaQueries.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.SqlMigration.MsSQL
             " ORDER BY ORDINAL_POSITION";
 
         public override string SelectReferentialConstraintsQuery { get; } =
-            "SELECT CONSTRAINT_NAME, UNIQUE_CONSTRAINT_NAME " +
+            "SELECT CONSTRAINT_SCHEMA, CONSTRAINT_NAME, UNIQUE_CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_NAME " +
             "FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS";
 
         public override string SelectKeyColumnUsageQuery { get; } =

--- a/src/Raven.Server/SqlMigration/MsSQL/MsSqlSchemaQueries.cs
+++ b/src/Raven.Server/SqlMigration/MsSQL/MsSqlSchemaQueries.cs
@@ -25,7 +25,14 @@ namespace Raven.Server.SqlMigration.MsSQL
             "SELECT TC.TABLE_SCHEMA, TC.TABLE_NAME, COLUMN_NAME " +
             "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC " +
             "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KU " +
-            "ON TC.CONSTRAINT_TYPE = 'PRIMARY KEY' AND TC.CONSTRAINT_NAME = KU.CONSTRAINT_NAME" +
+            // SQL Server constraint names are not database-wide unique; joining on CONSTRAINT_NAME
+            // alone cross-joins identically-named PKs across schemas and attaches the wrong PK columns.
+            // Qualify by schema + table.
+            "ON TC.CONSTRAINT_TYPE = 'PRIMARY KEY' " +
+            "AND TC.CONSTRAINT_NAME = KU.CONSTRAINT_NAME " +
+            "AND TC.CONSTRAINT_SCHEMA = KU.CONSTRAINT_SCHEMA " +
+            "AND TC.TABLE_SCHEMA = KU.TABLE_SCHEMA " +
+            "AND TC.TABLE_NAME = KU.TABLE_NAME" +
             " ORDER BY ORDINAL_POSITION";
 
         public override string SelectReferentialConstraintsQuery { get; } =

--- a/src/Raven.Server/SqlMigration/MySQL/MySqlSchemaQueries.cs
+++ b/src/Raven.Server/SqlMigration/MySQL/MySqlSchemaQueries.cs
@@ -22,7 +22,10 @@ namespace Raven.Server.SqlMigration.MySQL
         public override string SelectReferentialConstraintsQuery { get; } =
             "SELECT CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_NAME, REFERENCED_TABLE_NAME " +
             "FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS " +
-            "WHERE UNIQUE_CONSTRAINT_SCHEMA = @schema ";
+            // Filter on the FK's OWN schema (outgoing FKs from the discovered schema), not the
+            // referenced unique constraint's schema: UNIQUE_CONSTRAINT_SCHEMA dropped FKs pointing at
+            // another schema and admitted FKs whose source table isn't in the discovery set.
+            "WHERE CONSTRAINT_SCHEMA = @schema ";
 
         public override string SelectKeyColumnUsageQuery { get; } =
             "SELECT CONSTRAINT_SCHEMA, CONSTRAINT_NAME, COLUMN_NAME, REFERENCED_COLUMN_NAME " +

--- a/src/Raven.Server/SqlMigration/MySQL/MySqlSchemaQueries.cs
+++ b/src/Raven.Server/SqlMigration/MySQL/MySqlSchemaQueries.cs
@@ -22,9 +22,6 @@ namespace Raven.Server.SqlMigration.MySQL
         public override string SelectReferentialConstraintsQuery { get; } =
             "SELECT CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_SCHEMA, CONSTRAINT_NAME, TABLE_NAME, REFERENCED_TABLE_NAME " +
             "FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS " +
-            // Filter on the FK's OWN schema (outgoing FKs from the discovered schema), not the
-            // referenced unique constraint's schema: UNIQUE_CONSTRAINT_SCHEMA dropped FKs pointing at
-            // another schema and admitted FKs whose source table isn't in the discovery set.
             "WHERE CONSTRAINT_SCHEMA = @schema ";
 
         public override string SelectKeyColumnUsageQuery { get; } =

--- a/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlDatabaseMigrator.Migration.cs
+++ b/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlDatabaseMigrator.Migration.cs
@@ -20,6 +20,17 @@ namespace Raven.Server.SqlMigration.NpgSQL
         {
             return $"{schema}.{tableName}";
         }
+
+        // CDC test-mapping path only (see GenericDatabaseMigrator): Postgres folds unquoted
+        // identifiers to lower-case, so mixed-case / reserved-word / special-char names must be
+        // double-quoted (embedded quotes doubled). QuoteTable/QuoteColumn above stay raw to
+        // preserve the existing SQL-import behaviour.
+        protected override string QuoteColumnForRowFetch(string columnName) => PgQuoteIdentifier(columnName);
+
+        protected override string QuoteTableForRowFetch(string schema, string tableName) =>
+            $"{PgQuoteIdentifier(schema)}.{PgQuoteIdentifier(tableName)}";
+
+        private static string PgQuoteIdentifier(string identifier) => "\"" + identifier.Replace("\"", "\"\"") + "\"";
         
         private ColumnType MapColumnType(string type)
         {

--- a/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlSchemaQueries.cs
+++ b/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlSchemaQueries.cs
@@ -34,9 +34,8 @@ namespace Raven.Server.SqlMigration.NpgSQL
             "SELECT TC.TABLE_SCHEMA, TC.TABLE_NAME, COLUMN_NAME " +
             "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC " +
             "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KU " +
-            // Postgres constraint names are unique only within (catalog, schema); joining on
-            // CONSTRAINT_NAME alone cross-joins identically-named PKs across schemas (e.g. customers_pkey
-            // in both public and tenant_a) and attaches the wrong PK columns. Qualify by schema + table.
+            // Postgres constraint names are unique only within (catalog, schema), so qualify the
+            // PK-constraint join by schema + table.
             "ON TC.CONSTRAINT_TYPE = 'PRIMARY KEY' " +
             "AND TC.CONSTRAINT_NAME = KU.CONSTRAINT_NAME " +
             "AND TC.CONSTRAINT_SCHEMA = KU.CONSTRAINT_SCHEMA " +

--- a/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlSchemaQueries.cs
+++ b/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlSchemaQueries.cs
@@ -34,7 +34,14 @@ namespace Raven.Server.SqlMigration.NpgSQL
             "SELECT TC.TABLE_SCHEMA, TC.TABLE_NAME, COLUMN_NAME " +
             "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC " +
             "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KU " +
-            "ON TC.CONSTRAINT_TYPE = 'PRIMARY KEY' AND TC.CONSTRAINT_NAME = KU.CONSTRAINT_NAME" +
+            // Postgres constraint names are unique only within (catalog, schema); joining on
+            // CONSTRAINT_NAME alone cross-joins identically-named PKs across schemas (e.g. customers_pkey
+            // in both public and tenant_a) and attaches the wrong PK columns. Qualify by schema + table.
+            "ON TC.CONSTRAINT_TYPE = 'PRIMARY KEY' " +
+            "AND TC.CONSTRAINT_NAME = KU.CONSTRAINT_NAME " +
+            "AND TC.CONSTRAINT_SCHEMA = KU.CONSTRAINT_SCHEMA " +
+            "AND TC.TABLE_SCHEMA = KU.TABLE_SCHEMA " +
+            "AND TC.TABLE_NAME = KU.TABLE_NAME" +
             " ORDER BY ORDINAL_POSITION";
 
         public override string SelectReferentialConstraintsQuery { get; } =

--- a/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlSchemaQueries.cs
+++ b/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlSchemaQueries.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.SqlMigration.NpgSQL
             " ORDER BY ORDINAL_POSITION";
 
         public override string SelectReferentialConstraintsQuery { get; } =
-            "SELECT CONSTRAINT_NAME, UNIQUE_CONSTRAINT_NAME " +
+            "SELECT CONSTRAINT_SCHEMA, CONSTRAINT_NAME, UNIQUE_CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_NAME " +
             "FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS";
 
         public override string SelectKeyColumnUsageQuery { get; } =

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlSchemaDiscoveryTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlSchemaDiscoveryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -109,6 +110,42 @@ namespace SlowTests.Server.Documents.CdcSink
             // but they are ordinary columns present in the binlog row image - they must stay capturable.
             Assert.True(products.Columns.Single(c => c.Name == "created_at").IsCdcCapturable);
             Assert.True(products.Columns.Single(c => c.Name == "expr_default").IsCdcCapturable);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, MySqlRequired = true)]
+        public async Task DiscoversCrossDatabaseForeignKey()
+        {
+            using var teardown = WithSqlDatabase(MigrationProvider.MySQL_MySqlConnector, out var connectionString, out _, dataSet: null, includeData: false);
+
+            var otherDb = "cdc_xdb_" + Guid.NewGuid().ToString("N");
+            try
+            {
+                ExecuteMySql(connectionString, $"CREATE DATABASE `{otherDb}`");
+                ExecuteMySql(connectionString, $"CREATE TABLE `{otherDb}`.parent_other (id INT PRIMARY KEY)");
+                ExecuteMySql(connectionString, $@"
+                    CREATE TABLE child_main (
+                        cid INT PRIMARY KEY,
+                        ref INT NOT NULL,
+                        CONSTRAINT fk_cross FOREIGN KEY (ref) REFERENCES `{otherDb}`.parent_other(id)
+                    );");
+
+                var discovery = CdcSinkSchemaDiscovery.For("MySqlConnector.MySqlConnectorFactory");
+                var schema = await discovery.DiscoverAsync(connectionString, schemas: null, CancellationToken.None);
+
+                var child = Assert.Single(schema.Tables);
+                Assert.Equal("child_main", child.SourceTableName);
+
+                var fk = Assert.Single(child.ForeignKeys);
+                Assert.Equal(new[] { "ref" }, fk.Columns);
+                Assert.Equal(otherDb, fk.ReferencedSchema);
+                Assert.Equal("parent_other", fk.ReferencedTable);
+                Assert.Equal(new[] { "id" }, fk.ReferencedColumns);
+            }
+            finally
+            {
+                ExecuteMySql(connectionString, "DROP TABLE IF EXISTS child_main");
+                ExecuteMySql(connectionString, $"DROP DATABASE IF EXISTS `{otherDb}`");
+            }
         }
     }
 }

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresSchemaDiscoveryTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresSchemaDiscoveryTests.cs
@@ -142,5 +142,54 @@ namespace SlowTests.Server.Documents.CdcSink
             Assert.False(total.IsCdcCapturable);
             Assert.False(string.IsNullOrEmpty(total.UnsupportedReason));
         }
+
+        [RavenFact(RavenTestCategory.Sinks, NpgSqlRequired = true)]
+        public async Task TwoSchemasWithIdenticalConstraintNames_DoNotCollide()
+        {
+            // Regression for RavenDB-26636: the PK join and FK cache used to be keyed by the bare
+            // CONSTRAINT_NAME. Postgres constraint names are unique only within a schema, so two
+            // schemas each carrying a 'pk_shared'/'fk_shared' pair collapsed onto one cache entry —
+            // the second overwrote the first, cross-wiring a child's foreign key to the wrong
+            // parent (or dropping it). The fix keys both by (schema, constraint name); discovery
+            // must keep the two pairs distinct and resolve each FK within its own schema.
+            using var teardown = WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out _, dataSet: null, includeData: false);
+
+            ExecuteNpgSql(connectionString, @"
+                CREATE SCHEMA s1;
+                CREATE SCHEMA s2;
+
+                CREATE TABLE s1.parent_a (id_a INTEGER NOT NULL, CONSTRAINT pk_shared PRIMARY KEY (id_a));
+                CREATE TABLE s1.child_a  (cid INTEGER PRIMARY KEY, ref_a INTEGER NOT NULL,
+                                          CONSTRAINT fk_shared FOREIGN KEY (ref_a) REFERENCES s1.parent_a(id_a));
+
+                CREATE TABLE s2.parent_b (id_b INTEGER NOT NULL, CONSTRAINT pk_shared PRIMARY KEY (id_b));
+                CREATE TABLE s2.child_b  (cid INTEGER PRIMARY KEY, ref_b INTEGER NOT NULL,
+                                          CONSTRAINT fk_shared FOREIGN KEY (ref_b) REFERENCES s2.parent_b(id_b));
+            ");
+
+            var discovery = CdcSinkSchemaDiscovery.For("Npgsql");
+            var schema = await discovery.DiscoverAsync(connectionString, new[] { "s1", "s2" }, CancellationToken.None);
+
+            // PK join keyed by (schema, constraint): each parent keeps its own PK column.
+            var parentA = schema.Tables.Single(t => t.SourceTableSchema == "s1" && t.SourceTableName == "parent_a");
+            Assert.Equal(new[] { "id_a" }, parentA.PrimaryKeyColumns);
+            var parentB = schema.Tables.Single(t => t.SourceTableSchema == "s2" && t.SourceTableName == "parent_b");
+            Assert.Equal(new[] { "id_b" }, parentB.PrimaryKeyColumns);
+
+            // FK cache keyed by (schema, constraint): each child resolves to the parent in its own schema.
+            var childA = schema.Tables.Single(t => t.SourceTableSchema == "s1" && t.SourceTableName == "child_a");
+            var fkA = Assert.Single(childA.ForeignKeys);
+            Assert.Equal(new[] { "ref_a" }, fkA.Columns);
+            Assert.Equal("s1", fkA.ReferencedSchema);
+            Assert.Equal("parent_a", fkA.ReferencedTable);
+            Assert.Equal(new[] { "id_a" }, fkA.ReferencedColumns);
+
+            var childB = schema.Tables.Single(t => t.SourceTableSchema == "s2" && t.SourceTableName == "child_b");
+            var fkB = Assert.Single(childB.ForeignKeys);
+            Assert.Equal(new[] { "ref_b" }, fkB.Columns);
+            Assert.Equal("s2", fkB.ReferencedSchema);
+            Assert.Equal("parent_b", fkB.ReferencedTable);
+            Assert.Equal(new[] { "id_b" }, fkB.ReferencedColumns);
+        }
     }
 }

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresSchemaDiscoveryTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresSchemaDiscoveryTests.cs
@@ -146,12 +146,6 @@ namespace SlowTests.Server.Documents.CdcSink
         [RavenFact(RavenTestCategory.Sinks, NpgSqlRequired = true)]
         public async Task TwoSchemasWithIdenticalConstraintNames_DoNotCollide()
         {
-            // Regression for RavenDB-26636: the PK join and FK cache used to be keyed by the bare
-            // CONSTRAINT_NAME. Postgres constraint names are unique only within a schema, so two
-            // schemas each carrying a 'pk_shared'/'fk_shared' pair collapsed onto one cache entry —
-            // the second overwrote the first, cross-wiring a child's foreign key to the wrong
-            // parent (or dropping it). The fix keys both by (schema, constraint name); discovery
-            // must keep the two pairs distinct and resolve each FK within its own schema.
             using var teardown = WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out _, dataSet: null, includeData: false);
 
             ExecuteNpgSql(connectionString, @"

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresTestMappingClientApiTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresTestMappingClientApiTests.cs
@@ -903,13 +903,9 @@ namespace SlowTests.Server.Documents.CdcSink
         [RavenFact(RavenTestCategory.Sinks, NpgSqlRequired = true)]
         public async Task ClientOperation_MixedCaseAndReservedWordIdentifiers_AreQuoted()
         {
-            // Regression for RavenDB-26636: the Postgres test-mapping row fetch emitted raw,
-            // unquoted identifiers. Postgres folds unquoted identifiers to lower-case and chokes
-            // on reserved words, so a mixed-case/reserved-word table ("Order") or column
-            // ("Select", "FromDate") produced a SQL syntax/lookup error instead of returning the
-            // row. The fix double-quotes identifiers in BuildSelectByPrimaryKeyQuery /
-            // BuildSelectFirstRowsQuery. Every identifier here passes the handler's
-            // [A-Za-z_][A-Za-z0-9_]* gate (no spaces/punctuation) yet still requires quoting.
+            // The mixed-case table ("Order") and reserved-word columns ("Select", "FromDate") pass
+            // the handler's [A-Za-z_][A-Za-z0-9_]* identifier gate yet still require double-quoting:
+            // Postgres folds unquoted identifiers to lower-case and rejects reserved words.
             using var teardown = WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out _, dataSet: null, includeData: false);
 
             ExecuteNpgSql(connectionString, @"

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresTestMappingClientApiTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresTestMappingClientApiTests.cs
@@ -899,5 +899,70 @@ namespace SlowTests.Server.Documents.CdcSink
             Assert.Contains("Oracle.ManagedDataAccess.Client", error);
             Assert.Contains("does not support provider", error);
         }
+
+        [RavenFact(RavenTestCategory.Sinks, NpgSqlRequired = true)]
+        public async Task ClientOperation_MixedCaseAndReservedWordIdentifiers_AreQuoted()
+        {
+            // Regression for RavenDB-26636: the Postgres test-mapping row fetch emitted raw,
+            // unquoted identifiers. Postgres folds unquoted identifiers to lower-case and chokes
+            // on reserved words, so a mixed-case/reserved-word table ("Order") or column
+            // ("Select", "FromDate") produced a SQL syntax/lookup error instead of returning the
+            // row. The fix double-quotes identifiers in BuildSelectByPrimaryKeyQuery /
+            // BuildSelectFirstRowsQuery. Every identifier here passes the handler's
+            // [A-Za-z_][A-Za-z0-9_]* gate (no spaces/punctuation) yet still requires quoting.
+            using var teardown = WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out _, dataSet: null, includeData: false);
+
+            ExecuteNpgSql(connectionString, @"
+                CREATE TABLE ""Order"" (
+                    ""Id""       SERIAL PRIMARY KEY,
+                    ""Select""   VARCHAR(200),
+                    ""FromDate"" VARCHAR(200)
+                );
+                INSERT INTO ""Order"" (""Id"", ""Select"", ""FromDate"") VALUES (1, 'asc', '2026-01-01');");
+
+            using var store = GetDocumentStore();
+
+            var table = new CdcSinkTableConfig
+            {
+                CollectionName = "Orders",
+                SourceTableSchema = "public",
+                SourceTableName = "Order",
+                PrimaryKeyColumns = new List<string> { "Id" },
+                Columns = new List<CdcColumnMapping>
+                {
+                    new() { Column = "Id", Name = "DbId" },
+                    new() { Column = "Select", Name = "Sort" },
+                    new() { Column = "FromDate", Name = "Since" },
+                },
+            };
+
+            var request = new TestCdcSinkMappingRequest
+            {
+                Configuration = new CdcSinkConfiguration
+                {
+                    Name = "client-api-quoted-identifiers",
+                    Tables = new List<CdcSinkTableConfig> { table },
+                },
+                Connection = new SqlConnectionString
+                {
+                    FactoryName = "Npgsql",
+                    ConnectionString = connectionString,
+                },
+                SourceTableSchema = "public",
+                SourceTableName = "Order",
+                RowSelector = TestCdcSinkRowSelector.ByPrimaryKey,
+                PrimaryKeyValues = new[] { "1" },
+                Operation = TestCdcSinkOperation.Upsert,
+                MaxRows = 1,
+            };
+
+            var result = await store.Maintenance.SendAsync(new TestCdcSinkMappingOperation(request));
+
+            Assert.Empty(result.Errors);
+            var row = Assert.Single(result.Results);
+            Assert.Equal("Orders/1", row.DocumentId);
+            Assert.Contains("\"Sort\":\"asc\"", row.Document);
+            Assert.Contains("\"Since\":\"2026-01-01\"", row.Document);
+        }
     }
 }

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerSchemaDiscoveryTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerSchemaDiscoveryTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace SlowTests.Server.Documents.CdcSink
 {
+    [Collection(nameof(CdcSinkSqlServerTests))]
     public class CdcSinkSqlServerSchemaDiscoveryTests : CdcSinkIntegrationTestBase
     {
         public CdcSinkSqlServerSchemaDiscoveryTests(ITestOutputHelper output) : base(output)

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerSchemaDiscoveryTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerSchemaDiscoveryTests.cs
@@ -158,11 +158,6 @@ namespace SlowTests.Server.Documents.CdcSink
         [RavenFact(RavenTestCategory.Sinks, MsSqlRequired = true)]
         public async Task TwoSchemasWithIdenticalConstraintNames_DoNotCollide()
         {
-            // Regression for RavenDB-26636: the PK join and FK cache used to be keyed by the bare
-            // CONSTRAINT_NAME. SQL Server constraint names are unique only within a schema, so two
-            // schemas each carrying a 'pk_shared'/'fk_shared' pair collapsed onto one cache entry,
-            // cross-wiring a child's foreign key to the wrong parent. The fix keys both by
-            // (schema, constraint name); discovery must keep the two pairs distinct.
             using var teardown = WithSqlDatabase(MigrationProvider.MsSQL, out var connectionString, out _, dataSet: null, includeData: false);
 
             ExecuteMsSql(connectionString, "CREATE SCHEMA s1;");

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerSchemaDiscoveryTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerSchemaDiscoveryTests.cs
@@ -154,5 +154,51 @@ namespace SlowTests.Server.Documents.CdcSink
             Assert.DoesNotContain(schema.Tables, t => string.Equals(t.SourceTableName, "systranschemas", StringComparison.OrdinalIgnoreCase));
             Assert.Contains(schema.Tables, t => string.Equals(t.SourceTableName, "tracked", StringComparison.OrdinalIgnoreCase));
         }
+
+        [RavenFact(RavenTestCategory.Sinks, MsSqlRequired = true)]
+        public async Task TwoSchemasWithIdenticalConstraintNames_DoNotCollide()
+        {
+            // Regression for RavenDB-26636: the PK join and FK cache used to be keyed by the bare
+            // CONSTRAINT_NAME. SQL Server constraint names are unique only within a schema, so two
+            // schemas each carrying a 'pk_shared'/'fk_shared' pair collapsed onto one cache entry,
+            // cross-wiring a child's foreign key to the wrong parent. The fix keys both by
+            // (schema, constraint name); discovery must keep the two pairs distinct.
+            using var teardown = WithSqlDatabase(MigrationProvider.MsSQL, out var connectionString, out _, dataSet: null, includeData: false);
+
+            ExecuteMsSql(connectionString, "CREATE SCHEMA s1;");
+            ExecuteMsSql(connectionString, "CREATE SCHEMA s2;");
+            ExecuteMsSql(connectionString, "CREATE TABLE s1.parent_a (id_a INT NOT NULL, CONSTRAINT pk_shared PRIMARY KEY (id_a));");
+            ExecuteMsSql(connectionString, @"
+                CREATE TABLE s1.child_a (cid INT PRIMARY KEY, ref_a INT NOT NULL,
+                    CONSTRAINT fk_shared FOREIGN KEY (ref_a) REFERENCES s1.parent_a(id_a));");
+            ExecuteMsSql(connectionString, "CREATE TABLE s2.parent_b (id_b INT NOT NULL, CONSTRAINT pk_shared PRIMARY KEY (id_b));");
+            ExecuteMsSql(connectionString, @"
+                CREATE TABLE s2.child_b (cid INT PRIMARY KEY, ref_b INT NOT NULL,
+                    CONSTRAINT fk_shared FOREIGN KEY (ref_b) REFERENCES s2.parent_b(id_b));");
+
+            var discovery = CdcSinkSchemaDiscovery.For("Microsoft.Data.SqlClient");
+            var schema = await discovery.DiscoverAsync(connectionString, new[] { "s1", "s2" }, CancellationToken.None);
+
+            // PK join keyed by (schema, constraint): each parent keeps its own PK column.
+            var parentA = schema.Tables.Single(t => t.SourceTableSchema == "s1" && t.SourceTableName == "parent_a");
+            Assert.Equal(new[] { "id_a" }, parentA.PrimaryKeyColumns);
+            var parentB = schema.Tables.Single(t => t.SourceTableSchema == "s2" && t.SourceTableName == "parent_b");
+            Assert.Equal(new[] { "id_b" }, parentB.PrimaryKeyColumns);
+
+            // FK cache keyed by (schema, constraint): each child resolves to the parent in its own schema.
+            var childA = schema.Tables.Single(t => t.SourceTableSchema == "s1" && t.SourceTableName == "child_a");
+            var fkA = Assert.Single(childA.ForeignKeys);
+            Assert.Equal(new[] { "ref_a" }, fkA.Columns);
+            Assert.Equal("s1", fkA.ReferencedSchema);
+            Assert.Equal("parent_a", fkA.ReferencedTable);
+            Assert.Equal(new[] { "id_a" }, fkA.ReferencedColumns);
+
+            var childB = schema.Tables.Single(t => t.SourceTableSchema == "s2" && t.SourceTableName == "child_b");
+            var fkB = Assert.Single(childB.ForeignKeys);
+            Assert.Equal(new[] { "ref_b" }, fkB.Columns);
+            Assert.Equal("s2", fkB.ReferencedSchema);
+            Assert.Equal("parent_b", fkB.ReferencedTable);
+            Assert.Equal(new[] { "id_b" }, fkB.ReferencedColumns);
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26636/CDC-schema-discovery-SQL-migration-multi-schema-correctness-Postgres-identifier-quoting

### Additional description

Multi-schema correctness for CDC schema discovery

- Key PK joins and FK caches by `(schema, constraint name)` (Postgres + SQL Server),
  keeping identically-named constraints in different schemas distinct.
- Filter MySQL referential constraints by the FK's own `CONSTRAINT_SCHEMA`.
- Double-quote identifiers in the Postgres test-mapping row fetch so mixed-case and
  reserved-word names (`"Order"`, `"Select"`) resolve; the migrator's SQL-import
  quoting is unchanged.
- `ValueAsObject`: case-insensitive column lookup and a widened numeric PK parse
  (long, then decimal) for bigint/decimal keys.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
