### PR TITLE
RavenDB-26742 - CDC/SqlMigration: parameterize the Npgsql schema filter

### DIFF
--- a/src/Raven.Server/Documents/CdcSink/Schema/PostgresCdcSinkSchemaDiscovery.cs
+++ b/src/Raven.Server/Documents/CdcSink/Schema/PostgresCdcSinkSchemaDiscovery.cs
@@ -22,8 +22,9 @@ namespace Raven.Server.Documents.CdcSink.Schema
             var columnLookup = new Dictionary<(string Schema, string Table, string Column), CdcSinkSourceColumn>();
 
             await using (var cmd = new NpgsqlCommand(queries.SelectColumnsQuery, conn))
-            await using (var reader = await cmd.ExecuteReaderAsync(ct))
             {
+                queries.AddSchemaParameter(cmd, conn);
+                await using var reader = await cmd.ExecuteReaderAsync(ct);
                 while (await reader.ReadAsync(ct))
                 {
                     var schemaName = reader["TABLE_SCHEMA"].ToString();

--- a/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlSchemaQueries.cs
+++ b/src/Raven.Server/SqlMigration/NpgSQL/NpgSqlSchemaQueries.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,12 +21,31 @@ namespace Raven.Server.SqlMigration.NpgSQL
             " ON C.TABLE_CATALOG = T.TABLE_CATALOG AND C.TABLE_SCHEMA = T.TABLE_SCHEMA AND C.TABLE_NAME = T.TABLE_NAME " +
             " WHERE T.TABLE_TYPE <> 'VIEW' AND T.TABLE_SCHEMA IN ({0})";
 
+        private readonly string[] _schemas;
+
         public NpgSqlSchemaQueries(string[] schemas)
         {
-            const string defaultSchema = "'public'";
-            var schemasString = schemas == null || schemas.Length == 0 ? defaultSchema : string.Join(',', schemas.Select(x => $"'{x}'"));
+            // Bind the schema filter as @s0, @s1, ... parameters (defense-in-depth against injection);
+            // AddSchemaParameter supplies the values. Default to "public" when no schemas are requested.
+            _schemas = schemas is { Length: > 0 } ? schemas : new[] { "public" };
+            var placeholders = string.Join(", ", _schemas.Select((_, i) => $"@s{i}"));
+            SelectColumnsQuery = string.Format(SelectColumnsTemplate, placeholders);
+        }
 
-            SelectColumnsQuery = string.Format(SelectColumnsTemplate, schemasString);
+        protected internal override void AddSchemaParameter(DbCommand cmd, DbConnection connection)
+        {
+            // Only SelectColumnsQuery carries the @s0.. schema filter; the other queries scan across
+            // schemas (constrained by their join predicates / reader), so don't bind unused parameters.
+            if (cmd.CommandText != SelectColumnsQuery)
+                return;
+
+            for (var i = 0; i < _schemas.Length; i++)
+            {
+                var p = cmd.CreateParameter();
+                p.ParameterName = $"s{i}";
+                p.Value = _schemas[i];
+                cmd.Parameters.Add(p);
+            }
         }
 
         public override string SelectColumnsQuery { get; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26742/CDC-SqlMigration-parameterize-NpgSqlSchemaQueries-schema-filter-instead-of-interpolating-schema-names-into-SQL

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
