### PR TITLE
RavenDB-26805 fix QueueSink fallback back-off was stuck at 5s, never escalated

### DIFF
--- a/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
+++ b/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
@@ -505,19 +505,22 @@ public abstract class QueueSinkProcess : IDisposable, ILowMemoryHandler
 
     private void EnterFallbackMode()
     {
+        var now = Database.Time.GetUtcNow();
         if (Statistics.LastConsumeErrorTime == null)
+        {
             FallbackTime = TimeSpan.FromSeconds(5);
+        }
         else
         {
             // double the fallback time (but don't cross QueueSink.MaxFallbackTimeInSec)
-            var secondsSinceLastError =
-                (Database.Time.GetUtcNow() - Statistics.LastConsumeErrorTime.Value).TotalSeconds;
+            var secondsSinceLastError = (now - Statistics.LastConsumeErrorTime.Value).TotalSeconds;
 
             FallbackTime = TimeSpan.FromSeconds(Math.Min(
                 Database.Configuration.QueueSink
                     .MaxFallbackTime.AsTimeSpan.TotalSeconds,
                 Math.Max(5, secondsSinceLastError * 2)));
         }
+        Statistics.LastConsumeErrorTime = now;
     }
 
     public QueueSinkPerformanceStats[] GetPerformanceStats()

--- a/src/Raven.Server/Documents/QueueSink/QueueSinkProcessStatistics.cs
+++ b/src/Raven.Server/Documents/QueueSink/QueueSinkProcessStatistics.cs
@@ -24,7 +24,7 @@ public class QueueSinkProcessStatistics
     
     public int ConsumeErrors { get; set; }
     
-    public DateTime? LastConsumeErrorTime { get; private set; }
+    public DateTime? LastConsumeErrorTime { get; set; }
     
     public Queue<QueueSinkErrorInfo> ConsumeErrorsInCurrentBatch { get; } = new();
     
@@ -40,6 +40,7 @@ public class QueueSinkProcessStatistics
     {
         WasLatestConsumeSuccessful = true;
         ConsumeSuccesses += items;
+        LastConsumeErrorTime = null;
     }
     
     public void RecordConsumeError(string error, int count = 1)
@@ -49,8 +50,6 @@ public class QueueSinkProcessStatistics
         ConsumeErrors += count;
 
         ConsumeErrorsInCurrentBatch.Enqueue(new QueueSinkErrorInfo(error));
-
-        LastConsumeErrorTime = SystemTime.UtcNow;
 
         if (ConsumeErrors <= ConsumeSuccesses)
             return;

--- a/test/SlowTests/Server/Documents/QueueSink/AzureServiceBusSinkTests.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/AzureServiceBusSinkTests.cs
@@ -387,6 +387,6 @@ public class AzureServiceBusSinkTests : AzureServiceBusQueueSinkTestBase
 
         var errorTimes = alert.Errors.Select(x => x.Date);
         var diffBetweenErrors = errorTimes.Zip(errorTimes.Skip(1), (first, second) => second - first);
-        Assert.InRange(diffBetweenErrors.Min(), TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(6));
+        Assert.InRange(diffBetweenErrors.Min(), TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(10));
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26805

### Additional description

Two related fixes around Queue Sink fallback behavior, surfaced by the flaky test `AzureServiceBusSinkTests.FallbackOnConsumeErrors`.

1. exponential back-off never escalated.
2. Flaky test window.

### Type of change

- [x] Test fix
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed