### PR TITLE
RavenDB-26855 Fix test replication ack wait

### DIFF
--- a/test/SlowTests/Client/Attachments/RavenDB_20601.cs
+++ b/test/SlowTests/Client/Attachments/RavenDB_20601.cs
@@ -39,7 +39,7 @@ namespace SlowTests.Client.Attachments
                 }
 
                 await SetupReplicationAsync(store1, store2);
-                await EnsureReplicatingAsync(store1, store2, server);
+                await EnsureReplicatingAsync(store1, store2);
 
                 var d = await BreakReplication(server.ServerStore, store1.Database);
                 using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
@@ -65,7 +65,7 @@ namespace SlowTests.Client.Attachments
 
                 d.Mend();
 
-                await EnsureReplicatingAsync(store1, store2, server);
+                await EnsureReplicatingAsync(store1, store2);
             }
         }
 
@@ -138,7 +138,7 @@ namespace SlowTests.Client.Attachments
 
                 await SetupReplicationAsync(store1, store2);
 
-                await EnsureReplicatingAsync(store1, store2, server);
+                await EnsureReplicatingAsync(store1, store2);
                 var d = await BreakReplication(server.ServerStore, store1.Database);
                 using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
                 {
@@ -178,7 +178,7 @@ namespace SlowTests.Client.Attachments
 
                 d.Mend();
 
-                await EnsureReplicatingAsync(store1, store2, server);
+                await EnsureReplicatingAsync(store1, store2);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_15538.cs
+++ b/test/SlowTests/Issues/RavenDB_15538.cs
@@ -153,7 +153,7 @@ namespace SlowTests.Issues
                         }
                         // Replication from source to firstDestination
                         await SetupReplicationAsync(source, firstDestination);
-                        await EnsureReplicatingAsync(source, firstDestination, server);
+                        await EnsureReplicatingAsync(source, firstDestination);
 
                         var stats = await GetDatabaseStatisticsAsync(source, servers: servers);
                         Assert.True(await WaitForValueAsync(async () => await AssertReplicationAsync(firstDestination, firstDestination.Database, stats, servers), true, reasonableWaitTime, 333));
@@ -165,7 +165,7 @@ namespace SlowTests.Issues
                             await session.SaveChangesAsync();
                         }
 
-                        await EnsureReplicatingAsync(source, firstDestination, server);
+                        await EnsureReplicatingAsync(source, firstDestination);
 
                         stats = await GetDatabaseStatisticsAsync(source, servers: servers);
                         Assert.True(await WaitForValueAsync(async () => await AssertReplicationAsync(firstDestination, firstDestination.Database, stats, servers), true, reasonableWaitTime, 333));

--- a/test/StressTests/Rachis/DatabaseCluster/ReplicationTestsStress.cs
+++ b/test/StressTests/Rachis/DatabaseCluster/ReplicationTestsStress.cs
@@ -124,7 +124,7 @@ namespace StressTests.Rachis.DatabaseCluster
                     await Task.Delay(TimeSpan.FromSeconds(5));
                 }
 
-                await EnsureReplicatingAsync(src, dst);
+                await WaitForMarkerAsync(src, dst);
             }
         }
 

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -13,9 +13,11 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
+using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
@@ -24,12 +26,12 @@ using Raven.Server;
 using Raven.Server.Commercial;
 using Raven.Server.Config;
 using Raven.Server.Documents;
-using Raven.Server.Documents.Replication;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.ServerWide.Maintenance;
 using Raven.Server.Utils;
+using Raven.Server.Web.System;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -175,35 +177,27 @@ namespace Tests.Infrastructure
             }
         }
 
-        public async Task EnsureReplicatingAsync(IDocumentStore src, IDocumentStore dst, RavenServer server = null)
+        public async Task EnsureReplicatingAsync(IDocumentStore src, IDocumentStore dst)
         {
             var sharding = await Sharding.GetShardingConfigurationAsync(src);
             if (sharding == null)
             {
-                var srcDb = await Databases.GetDocumentDatabaseInstanceFor(server, src);
-                await EnsureReplicatingAndAckedAsync(srcDb, src, dst, src.Database, "marker/" + Guid.NewGuid(), timeoutMs: 15 * 1000);
+                await EnsureReplicatingAndAckedAsync(src, dst, src.Database, "marker/" + Guid.NewGuid(), timeoutMs: 15 * 1000);
                 return;
             }
 
             foreach (var shardNumber in sharding.Shards.Keys)
             {
-                var srcServers = server == null ? GetServers().Where(s => src.Urls.Contains(s.WebUrl)).ToList() : [server];
-                if (srcServers.Count == 0)
-                    throw new InvalidOperationException("Source server not found, do you use a custom server?");
-
                 var database = ShardHelper.ToShardName(src.Database, shardNumber);
-                var shardDb = await Sharding.GetAnyShardDocumentDatabaseInstanceFor(database, srcServers);
                 var id = $"marker/{Guid.NewGuid()}${Sharding.GetRandomIdForShard(sharding, shardNumber)}";
-                await EnsureReplicatingAndAckedAsync(shardDb, src, dst, database, id, timeoutMs: 30 * 1000);
+                await EnsureReplicatingAndAckedAsync(src, dst, database, id, timeoutMs: 30 * 1000);
             }
         }
 
