### PR TITLE
RavenDB-26851 - Harden HubToSink pull replication lifecycle races

### DIFF
--- a/src/Raven.Server/Documents/Replication/AbstractReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/AbstractReplicationLoader.cs
@@ -82,6 +82,7 @@ namespace Raven.Server.Documents.Replication
             public Action<DatabaseOutgoingReplicationHandler> OnOutgoingReplicationStart;
             public Action<Exception> OnIncomingReplicationHandlerFailure;
             public Action OnIncomingReplicationHandlerStart;
+            public Action BeforePullReplicationAsSinkHandoff;
             public Action BeforeDisposingIncomingReplicationHandlers;
             public Func<Stream, Stream> WrapIncomingReplicationStream;
             public Func<ExternalReplicationBase, bool?> ShouldOwnExternalReplicationTask;

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -71,7 +71,7 @@ namespace Raven.Server.Documents.Replication.Incoming
         public IncomingConnectionInfo ConnectionInfo { get; protected set; }
         public TcpConnectionHeaderMessage.SupportedFeatures SupportedFeatures { get; set; }
         public string SourceFormatted => $"{ConnectionInfo.SourceUrl}/databases/{ConnectionInfo.SourceDatabaseName} ({ConnectionInfo.SourceDatabaseId})";
-        protected string IncomingReplicationThreadName => $"Incoming replication {FromToString}";
+        protected virtual ThreadNames.ThreadInfo IncomingReplicationThreadInfo => ThreadNames.ForIncomingReplication(_databaseName, ConnectionInfo.SourceDatabaseName, FromToString);
         public virtual string FromToString => $"In database {_server.NodeTag}-{_databaseName} @ {_server.GetNodeTcpServerUrl()} " +
                                               $"from {ConnectionInfo.SourceTag}-{ConnectionInfo.SourceDatabaseName} @ {ConnectionInfo.SourceUrl}";
 
@@ -114,8 +114,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                 if (_incomingWork != null)
                     return; // already set by someone else, they can start it
 
