### PR TITLE
RavenDB-26859 Fail clearly on WriteMode=IoRing with IoRingQueueSize=-1

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using Microsoft.Extensions.Configuration;
 using Raven.Server.Config.Attributes;
 using Raven.Server.Config.Settings;
+using Raven.Server.ServerWide;
 using Sparrow;
 using Sparrow.Platform;
 using Sparrow.Server.Platform;
@@ -176,28 +180,44 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(false)]
         [ConfigurationEntry("Storage.LowPriorityFlushAndSync", ConfigurationEntryScope.ServerWideOnly)]
         public bool LowPriorityFlushAndSync { get; set; }
-
-        [Description("EXPERT: The queue size to use for I/O ring operations, using -1 will disable I/O ring entirely")]
+        
+        [Description("EXPERT: The queue size to use for I/O ring operations. Use -1 to disable I/O ring entirely, which is only honored when Storage.WriteMode=Auto.")]
         [DefaultValue(1024)]
         [ConfigurationEntry("Storage.IoRingQueueSize", ConfigurationEntryScope.ServerWideOnly)]
         public int IoRingQueueSize { get; set; }
-
 
         [Description("EXPERT: The write mode for writing to the data file (Auto/VectoredFileIo,FileIo,IoRing,Mmap).")]
         [DefaultValue(Pal.RvnWriteMode.Auto)]
         [ConfigurationEntry("Storage.WriteMode", ConfigurationEntryScope.ServerWideOnly)]
         public Pal.RvnWriteMode WriteMode { get; set; }
 
-        [Description("Max number of recyclable journals that will be reused. ")]
-        [DefaultValue(32)]
-        [MinValue(0)]
-        [ConfigurationEntry("Storage.MaxNumberOfRecyclableJournals", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        public int MaxNumberOfRecyclableJournals { get; set; }
-
         [Description("Threshold (in KB) for the block device read_ahead_kb alert raised on server startup on Linux. If any block device's read_ahead_kb exceeds this value, a warning alert is raised. Set to null to disable the check.")]
         [DefaultValue(128)]
         [MinValue(0)]
         [ConfigurationEntry("Storage.ReadAheadKbAlertThresholdInKb", ConfigurationEntryScope.ServerWideOnly)]
         public int? ReadAheadKbAlertThreshold { get; set; }
+
+        public override void Initialize(IConfigurationRoot settings, HashSet<string> settingsNames, IConfigurationRoot serverWideSettings, HashSet<string> serverWideSettingsNames, ResourceType type, string resourceName)
+        {
+            base.Initialize(settings, settingsNames, serverWideSettings, serverWideSettingsNames, type, resourceName);
+
+            if (type != ResourceType.Server)
+                return;
+
+            ValidateIoRingConfiguration();
+        }
+
+        private void ValidateIoRingConfiguration()
+        {
+            if (WriteMode == Pal.RvnWriteMode.IoRing && IoRingQueueSize == -1)
+            {
+                var sizeKey = RavenConfiguration.GetKey(x => x.Storage.IoRingQueueSize);
+                var modeKey = RavenConfiguration.GetKey(x => x.Storage.WriteMode);
+                throw new InvalidOperationException(
+                    $"'{modeKey}' is set to '{Pal.RvnWriteMode.IoRing}' but '{sizeKey}' is -1, which disables I/O ring. " +
+                    $"Disabling I/O ring is only supported with '{modeKey}={Pal.RvnWriteMode.Auto}'. " +
+                    $"Either set '{modeKey}={Pal.RvnWriteMode.Auto}' or use a positive '{sizeKey}'.");
+            }
+        }
     }
 }

--- a/test/FastTests/Issues/RavenDB_26859.cs
+++ b/test/FastTests/Issues/RavenDB_26859.cs
@@ -1,0 +1,40 @@
+using System;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_26859 : NoDisposalNeeded
+    {
+        public RavenDB_26859(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Configuration | RavenTestCategory.Voron)]
+        public void DisablingIoRingUnderExplicitIoRingWriteModeFailsClearly()
+        {
+            var configuration = RavenConfiguration.CreateForServer(null);
+            configuration.SetSetting(RavenConfiguration.GetKey(x => x.Storage.WriteMode), "IoRing");
+            configuration.SetSetting(RavenConfiguration.GetKey(x => x.Storage.IoRingQueueSize), "-1");
+
+            var error = Assert.Throws<InvalidOperationException>(() => configuration.Initialize());
+            Assert.Contains("Auto", error.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Configuration | RavenTestCategory.Voron)]
+        [InlineData("IoRing", "1024")]
+        [InlineData("Auto", "-1")]
+        [InlineData("Auto", "0")]
+        [InlineData("FileIo", "-1")]
+        [InlineData("FileIo", "0")]
+        public void ValidIoRingConfigurationInitializes(string writeMode, string queueSize)
+        {
+            var configuration = RavenConfiguration.CreateForServer(null);
+            configuration.SetSetting(RavenConfiguration.GetKey(x => x.Storage.WriteMode), writeMode);
+            configuration.SetSetting(RavenConfiguration.GetKey(x => x.Storage.IoRingQueueSize), queueSize);
+
+            configuration.Initialize();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26859

### Additional description

WriteMode=IoRing combined with IoRingQueueSize=-1 (which disables I/O ring) now throws a clear error at config init pointing to WriteMode=Auto, instead of failing later with the generic PAL "FailCreateIoRing" error. Also clarified the IoRingQueueSize description that -1 only disables I/O ring under WriteMode=Auto.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