-        private async Task EnsureReplicatingAndAckedAsync(DocumentDatabase srcDb, IDocumentStore src, IDocumentStore dst, string database, string markerId, int timeoutMs)
+        private async Task EnsureReplicatingAndAckedAsync(IDocumentStore src, IDocumentStore dst, string database, string markerId, int timeoutMs)
         {
-            long lastEtagBefore = 0;
-            using (srcDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
-            using (ctx.OpenReadTransaction())
-                lastEtagBefore = srcDb.DocumentsStorage.ReadLastEtag(ctx.Transaction.InnerTransaction);
+            var stats = await GetDatabaseStatisticsAsync(src, database);
+            var lastEtagBefore = stats.LastDatabaseEtag ?? 0;
 
             using (var s = src.OpenSession(database))
             {
@@ -212,34 +206,119 @@ namespace Tests.Infrastructure
             }
 
             Assert.NotNull(await WaitForDocumentToReplicateAsync<object>(dst, markerId, timeoutMs));
-            var r = await WaitForValueAsync(() => GetMinimalEtagForExternalReplication(srcDb) >= lastEtagBefore, true);
-            Assert.True(r, $"'{srcDb.Name}' did not get the replication ack from '{dst.Database}' up to etag {lastEtagBefore} (current: {GetMinimalEtagForExternalReplication(srcDb)}).");
+            var r = await WaitForValueAsync(async () => await GetMinimalEtagForExternalReplication(src, database, stats) >= lastEtagBefore, true);
+            var current = await GetMinimalEtagForExternalReplication(src, database, stats);
+            Assert.True(r, $"'{src.Database}' did not get the replication ack from '{dst.Database}' up to etag {lastEtagBefore} (current: {current}).");
         }
 
-        private long GetMinimalEtagForExternalReplication(DocumentDatabase database)
+        private static async Task<long> GetMinimalEtagForExternalReplication(IDocumentStore src, string database, DatabaseStatistics stats)
         {
             var minEtag = long.MaxValue;
-            var server = database.ServerStore;
-            using (server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-            using (ctx.OpenReadTransaction())
+            var replicationResult = await src.Maintenance.ForDatabase(database).SendAsync(new GetOngoingTasksInfoOperation(OngoingTaskType.Replication));
+            foreach (var externalReplication in replicationResult.OngoingTasks.OfType<OngoingTaskReplication>())
             {
-                var dbRecord = server.Cluster.ReadRawDatabaseRecord(ctx, database.Name);
-                var externals = dbRecord.ExternalReplications;
-                if (externals != null)
-                {
-                    foreach (var external in externals)
-                    {
-                        if (external.Disabled)
-                            continue;
+                if (externalReplication.TaskState == OngoingTaskState.Disabled)
+                    continue;
 
-                        var state = ReplicationLoader.GetExternalReplicationState(server, database.Name, external.TaskId, ctx);
-                        var myEtag = ChangeVectorUtils.GetEtagById(state.SourceChangeVector, database.DbBase64Id);
-                        minEtag = Math.Min(myEtag, minEtag);
-                    }
-                }
+                var myEtag = ChangeVectorUtils.GetEtagById(externalReplication.SourceDatabaseChangeVector, stats.DatabaseId);
+                minEtag = Math.Min(myEtag, minEtag);
             }
 
             return minEtag;
+        }
+
+        public sealed class GetOngoingTasksInfoOperation : IMaintenanceOperation<OngoingTasksResult>
+        {
+            private readonly OngoingTaskType _type;
+
+            public GetOngoingTasksInfoOperation(OngoingTaskType type)
+            {
+                _type = type;
+
+                if (type == OngoingTaskType.PullReplicationAsHub)
+                {
+                    throw new ArgumentException(nameof(OngoingTaskType.PullReplicationAsHub) + " type is not supported. Please use " + nameof(GetPullReplicationTasksInfoOperation) + " instead.");
+                }
+            }
+
+
+            public RavenCommand<OngoingTasksResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
+            {
+                return new GetOngoingTasksInfoCommand(_type);
+            }
+
+            internal sealed class GetOngoingTasksInfoCommand : RavenCommand<OngoingTasksResult>
+            {
+                private readonly OngoingTaskType _type;
+                public GetOngoingTasksInfoCommand(OngoingTaskType type)
+                {
+                    _type = type;
+                }
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/databases/{node.Database}/tasks?type={_type}";
+
+                    var request = new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Get
+                    };
+
+                    return request;
+                }
+
+                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+                {
+                    var result = new OngoingTasksResult();
+
+                    if (response == null)
+                    {
+                        Result = result;
+                        return;
+                    }
+
+                    if (response.TryGet(nameof(OngoingTasksResult.SubscriptionsCount), out int subscriptionsCount))
+                        result.SubscriptionsCount = subscriptionsCount;
+
+                    if (response.TryGetMember(nameof(OngoingTasksResult.OngoingTasks), out var tasks) &&
+                        tasks is BlittableJsonReaderArray tasksArray)
+                    {
+                        foreach (BlittableJsonReaderObject taskJson in tasksArray)
+                        {
+                            if (taskJson.TryGet(nameof(OngoingTask.TaskType), out OngoingTaskType taskType) == false)
+                                continue;
+
+                            if (taskType != _type)
+                                continue;
+
+                            result.OngoingTasks.Add(DeserializeTask(taskType, taskJson));
+                        }
+                    }
+
+                    Result = result;
+                }
+
+                private static OngoingTask DeserializeTask(OngoingTaskType taskType, BlittableJsonReaderObject taskJson)
+                {
+                    return taskType switch
+                    {
+                        OngoingTaskType.Replication => JsonDeserializationClient.GetOngoingTaskReplicationResult(taskJson),
+                        OngoingTaskType.RavenEtl => JsonDeserializationClient.GetOngoingTaskRavenEtlResult(taskJson),
+                        OngoingTaskType.SqlEtl => JsonDeserializationClient.GetOngoingTaskSqlEtlResult(taskJson),
+                        OngoingTaskType.OlapEtl => JsonDeserializationClient.GetOngoingTaskOlapEtlResult(taskJson),
+                        OngoingTaskType.ElasticSearchEtl => JsonDeserializationClient.GetOngoingTaskElasticSearchEtlResult(taskJson),
+                        OngoingTaskType.QueueEtl => JsonDeserializationClient.GetOngoingTaskQueueEtlResult(taskJson),
+                        OngoingTaskType.Backup => JsonDeserializationClient.GetOngoingTaskBackupResult(taskJson),
+                        OngoingTaskType.Subscription => JsonDeserializationClient.GetOngoingTaskSubscriptionResult(taskJson),
+                        OngoingTaskType.PullReplicationAsSink => JsonDeserializationClient.OngoingTaskPullReplicationAsSinkResult(taskJson),
+                        OngoingTaskType.PullReplicationAsHub => JsonDeserializationClient.OngoingTaskPullReplicationAsHubResult(taskJson),
+                        OngoingTaskType.QueueSink => JsonDeserializationClient.GetOngoingTaskQueueSinkResult(taskJson),
+                        _ => throw new ArgumentOutOfRangeException(nameof(taskType), taskType, "Unknown task type")
+                    };
+                }
+
+                public override bool IsReadRequest => false;
+            }
         }
 
         protected static async Task<T> WaitForDocumentToReplicateAsync<T>(IDocumentStore store, string id, TimeSpan timeout)

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -91,7 +91,7 @@ namespace FastTests
             return await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
         }
 
-        protected virtual async ValueTask<DatabaseStatistics> GetDatabaseStatisticsAsync(DocumentStore store, string database = null, DatabaseRecord record = null, List<RavenServer> servers = null)
+        protected virtual async ValueTask<DatabaseStatistics> GetDatabaseStatisticsAsync(IDocumentStore store, string database = null, DatabaseRecord record = null, List<RavenServer> servers = null)
         {
             var dbRecord = record ?? await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database ?? store.Database));
             if (dbRecord.IsSharded)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26855
https://issues.hibernatingrhinos.com/issue/RavenDB-26856

### Additional description

Fix test replication ack wait

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