-                _incomingWork = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => { DoIncomingReplication(); }, null, ThreadNames.ForIncomingReplication(IncomingReplicationThreadName,
-                    _databaseName, ConnectionInfo.SourceDatabaseName));
+                _incomingWork = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => { DoIncomingReplication(); }, null, IncomingReplicationThreadInfo);
             }
 
             if (Logger.IsDebugEnabled)

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsHub.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsHub.cs
@@ -7,6 +7,7 @@ using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Server.Utils;
 
 namespace Raven.Server.Documents.Replication.Incoming
 {
@@ -27,6 +28,9 @@ namespace Raven.Server.Documents.Replication.Incoming
 
         protected override bool PreventIncomingSinkDeletions =>
             IncomingPullReplicationParams.PreventDeletionsMode?.HasFlag(PreventDeletionsMode.PreventSinkToHubDeletions) == true;
+
+        protected override ThreadNames.ThreadInfo IncomingReplicationThreadInfo =>
+            ThreadNames.ForPullReplicationAsHub(ConnectionInfo.SourceDatabaseName, ConnectionInfo.SourceUrl, IncomingPullReplicationParams.Name);
 
         protected override void MergeSourceChangeVectorFromHeartbeat(DocumentsOperationContext documentsContext, string changeVector)
         {

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
@@ -11,6 +11,7 @@ using Raven.Server.ServerWide.Commands;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Server.Utils;
 
 namespace Raven.Server.Documents.Replication.Incoming
 {
@@ -30,6 +31,9 @@ namespace Raven.Server.Documents.Replication.Incoming
         }
 
         protected override bool PreventIncomingSinkDeletions => false;
+
+        protected override ThreadNames.ThreadInfo IncomingReplicationThreadInfo =>
+            ThreadNames.ForPullReplicationAsSink(ConnectionInfo.SourceDatabaseName, ConnectionInfo.SourceUrl, IncomingPullReplicationParams.Name);
 
         internal bool MatchesHubToSinkTask(PullReplicationAsSink destination)
         {

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -566,22 +566,29 @@ namespace Raven.Server.Documents.Replication
                     Type = PullReplicationParams.ConnectionType.Incoming,
                     TaskId = destination.TaskId
                 };
+
                 var newIncoming = CreateIncomingReplicationHandler(tcpConnectionOptions, buffer, incomingPullParams);
                 newIncoming.Failed += RetryPullReplication;
 
                 ForTestingPurposes?.BeforePullReplicationAsSinkHandoff?.Invoke();
 
-                if (CompletePullReplicationAsSinkHandoff(source, destination, newIncoming) == false)
+                if (RemoveOutgoingHandler(source) && TryRegisterIncomingInstance(newIncoming))
                 {
+                    if (_outgoingFailureInfo.TryRemove(destination, out ConnectionShutdownInfo info))
+                        _reconnectQueue.TryRemove(info);
+
+                    newIncoming.Start();
+                    ForceTryReconnectAll();
+                }
+                else
+                {
+                    if (_logger.IsInfoEnabled)
+                    {
+                        _logger.Info("you can't add two identical connections.", new InvalidOperationException("you can't add two identical connections."));
+                    }
                     newIncoming.Failed -= RetryPullReplication;
                     newIncoming.Dispose();
-                    return;
                 }
-
-                PoolOfThreads.PooledThread.ResetCurrentThreadName();
-                Thread.CurrentThread.Name = ThreadNames.GetNameToUse(ThreadNames.ForPullReplicationAsSink($"Pull Replication as Sink from {destination.Database} at {destination.Url}", destination.Database, destination.Url));
-
-                newIncoming.DoIncomingReplication();
 
                 void RetryPullReplication(IncomingReplicationHandler instance, Exception e)
                 {
@@ -603,12 +610,8 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        private bool CompletePullReplicationAsSinkHandoff(DatabaseOutgoingReplicationHandler source, ReplicationNode destination, IncomingReplicationHandler newIncoming)
+        private bool TryRegisterIncomingInstance(IncomingReplicationHandler newIncoming)
         {
-            // we are pulling and therefore incoming, upon failure 'RetryPullReplication' will put us back as an outgoing
-            if (RemoveOutgoingHandler(source) == false)
-                return false;
-
             var current = _incoming.AddOrUpdate(newIncoming.ConnectionInfo.SourceDatabaseId, newIncoming,
                 (_, val) => val.IsDisposed ? newIncoming : val);
 
@@ -616,10 +619,6 @@ namespace Raven.Server.Documents.Replication
                 return false;
 
             IncomingReplicationAdded?.Invoke(newIncoming);
-
-            if (_outgoingFailureInfo.TryRemove(destination, out ConnectionShutdownInfo info))
-                _reconnectQueue.TryRemove(info);
-
             return true;
         }
 
@@ -647,13 +646,9 @@ namespace Raven.Server.Documents.Replication
             newIncoming.Failed += OnIncomingReceiveFailed;
 
             // need to safeguard against two concurrent connection attempts
-            var current = _incoming.AddOrUpdate(newIncoming.ConnectionInfo.SourceDatabaseId, newIncoming,
-                (_, val) => val.IsDisposed ? newIncoming : val);
-
-            if (current == newIncoming)
+            if (TryRegisterIncomingInstance(newIncoming))
             {
                 newIncoming.Start();
-                IncomingReplicationAdded?.Invoke(newIncoming);
                 ForceTryReconnectAll();
             }
             else
@@ -662,6 +657,7 @@ namespace Raven.Server.Documents.Replication
                 {
                     _logger.Info("you can't add two identical connections.", new InvalidOperationException("you can't add two identical connections."));
                 }
+                newIncoming.Failed -= OnIncomingReceiveFailed;
                 newIncoming.Dispose();
             }
         }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -569,7 +569,14 @@ namespace Raven.Server.Documents.Replication
                 var newIncoming = CreateIncomingReplicationHandler(tcpConnectionOptions, buffer, incomingPullParams);
                 newIncoming.Failed += RetryPullReplication;
 
-                CompletePullReplicationAsSinkHandoff(source, destination, newIncoming);
+                ForTestingPurposes?.BeforePullReplicationAsSinkHandoff?.Invoke();
+
+                if (CompletePullReplicationAsSinkHandoff(source, destination, newIncoming) == false)
+                {
+                    newIncoming.Failed -= RetryPullReplication;
+                    newIncoming.Dispose();
+                    return;
+                }
 
                 PoolOfThreads.PooledThread.ResetCurrentThreadName();
                 Thread.CurrentThread.Name = ThreadNames.GetNameToUse(ThreadNames.ForPullReplicationAsSink($"Pull Replication as Sink from {destination.Database} at {destination.Url}", destination.Database, destination.Url));
@@ -596,26 +603,37 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        private void CompletePullReplicationAsSinkHandoff(DatabaseOutgoingReplicationHandler source, ReplicationNode destination, IncomingReplicationHandler newIncoming)
+        private bool CompletePullReplicationAsSinkHandoff(DatabaseOutgoingReplicationHandler source, ReplicationNode destination, IncomingReplicationHandler newIncoming)
         {
-            _incoming[newIncoming.ConnectionInfo.SourceDatabaseId] = newIncoming;
-            IncomingReplicationAdded?.Invoke(newIncoming);
-
             // we are pulling and therefore incoming, upon failure 'RetryPullReplication' will put us back as an outgoing
-            RemoveOutgoingHandler(source);
+            if (RemoveOutgoingHandler(source) == false)
+                return false;
+
+            var current = _incoming.AddOrUpdate(newIncoming.ConnectionInfo.SourceDatabaseId, newIncoming,
+                (_, val) => val.IsDisposed ? newIncoming : val);
+
+            if (current != newIncoming)
+                return false;
+
+            IncomingReplicationAdded?.Invoke(newIncoming);
 
             if (_outgoingFailureInfo.TryRemove(destination, out ConnectionShutdownInfo info))
                 _reconnectQueue.TryRemove(info);
+
+            return true;
         }
 
-        private void RemoveOutgoingHandler(DatabaseOutgoingReplicationHandler instance)
+        private bool RemoveOutgoingHandler(DatabaseOutgoingReplicationHandler instance)
         {
             instance.Failed -= OnOutgoingSendingFailed;
             instance.SuccessfulTwoWaysCommunication -= OnOutgoingSendingSucceeded;
             instance.SuccessfulReplication -= ResetReplicationFailuresInfo;
 
-            _outgoing.TryRemove(instance);
+            if (_outgoing.TryRemove(instance) == false)
+                return false;
+
             OutgoingReplicationRemoved?.Invoke(instance);
+            return true;
         }
 
         private void OnAttachmentStreamsReceived(IncomingReplicationHandler source, int attachmentsStreamCount)

--- a/src/Sparrow.Server/Utils/ThreadNames.cs
+++ b/src/Sparrow.Server/Utils/ThreadNames.cs
@@ -73,11 +73,12 @@ public static class ThreadNames
         };
     }
 
