### PR TITLE
RavenDB-25201: fixed flaky test from 7.2 on 7.1 base CanResumeConversationWithSummarization

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -49,6 +49,26 @@ public class RavenDB_24407 : RavenTestBase
 
         [JsonProperty("content")]
         public JToken Content { get; set; }
+
+        [JsonProperty("tool_calls")]
+        public List<ToolCall> ToolCalls { get; set; }
+
+        [JsonProperty("tool_call_id")]
+        public string ToolCallId { get; set; }
+    }
+
+    private class ToolCall
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+
+    private class Drink
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public int Price { get; set; }
+        public string[] Tags { get; set; }
     }
 
     [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
@@ -59,31 +79,127 @@ public class RavenDB_24407 : RavenTestBase
     public async Task CanResumeConversationWithSummarization(Options options, GenAiConfiguration config, bool summarization, bool withHistory)
     {
         using var store = GetDocumentStore(options);
-        await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/1",
+                Name = "coca cola",
+                Price = 10,
+                Tags = ["sweet", "cold", "carbonated"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/2",
+                Name = "sprite",
+                Price = 10,
+                Tags = ["sweet", "sour", "cold", "carbonated"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/3",
+                Name = "fanta orange",
+                Price = 11,
+                Tags = ["sweet", "fruity", "cold", "carbonated"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/4",
+                Name = "sparkling water",
+                Price = 8,
+                Tags = ["bitter", "cold", "carbonated"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/5",
+                Name = "beer",
+                Price = 18,
+                Tags = ["bitter", "alcoholic", "cold"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/6",
+                Name = "lager beer",
+                Price = 20,
+                Tags = ["bitter", "alcoholic", "cold", "light"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/7",
+                Name = "red wine",
+                Price = 95,
+                Tags = ["bitter", "sour", "very alcoholic"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/8",
+                Name = "whiskey",
+                Price = 140,
+                Tags = ["bitter", "very alcoholic", "strong"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/9",
+                Name = "vodka",
+                Price = 120,
+                Tags = ["very alcoholic", "strong"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/10",
+                Name = "mojito",
+                Price = 55,
+                Tags = ["sweet", "sour", "alcoholic", "mint"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/11",
+                Name = "lemonade",
+                Price = 14,
+                Tags = ["sweet", "sour", "cold"]
+            });
+
+            await session.StoreAsync(new Drink
+            {
+                Id = "drinks/12",
+                Name = "iced tea",
+                Price = 13,
+                Tags = ["sweet", "cold", "tea"]
+            });
+
+            await session.SaveChangesAsync();
+        }
 
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
-        const string systemPrompt = "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.";
+        const string systemPrompt = """
+                                    You are a shopping assistant.
+
+                                    Rules:
+                                    - Use DrinkSearch for recommendations.
+                                    - Never invent drink pairings, only use the tool results.
+                                    """;
         var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName, systemPrompt);
         agent.Identifier = "shopping-assistant";
-        agent.Parameters.Add(new AiAgentParameter("company"));
 
         agent.Queries =
         [
             new AiAgentToolQuery
                 {
-                    Name = "ProductSearch",
-                    Description =  "semantic search the store product catalog",
-                    Query = "from Products where vector.search(embedding.text(Name), $query) limit 5",
-                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
-                }
-                ,
-                new AiAgentToolQuery
-                {
-                    Name = "RecentOrder",
-                    Description = "Get the recent orders of the current user",
-                    Query = "from Orders where Company = $company order by OrderedAt desc limit 3",
-                    ParametersSampleObject = "{}"
+                    Name = "DrinkSearch",
+                    Description =  "semantic search the store drinks catalog",
+                    Query = "from Drinks where vector.search(embedding.text(Name), $query) limit 5",
+                    ParametersSampleObject = "{\"query\": [\"Term or phrase to search in the catalog, for example: sweet and low alcoholic drink\"]}"
                 }
         ];
         agent.MaxModelIterationsPerCall = 5;
@@ -91,20 +207,20 @@ public class RavenDB_24407 : RavenTestBase
         var identifier = (await store.AI.CreateAgentAsync<OutputSampleObject>(agent, OutputSampleObject.Instance)).Identifier;
         // start chat
         var chat = store.AI.Conversation(
-            agent.Identifier,
+            identifier,
             "chats/",
-            new AiConversationCreationOptions().AddParameter("company", "companies/90-A"));
+            new AiConversationCreationOptions());
 
-        chat.SetUserPrompt("what goes well with my cheese for recent orders?");
+        chat.SetUserPrompt("What sweet alcoholic drink do you recommend? recommend 1 drink please");
         var r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
-
         Assert.NotNull(r.Answer);
 
         // resume
-        chat.SetUserPrompt("can you give me a cheaper alternative?");
-        r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
+        chat.SetUserPrompt("is it sweet?");
+        var r2 = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
 
-        Assert.NotNull(r.Answer);
+        Assert.NotNull(r2.Answer);
+        Assert.NotEqual(r.Answer, r2.Answer);
 
         var chatDoc = await GetChat(store, chat.Id);
         Assert.True(chatDoc.Messages.Count > 2, "messages count: " + chatDoc.Messages.Count);
@@ -135,17 +251,18 @@ public class RavenDB_24407 : RavenTestBase
         }
         if (withHistory)
             agent.ChatTrimming.History = new();
-        
+
         await store.AI.CreateAgentAsync(agent, OutputSampleObject.Instance);
 
-        chat.SetUserPrompt("use the tool I gave you and try to give me a cheaper alternative");
+        chat.SetUserPrompt("is it bitter? use the DrinkSearch tool to check");
         r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
 
         Assert.NotNull(r.Answer);
 
         chatDoc = await GetChat(store, chat.Id);
-        Assert.Equal(summarization ? 3 : 2, chatDoc.Messages.Count);
+        Assert.Equal(2, chatDoc.Messages.Count);
         Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
+        AssertNoOrphanToolMessages(chatDoc);
 
         if (withHistory)
         {
@@ -163,14 +280,15 @@ public class RavenDB_24407 : RavenTestBase
 
         // resume - still with summarization
 
-        chat.SetUserPrompt("can you give me a cheaper alternative?");
+        chat.SetUserPrompt("is it super alcoholic?");
         r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
 
         Assert.NotNull(r.Answer);
 
         chatDoc = await GetChat(store, chat.Id);
-        Assert.Equal(summarization ? 3 : 2, chatDoc.Messages.Count);
+        Assert.Equal(2, chatDoc.Messages.Count);
         Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
+        AssertNoOrphanToolMessages(chatDoc);
 
         // resume
         agent.ChatTrimming = null;
@@ -197,7 +315,13 @@ public class RavenDB_24407 : RavenTestBase
 
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
-        const string systemPrompt = "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.";
+        const string systemPrompt = "You are an AI agent of an online shop. " +
+                                    "You must use the available tools to answer user questions whenever relevant. " +
+                                    "For any question about products, recommendations, or catalog items, you MUST call ProductSearch. " +
+                                    "For any question related to the user's orders, you MUST call RecentOrder. " +
+                                    "Do not answer from your own knowledge. " +
+                                    "Always base your response on tool results. " +
+                                    "When talking about orders or products, include the ids as well.";
 
         var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName, systemPrompt);
         agent.Identifier = "shopping-assistant";
@@ -231,14 +355,16 @@ public class RavenDB_24407 : RavenTestBase
             new AiAgentToolAction
                 {
                     Name = "ProductSearch",
-                    Description =  "semantic search the store product catalog",
+                    Description =  "semantic search the store product catalog" +
+                                   ", MUST be used for any product-related query. Do not answer without calling this tool.",
                     ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
                 }
                 ,
                 new AiAgentToolAction
                 {
                     Name = "RecentOrder",
-                    Description = "Get the recent orders of the current user",
+                    Description = "Get the recent orders of the current user" +
+                                  ", MUST be used for any question about user orders or history. Do not answer without calling this tool.",
                     ParametersSampleObject = "{}"
                 }
         ];
@@ -248,9 +374,9 @@ public class RavenDB_24407 : RavenTestBase
             agent.Identifier,
             "chats/",
             creationOptions: null);
-        
+
         chat.OnUnhandledAction += args => Task.CompletedTask;
-        
+
         chat.SetUserPrompt("what goes well with my cheese for recent orders?");
         var r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
         Assert.Equal(AiConversationResult.ActionRequired, r.Status);
@@ -303,6 +429,40 @@ public class RavenDB_24407 : RavenTestBase
             var msg = await dumpFactory(); // build dump only on failure
             Assert.Fail($"Expected last history message role 'tool' but was '{lastMsgRole}'.\n{msg}");
         }
+    }
+
+    // Validates that the conversation is structurally valid for OpenAI:
+    // every role="tool" message must reference a preceding assistant tool_calls entry,
+    // and no assistant tool_call may be left unanswered.
+    private static void AssertNoOrphanToolMessages(Chat chatDoc)
+    {
+        var outstanding = new HashSet<string>();
+
+        for (int i = 0; i < chatDoc.Messages.Count; i++)
+        {
+            var m = chatDoc.Messages[i];
+
+            if (m.Role == "tool")
+            {
+                Assert.False(string.IsNullOrEmpty(m.ToolCallId),
+                    $"Tool message at index {i} has no tool_call_id. Dump:\n{Dump(chatDoc)}");
+                Assert.True(outstanding.Remove(m.ToolCallId),
+                    $"Orphan tool response at index {i}: tool_call_id '{m.ToolCallId}' has no preceding assistant tool_calls entry. Dump:\n{Dump(chatDoc)}");
+                continue;
+            }
+
+            if (m.ToolCalls == null)
+                continue;
+
+            foreach (var tc in m.ToolCalls)
+            {
+                if (string.IsNullOrEmpty(tc.Id) == false)
+                    outstanding.Add(tc.Id);
+            }
+        }
+
+        Assert.True(outstanding.Count == 0,
+            $"Orphan assistant tool_calls left unanswered: [{string.Join(", ", outstanding)}]. Dump:\n{Dump(chatDoc)}");
     }
 
     private static string Dump(Chat c)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25201/SlowTests.Server.Documents.AI.AiAgent.RavenDB24407.CanResumeConversationWithSummarizationoptions-DatabaseMode-Single-config

### Additional description

About 80% of the test was changes on 7.2 version(the purpose stayed the same) to make the test lighter.
made those changes here on 7.2 and fixed the prompt before the assertion so the tool usage will be deterministic

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
