### PR TITLE
RavenDB-26610 Fix lost-wakeup hang in WaitForTaskAndExecuteBranchTransactions

### DIFF
--- a/test/FastTests/Voron/SharedJournal/SharedJournalTests.cs
+++ b/test/FastTests/Voron/SharedJournal/SharedJournalTests.cs
@@ -695,7 +695,11 @@ public class SharedJournalTests(ITestOutputHelper output) : RavenTestBase(output
     {
         while (task.IsCompleted is false)
         {
-            mre.Wait();
+            // bounded wait so the loop re-checks task.IsCompleted; the branch can complete and the
+            // merge/completion Set can be consumed-and-reset before we observe it, so a plain mre.Wait()
+            // here deadlocks once the last signal is lost (RavenDB-26610)
+            if (mre.Wait(TimeSpan.FromMilliseconds(100)) == false)
+                continue;
             mre.Reset();
             using (var tx = root.WriteTransaction())
             {


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26610/Hanging-test-FastTests.Voron.SharedJournal.SharedJournalTests.WillRestoreMissingHardLinksOnRootRecovery

### Additional description

Test fix 

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