-    public static ThreadInfo ForIncomingReplication(string threadName, string dbName, string sourceDbName)
+    public static ThreadInfo ForIncomingReplication(string dbName, string sourceDbName, string fromToString)
     {
-        return new ThreadInfo(threadName)
+        var details = new ThreadDetails.IncomingReplication(dbName, sourceDbName, fromToString);
+        return new ThreadInfo(details.GetFullName())
         {
-            Details = new ThreadDetails.IncomingReplication(dbName, sourceDbName)
+            Details = details
         };
     }
 
@@ -192,11 +193,21 @@ public static class ThreadNames
         };
     }
 
-    public static ThreadInfo ForPullReplicationAsSink(string threadName, string destinationDatabase, string destinationUrl)
+    public static ThreadInfo ForPullReplicationAsSink(string databaseName, string url, string pullReplicationDefinitionName)
     {
-        return new ThreadInfo(threadName)
+        var details = new ThreadDetails.PullReplicationAsSink(databaseName, url, pullReplicationDefinitionName);
+        return new ThreadInfo(details.GetFullName())
         {
-            Details = new ThreadDetails.PullReplicationAsSink(destinationDatabase, destinationUrl)
+            Details = details
+        };
+    }
+
+    public static ThreadInfo ForPullReplicationAsHub(string sourceDatabase, string sourceUrl, string pullReplicationDefinitionName)
+    {
+        var details = new ThreadDetails.PullReplicationAsHub(sourceDatabase, sourceUrl, pullReplicationDefinitionName);
+        return new ThreadInfo(details.GetFullName())
+        {
+            Details = details
         };
     }
 
