### PR TITLE
RavenDB-26709 - Set the number of siblings before starting a new outgoing replication task

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -831,6 +831,7 @@ namespace Raven.Server.Documents.Replication
             _pullReplicationCompositeChangeVectorsSupported = SupportsPullReplicationCompositeChangeVectors(record);
             ConflictSolverConfig = record.ConflictSolverConfig;
             ConflictResolver = new ResolveConflictOnReplicationConfigurationChange(this, _logger);
+            SetNumberOfSiblings(record);
             Task.Run(() => ConflictResolver.RunConflictResolversOnce(record.ConflictSolverConfig, index));
             _isInitialized.Raise();
 
@@ -977,6 +978,8 @@ namespace Raven.Server.Documents.Replication
 
             _clusterTopology = GetClusterTopology();
 
+            SetNumberOfSiblings(newRecord);
+
             HandleReplicationChanges(newRecord, instancesToDispose);
 
             var destinations = new List<ReplicationNode>();
@@ -984,10 +987,13 @@ namespace Raven.Server.Documents.Replication
             destinations.AddRange(_externalDestinations);
             _destinations = destinations;
 
+            DisposeConnections(instancesToDispose);
+        }
+
+        private void SetNumberOfSiblings(DatabaseRecord newRecord)
+        {
             // a promotable node isn't counted as a sibling, it is a new node that was added and doesn't hold all the data yet
             NumberOfSiblingsInInternalReplication = Math.Max(newRecord.Topology.Members.Count + newRecord.Topology.Rehabs.Count - 1, 0);
-
-            DisposeConnections(instancesToDispose);
         }
 
         protected virtual void HandleReplicationChanges(DatabaseRecord newRecord, List<IDisposable> instancesToDispose)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26709/SinkToHub-pull-replication-re-sends-all-documents-from-scratch-after-hub-node-failover

### Additional description

#### Summary

`ReplicationLoader.NumberOfSiblingsInInternalReplication` was assigned only inside
`HandleTopologyChange`, and there only *after* the outgoing internal replication tasks were started.
Because the field is an `int` (default `0`) and is read by the cluster-wide confirmation logic, there
was a window in which replication was already running while the sibling count was still
uninitialized/stale.

#### Why it matters

`PullReplicationBatchHistory.GetConfirmedMinimalClusterWideReplicatedEtag()` uses this count to decide
when a sink-to-hub batch has been replicated across all hub nodes. A count of `0` is treated as
"single-node topology — confirm the whole batch immediately." If that runs before the count has been
initialized (right after `Initialize`, or before it is set during a topology change), a multi-node hub
could report a batch as cluster-wide confirmed before it is durably replicated to its siblings, which
would let the sink cursor advance past data that only reached one node.

The same value also feeds `GetMinNumberOfReplicas()` (the write-assurance / `WaitForReplicationAsync`
majority), so keeping it correct matters there as well.

#### Changes

- Set the sibling count in `ReplicationLoader.Initialize` (from the database record it already
  receives), so it is correct before the loader becomes active.
- In `HandleTopologyChange`, set the count **before** `HandleReplicationChanges` starts/updates the
  outgoing replication tasks, so a task is never started against a stale count.
- Extracted the computation into a single `SetNumberOfSiblings` helper used by both paths.
- Exclude promotable nodes from the count — a promotable was just added and does not yet hold all the
  data, so it should not be treated as a sibling — and clamp to `>= 0`. The count is now
  `Members + Rehabs - 1` (previously `Topology.Count - 1`).
- Tightened the setter to `private set`.

#### Scope / risk

- In a healthy, all-members topology this is behavior-preserving: the value is `Members - 1`, the same
  as before.
- Low risk: the change only removes an uninitialized/stale-count state; it does not relax any
  confirmation condition (the confirmation still waits when not all siblings are accounted for).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
