### PR TITLE
RavenDB-26858 Widen TensorsTests reference-comparison tolerance to 1e-5

### DIFF
--- a/test/FastTests/Sparrow/TensorsTests.cs
+++ b/test/FastTests/Sparrow/TensorsTests.cs
@@ -14,7 +14,8 @@ namespace FastTests.Sparrow
 {
     public unsafe class TensorsTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        private const float Eps = 1e-6f;
+        // not tighter than 1e-5: ARM64 SIMD/FMA reductions diverge from the scalar reference by ~1e-6 over ~1k elements
+        private const float Eps = 1e-5f;
 
         // Test that for identical vectors, we get maximum similarity (and so a distance of zero).
         [RavenFact(RavenTestCategory.Core)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26858

### Additional description

ARM64 SIMD/FMA cosine-similarity reductions diverge from the scalar reference by up to ~2.2e-6 over ~1k elements; the 1e-6 tolerance failed on ~0.79% of random seeds (ARM64/Apple Silicon CI), passes on x64.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