@@ -348,11 +359,18 @@ public static class ThreadNames
         {
             private readonly string _dbName;
             private readonly string _sourceDbName;
+            private readonly string _fromToString;
 
-            public IncomingReplication(string dbName, string sourceDbName)
+            public IncomingReplication(string dbName, string sourceDbName, string fromToString)
             {
                 _dbName = dbName;
                 _sourceDbName = sourceDbName;
+                _fromToString = fromToString;
+            }
+
+            public string GetFullName()
+            {
+                return $"Incoming replication {_fromToString}";
             }
 
             public string GetShortName()
@@ -589,19 +607,55 @@ public static class ThreadNames
 
         public sealed class PullReplicationAsSink : IThreadDetails
         {
-            private readonly string _destinationDatabase;
-            private readonly string _destinationUrl;
+            private readonly string _databaseName;
+            private readonly string _url;
+            private readonly string _pullReplicationDefinitionName;
 
-            public PullReplicationAsSink(string destinationDatabase, string destinationUrl)
+            public PullReplicationAsSink(string databaseName, string url, string pullReplicationDefinitionName)
             {
-                _destinationDatabase = destinationDatabase;
-                _destinationUrl = destinationUrl;
+                _databaseName = databaseName;
+                _url = url;
+                _pullReplicationDefinitionName = pullReplicationDefinitionName;
+            }
+
+            public string GetFullName()
+            {
+                return $"Pull Replication as Sink from {_databaseName} at {_url}{ThreadDetails.GetPullReplicationDefinitionNameSuffix(_pullReplicationDefinitionName)}";
             }
 
             public string GetShortName()
             {
-                return $"PllRepSnk {_destinationDatabase} at {_destinationUrl}";
+                return $"PllRepSnk {_databaseName} at {_url}";
             }
+        }
+
+        public sealed class PullReplicationAsHub : IThreadDetails
+        {
+            private readonly string _sourceDatabase;
+            private readonly string _sourceUrl;
+            private readonly string _pullReplicationDefinitionName;
+
+            public PullReplicationAsHub(string sourceDatabase, string sourceUrl, string pullReplicationDefinitionName)
+            {
+                _sourceDatabase = sourceDatabase;
+                _sourceUrl = sourceUrl;
+                _pullReplicationDefinitionName = pullReplicationDefinitionName;
+            }
+
+            public string GetFullName()
+            {
+                return $"Pull Replication as Hub from {_sourceDatabase} at {_sourceUrl}{ThreadDetails.GetPullReplicationDefinitionNameSuffix(_pullReplicationDefinitionName)}";
+            }
+
+            public string GetShortName()
+            {
+                return $"PllRepHub {_sourceDatabase} at {_sourceUrl}";
+            }
+        }
+
+        private static string GetPullReplicationDefinitionNameSuffix(string pullReplicationDefinitionName)
+        {
+            return pullReplicationDefinitionName == null ? null : $" (pull definition: {pullReplicationDefinitionName})";
         }
 
         public class ClusterTransaction : IThreadDetails

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -878,6 +878,109 @@ namespace SlowTests.Server.Replication
         }
 
         [RavenFact(RavenTestCategory.Replication)]
