### PR TITLE
RavenDB-26742 - Add test for quote-containing schema name in Postgres CDC schema discovery

### DIFF
--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresSchemaDiscoveryTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresSchemaDiscoveryTests.cs
@@ -120,6 +120,30 @@ namespace SlowTests.Server.Documents.CdcSink
         }
 
         [RavenFact(RavenTestCategory.Sinks, NpgSqlRequired = true)]
+        public async Task SchemaNameWithQuote_IsHandledByTheSchemaFilter()
+        {
+            using var teardown = WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out _, dataSet: null, includeData: false);
+
+            // The schema filter is bound as a query parameter, so a single quote in the
+            // schema name must round-trip instead of breaking the discovery SQL.
+            const string schema = "o'brien";
+
+            ExecuteNpgSql(connectionString, @"
+                CREATE SCHEMA ""o'brien"";
+                CREATE TABLE ""o'brien"".widgets (id SERIAL PRIMARY KEY, name VARCHAR(100));
+                CREATE TABLE public.unrelated (id SERIAL PRIMARY KEY, junk VARCHAR(100));
+            ");
+
+            var discovery = CdcSinkSchemaDiscovery.For("Npgsql");
+            var result = await discovery.DiscoverAsync(connectionString, new[] { schema }, CancellationToken.None);
+
+            var table = Assert.Single(result.Tables);
+            Assert.Equal(schema, table.SourceTableSchema);
+            Assert.Equal("widgets", table.SourceTableName);
+            Assert.Equal(new[] { "id" }, table.PrimaryKeyColumns);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, NpgSqlRequired = true)]
         public async Task GeneratedColumnsAreMarkedNotCapturable()
         {
             using var teardown = WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out _, dataSet: null, includeData: false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26742/CDC-SqlMigration-parameterize-NpgSqlSchemaQueries-schema-filter-instead-of-interpolating-schema-names-into-SQL

### Additional description

Added test for quote-containing schema name in Postgres CDC schema discovery

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
