### PR TITLE
RavenDB-26850 Gen AI + AI Agents + Task Errors: Add link to docs in info hub

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentInfoHub.tsx
@@ -1,6 +1,11 @@
 import AboutViewFloating, { AccordionItemWrapper } from "components/common/AboutView";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "components/hooks/useRavenLink";
 
 export default function EditAiAgentInfoHub() {
+    const aiAgentsOverviewDocsLink = useRavenLink({ hash: "XNWAXB" });
+    const aiAgentsCreateAgentDocsLink = useRavenLink({ hash: "72VEQI" });
+
     return (
         <AboutViewFloating>
             <AccordionItemWrapper
@@ -53,6 +58,15 @@ export default function EditAiAgentInfoHub() {
                         </li>
                     </ul>
                 </div>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href={aiAgentsOverviewDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - AI Agents Overview
+                </a>
+                <br />
+                <a href={aiAgentsCreateAgentDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - Create AI Agent
+                </a>
             </AccordionItemWrapper>
         </AboutViewFloating>
     );

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentsInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentsInfoHub.tsx
@@ -2,12 +2,15 @@ import AboutViewFloating, { AccordionItemWrapper } from "components/common/About
 import FeatureAvailabilitySummaryWrapper, {
     FeatureAvailabilityData,
 } from "components/common/FeatureAvailabilitySummary";
+import { Icon } from "components/common/Icon";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
+import { useRavenLink } from "components/hooks/useRavenLink";
 import { useAppSelector } from "components/store";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export default function AiAgentsInfoHub() {
     const hasAiAgent = useAppSelector(licenseSelectors.statusValue("HasAiAgent"));
+    const aiAgentsOverviewDocsLink = useRavenLink({ hash: "XNWAXB" });
 
     const featureAvailability = useLimitedFeatureAvailability({
         defaultFeatureAvailability,
@@ -48,6 +51,11 @@ export default function AiAgentsInfoHub() {
                         </li>
                     </ul>
                 </div>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href={aiAgentsOverviewDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - AI Agents Overview
+                </a>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper isUnlimited={hasAiAgent} data={featureAvailability} />
         </AboutViewFloating>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiTasks/AiTasksInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiTasks/AiTasksInfoHub.tsx
@@ -1,6 +1,11 @@
 import AboutViewFloating, { AccordionItemWrapper } from "components/common/AboutView";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "components/hooks/useRavenLink";
 
 export default function AiTasksInfoHub() {
+    const genAiTaskOverviewDocsLink = useRavenLink({ hash: "GEHC2I" });
+    const embeddingsGenerationOverviewDocsLink = useRavenLink({ hash: "H6GDNY" });
+
     return (
         <AboutViewFloating>
             <AccordionItemWrapper
@@ -30,6 +35,15 @@ export default function AiTasksInfoHub() {
                         <li>Use the embeddings to perform vector search queries.</li>
                     </ul>
                 </div>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href={genAiTaskOverviewDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - GenAI Task Overview
+                </a>
+                <br />
+                <a href={embeddingsGenerationOverviewDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - Generating Embeddings Overview
+                </a>
             </AccordionItemWrapper>
         </AboutViewFloating>
     );

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTaskInfoHub.tsx
@@ -6,12 +6,17 @@ import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabi
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "components/hooks/useRavenLink";
 
 export default function EditGenAiTaskInfoHub() {
     const { appUrl } = useAppUrls();
     const activeDatabaseName = useAppSelector(databaseSelectors.activeDatabaseName);
 
     const hasGenAi = useAppSelector(licenseSelectors.statusValue("HasGenAi"));
+
+    const genAiOverviewDocsLink = useRavenLink({ hash: "GEHC2I" });
+    const genAiCreateTaskDocsLink = useRavenLink({ hash: "HTGCZZ" });
 
     const featureAvailability = useLimitedFeatureAvailability({
         defaultFeatureAvailability,
@@ -94,6 +99,15 @@ export default function EditGenAiTaskInfoHub() {
                     <br /> Once the task is active, any modification to a document in the selected collection
                     <br /> will trigger the task to retrieve content from the model and apply the update script.
                 </p>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href={genAiOverviewDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - GenAI Task Overview
+                </a>
+                <br />
+                <a href={genAiCreateTaskDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - Create GenAI Task
+                </a>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper isUnlimited={hasGenAi} data={featureAvailability} />
         </AboutViewFloating>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/tasksErrors/partials/TasksErrorsAboutView.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/tasksErrors/partials/TasksErrorsAboutView.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { AboutViewFloating, AccordionItemWrapper } from "components/common/AboutView";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "components/hooks/useRavenLink";
 
 export default function TasksErrorsAboutView() {
+    const taskErrorsOverviewDocsLink = useRavenLink({ hash: "17261M" });
+
     return (
         <AboutViewFloating>
             <AccordionItemWrapper
@@ -77,6 +81,11 @@ export default function TasksErrorsAboutView() {
                         The task health will recover gradually as new batches complete successfully.
                     </li>
                 </ul>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href={taskErrorsOverviewDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - Task Errors Overview
+                </a>
             </AccordionItemWrapper>
         </AboutViewFloating>
     );


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26850/Gen-AI-AI-Agents-Task-Errors-Add-link-to-docs-in-info-hub

### Additional description
Added links to documentation in Info Hub sections

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