+        public async Task DisabledHubToSinkPullReplicationShouldNotKeepReplicatingAfterStaleHandoff()
+        {
+            DoNotReuseServer();
+
+            var definitionName = $"pull-replication {GetDatabaseName()}";
+            const int timeout = 20_000;
+
+            using (var sinkServer = GetNewServer())
+            using (var hubServer = GetNewServer())
+            using (var sink = GetDocumentStore(new Options { Server = sinkServer }))
+            using (var hub = GetDocumentStore(new Options { Server = hubServer }))
+            {
+                var sinkDatabase = await GetDatabase(sink.Database, sinkServer);
+                var firstHandoffReached = new AsyncManualResetEvent();
+                var allowFirstHandoffToContinue = new AsyncManualResetEvent();
+                var handoffAttempt = 0;
+
+                sinkDatabase.ReplicationLoader.ForTestingPurposesOnly().BeforePullReplicationAsSinkHandoff = () =>
+                {
+                    if (Interlocked.Increment(ref handoffAttempt) != 1)
+                        return;
+
+                    firstHandoffReached.Set();
+                    if (allowFirstHandoffToContinue.WaitAsync(TimeSpan.FromMilliseconds(timeout)).GetAwaiter().GetResult() == false)
+                        throw new TimeoutException("Timed out while waiting to continue the first HubToSink handoff.");
+                };
+
+                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(definitionName)
+                {
+                    Mode = PullReplicationMode.HubToSink
+                }));
+
+                var pullReplication = new PullReplicationAsSink(hub.Database, $"ConnectionString-{hub.Database}", definitionName)
+                {
+                    Mode = PullReplicationMode.HubToSink
+                };
+                var sinkTask = await AddWatcherToReplicationTopology(sink, pullReplication, hub.Urls);
+
+                Assert.True(await firstHandoffReached.WaitAsync(TimeSpan.FromMilliseconds(timeout)), "Expected the first HubToSink handoff to reach the test barrier.");
+
+                await sink.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(sinkTask.TaskId, OngoingTaskType.PullReplicationAsSink, disable: true));
+                await AssertPullReplicationAsSinkTaskDisabled(sink, sinkTask.TaskId);
+                Assert.True(WaitForValue(() => HasOutgoingHubToSinkPullConnection(sinkDatabase, sinkTask.TaskId) == false, true, timeout),
+                    "Disabling the HubToSink task should remove the first outgoing connector.");
+                Assert.False(HasIncomingHubToSinkPullHandler(sinkDatabase, sinkTask.TaskId),
+                    "Disabling the HubToSink task before handoff completes should not leave a tracked incoming handler.");
+
+                await sink.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(sinkTask.TaskId, OngoingTaskType.PullReplicationAsSink, disable: false));
+
+                using (var session = hub.OpenSession())
+                {
+                    session.Store(new User { Name = "before-stale-handoff" }, "users/before-stale-handoff");
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(sink, "users/before-stale-handoff", u => u.Name == "before-stale-handoff", timeout), sink.Identifier);
+                Assert.True(WaitForValue(() => HasIncomingHubToSinkPullHandler(sinkDatabase, sinkTask.TaskId), true, timeout),
+                    "Expected the re-enabled HubToSink task to complete a replacement handoff.");
+                Assert.False(HasOutgoingHubToSinkPullConnection(sinkDatabase, sinkTask.TaskId),
+                    "After the replacement handoff, the sink should track HubToSink as incoming only.");
+
+                var staleIncomingAdded = new AsyncManualResetEvent();
+                sinkDatabase.ReplicationLoader.IncomingReplicationAdded += handler =>
+                {
+                    if (handler is IncomingPullReplicationHandlerAsSink pullAsSink &&
+                        pullAsSink.IncomingPullReplicationParams.TaskId == sinkTask.TaskId &&
+                        pullAsSink.IncomingPullReplicationParams.Mode == PullReplicationMode.HubToSink)
+                    {
+                        staleIncomingAdded.Set();
+                    }
+                };
+
+                allowFirstHandoffToContinue.Set();
+
+                await staleIncomingAdded.WaitAsync(TimeSpan.FromSeconds(3));
+
+                using (var session = hub.OpenSession())
+                {
+                    session.Store(new User { Name = "after-stale-handoff" }, "users/after-stale-handoff");
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(sink, "users/after-stale-handoff", u => u.Name == "after-stale-handoff", timeout), sink.Identifier);
+
+                await sink.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(sinkTask.TaskId, OngoingTaskType.PullReplicationAsSink, disable: true));
+                await AssertPullReplicationAsSinkTaskDisabled(sink, sinkTask.TaskId);
+                Assert.True(WaitForValue(() => HasIncomingHubToSinkPullHandler(sinkDatabase, sinkTask.TaskId) == false, true, timeout),
+                    "Disabling the HubToSink task should remove the tracked incoming handler.");
+                Assert.False(HasOutgoingHubToSinkPullConnection(sinkDatabase, sinkTask.TaskId),
+                    "The disabled HubToSink task should not have an outgoing connector.");
+
+                using (var session = hub.OpenSession())
+                {
+                    session.Store(new User { Name = "after-disable" }, "users/after-disable");
+                    session.SaveChanges();
+                }
+
+                Assert.False(WaitForDocument<User>(sink, "users/after-disable", u => u.Name == "after-disable", 5_000),
+                    "The disabled HubToSink task must not keep replicating through an untracked stale incoming handler.");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
         public async Task DisablePullReplicationOnHub()
         {
             DebuggerAttachedTimeout.DisableLongTimespan = true;
@@ -2055,6 +2158,11 @@ namespace SlowTests.Server.Replication
                             destinationTaskId == taskId);
         }
 
