### PR TITLE
RavenDB-26822 : Added info to SlowTests.Server.Documents.AI.AiAgent.AiAgentErrors.BadModel(options: DatabaseMode = Single, config: Google_AiIntegrationTask)

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
@@ -281,7 +281,8 @@ public class AiAgentErrors : RavenTestBase
                 Assert.Contains($"The model `{p.Model}` does not exist or you do not have access to it", e.Message);
                 break;
             case GoogleSettings:
-                Assert.Contains($"models/{p.Model} is not found", e.Message);
+                Assert.True(e.Message.Contains($"models/{p.Model} is not found"),
+                    $"Expected a model-not-found error for '{p.Model}', but got: {e.Message}");
                 break;
             default:
                 throw new InvalidOperationException($"Unknown provider '{p.GetType().Name}'");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26822/SlowTests.Server.Documents.AI.AiAgent.AiAgentErrors.BadModeloptions-DatabaseMode-Single-config-GoogleAiIntegrationTask

### Additional description

Added info for the next time the test fails

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
