### PR TITLE
RavenDB-26758 - Fix test CanUseQueryToolsInGenAiTaskSecured

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25255.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25255.cs
@@ -193,7 +193,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 session.SaveChanges();
             }
 
-            await Etl.AssertEtlDoneAsync(etlDone, TimeSpan.FromSeconds(60), store.Database, config);
+            await Etl.AssertEtlDoneAsync(etlDone, TimeSpan.FromSeconds(120), store.Database, config);
 
             using (var session = store.OpenSession())
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26758/SlowTests.Server.Documents.AI.AiAgent.RavenDB25255.CanUseQueryToolsInGenAiTaskSecuredoptions-DatabaseMode-Single-config

### Additional description

The issue is that one of the tasks (an LLM request in SendToModel) within the GenAI batch takes longer than 60 seconds, 
causing the test to fail before the ETL has a chance to retry the batch.
To deal with this scenario, I increased the timeout to 120 seconds so the ETL has enough time to retry and execute the batch a second time.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