+        private static bool HasOutgoingHubToSinkPullConnection(Raven.Server.Documents.DocumentDatabase database, long taskId)
+        {
+            return CountOutgoingHubToSinkPullHandlers(database, taskId) > 0;
+        }
+
         private static OutgoingPullReplicationHandlerAsSink GetOutgoingSinkToHubPullHandler(Raven.Server.Documents.DocumentDatabase database, long taskId)
         {
             return database.ReplicationLoader.OutgoingHandlers
@@ -2071,6 +2179,12 @@ namespace SlowTests.Server.Replication
         private static PullReplicationAsSink GetQueuedHubToSinkDestination(Raven.Server.Documents.DocumentDatabase database, long taskId)
         {
             return database.ReplicationLoader.ReconnectQueue.OfType<PullReplicationAsSink>().FirstOrDefault(x => x.TaskId == taskId && x.Mode == PullReplicationMode.HubToSink);
+        }
+
+        private static async Task AssertPullReplicationAsSinkTaskDisabled(IDocumentStore store, long taskId)
+        {
+            var taskInfo = (OngoingTaskPullReplicationAsSink)await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.PullReplicationAsSink));
+            Assert.Equal(OngoingTaskState.Disabled, taskInfo.TaskState);
         }
 
         private class AsyncGate


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26851

### Additional description

Hardens a HubToSink pull replication lifecycle race on the sink side.

This PR is split from the basic cleanup work in https://github.com/ravendb/ravendb/pull/23045. The companion PR handles the user-visible cleanup paths and the feature-toggle reconnect scenario. This PR keeps the race-condition hardening only.

The fixed race is a stale HubToSink handoff:

- an outgoing HubToSink connector reaches the handoff point;
- the sink task is disabled before the handoff completes;
- the task is re-enabled and a replacement incoming handler is established;
- the old handoff resumes later and must not overwrite or remove the active incoming handler;
- disabling the task again must stop replication.

The fix avoids broad locking. The handoff first claims the outgoing connector by removing the exact active outgoing handler. Only then does it publish the incoming handler, using `_incoming.AddOrUpdate` without overwriting a live existing handler.
Pull incoming handlers now keep pull-specific thread names while still using the normal incoming handler startup path. Examples:

- HubToSink incoming on sink:
  - Windows/full: `Pull Replication as Sink from HubDb at tcp://hub:38888 (pull definition: PullCars)`
  - Posix short: `PllRepSnk HubDb at tcp://hub:38888`
- SinkToHub incoming on hub:
  - Windows/full: `Pull Replication as Hub from SinkDb at tcp://sink:38888 (pull definition: PullCars)`
  - Posix short: `PllRepHub SinkDb at tcp://sink:38888`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
