### PR TITLE
RavenDB-26721 - Fix `NullReferenceException` in encrypted streaming queries when the read transaction is disposed during an in-flight `VoronStream` read

### DIFF
--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -11,28 +11,35 @@ namespace Raven.Server.Indexing;
 
 public sealed class LuceneVoronStream : VoronStream
 {
-    // A single, reusable handler shared across every transaction this stream is bound to.
-    // It captures only 'this' (so it can write the Llt field) and crucially does NOT capture any
-    // LowLevelTransaction - otherwise it would pin the disposed transaction and reintroduce the
-    // retention that RavenDB-26186 set out to remove. The transaction to compare against comes from
-    // the OnDispose argument instead.
+    // A single, reusable handler shared across every transaction this stream is bound to (used for both
+    // += and -=, so detaching removes the exact same delegate instance). It is bound to the
+    // CleanupTransaction method rather than a lambda on purpose: a method cannot capture enclosing locals,
+    // so it is impossible to accidentally capture - and thereby pin - a LowLevelTransaction here and
+    // reintroduce the retention that RavenDB-26186 set out to remove.
     private readonly Action<IPagerLevelTransactionState> _cleanupHandler;
 
     public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt) : base(name, chunksDetails, llt)
     {
-        // LowLevelTransaction.Dispose() invokes OnDispose with itself as the argument, so the handler
-        // receives the exact transaction being disposed. The compare-exchange nulls Llt only when it still
-        // points to that transaction, which makes a stale handler (one whose transaction was already replaced
-        // by UpdateCurrentTransaction) a safe no-op, and is race-safe against a concurrent in-flight read.
-        //
-        // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive the
-        // transaction that created them. Nulling Llt on dispose lets the GC collect the disposed
-        // LowLevelTransaction and its associated structures (page positions, journal references, etc.),
-        // which can be substantial depending on the indexing batch size.
-        // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
-        _cleanupHandler = txBeingDisposed => Interlocked.CompareExchange(ref Llt, null, (LowLevelTransaction)txBeingDisposed);
+        _cleanupHandler = CleanupTransaction;
 
         Llt.Transaction.LowLevelTransaction.OnDispose += _cleanupHandler;
+    }
+
+    // Nulls Llt when the transaction it currently points at is disposed. LowLevelTransaction.Dispose() invokes
+    // OnDispose with itself as the argument, so we receive the exact transaction being disposed; the compare-exchange
+    // nulls Llt only when it still points to that transaction. That makes a stale handler (one whose transaction was
+    // already replaced by UpdateCurrentTransaction) a safe no-op, and is race-safe against a concurrent in-flight read.
+    //
+    // Why null Llt at all: Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive the
+    // transaction that created them. Nulling Llt on dispose lets the GC collect the disposed LowLevelTransaction and its
+    // associated structures (page positions, journal references, etc.), which can be substantial depending on the
+    // indexing batch size. When the stream is reused, UpdateCurrentTransaction sets a fresh transaction.
+    //
+    // This is a method, not a lambda, so it cannot capture (and thereby pin) a LowLevelTransaction. The transaction to
+    // compare against always comes from the argument, never a captured variable.
+    private void CleanupTransaction(IPagerLevelTransactionState txBeingDisposed)
+    {
+        Interlocked.CompareExchange(ref Llt, null, (LowLevelTransaction)txBeingDisposed);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Voron;
 using Voron.Data;
 using Voron.Data.BTrees;
@@ -10,22 +11,28 @@ namespace Raven.Server.Indexing;
 
 public sealed class LuceneVoronStream : VoronStream
 {
+    // A single, reusable handler shared across every transaction this stream is bound to.
+    // It captures only 'this' (so it can write the Llt field) and crucially does NOT capture any
+    // LowLevelTransaction - otherwise it would pin the disposed transaction and reintroduce the
+    // retention that RavenDB-26186 set out to remove. The transaction to compare against comes from
+    // the OnDispose argument instead.
+    private readonly Action<IPagerLevelTransactionState> _cleanupHandler;
+
     public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt) : base(name, chunksDetails, llt)
     {
-        RegisterTransactionCleanup();
-    }
+        // LowLevelTransaction.Dispose() invokes OnDispose with itself as the argument, so the handler
+        // receives the exact transaction being disposed. The compare-exchange nulls Llt only when it still
+        // points to that transaction, which makes a stale handler (one whose transaction was already replaced
+        // by UpdateCurrentTransaction) a safe no-op, and is race-safe against a concurrent in-flight read.
+        //
+        // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive the
+        // transaction that created them. Nulling Llt on dispose lets the GC collect the disposed
+        // LowLevelTransaction and its associated structures (page positions, journal references, etc.),
+        // which can be substantial depending on the indexing batch size.
+        // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
+        _cleanupHandler = txBeingDisposed => Interlocked.CompareExchange(ref Llt, null, (LowLevelTransaction)txBeingDisposed);
 
-    private void RegisterTransactionCleanup()
-    {
-        Llt.Transaction.LowLevelTransaction.OnDispose += _ =>
-        {
-            // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive
-            // the transaction that created them. Nulling _llt here allows the GC to collect the
-            // disposed LowLevelTransaction and its associated structures (page positions, journal
-            // references, etc.), which can be substantial depending on the indexing batch size.
-            // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
-            Llt = null;
-        };
+        Llt.Transaction.LowLevelTransaction.OnDispose += _cleanupHandler;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -33,11 +40,24 @@ public sealed class LuceneVoronStream : VoronStream
     {
         if (tx != null)
         {
-            if (Llt == tx.LowLevelTransaction)
+            var newLlt = tx.LowLevelTransaction;
+            if (Llt == newLlt)
                 return;
 
-            Llt = tx.LowLevelTransaction;
-            RegisterTransactionCleanup();
+            // Detach the handler from the old transaction. This is NOT required for correctness - the
+            // compare-exchange in _cleanupHandler already makes a leftover handler a safe no-op (it only nulls
+            // Llt when Llt still points to the transaction being disposed), and since the handler captures only 'this'
+            // (never a LowLevelTransaction) a leftover handler does not pin the old transaction either.
+            // We detach anyway to keep things tidy: handlers don't pile up on a still-live transaction's
+            // OnDispose list, and a disposed transaction's list doesn't carry a dead no-op handler.
+            // (If the old transaction was already disposed, Llt is null here and there is nothing to detach -
+            // the handler already ran and nulled Llt.)
+            var oldLlt = Llt;
+            if (oldLlt != null)
+                oldLlt.Transaction.LowLevelTransaction.OnDispose -= _cleanupHandler;
+
+            Llt = newLlt;
+            newLlt.Transaction.LowLevelTransaction.OnDispose += _cleanupHandler;
             LastPage = default(Page);
             return;
         }

--- a/test/StressTests/Issues/RavenDB-26721.cs
+++ b/test/StressTests/Issues/RavenDB-26721.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Issues;
+
+public class RavenDB_26721 : RavenTestBase
+{
+    public RavenDB_26721(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Doc
+    {
+        public string Id { get; set; }
+        public string Body { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<Doc>
+    {
+        public Index()
+        {
+            Map = docs => from d in docs select new { d.Body };
+            Index(x => x.Body, FieldIndexing.Search);
+            Store(x => x.Body, FieldStorage.Yes);
+        }
+    }
+
+    private class Projection
+    {
+        public string Body { get; set; }
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Encryption | RavenTestCategory.Indexes)]
+    public async Task Streaming_Projection_Query_On_Encrypted_Db_Aborted_MidStream_Does_Not_Throw()
+    {
+        // Repro for RavenDB-26721: during a streaming projection query over an encrypted database, the index read
+        // transaction could be disposed on one thread while a VoronStream read was still in flight on another thread
+        // (Lucene caches VoronStream instances per-thread via SegmentReader, and the streaming loop can resume its
+        // async continuation on a different thread). The transaction's OnDispose handler nulled LuceneVoronStream.Llt,
+        // and the in-flight read then dereferenced the now-null Llt in VoronStream.UpdateLastPageIfNeeded -> NRE,
+        // which surfaced to the client as a confusing "Invalid JSON" error.
+        //
+        // It only manifests on encrypted databases because the encrypted read path calls Llt.GetPageWithoutCache at
+        // every page boundary (decrypting each page) - that is ~100-1000x slower than the memory-mapped non-encrypted
+        // path, widening the race window enough for the concurrent dispose to land inside an in-flight read.
+
+        var enc = await Encryption.EncryptedServerAsync();
+        var cert = enc.Certificates.ServerCertificateForCommunication.Value;
+
+        using var store = GetDocumentStore(new Options
+        {
+            AdminCertificate = cert,
+            ClientCertificate = cert,
+            ModifyDatabaseName = _ => enc.DatabaseName,
+            ModifyDatabaseRecord = r => r.Encrypted = true,
+            Path = NewDataPath()
+        });
+
+        await new Index().ExecuteAsync(store);
+
+        const int docCount = 50_000;
+        var filler = new string('x', 300);
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < docCount; i++)
+                await bulk.StoreAsync(new Doc { Body = "common " + filler + " " + i });
+        }
+
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(20));
+
+        Exception failure = null;
+        var deadline = DateTime.UtcNow.AddMinutes(3);
+
+        var workers = Enumerable.Range(0, 32).Select(_ => Task.Run(async () =>
+        {
+            while (DateTime.UtcNow < deadline && Volatile.Read(ref failure) == null)
+            {
+                try
+                {
+                    using var session = store.OpenAsyncSession();
+                    var q = session.Advanced.AsyncDocumentQuery<Doc, Index>()
+                        .Search(x => x.Body, "common")
+                        .SelectFields<Projection>();
+
+                    await using var stream = await session.Advanced.StreamAsync(q);
+
+                    int c = 0;
+                    while (await stream.MoveNextAsync())
+                    {
+                        if (++c >= 2000)
+                            break; // read many, then abort (dispose) -> abort the request mid-stream
+                    }
+                }
+                catch (Exception e)
+                {
+                    var msg = e.GetType().Name + ": " + e.Message;
+                    if (msg.Contains("Invalid JSON") || msg.Contains("NullReference"))
+                        Interlocked.CompareExchange(ref failure, e, null);
+
+                    // any other exception (e.g. an expected cancellation/abort of the stream) is ignored on purpose
+                }
+            }
+        })).ToArray();
+
+        await Task.WhenAll(workers);
+
+        Assert.True(failure == null,
+            "Streaming an encrypted projection query and aborting mid-stream must not surface a NullReferenceException " +
+            "(seen by the client as 'Invalid JSON'). Got: " + failure);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26721/Encrypted-streaming-query-NullReferenceException-at-VoronStream.UpdateLastPageIfNeeded-read-transaction-disposed-Llt-nulled

### Additional description

#### Summary
A streaming projection query over an **encrypted** database could fail with a
`NullReferenceException` thrown from `VoronStream.UpdateLastPageIfNeeded`. The client
saw it as a confusing `InvalidOperationException: Invalid JSON. Last N KB of read stream ...`.

The root cause is a transaction-lifetime / thread-safety race in `LuceneVoronStream`:
the index read transaction is disposed on one thread while a `VoronStream` read is still
in flight on another, and the dispose handler nulls `LuceneVoronStream.Llt` out from under
the reader.

#### Why it happens

`LuceneVoronStream` instances are cached **per thread** by Lucene (via `SegmentReader`'s
thread-local `FieldsReader`), so a single stream instance outlives any one transaction and is
rebound to the current query's transaction on each use via `UpdateCurrentTransaction`.

For lifetime cleanup (RavenDB-26186), `RegisterTransactionCleanup` subscribed to the
transaction's `OnDispose` event with a handler that set `Llt = null`, so a disposed
`LowLevelTransaction` (and its substantial associated structures) could be collected while the
cached stream sat idle.

Two problems combined:

1. **Stale handlers accumulated.** Every call to `UpdateCurrentTransaction` registered a new
   `OnDispose` handler but never removed the handler from the previous transaction. Each old
   transaction therefore retained a handler that would null this stream's `Llt` whenever it was
   eventually disposed — even after `Llt` had already moved on to a newer, still-in-use transaction.

2. **The streaming loop can switch threads.** `Index.QueryInternal` does
   `await resultToFill.AddResultAsync(...)` inside the `enumerator.MoveNext()` loop. After the
   await, the continuation can resume on a **different** thread-pool thread. That thread reuses its
   own per-thread cached `LuceneVoronStream`, rebinds it (`UpdateCurrentTransaction`) to the current
   request's transaction, and starts reading — while the previous request's transaction is being
   disposed concurrently on another thread.

When the old transaction is disposed, its still-registered handler executes `Llt = null` (a plain,
unsynchronized write) on the stream that another thread is actively reading through. The reader
then dereferences the now-null `Llt` in `UpdateLastPageIfNeeded` → `NullReferenceException`.

#### Why only on encrypted databases

`VoronStream.UpdateLastPageIfNeeded` takes two very different paths:

- **Non-encrypted:** `LastPage = Llt.GetPage(pageNumber)` — a memory-mapped pointer lookup
  (page-locator cache hit or pointer arithmetic), on the order of nanoseconds.
- **Encrypted:** `Llt.TryReleasePage(old)` + `Llt.GetPageWithoutCache(pageNumber)` — releases the
  previous decrypted buffer and **decrypts the new 4 KB page** (AES), explicitly bypassing the page
  locator cache, on the order of microseconds — roughly 100–1000× slower per page boundary.

Both paths share the bug, but the race window is the time spent inside `ReadEntireBlock` crossing
page boundaries with `Llt` live. The encrypted path is slow enough (and crosses many page
boundaries while decrypting) that the concurrent transaction dispose reliably lands inside an
in-flight read. The non-encrypted path completes so quickly that the window is effectively never
hit (~33k abort cycles produced zero failures; encrypted reproduces within seconds, ~6% of streams
under load).

The `Llt = null` write was introduced by [RavenDB-26186](https://github.com/ravendb/ravendb/pull/22459). Before that, the same race would have
surfaced as an `ObjectDisposedException` from `GetPageWithoutCache` (or, in a narrower window, an
AccessViolation in the decrypt buffer copy). Found while investigating RavenDB-25135; it reproduces
independently of that fix.

#### The fix

`LuceneVoronStream` now uses a single, reusable `OnDispose` handler that is **race-safe** and
**leak-free**:

- The handler nulls `Llt` via `Interlocked.CompareExchange(ref Llt, null, txBeingDisposed)`, where
  `txBeingDisposed` is the transaction passed to the `OnDispose` callback. It nulls `Llt` **only if
  it still points at the transaction actually being disposed**. A stale handler whose transaction
  was already replaced is a safe no-op, and the compare-exchange is safe against a concurrent reader.
- The handler captures **only `this`** — not a `LowLevelTransaction` — so it does not pin the
  disposed transaction. This preserves the memory-reclamation goal of RavenDB-26186 (an earlier
  draft of this fix captured the transaction in the closure and would have reintroduced that
  retention).
- `UpdateCurrentTransaction` detaches the handler (`OnDispose -=`) from the old transaction before
  attaching to the new one. With the compare-exchange in place this is not required for correctness —
  it's a tidy-up so handlers don't pile up on a still-live transaction's `OnDispose` list and a
  disposed transaction's list doesn't carry a dead no-op handler. Because the handler captures only
  `this`, even a leftover handler neither pins the old transaction nor can it clobber a live `Llt`.

#### Tests
- Added `StressTests/Issues/RavenDB_26721.cs`: 32 concurrent clients run streaming projection
  queries against an encrypted index and abort mid-stream for 3 minutes; the test asserts no
  `NullReferenceException` / `Invalid JSON` surfaces. Reproduces reliably on the unpatched code and
  passes with the fix.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
