### PR TITLE
RavenDB-26848 Pass only documentId when edit mode is disabled

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/hooks/useEditGenAiTaskTests.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/hooks/useEditGenAiTaskTests.ts
@@ -15,6 +15,7 @@ export function useEditGenAiTaskTests() {
 
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const taskId = useAppSelector(editGenAiTaskSelectors.taskId);
+    const isPlaygroundEditMode = useAppSelector(editGenAiTaskSelectors.isPlaygroundEditMode);
 
     const handleContextTest = async () => {
         const areTestRelatedFieldsValid = await trigger(["collectionName", "script"]);
@@ -22,11 +23,17 @@ export function useEditGenAiTaskTests() {
             return;
         }
 
+        const { Document, DocumentId } = editGenAiTaskUtils.getTestDocumentPayload(
+            formValues.playgroundDocument,
+            formValues.documentId,
+            isPlaygroundEditMode
+        );
+
         const dto: Raven.Server.Documents.ETL.Providers.AI.GenAi.Test.TestGenAiScript = {
             TestStage: "CreateContextObjects",
             Input: null,
-            Document: JSON.parse(formValues.playgroundDocument),
-            DocumentId: getDocumentId(formValues),
+            Document,
+            DocumentId,
             IsDelete: false,
             Configuration: editGenAiTaskUtils.mapToDto(formValues, taskId),
         };
@@ -123,11 +130,17 @@ export function useEditGenAiTaskTests() {
             };
         });
 
+        const { Document, DocumentId } = editGenAiTaskUtils.getTestDocumentPayload(
+            formValues.playgroundDocument,
+            formValues.documentId,
+            isPlaygroundEditMode
+        );
+
         const dto: Raven.Server.Documents.ETL.Providers.AI.GenAi.Test.TestGenAiScript = {
             TestStage: "ApplyUpdateScript",
             Input: input,
-            Document: JSON.parse(formValues.playgroundDocument),
-            DocumentId: undefined,
+            Document,
+            DocumentId,
             IsDelete: false,
             Configuration: editGenAiTaskUtils.mapToDto(formValues, taskId),
         };

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/utils/editGenAiTaskUtils.spec.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/utils/editGenAiTaskUtils.spec.ts
@@ -1,0 +1,43 @@
+import { editGenAiTaskUtils } from "./editGenAiTaskUtils";
+
+const { getTestDocumentPayload } = editGenAiTaskUtils;
+
+describe("editGenAiTaskUtils", () => {
+    describe("getTestDocumentPayload", () => {
+        const documentJson = JSON.stringify({
+            Name: "Post",
+            "@metadata": { "@collection": "Posts" },
+        });
+
+        it("should send only the document id for an existing, unedited document", () => {
+            const payload = getTestDocumentPayload(documentJson, "posts/1", false);
+
+            // Only the id is sent so the server loads the full document (with attachment
+            // metadata and the HasAttachments flag) from storage, instead of overwriting it
+            // with the playground body that has '@attachments' stripped.
+            expect(payload.DocumentId).toBe("posts/1");
+            expect(payload.Document).toBeNull();
+        });
+
+        it("should send the document body when the content was edited in the playground", () => {
+            const payload = getTestDocumentPayload(documentJson, "posts/1", true);
+
+            expect(payload.DocumentId).toBe("posts/1");
+            expect(payload.Document).toEqual(JSON.parse(documentJson));
+        });
+
+        it("should send only the document body for a manually entered document (no id)", () => {
+            const payload = getTestDocumentPayload(documentJson, null, true);
+
+            expect(payload.DocumentId).toBeUndefined();
+            expect(payload.Document).toEqual(JSON.parse(documentJson));
+        });
+
+        it("should send nothing when there is no playground document", () => {
+            const payload = getTestDocumentPayload("", "posts/1", false);
+
+            expect(payload.DocumentId).toBeUndefined();
+            expect(payload.Document).toBeNull();
+        });
+    });
+});

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/utils/editGenAiTaskUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/utils/editGenAiTaskUtils.ts
@@ -127,6 +127,43 @@ const mapToDto = (
     };
 };
 
+export interface GenAiTestDocumentPayload {
+    Document: any;
+    DocumentId: string;
+}
+
+// Decides what to send to the server as the test document for the
+// CreateContextObjects / ApplyUpdateScript stages.
+//
+// When an existing, unedited document is selected, we send only its id so the server
+// loads the full document from storage (including attachment metadata and the
+// HasAttachments flag). Sending the document body in this case is harmful: the playground
+// strips '@attachments' from the metadata (via documentMetadata.filterMetadata) and the
+// server overwrites the real document data with this stripped version, which breaks
+// getAttachments/loadAttachment in the test/debug flow.
+//
+// Only when the content was entered or edited manually (playground edit mode) we send
+// the document body itself, since there is no stored document that represents it.
+const getTestDocumentPayload = (
+    playgroundDocument: string,
+    documentId: string,
+    isPlaygroundEditMode: boolean
+): GenAiTestDocumentPayload => {
+    // playgroundDocument should always exist when the document ID is selected
+    if (!playgroundDocument) {
+        return { Document: null, DocumentId: undefined };
+    }
+
+    if (documentId && !isPlaygroundEditMode) {
+        return { Document: null, DocumentId: documentId };
+    }
+
+    return {
+        Document: JSON.parse(playgroundDocument),
+        DocumentId: documentId || undefined,
+    };
+};
+
 const getSerializedChangeVector = (data: EditGenAiTaskFormData, taskId: number): string => {
     let changeVector = taskId ? "DoNotChange" : "BeginningOfTime";
 
@@ -149,6 +186,7 @@ const getSerializedChangeVector = (data: EditGenAiTaskFormData, taskId: number):
 export const editGenAiTaskUtils = {
     getDefaultValues,
     mapToDto,
+    getTestDocumentPayload,
     getSerializedChangeVector,
     defaultMaxConcurrency: 4,
 };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26848/GenAI-scripts-with-getAttachments-does-not-work-in-Studio-test-debug

### Additional description

Decides what to send to the server as the test document for the
CreateContextObjects / ApplyUpdateScript stages.

When an existing, unedited document is selected, we send only its id so the server
loads the full document from storage (including attachment metadata and the
HasAttachments flag). Sending the document body in this case is harmful: the playground
strips '@attachments' from the metadata (via documentMetadata.filterMetadata) and the
server overwrites the real document data with this stripped version, which breaks
getAttachments/loadAttachment in the test/debug flow.

Only when the content was entered or edited manually (playground edit mode) we send
the document body itself, since there is no stored document that represents it.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
