### PR TITLE
RavenDB-26851 - Fix HubToSink pull replication cleanup

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -670,6 +670,11 @@ namespace Raven.Server.Documents.Replication.Incoming
             _incomingWork = null;
         }
 
+        internal void ReportFailure(Exception exception)
+        {
+            InvokeOnFailed(exception);
+        }
+
         protected virtual void DisposeInternal()
         {
             var releaser = _copiedBuffer.ReleaseBuffer;

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -62,6 +62,7 @@ namespace Raven.Server.Documents.Replication.Incoming
         protected readonly AsyncManualResetEvent _replicationFromAnotherSource;
         protected RavenLogger Logger;
         private DeescalatingWarnToDebugLogger _endOfStreamExceptionLogger;
+        private Exception _reportedFailure;
 
         public long LastDocumentEtag => _lastDocumentEtag;
 
@@ -257,25 +258,29 @@ namespace Raven.Server.Documents.Replication.Incoming
             }
             catch (Exception e)
             {
+                var reportedFailure = Interlocked.Exchange(ref _reportedFailure, null);
+
                 // if we are disposing, do not notify about failure (not relevant)
-                if (_cts.IsCancellationRequested == false)
+                if (_cts.IsCancellationRequested == false || reportedFailure != null)
                 {
+                    var failure = reportedFailure ?? e;
+
                     if (Logger.IsInfoEnabled)
-                        Logger.Info($"Connection error {FromToString}: an exception was thrown during receiving incoming document replication batch.", e);
+                        Logger.Info($"Connection error {FromToString}: an exception was thrown during receiving incoming document replication batch.", failure);
 
                     var stats = _lastStats = new IncomingReplicationStatsAggregator(GetNextReplicationStatsId(), _lastStats);
                     try
                     {
                         AddReplicationPerformance(stats);
                         using (var scope = stats.CreateScope())
-                            scope.AddError(e);
+                            scope.AddError(failure);
                     }
                     finally
                     {
                         stats.Complete();
                     }
                     
-                    InvokeOnFailed(e);
+                    InvokeOnFailed(failure);
                 }
             }
         }
@@ -672,7 +677,13 @@ namespace Raven.Server.Documents.Replication.Incoming
 
         internal void ReportFailure(Exception exception)
         {
-            InvokeOnFailed(exception);
+            if (exception == null)
+                throw new ArgumentNullException(nameof(exception));
+
+            if (Interlocked.CompareExchange(ref _reportedFailure, exception, null) != null)
+                return;
+
+            _cts.SafeCancel(Logger, $"Failed to cancel {nameof(CancellationTokenSource)} while reporting failure for {GetType().Name} ({FromToString})");
         }
 
         protected virtual void DisposeInternal()

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
@@ -33,16 +33,11 @@ namespace Raven.Server.Documents.Replication.Incoming
 
         internal bool MatchesHubToSinkTask(PullReplicationAsSink destination)
         {
-            if (destination == null ||
-                IncomingPullReplicationParams.Mode != PullReplicationMode.HubToSink ||
+            if (IncomingPullReplicationParams.Mode != PullReplicationMode.HubToSink ||
                 destination.Mode != PullReplicationMode.HubToSink)
                 return false;
 
-            if (IncomingPullReplicationParams.TaskId != 0 && destination.TaskId != 0)
-                return IncomingPullReplicationParams.TaskId == destination.TaskId;
-
-            return string.Equals(IncomingPullReplicationParams.Name, destination.HubName, StringComparison.OrdinalIgnoreCase) &&
-                   string.Equals(IncomingPullReplicationParams.SourceDatabaseName, destination.Database, StringComparison.OrdinalIgnoreCase);
+            return IncomingPullReplicationParams.TaskId == destination.TaskId;
         }
 
         protected override DynamicJsonValue GetHeartbeatStatusMessage(DocumentsOperationContext documentsContext, long lastDocumentEtag, string handledMessageType)

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.AsSink.cs
@@ -1,5 +1,6 @@
 using System;
 using Raven.Client.Extensions;
+using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.Util;
 using Raven.Server.Documents.Replication.Outgoing;
@@ -29,6 +30,20 @@ namespace Raven.Server.Documents.Replication.Incoming
         }
 
         protected override bool PreventIncomingSinkDeletions => false;
+
+        internal bool MatchesHubToSinkTask(PullReplicationAsSink destination)
+        {
+            if (destination == null ||
+                IncomingPullReplicationParams.Mode != PullReplicationMode.HubToSink ||
+                destination.Mode != PullReplicationMode.HubToSink)
+                return false;
+
+            if (IncomingPullReplicationParams.TaskId != 0 && destination.TaskId != 0)
+                return IncomingPullReplicationParams.TaskId == destination.TaskId;
+
+            return string.Equals(IncomingPullReplicationParams.Name, destination.HubName, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(IncomingPullReplicationParams.SourceDatabaseName, destination.Database, StringComparison.OrdinalIgnoreCase);
+        }
 
         protected override DynamicJsonValue GetHeartbeatStatusMessage(DocumentsOperationContext documentsContext, long lastDocumentEtag, string handledMessageType)
         {

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -119,7 +119,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         public void Start()
         {
             _longRunningSendingWork =
-                PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => HandleReplicationErrors(Replication), null, ThreadNames.ForOutgoingReplication(OutgoingReplicationThreadName,
+                PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => RunReplicationWithErrorHandling(Replication), null, ThreadNames.ForOutgoingReplication(OutgoingReplicationThreadName,
                     _databaseName, Destination.FromString(), pullReplicationAsHub: false));
         }
 
@@ -691,7 +691,17 @@ namespace Raven.Server.Documents.Replication.Outgoing
             throw new OperationCanceledException("The connection has been closed by the Dispose method");
         }
 
-        protected virtual void HandleReplicationErrors(Action replicationAction)
+        protected void RunReplicationWithErrorHandling(Action replicationAction)
+        {
+            OnReplicationRunStarted();
+            HandleReplicationErrors(replicationAction);
+        }
+
+        protected virtual void OnReplicationRunStarted()
+        {
+        }
+
+        private void HandleReplicationErrors(Action replicationAction)
         {
             try
             {
@@ -902,6 +912,11 @@ namespace Raven.Server.Documents.Replication.Outgoing
             }
 
             _connectionDisposed.Dispose();
+        }
+
+        internal void ReportFailure(Exception exception)
+        {
+            HandleReplicationErrors(() => throw exception);
         }
 
         private void DisposeTcpClient()

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -83,7 +83,6 @@ namespace Raven.Server.Documents.Replication.Outgoing
         public string LastSentChangeVector;
         public string LastAcceptedChangeVector { get; set; }
         public long LastHeartbeatTicks;
-        public ReplicationNode Node => Destination;
         public string DestinationFormatted => $"{Destination.Url}/databases/{Destination.Database}";
 
         public int MissingAttachmentsRetries;
@@ -878,7 +877,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
             _cts.SafeCancel(Logger, $"Failed to cancel {nameof(CancellationTokenSource)} while disposing of {GetType().Name} ({FromToString})");
 
-            _tcpConnectionOptions.Dispose();
+            _tcpConnectionOptions?.Dispose();
             DisposeTcpClient();
 
             _connectionDisposed.Set();

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -72,6 +72,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         protected OutgoingReplicationStatsAggregator _lastStats;
         protected RavenLogger Logger;
         private DeescalatingWarnToDebugLogger _endOfStreamExceptionLogger;
+        private Exception _reportedFailure;
 
         public ServerStore Server => _server;
         public long LastSentDocumentEtag => _lastSentDocumentEtag;
@@ -691,14 +692,9 @@ namespace Raven.Server.Documents.Replication.Outgoing
             throw new OperationCanceledException("The connection has been closed by the Dispose method");
         }
 
-        protected void RunReplicationWithErrorHandling(Action replicationAction)
+        protected virtual void RunReplicationWithErrorHandling(Action replicationAction)
         {
-            OnReplicationRunStarted();
             HandleReplicationErrors(replicationAction);
-        }
-
-        protected virtual void OnReplicationRunStarted()
-        {
         }
 
         private void HandleReplicationErrors(Action replicationAction)
@@ -759,6 +755,13 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
             void HandleOperationCancelException(OperationCanceledException e)
             {
+                var reportedFailure = Interlocked.Exchange(ref _reportedFailure, null);
+                if (reportedFailure != null)
+                {
+                    OnFailed(reportedFailure);
+                    return;
+                }
+
                 if (Logger.IsDebugEnabled)
                     Logger.Debug($"Operation canceled on replication thread ({FromToString}). " +
                                 $"This is not necessarily due to an issue. Stopped the thread.");
@@ -887,7 +890,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
             _cts.SafeCancel(Logger, $"Failed to cancel {nameof(CancellationTokenSource)} while disposing of {GetType().Name} ({FromToString})");
 
-            _tcpConnectionOptions?.Dispose();
+            _tcpConnectionOptions.Dispose();
             DisposeTcpClient();
 
             _connectionDisposed.Set();
@@ -916,7 +919,13 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
         internal void ReportFailure(Exception exception)
         {
-            HandleReplicationErrors(() => throw exception);
+            if (exception == null)
+                throw new ArgumentNullException(nameof(exception));
+
+            if (Interlocked.CompareExchange(ref _reportedFailure, exception, null) != null)
+                return;
+
+            _cts.SafeCancel(Logger, $"Failed to cancel {nameof(CancellationTokenSource)} while reporting failure for {GetType().Name} ({FromToString})");
         }
 
         private void DisposeTcpClient()

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -161,9 +161,10 @@ namespace Raven.Server.Documents.Replication.Outgoing
             }
         }
 
-        protected override void OnReplicationRunStarted()
+        protected override void RunReplicationWithErrorHandling(Action replicationAction)
         {
             _parent.ForTestingPurposes?.OnOutgoingReplicationStart?.Invoke(this);
+            base.RunReplicationWithErrorHandling(replicationAction);
         }
 
         public long NextReplicateTicks;

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -47,21 +47,31 @@ namespace Raven.Server.Documents.Replication.Outgoing
         public event Action<DatabaseOutgoingReplicationHandler> DocumentsSend;
 
         protected DatabaseOutgoingReplicationHandler(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo)
-        : base(connectionInfo, parent._server, database.Name, database.NotificationCenter, node, database.DocumentsStorage.ContextPool, database.DatabaseShutdown)
+            : this(parent, database, node, connectionInfo, CreateTcpConnectionOptions(database))
+        {
+        }
+
+        protected DatabaseOutgoingReplicationHandler(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo, TcpConnectionOptions tcpConnectionOptions)
+            : base(connectionInfo, parent._server, database.Name, database.NotificationCenter, node, database.DocumentsStorage.ContextPool, database.DatabaseShutdown)
         {
             _parent = parent;
             _database = database;
             _waitForChanges = new AsyncManualResetEvent(database.DatabaseShutdown);
             _replicationMinimalHeartbeatInMs = (int)database.Configuration.Replication.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
-            _tcpConnectionOptions = new TcpConnectionOptions
-            {
-                DocumentDatabase = database,
-                Operation = TcpConnectionHeaderMessage.OperationTypes.Replication
-            };
+            _tcpConnectionOptions = tcpConnectionOptions;
 
             _database.Changes.OnDocumentChange += OnDocumentChange;
             _database.Changes.OnCounterChange += OnCounterChange;
             _database.Changes.OnTimeSeriesChange += OnTimeSeriesChange;
+        }
+
+        private static TcpConnectionOptions CreateTcpConnectionOptions(DocumentDatabase database)
+        {
+            return new TcpConnectionOptions
+            {
+                DocumentDatabase = database,
+                Operation = TcpConnectionHeaderMessage.OperationTypes.Replication
+            };
         }
 
         public override int GetHashCode()

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -161,10 +161,9 @@ namespace Raven.Server.Documents.Replication.Outgoing
             }
         }
 
-        protected override void HandleReplicationErrors(Action replicationAction)
+        protected override void OnReplicationRunStarted()
         {
             _parent.ForTestingPurposes?.OnOutgoingReplicationStart?.Invoke(this);
-            base.HandleReplicationErrors(replicationAction);
         }
 
         public long NextReplicateTicks;

--- a/src/Raven.Server/Documents/Replication/Outgoing/IAbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/IAbstractOutgoingReplicationHandler.cs
@@ -5,7 +5,6 @@ namespace Raven.Server.Documents.Replication.Outgoing
 {
     public interface IAbstractOutgoingReplicationHandler : IDisposable, IReportOutgoingReplicationPerformance
     {
-        public ReplicationNode Node { get; }
         public long LastSentDocumentEtag { get; }
         public string LastAcceptedChangeVector { get; set; }
         public ReplicationNode Destination { get; }

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Replication;
@@ -46,6 +45,11 @@ namespace Raven.Server.Documents.Replication.Outgoing
         {
         }
 
+        protected OutgoingPullReplicationHandler(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo, TcpConnectionOptions tcpConnectionOptions) :
+            base(parent, database, node, connectionInfo, tcpConnectionOptions)
+        {
+        }
+
         public override ReplicationDocumentSenderBase CreateDocumentSender(Stream stream, RavenLogger logger)
         {
             return new FilteredReplicationDocumentSender(stream, this, logger, PathsToSend, _destinationAcceptablePaths);
@@ -82,25 +86,19 @@ namespace Raven.Server.Documents.Replication.Outgoing
         // we need to associate this instance to the replication definition.
         public string PullReplicationDefinitionName;
 
-        /// <summary>
-        /// The replication scope that should be disposed when the replication is done.
-        /// </summary>
-        private IDisposable _replicationScope;
-
-        public OutgoingPullReplicationHandlerAsHub(ReplicationLoader parent, DocumentDatabase database, PullReplicationAsHub node, TcpConnectionInfo connectionInfo) : 
-            base(parent, database, node, connectionInfo)
-        {
-        }
-
-        public void StartPullReplicationAsHub(IDisposable replicationScope, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures supportedVersions)
+        public OutgoingPullReplicationHandlerAsHub(ReplicationLoader parent, DocumentDatabase database, PullReplicationAsHub node, TcpConnectionInfo connectionInfo, TcpConnectionOptions tcpConnectionOptions,
+            TcpConnectionHeaderMessage.SupportedFeatures supportedVersions) :
+            base(parent, database, node, connectionInfo, tcpConnectionOptions)
         {
             SupportedFeatures = supportedVersions;
-            _stream = stream;
-            _replicationScope = replicationScope;
-            if (replicationScope is TcpConnectionOptions tcpConnectionOptions)
-                _tcpConnectionOptions = tcpConnectionOptions;
+            _stream = tcpConnectionOptions.Stream;
+            _tcpConnectionOptions = tcpConnectionOptions;
 
             OutgoingReplicationThreadName = $"Pull replication as hub {FromToString}";
+        }
+
+        public void StartPullReplicationAsHub()
+        {
             _longRunningSendingWork =
                 PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => HandleReplicationErrors(PullReplication), null, ThreadNames.ForOutgoingReplication(OutgoingReplicationThreadName,
                     _database.Name, Destination.FromString(), pullReplicationAsHub: true));
@@ -114,7 +112,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
             if (Logger.IsInfoEnabled)
                 Logger.Info($"Start pull replication as hub {FromToString}");
 
-            using (_replicationScope)
+            using (_tcpConnectionOptions)
             using (_stream)
             using (_interruptibleRead = new InterruptibleRead<DocumentsContextPool, DocumentsOperationContext>(_parent.ContextPool, _stream))
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -92,7 +92,6 @@ namespace Raven.Server.Documents.Replication.Outgoing
         {
             SupportedFeatures = supportedVersions;
             _stream = tcpConnectionOptions.Stream;
-            _tcpConnectionOptions = tcpConnectionOptions;
 
             OutgoingReplicationThreadName = $"Pull replication as hub {FromToString}";
         }

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -100,7 +100,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         public void StartPullReplicationAsHub()
         {
             _longRunningSendingWork =
-                PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => HandleReplicationErrors(PullReplication), null, ThreadNames.ForOutgoingReplication(OutgoingReplicationThreadName,
+                PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => RunReplicationWithErrorHandling(PullReplication), null, ThreadNames.ForOutgoingReplication(OutgoingReplicationThreadName,
                     _database.Name, Destination.FromString(), pullReplicationAsHub: true));
         }
 

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -10,6 +10,7 @@ using Raven.Client.Util;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Replication.Senders;
 using Raven.Server.Documents.Replication.Stats;
+using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -96,6 +97,9 @@ namespace Raven.Server.Documents.Replication.Outgoing
             SupportedFeatures = supportedVersions;
             _stream = stream;
             _replicationScope = replicationScope;
+            if (replicationScope is TcpConnectionOptions tcpConnectionOptions)
+                _tcpConnectionOptions = tcpConnectionOptions;
+
             OutgoingReplicationThreadName = $"Pull replication as hub {FromToString}";
             _longRunningSendingWork =
                 PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => HandleReplicationErrors(PullReplication), null, ThreadNames.ForOutgoingReplication(OutgoingReplicationThreadName,

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -919,8 +919,6 @@ namespace Raven.Server.Documents.Replication
                         _logger.Warn($"Failed to reset outgoing pull replication to {repl.DestinationFormatted} after pull replication composite change-vector support changed.", e);
                 }
             }
-
-            ForceTryReconnectAll();
         }
 
         private static bool SupportsPullReplicationCompositeChangeVectors(DatabaseRecord record)

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -906,7 +906,7 @@ namespace Raven.Server.Documents.Replication
                             .OfType<PullReplicationAsSink>()
                             .FirstOrDefault(x => x.Disabled == false &&
                                                  x.Mode == PullReplicationMode.HubToSink &&
-                                                 IsSameHubToSinkPullReplicationTask(pullAsSink, x));
+                                                 pullAsSink.MatchesHubToSinkTask(x));
                         if (destination != null)
                         {
                             incomingPullReplicationAsSinkToReconnect ??= new List<PullReplicationAsSink>();
@@ -1235,25 +1235,10 @@ namespace Raven.Server.Documents.Replication
             if (incoming is IncomingPullReplicationHandlerAsSink pullAsSink &&
                 connectionToRemove is PullReplicationAsSink pullReplicationAsSink)
             {
-                return IsSameHubToSinkPullReplicationTask(pullAsSink, pullReplicationAsSink);
+                return pullAsSink.MatchesHubToSinkTask(pullReplicationAsSink);
             }
 
             return connectionToRemove.Url == incoming.ConnectionInfo.SourceUrl;
-        }
-
-        private static bool IsSameHubToSinkPullReplicationTask(IncomingPullReplicationHandlerAsSink incoming, PullReplicationAsSink destination)
-        {
-            var incomingParams = incoming.IncomingPullReplicationParams;
-            if (destination == null ||
-                incomingParams.Mode != PullReplicationMode.HubToSink ||
-                destination.Mode != PullReplicationMode.HubToSink)
-                return false;
-
-            if (incomingParams.TaskId != 0 && destination.TaskId != 0)
-                return incomingParams.TaskId == destination.TaskId;
-
-            return string.Equals(incomingParams.Name, destination.HubName, StringComparison.OrdinalIgnoreCase) &&
-                   string.Equals(incomingParams.SourceDatabaseName, destination.Database, StringComparison.OrdinalIgnoreCase);
         }
 
         private void DisposeConnections(List<IDisposable> instancesToDispose)

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -891,6 +891,7 @@ namespace Raven.Server.Documents.Replication
 
             _pullReplicationCompositeChangeVectorsSupported = supportsPullReplicationCompositeChangeVectors;
 
+            List<PullReplicationAsSink> incomingPullReplicationAsSinkToReconnect = null;
             foreach (var (key, repl) in _incoming)
             {
                 if (repl is IncomingPullReplicationHandler == false)
@@ -900,6 +901,20 @@ namespace Raven.Server.Documents.Replication
                 {
                     if (_logger.IsInfoEnabled)
                         _logger.Info($"Resetting {repl.ConnectionInfo} because pull replication composite change-vector support changed. Will be reconnected.");
+                    if (repl is IncomingPullReplicationHandlerAsSink pullAsSink)
+                    {
+                        var destination = _externalDestinations
+                            .OfType<PullReplicationAsSink>()
+                            .FirstOrDefault(x => x.Disabled == false &&
+                                                 x.Mode == PullReplicationMode.HubToSink &&
+                                                 IsSameHubToSinkPullReplicationTask(pullAsSink, x));
+                        if (destination != null)
+                        {
+                            incomingPullReplicationAsSinkToReconnect ??= new List<PullReplicationAsSink>();
+                            incomingPullReplicationAsSinkToReconnect.Add(destination);
+                        }
+                    }
+
                     repl.Dispose();
                     _incoming.TryRemove(key, out _);
                 }
@@ -910,6 +925,9 @@ namespace Raven.Server.Documents.Replication
                 }
             }
 
+            if (incomingPullReplicationAsSinkToReconnect != null && Database.DisableOngoingTasks == false)
+                Task.Run(() => StartOutgoingConnections(incomingPullReplicationAsSinkToReconnect));
+
             var shouldTryReconnect = false;
             foreach (var repl in _outgoing)
             {
@@ -918,8 +936,12 @@ namespace Raven.Server.Documents.Replication
 
                 try
                 {
-                    QueueOutgoingForImmediateReconnect(repl);
-                    shouldTryReconnect = true;
+                    if (repl is OutgoingPullReplicationHandlerAsHub == false)
+                    {
+                        QueueOutgoingForImmediateReconnect(repl);
+                        shouldTryReconnect = true;
+                    }
+
                     repl.Dispose();
                     _outgoing.TryRemove(repl);
                 }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -606,12 +606,6 @@ namespace Raven.Server.Documents.Replication
 
             if (_outgoingFailureInfo.TryRemove(destination, out ConnectionShutdownInfo info))
                 _reconnectQueue.TryRemove(info);
-
-            foreach (var reconnect in _reconnectQueue.ToList())
-            {
-                if (destination.IsEqualTo(reconnect.Node))
-                    _reconnectQueue.TryRemove(reconnect);
-            }
         }
 
         private void RemoveOutgoingHandler(DatabaseOutgoingReplicationHandler instance)
@@ -620,8 +614,8 @@ namespace Raven.Server.Documents.Replication
             instance.SuccessfulTwoWaysCommunication -= OnOutgoingSendingSucceeded;
             instance.SuccessfulReplication -= ResetReplicationFailuresInfo;
 
-            if (_outgoing.TryRemove(instance))
-                OutgoingReplicationRemoved?.Invoke(instance);
+            _outgoing.TryRemove(instance);
+            OutgoingReplicationRemoved?.Invoke(instance);
         }
 
         private void OnAttachmentStreamsReceived(IncomingReplicationHandler source, int attachmentsStreamCount)
@@ -890,32 +884,18 @@ namespace Raven.Server.Documents.Replication
 
             _pullReplicationCompositeChangeVectorsSupported = supportsPullReplicationCompositeChangeVectors;
 
-            List<PullReplicationAsSink> incomingPullReplicationAsSinkToReconnect = null;
-            foreach (var (key, repl) in _incoming)
+            var resetException = new OperationCanceledException("Pull replication composite change-vector support changed.");
+            foreach (var (_, repl) in _incoming)
             {
-                if (repl is IncomingPullReplicationHandler == false)
+                if (repl is not IncomingPullReplicationHandler incomingPullReplicationHandler)
                     continue;
 
                 try
                 {
                     if (_logger.IsInfoEnabled)
                         _logger.Info($"Resetting {repl.ConnectionInfo} because pull replication composite change-vector support changed. Will be reconnected.");
-                    if (repl is IncomingPullReplicationHandlerAsSink pullAsSink)
-                    {
-                        var destination = _externalDestinations
-                            .OfType<PullReplicationAsSink>()
-                            .FirstOrDefault(x => x.Disabled == false &&
-                                                 x.Mode == PullReplicationMode.HubToSink &&
-                                                 pullAsSink.MatchesHubToSinkTask(x));
-                        if (destination != null)
-                        {
-                            incomingPullReplicationAsSinkToReconnect ??= new List<PullReplicationAsSink>();
-                            incomingPullReplicationAsSinkToReconnect.Add(destination);
-                        }
-                    }
 
-                    repl.Dispose();
-                    _incoming.TryRemove(key, out _);
+                    incomingPullReplicationHandler.ReportFailure(resetException);
                 }
                 catch (Exception e)
                 {
@@ -924,25 +904,14 @@ namespace Raven.Server.Documents.Replication
                 }
             }
 
-            if (incomingPullReplicationAsSinkToReconnect != null && Database.DisableOngoingTasks == false)
-                Task.Run(() => StartOutgoingConnections(incomingPullReplicationAsSinkToReconnect));
-
-            var shouldTryReconnect = false;
             foreach (var repl in _outgoing)
             {
-                if (repl is OutgoingPullReplicationHandler == false)
+                if (repl is not OutgoingPullReplicationHandler outgoingPullReplicationHandler)
                     continue;
 
                 try
                 {
-                    if (repl is OutgoingPullReplicationHandlerAsHub == false)
-                    {
-                        QueueOutgoingForImmediateReconnect(repl);
-                        shouldTryReconnect = true;
-                    }
-
-                    repl.Dispose();
-                    _outgoing.TryRemove(repl);
+                    outgoingPullReplicationHandler.ReportFailure(resetException);
                 }
                 catch (Exception e)
                 {
@@ -951,8 +920,7 @@ namespace Raven.Server.Documents.Replication
                 }
             }
 
-            if (shouldTryReconnect)
-                ForceTryReconnectAll();
+            ForceTryReconnectAll();
         }
 
         private static bool SupportsPullReplicationCompositeChangeVectors(DatabaseRecord record)

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -25,7 +25,6 @@ using Raven.Client.Util;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents.Replication.Incoming;
 using Raven.Server.Documents.Replication.Outgoing;
-using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Extensions;
@@ -571,13 +570,11 @@ namespace Raven.Server.Documents.Replication
                 var newIncoming = CreateIncomingReplicationHandler(tcpConnectionOptions, buffer, incomingPullParams);
                 newIncoming.Failed += RetryPullReplication;
 
-                _outgoing.TryRemove(source); // we are pulling and therefore incoming, upon failure 'RetryPullReplication' will put us back as an outgoing
+                CompletePullReplicationAsSinkHandoff(source, destination, newIncoming);
 
                 PoolOfThreads.PooledThread.ResetCurrentThreadName();
                 Thread.CurrentThread.Name = ThreadNames.GetNameToUse(ThreadNames.ForPullReplicationAsSink($"Pull Replication as Sink from {destination.Database} at {destination.Url}", destination.Database, destination.Url));
 
-                _incoming[newIncoming.ConnectionInfo.SourceDatabaseId] = newIncoming;
-                IncomingReplicationAdded?.Invoke(newIncoming);
                 newIncoming.DoIncomingReplication();
 
                 void RetryPullReplication(IncomingReplicationHandler instance, Exception e)
@@ -598,6 +595,34 @@ namespace Raven.Server.Documents.Replication
                     AddAndStartOutgoingReplication(destination);
                 }
             }
+        }
+
+        private void CompletePullReplicationAsSinkHandoff(DatabaseOutgoingReplicationHandler source, ReplicationNode destination, IncomingReplicationHandler newIncoming)
+        {
+            _incoming[newIncoming.ConnectionInfo.SourceDatabaseId] = newIncoming;
+            IncomingReplicationAdded?.Invoke(newIncoming);
+
+            // we are pulling and therefore incoming, upon failure 'RetryPullReplication' will put us back as an outgoing
+            RemoveOutgoingHandler(source);
+
+            if (_outgoingFailureInfo.TryRemove(destination, out ConnectionShutdownInfo info))
+                _reconnectQueue.TryRemove(info);
+
+            foreach (var reconnect in _reconnectQueue.ToList())
+            {
+                if (destination.IsEqualTo(reconnect.Node))
+                    _reconnectQueue.TryRemove(reconnect);
+            }
+        }
+
+        private void RemoveOutgoingHandler(DatabaseOutgoingReplicationHandler instance)
+        {
+            instance.Failed -= OnOutgoingSendingFailed;
+            instance.SuccessfulTwoWaysCommunication -= OnOutgoingSendingSucceeded;
+            instance.SuccessfulReplication -= ResetReplicationFailuresInfo;
+
+            if (_outgoing.TryRemove(instance))
+                OutgoingReplicationRemoved?.Invoke(instance);
         }
 
         private void OnAttachmentStreamsReceived(IncomingReplicationHandler source, int attachmentsStreamCount)
@@ -1174,7 +1199,7 @@ namespace Raven.Server.Documents.Replication
             foreach (var incoming in _incoming)
             {
                 var instance = incoming.Value as IncomingReplicationHandler;
-                if (toRemove.Any(conn => conn.Url == incoming.Value.ConnectionInfo.SourceUrl))
+                if (toRemove.Any(conn => ShouldDropIncomingConnection(conn, incoming.Value)))
                 {
                     if (_incoming.TryRemove(incoming.Value.ConnectionInfo.SourceDatabaseId, out _))
                         IncomingReplicationRemoved?.Invoke(instance);
@@ -1182,6 +1207,30 @@ namespace Raven.Server.Documents.Replication
                     instancesToDispose.Add(incoming.Value);
                 }
             }
+        }
+
+        private static bool ShouldDropIncomingConnection(ReplicationNode connectionToRemove, IAbstractIncomingReplicationHandler incoming)
+        {
+            if (incoming is IncomingPullReplicationHandlerAsSink pullAsSink &&
+                connectionToRemove is PullReplicationAsSink { Mode: PullReplicationMode.HubToSink } pullReplicationAsSink)
+            {
+                return IsSameHubToSinkPullReplicationTask(pullAsSink, pullReplicationAsSink);
+            }
+
+            return connectionToRemove.Url == incoming.ConnectionInfo.SourceUrl;
+        }
+
+        private static bool IsSameHubToSinkPullReplicationTask(IncomingPullReplicationHandlerAsSink incoming, PullReplicationAsSink destination)
+        {
+            var incomingParams = incoming.IncomingPullReplicationParams;
+            if (incomingParams.Mode != PullReplicationMode.HubToSink)
+                return false;
+
+            if (incomingParams.TaskId != 0 && destination.TaskId != 0)
+                return incomingParams.TaskId == destination.TaskId;
+
+            return string.Equals(incomingParams.Name, destination.HubName, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(incomingParams.SourceDatabaseName, destination.Database, StringComparison.OrdinalIgnoreCase);
         }
 
         private void DisposeConnections(List<IDisposable> instancesToDispose)
@@ -1797,12 +1846,7 @@ namespace Raven.Server.Documents.Replication
         {
             using (instance)
             {
-                instance.Failed -= OnOutgoingSendingFailed;
-                instance.SuccessfulTwoWaysCommunication -= OnOutgoingSendingSucceeded;
-                instance.SuccessfulReplication -= ResetReplicationFailuresInfo;
-
-                _outgoing.TryRemove(instance);
-                OutgoingReplicationRemoved?.Invoke(instance);
+                RemoveOutgoingHandler(instance);
 
                 if (instance is OutgoingPullReplicationHandler)
                     _externalDestinations.Remove(instance.Destination as ExternalReplication);

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -83,7 +83,7 @@ namespace Raven.Server.Documents.Replication
         private readonly ConcurrentDictionary<ReplicationNode, LastEtagPerDestination> _lastSendEtagPerDestination = new ConcurrentDictionary<ReplicationNode, LastEtagPerDestination>();
         private bool _pullReplicationCompositeChangeVectorsSupported;
 
-        public IEnumerable<ReplicationNode> OutgoingConnections => _outgoing.Select(x => x.Node);
+        public IEnumerable<ReplicationNode> OutgoingConnections => _outgoing.Select(x => x.Destination);
         public IEnumerable<DatabaseOutgoingReplicationHandler> OutgoingHandlers => _outgoing;
         public IEnumerable<ReplicationNode> ReconnectQueue => _reconnectQueue.Select(x => x.Node);
         public IReadOnlyDictionary<ReplicationNode, ConnectionShutdownInfo> OutgoingFailureInfo => _outgoingFailureInfo;
@@ -400,9 +400,9 @@ namespace Raven.Server.Documents.Replication
         {
             UpdateLastEtag(replicationHandler);
 
-            var shutdownInfo = _outgoingFailureInfo.GetOrAdd(replicationHandler.Node, new ConnectionShutdownInfo
+            var shutdownInfo = _outgoingFailureInfo.GetOrAdd(replicationHandler.Destination, new ConnectionShutdownInfo
             {
-                Node = replicationHandler.Node,
+                Node = replicationHandler.Destination,
                 MaxConnectionTimeout = Database.Configuration.Replication.RetryMaxTimeout.AsTimeSpan.TotalMilliseconds
             });
             shutdownInfo.Reset();
@@ -509,7 +509,7 @@ namespace Raven.Server.Documents.Replication
             var taskId = pullReplicationDefinition.TaskId; // every connection to this pull replication on the hub will have the same task id.
             var externalReplication = pullReplicationDefinition.ToPullReplicationAsHub(initialRequest, taskId);
 
-            var outgoingReplication = new OutgoingPullReplicationHandlerAsHub(this, Database, externalReplication, initialRequest.Info)
+            var outgoingReplication = new OutgoingPullReplicationHandlerAsHub(this, Database, externalReplication, initialRequest.Info, tcpConnectionOptions, supportedVersions)
             {
                 OutgoingPullReplicationParams = new PullReplicationParams
                 {
@@ -544,8 +544,7 @@ namespace Raven.Server.Documents.Replication
             outgoingReplication.SuccessfulTwoWaysCommunication += OnOutgoingSendingSucceeded;
             outgoingReplication.SuccessfulReplication += ResetReplicationFailuresInfo;
 
-            // tcp ownership - the tcp is passed as a scope of the replication so that it can be properly disposed.
-            outgoingReplication.StartPullReplicationAsHub(tcpConnectionOptions, tcpConnectionOptions.Stream, supportedVersions);
+            outgoingReplication.StartPullReplicationAsHub();
             OutgoingReplicationAdded?.Invoke(outgoingReplication);
         }
 
@@ -1234,7 +1233,7 @@ namespace Raven.Server.Documents.Replication
         private static bool ShouldDropIncomingConnection(ReplicationNode connectionToRemove, IAbstractIncomingReplicationHandler incoming)
         {
             if (incoming is IncomingPullReplicationHandlerAsSink pullAsSink &&
-                connectionToRemove is PullReplicationAsSink { Mode: PullReplicationMode.HubToSink } pullReplicationAsSink)
+                connectionToRemove is PullReplicationAsSink pullReplicationAsSink)
             {
                 return IsSameHubToSinkPullReplicationTask(pullAsSink, pullReplicationAsSink);
             }
@@ -1245,7 +1244,9 @@ namespace Raven.Server.Documents.Replication
         private static bool IsSameHubToSinkPullReplicationTask(IncomingPullReplicationHandlerAsSink incoming, PullReplicationAsSink destination)
         {
             var incomingParams = incoming.IncomingPullReplicationParams;
-            if (incomingParams.Mode != PullReplicationMode.HubToSink)
+            if (destination == null ||
+                incomingParams.Mode != PullReplicationMode.HubToSink ||
+                destination.Mode != PullReplicationMode.HubToSink)
                 return false;
 
             if (incomingParams.TaskId != 0 && destination.TaskId != 0)
@@ -1873,7 +1874,7 @@ namespace Raven.Server.Documents.Replication
                 if (instance is OutgoingPullReplicationHandler)
                     _externalDestinations.Remove(instance.Destination as ExternalReplication);
 
-                if (_outgoingFailureInfo.TryGetValue(instance.Node, out ConnectionShutdownInfo failureInfo) == false)
+                if (_outgoingFailureInfo.TryGetValue(instance.Destination, out ConnectionShutdownInfo failureInfo) == false)
                     return;
 
                 UpdateLastEtag(instance);
@@ -1883,7 +1884,7 @@ namespace Raven.Server.Documents.Replication
                 failureInfo.LastHeartbeatTicks = instance.LastHeartbeatTicks;
 
                 if (_logger.IsDebugEnabled)
-                    _logger.Debug($"Document replication connection ({instance.Node}) failed {failureInfo.RetriesCount} times, the connection will be retried on {failureInfo.RetryOn}.", e);
+                    _logger.Debug($"Document replication connection ({instance.Destination}) failed {failureInfo.RetriesCount} times, the connection will be retried on {failureInfo.RetryOn}.", e);
 
                 _reconnectQueue.Add(failureInfo);
             }
@@ -1892,7 +1893,7 @@ namespace Raven.Server.Documents.Replication
         private void UpdateLastEtag(DatabaseOutgoingReplicationHandler instance)
         {
             var etagPerDestination = _lastSendEtagPerDestination.GetOrAdd(
-                instance.Node,
+                instance.Destination,
                 _ => new LastEtagPerDestination());
 
             if (etagPerDestination.LastEtag == instance._lastSentDocumentEtag)
@@ -1913,7 +1914,7 @@ namespace Raven.Server.Documents.Replication
 
         private void ResetReplicationFailuresInfo(DatabaseOutgoingReplicationHandler instance)
         {
-            if (_outgoingFailureInfo.TryGetValue(instance.Node, out ConnectionShutdownInfo failureInfo))
+            if (_outgoingFailureInfo.TryGetValue(instance.Destination, out ConnectionShutdownInfo failureInfo))
                 failureInfo.Reset();
         }
 

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -209,7 +209,7 @@ namespace Raven.Server.Documents.Replication.Senders
 
                         var msg = $"Found {_orderedReplicaItems.Count:#,#;;0} documents " +
                                   $"and {_replicaAttachmentStreams.Count} attachment's streams " +
-                                  $"to replicate to {_parent.Node.FromString()}, ";
+                                  $"to replicate to {_parent.Destination.FromString()}, ";
 
                         var encryptionSize = documentsContext.Transaction.InnerTransaction.LowLevelTransaction.AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes);
                         if (encryptionSize > 0)
@@ -336,7 +336,7 @@ namespace Raven.Server.Documents.Replication.Senders
             if (item.Type == ReplicationBatchItem.ReplicationItemType.TimeSeriesSegment || item.Type == ReplicationBatchItem.ReplicationItemType.DeletedTimeSeriesRange)
             {
                 // the other side doesn't support TimeSeries, stopping replication
-                var message = $"{_parent.Node.FromString()} found an item of type 'TimeSeries' to replicate to {_parent.Destination.FromString()}, " +
+                var message = $"Replication '{_parent.FromToString}' found an item of type 'TimeSeries', " +
                               $"while we are in legacy mode (downgraded our replication version to match the destination). " +
                               $"Can't send TimeSeries in legacy mode, destination {_parent.Destination.FromString()} does not support TimeSeries feature. Stopping replication. {item}";
 
@@ -353,8 +353,7 @@ namespace Raven.Server.Documents.Replication.Senders
             {
                 // the other side doesn't support counters, stopping replication
                 var message =
-                    $"{_parent.Node.FromString()} found an item of type `{nameof(ReplicationBatchItem.ReplicationItemType.CounterGroup)}` " +
-                    $"to replicate to {_parent.Destination.FromString()}, " +
+                    $"Replication '{_parent.FromToString}' found an item of type `{nameof(ReplicationBatchItem.ReplicationItemType.CounterGroup)}`, " +
                     "while we are in legacy mode (downgraded our replication version to match the destination). " +
                     $"Can't send Counters in legacy mode, destination {_parent.Destination.FromString()} ";
 
@@ -378,7 +377,7 @@ namespace Raven.Server.Documents.Replication.Senders
                 doc.Flags.HasFlag(DocumentFlags.FromClusterTransaction))
             {
                 // the other side doesn't support cluster transactions, stopping replication
-                var message = $"{_parent.Node.FromString()} found a document {doc.Id} with flag `FromClusterTransaction` to replicate to {_parent.Destination.FromString()}, " +
+                var message = $"Replication '{_parent.FromToString}' found a document {doc.Id} with flag `FromClusterTransaction`, " +
                               "while we are in legacy mode (downgraded our replication version to match the destination). " +
                               $"Can't use Cluster Transactions legacy mode, destination {_parent.Destination.FromString()} does not support this feature. " +
                               "Stopping replication.";
@@ -414,7 +413,7 @@ namespace Raven.Server.Documents.Replication.Senders
                 }
 
                 // the other side doesn't support incremental time series, stopping replication
-                var message = $"{_parent.Node.FromString()} found an item of type 'IncrementalTimeSeries' to replicate to {_parent.Destination.FromString()}, " +
+                var message = $"Replication '{_parent.FromToString}' found an item of type 'IncrementalTimeSeries', " +
                               $"while we are in legacy mode (downgraded our replication version to match the destination). " +
                               $"Can't send Incremental-TimeSeries in legacy mode, destination {_parent.Destination.FromString()} does not support Incremental-TimeSeries feature. Stopping replication.";
 

--- a/test/SlowTests.Issues/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests.Issues/Issues/FilteredReplicationTests.cs
@@ -18,6 +18,7 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.TimeSeries;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server.Config;
@@ -28,6 +29,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
+using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -845,6 +847,212 @@ namespace SlowTests.Issues
             await sinkStore1.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(sinkTask));
 
             EnsureReplicating(sinkStore1, hubStore);
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        public async Task HubToSinkShouldUseUpdatedSinkPathFilter()
+        {
+            const int timeout = 30_000;
+            const int filteredTimeout = 3_000;
+
+            var certificates = Certificates.SetupServerAuthentication();
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
+                .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            using var hubStore = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+            });
+            using var sinkStore = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+            });
+
+#pragma warning disable SYSLIB0057
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
+                X509KeyStorageFlags.Exportable);
+#pragma warning restore SYSLIB0057
+
+            const string hubName = "filtered-hub-to-sink";
+            var connectionStringName = hubStore.Database + "ConStr";
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = hubName,
+                Mode = PullReplicationMode.HubToSink,
+                WithFiltering = true
+            }));
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation(hubName, new ReplicationHubAccess
+            {
+                Name = "Sink",
+                AllowedHubToSinkPaths = new[] { "*" },
+                CertificateBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert)),
+            }));
+
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = hubStore.Database,
+                Name = connectionStringName,
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+
+            var sinkTask = new PullReplicationAsSink
+            {
+                ConnectionStringName = connectionStringName,
+                Mode = PullReplicationMode.HubToSink,
+                CertificateWithPrivateKey = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx)),
+                HubName = hubName,
+                AllowedHubToSinkPaths = new[] { "items/blue/*" }
+            };
+
+            var sinkTaskResult = await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(sinkTask));
+
+            await StoreOnHub("items/blue/before-update");
+            await StoreOnHub("items/red/before-update");
+
+            Assert.True(WaitForDocument(sinkStore, "items/blue/before-update", timeout), sinkStore.Identifier);
+            Assert.False(WaitForDocument(sinkStore, "items/red/before-update", filteredTimeout), sinkStore.Identifier);
+
+            sinkTask.TaskId = sinkTaskResult.TaskId;
+            sinkTask.AllowedHubToSinkPaths = new[] { "items/red/*" };
+
+            var updateResult = await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(sinkTask));
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                await sinkStore.GetRequestExecutor().ExecuteAsync(new WaitForRaftIndexCommand(updateResult.RaftCommandIndex), context);
+            }
+
+            await StoreOnHubUntilReplicated("items/red/after-update");
+
+            await StoreOnHub("items/blue/after-update");
+            Assert.False(WaitForDocument(sinkStore, "items/blue/after-update", filteredTimeout), sinkStore.Identifier);
+
+            async Task StoreOnHubUntilReplicated(string idPrefix)
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    var id = $"{idPrefix}-{i}";
+                    await StoreOnHub(id);
+
+                    if (WaitForDocument(sinkStore, id, filteredTimeout))
+                        return;
+                }
+
+                Assert.Fail($"Expected a document under '{idPrefix}' to replicate after updating the HubToSink path filter.");
+            }
+
+            async Task StoreOnHub(string id)
+            {
+                using var session = hubStore.OpenAsyncSession();
+                await session.StoreAsync(new User { Name = id }, id);
+                await session.SaveChangesAsync();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        public async Task SinkToHubShouldUseUpdatedSinkPathFilter()
+        {
+            const int timeout = 30_000;
+            const int filteredTimeout = 3_000;
+
+            var certificates = Certificates.SetupServerAuthentication();
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
+                .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            using var hubStore = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+            });
+            using var sinkStore = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+            });
+
+#pragma warning disable SYSLIB0057
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
+                X509KeyStorageFlags.Exportable);
+#pragma warning restore SYSLIB0057
+
+            const string hubName = "filtered-sink-to-hub";
+            var connectionStringName = hubStore.Database + "ConStr";
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = hubName,
+                Mode = PullReplicationMode.SinkToHub,
+                WithFiltering = true
+            }));
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation(hubName, new ReplicationHubAccess
+            {
+                Name = "Sink",
+                AllowedSinkToHubPaths = new[] { "*" },
+                CertificateBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert)),
+            }));
+
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = hubStore.Database,
+                Name = connectionStringName,
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+
+            var sinkTask = new PullReplicationAsSink
+            {
+                ConnectionStringName = connectionStringName,
+                Mode = PullReplicationMode.SinkToHub,
+                CertificateWithPrivateKey = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx)),
+                HubName = hubName,
+                AllowedSinkToHubPaths = new[] { "items/blue/*" }
+            };
+
+            var sinkTaskResult = await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(sinkTask));
+
+            await StoreOnSink("items/blue/before-update");
+            await StoreOnSink("items/red/before-update");
+
+            Assert.True(WaitForDocument(hubStore, "items/blue/before-update", timeout), hubStore.Identifier);
+            Assert.False(WaitForDocument(hubStore, "items/red/before-update", filteredTimeout), hubStore.Identifier);
+
+            sinkTask.TaskId = sinkTaskResult.TaskId;
+            sinkTask.AllowedSinkToHubPaths = new[] { "items/red/*" };
+
+            var updateResult = await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(sinkTask));
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                await sinkStore.GetRequestExecutor().ExecuteAsync(new WaitForRaftIndexCommand(updateResult.RaftCommandIndex), context);
+            }
+
+            await StoreOnSinkUntilReplicated("items/red/after-update");
+
+            await StoreOnSink("items/blue/after-update");
+            Assert.False(WaitForDocument(hubStore, "items/blue/after-update", filteredTimeout), hubStore.Identifier);
+
+            async Task StoreOnSinkUntilReplicated(string idPrefix)
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    var id = $"{idPrefix}-{i}";
+                    await StoreOnSink(id);
+
+                    if (WaitForDocument(hubStore, id, filteredTimeout))
+                        return;
+                }
+
+                Assert.Fail($"Expected a document under '{idPrefix}' to replicate after updating the SinkToHub path filter.");
+            }
+
+            async Task StoreOnSink(string id)
+            {
+                using var session = sinkStore.OpenAsyncSession();
+                await session.StoreAsync(new User { Name = id }, id);
+                await session.SaveChangesAsync();
+            }
         }
 
         [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]

--- a/test/SlowTests/Server/Replication/FilteredPullReplicationFailoverTests.cs
+++ b/test/SlowTests/Server/Replication/FilteredPullReplicationFailoverTests.cs
@@ -3911,7 +3911,7 @@ public class FilteredPullReplicationFailoverTests : ReplicationTestBase
 
     private async Task<(string DatabaseId, long LastEtag)> GetDatabaseIdAndLastEtagAsync(IDocumentStore store)
     {
-        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        var database = await GetDocumentDatabaseInstanceFor(store);
         return GetDatabaseIdAndLastEtag(database);
     }
 

--- a/test/SlowTests/Server/Replication/FilteredReplicationTestsPullReplicationCompositeChangeVectors.cs
+++ b/test/SlowTests/Server/Replication/FilteredReplicationTestsPullReplicationCompositeChangeVectors.cs
@@ -568,6 +568,44 @@ public sealed class FilteredReplicationTestsPullReplicationCompositeChangeVector
     }
 
     [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+    public async Task LiveFeatureToggleReopensFilteredPullReplicationWhenSinkSeesFeatureBeforeHub()
+    {
+        var certificates = Certificates.SetupServerAuthentication();
+        using var hub = GetDocumentStore(new Options
+        {
+            ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+            AdminCertificate = certificates.ServerCertificateForCommunication.Value,
+            ModifyDatabaseRecord = StripPullReplicationCompositeChangeVectorsToken
+        });
+        using var sink = GetDocumentStore(new Options
+        {
+            ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+            AdminCertificate = certificates.ServerCertificateForCommunication.Value,
+            ModifyDatabaseRecord = StripPullReplicationCompositeChangeVectorsToken
+        });
+        using var pullCert = ExportCertificate(certificates.ClientCertificate1.Value);
+
+        await SetupFilteredHubToSinkPullReplicationAsync(hub, sink, pullCert);
+
+        await StoreTestItemAsync(hub, "items/include/before-toggle-sink-first", "before-toggle-sink-first");
+        Assert.True(WaitForDocument(sink, "items/include/before-toggle-sink-first", 30_000));
+        Assert.DoesNotContain("|", GetChangeVectorFor(sink, "items/include/before-toggle-sink-first"));
+
+        await SetPullReplicationCompositeChangeVectorsFeatureAsync(sink, enabled: true);
+        await SetPullReplicationCompositeChangeVectorsFeatureAsync(hub, enabled: true);
+
+        var handler = await AssertOutgoingPullHandlerAsHubAsync(
+            hub,
+            FilteredPullName,
+            PullReplicationChangeVectorWireMode.SendAsIs);
+        Assert.False(handler.IsConnectionDisposed);
+
+        await StoreTestItemAsync(hub, "items/include/after-toggle-sink-first", "after-toggle-sink-first");
+        Assert.True(WaitForDocument(sink, "items/include/after-toggle-sink-first", 30_000));
+        Assert.Contains("|", GetChangeVectorFor(sink, "items/include/after-toggle-sink-first"));
+    }
+
+    [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
     public async Task LiveFeatureToggleFallsBackToLegacyLaneWhenFeatureIsDisabled()
     {
         const string pullName = "filtered-toggle-disable";

--- a/test/SlowTests/Server/Replication/PullReplicationFailoverTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationFailoverTests.cs
@@ -3392,7 +3392,7 @@ public class PullReplicationFailoverTests : ReplicationTestBase
 
     private async Task<(string DatabaseId, long LastEtag)> GetDatabaseIdAndLastEtagAsync(IDocumentStore store)
     {
-        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        var database = await GetDocumentDatabaseInstanceFor(store);
         return GetDatabaseIdAndLastEtag(database);
     }
 

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Sharding;
@@ -19,6 +20,7 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server.Config;
 using Raven.Server.Documents.Replication.Incoming;
+using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -33,6 +35,52 @@ namespace SlowTests.Server.Replication
     {
         public PullReplicationTests(ITestOutputHelper output) : base(output)
         {
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task DisposingPullReplicationAsHubBeforeStartShouldNotThrow()
+        {
+            var definitionName = $"pull-replication {GetDatabaseName()}";
+
+            using (var store = GetDocumentStore())
+            {
+                var database = await GetDocumentDatabaseInstanceFor(store);
+                var initialRequest = new ReplicationInitialRequest
+                {
+                    PullReplicationDefinitionName = definitionName,
+                    Database = store.Database,
+                    SourceUrl = store.Urls[0],
+                    Info = new TcpConnectionInfo
+                    {
+                        Url = store.Urls[0],
+                        Urls = store.Urls,
+                        NodeTag = Server.ServerStore.NodeTag
+                    }
+                };
+
+                var pullReplicationDefinition = new PullReplicationDefinition(definitionName)
+                {
+                    Mode = PullReplicationMode.HubToSink,
+                    TaskId = 1
+                };
+
+                var toPullReplicationAsHub = typeof(PullReplicationDefinition).GetMethod("ToPullReplicationAsHub",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                Assert.NotNull(toPullReplicationAsHub);
+                var pullReplicationAsHub = toPullReplicationAsHub.Invoke(pullReplicationDefinition, new object[] { initialRequest, pullReplicationDefinition.TaskId });
+
+                var outgoingPullReplicationHandlerAsHubType = typeof(OutgoingPullReplicationHandler).Assembly.GetType(
+                    "Raven.Server.Documents.Replication.Outgoing.OutgoingPullReplicationHandlerAsHub",
+                    throwOnError: true);
+                var handler = Assert.IsAssignableFrom<IDisposable>(Activator.CreateInstance(
+                    outgoingPullReplicationHandlerAsHubType,
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic,
+                    binder: null,
+                    args: new[] { database.ReplicationLoader, database, pullReplicationAsHub, initialRequest.Info },
+                    culture: null));
+
+                handler.Dispose();
+            }
         }
 
         [RavenTheory(RavenTestCategory.Replication)]
@@ -472,6 +520,264 @@ namespace SlowTests.Server.Replication
         }
 
         [RavenFact(RavenTestCategory.Replication)]
+        public async Task UpdatingHubToSinkPullReplicationInPlaceShouldReplaceIncomingHandler()
+        {
+            DoNotReuseServer();
+
+            var hubPort = GetReservedPort();
+            var hubSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = $"http://127.0.0.1:{hubPort}",
+                [RavenConfiguration.GetKey(x => x.Core.PublicServerUrl)] = $"http://localhost:{hubPort}"
+            };
+
+            var definitionName = $"pull-replication {GetDatabaseName()}";
+            var originalConnectionStringName = $"ConnectionString-{definitionName}-original";
+            var updatedConnectionStringName = $"ConnectionString-{definitionName}-updated";
+            var sinkTaskName = $"Sink task {definitionName}";
+            const int timeout = 10_000;
+
+            using (var sinkServer = GetNewServer())
+            using (var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = hubSettings }))
+            using (var sink = GetDocumentStore(new Options { Server = sinkServer }))
+            using (var hub = GetDocumentStore(new Options { Server = hubServer }))
+            {
+                var sinkDatabase = await GetDatabase(sink.Database, sinkServer);
+                // The sink connects to the hub through the bound URL, but the hub advertises PublicServerUrl
+                // in the handshake. URL-based cleanup cannot treat those strings as the task identity.
+                sinkDatabase.ReplicationLoader.ForTestingPurposesOnly().SelectPullReplicationRemoteUrls = (_, _, _) => hub.Urls;
+
+                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(definitionName)
+                {
+                    Mode = PullReplicationMode.HubToSink
+                }));
+
+                await PutHubConnectionString(originalConnectionStringName);
+                await PutHubConnectionString(updatedConnectionStringName);
+
+                var sinkTask = await sink.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(CreateSinkTask(originalConnectionStringName)));
+
+                using (var session = hub.OpenSession())
+                {
+                    session.Store(new User { Name = "before-update" }, "users/before-update");
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(sink, "users/before-update", u => u.Name == "before-update", timeout), sink.Identifier);
+
+                var originalHandler = WaitForHubToSinkHandler(
+                    "Expected an active IncomingPullReplicationHandlerAsSink before updating the sink task in place.");
+
+                await sink.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(CreateSinkTask(updatedConnectionStringName, sinkTask.TaskId)));
+
+                Assert.True(WaitForValue(() => originalHandler.IsDisposed, true, timeout),
+                    "Updating the HubToSink sink task in place should dispose the previous incoming handler.");
+
+                var replacementHandler = WaitForHubToSinkHandler(
+                    "Expected a replacement IncomingPullReplicationHandlerAsSink after updating the sink task in place.");
+
+                Assert.NotSame(originalHandler, replacementHandler);
+                Assert.False(replacementHandler.IsDisposed);
+
+                using (var session = hub.OpenSession())
+                {
+                    session.Store(new User { Name = "after-update" }, "users/after-update");
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(sink, "users/after-update", u => u.Name == "after-update", timeout), sink.Identifier);
+
+                async Task PutHubConnectionString(string connectionStringName)
+                {
+                    await sink.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                    {
+                        Name = connectionStringName,
+                        Database = hub.Database,
+                        TopologyDiscoveryUrls = hub.Urls
+                    }));
+                }
+
+                PullReplicationAsSink CreateSinkTask(string connectionStringName, long taskId = 0)
+                {
+                    return new PullReplicationAsSink(hub.Database, connectionStringName, definitionName)
+                    {
+                        Name = sinkTaskName,
+                        TaskId = taskId,
+                        Mode = PullReplicationMode.HubToSink
+                    };
+                }
+
+                IncomingPullReplicationHandlerAsSink WaitForHubToSinkHandler(string message)
+                {
+                    IncomingPullReplicationHandlerAsSink handler = null;
+                    Assert.True(WaitForValue(() =>
+                    {
+                        handler = GetIncomingHubToSinkPullHandler(sinkDatabase, sinkTask.TaskId);
+                        return handler != null && handler.IsDisposed == false;
+                    }, true, timeout), message);
+
+                    return handler;
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [PullReplicationMode.SinkToHub])]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [PullReplicationMode.HubToSink])]
+        public async Task UpdatingDualModePullReplicationShouldDropOnlyRemovedLane(Options options, PullReplicationMode remainingMode)
+        {
+            DoNotReuseServer();
+
+            var definitionName = $"pull-replication {GetDatabaseName()}";
+            var connectionStringName = $"ConnectionString-{definitionName}";
+            var sinkTaskName = $"Sink task {definitionName}";
+            const int timeout = 15_000;
+
+            var customSettings = new Dictionary<string, string>();
+            var certificates = Certificates.SetupServerAuthentication(customSettings: customSettings);
+            var serverCertificate = certificates.ServerCertificateForCommunication.Value;
+            var pullReplicationCertificate = certificates.ClientCertificate1.Value;
+            var pullReplicationCertificateWithPrivateKey = Convert.ToBase64String(pullReplicationCertificate.Export(X509ContentType.Pfx));
+
+            using (var server = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings }))
+            using (var sink = GetDocumentStore(new Options(options)
+            {
+                Server = server,
+                ModifyDatabaseName = s => $"Sink_{s}",
+                ClientCertificate = serverCertificate,
+                AdminCertificate = serverCertificate
+            }))
+            using (var hub = GetDocumentStore(new Options(options)
+            {
+                Server = server,
+                ModifyDatabaseName = s => $"Hub_{s}",
+                ClientCertificate = serverCertificate,
+                AdminCertificate = serverCertificate
+            }))
+            {
+                var sinkDatabase = await GetDatabase(sink.Database, server);
+
+                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(definitionName)
+                {
+                    Name = definitionName,
+                    Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink
+                }));
+
+                await hub.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation(definitionName, new ReplicationHubAccess
+                {
+                    Name = definitionName,
+                    CertificateBase64 = Convert.ToBase64String(pullReplicationCertificate.Export(X509ContentType.Cert))
+                }));
+
+                await sink.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Database = hub.Database,
+                    Name = connectionStringName,
+                    TopologyDiscoveryUrls = hub.Urls
+                }));
+
+                var sinkTask = await sink.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(CreateSinkTask(PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub)));
+
+                using (var session = hub.OpenSession())
+                {
+                    session.Store(new User { Name = "hub-before-mode-change" }, "users/hub-before-mode-change");
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(sink, "users/hub-before-mode-change", u => u.Name == "hub-before-mode-change", timeout), sink.Identifier);
+                var originalHubToSinkHandler = WaitForHubToSinkHandler(
+                    "Expected an active HubToSink incoming handler before narrowing the dual-mode sink task.");
+
+                using (var session = sink.OpenSession())
+                {
+                    session.Store(new User { Name = "sink-before-mode-change" }, "users/sink-before-mode-change");
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(hub, "users/sink-before-mode-change", u => u.Name == "sink-before-mode-change", timeout), hub.Identifier);
+                var originalSinkToHubHandler = WaitForSinkToHubHandler(
+                    "Expected an active SinkToHub outgoing handler before narrowing the dual-mode sink task.");
+
+                await sink.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(CreateSinkTask(remainingMode, sinkTask.TaskId)));
+
+                switch (remainingMode)
+                {
+                    case PullReplicationMode.SinkToHub:
+                        Assert.False(WaitForValue(() => HasIncomingHubToSinkPullHandler(sinkDatabase, sinkTask.TaskId), false, timeout),
+                            "Updating the dual-mode sink task to SinkToHub only should dispose the HubToSink incoming handler.");
+
+                        var currentSinkToHubHandler = WaitForSinkToHubHandler(
+                            "Updating the dual-mode sink task to SinkToHub only should keep the SinkToHub outgoing handler alive.");
+                        Assert.Same(originalSinkToHubHandler, currentSinkToHubHandler);
+
+                        using (var session = sink.OpenSession())
+                        {
+                            session.Store(new User { Name = "sink-after-mode-change" }, "users/sink-after-mode-change");
+                            session.SaveChanges();
+                        }
+
+                        Assert.True(WaitForDocument<User>(hub, "users/sink-after-mode-change", u => u.Name == "sink-after-mode-change", timeout), hub.Identifier);
+                        break;
+
+                    case PullReplicationMode.HubToSink:
+                        Assert.False(WaitForValue(() => GetOutgoingSinkToHubPullHandler(sinkDatabase, sinkTask.TaskId) != null, false, timeout),
+                            "Updating the dual-mode sink task to HubToSink only should dispose the SinkToHub outgoing handler.");
+
+                        var currentHubToSinkHandler = WaitForHubToSinkHandler(
+                            "Updating the dual-mode sink task to HubToSink only should keep the HubToSink incoming handler alive.");
+                        Assert.Same(originalHubToSinkHandler, currentHubToSinkHandler);
+
+                        using (var session = hub.OpenSession())
+                        {
+                            session.Store(new User { Name = "hub-after-mode-change" }, "users/hub-after-mode-change");
+                            session.SaveChanges();
+                        }
+
+                        Assert.True(WaitForDocument<User>(sink, "users/hub-after-mode-change", u => u.Name == "hub-after-mode-change", timeout), sink.Identifier);
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(remainingMode), remainingMode, null);
+                }
+
+                PullReplicationAsSink CreateSinkTask(PullReplicationMode mode, long taskId = 0)
+                {
+                    return new PullReplicationAsSink(hub.Database, connectionStringName, definitionName)
+                    {
+                        Name = sinkTaskName,
+                        TaskId = taskId,
+                        Mode = mode,
+                        CertificateWithPrivateKey = pullReplicationCertificateWithPrivateKey
+                    };
+                }
+
+                IncomingPullReplicationHandlerAsSink WaitForHubToSinkHandler(string message)
+                {
+                    IncomingPullReplicationHandlerAsSink handler = null;
+                    Assert.True(WaitForValue(() =>
+                    {
+                        handler = GetIncomingHubToSinkPullHandler(sinkDatabase, sinkTask.TaskId);
+                        return handler != null;
+                    }, true, timeout), message);
+
+                    return handler;
+                }
+
+                OutgoingPullReplicationHandlerAsSink WaitForSinkToHubHandler(string message)
+                {
+                    OutgoingPullReplicationHandlerAsSink handler = null;
+                    Assert.True(WaitForValue(() =>
+                    {
+                        handler = GetOutgoingSinkToHubPullHandler(sinkDatabase, sinkTask.TaskId);
+                        return handler != null;
+                    }, true, timeout), message);
+
+                    return handler;
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
         public async Task SuccessfulHubToSinkPullReplicationHandoffShouldClearQueuedReconnect()
         {
             DoNotReuseServer();
@@ -528,6 +834,92 @@ namespace SlowTests.Server.Replication
 
                 Assert.False(HasHubToSinkReconnectQueued(sinkDatabase, sinkTask.TaskId),
                     "A successful HubToSink handoff should clear the queued reconnect for the same sink task.");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task SuccessfulHubToSinkPullReplicationHandoffShouldNotOpenDuplicateConnectorOnReconnectTimer()
+        {
+            DoNotReuseServer();
+
+            var customSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.RetryReplicateAfter)] = "1",
+                [RavenConfiguration.GetKey(x => x.Replication.RetryMaxTimeout)] = "1"
+            };
+
+            var definitionName = $"pull-replication {GetDatabaseName()}";
+            const int timeout = 20_000;
+            const int reconnectTimerObservationTimeout = 5_000;
+
+            using (var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings }))
+            using (var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings }))
+            using (var sink = GetDocumentStore(new Options { Server = sinkServer }))
+            using (var hub = GetDocumentStore(new Options { Server = hubServer }))
+            {
+                var pullDefinition = new PullReplicationDefinition(definitionName)
+                {
+                    Mode = PullReplicationMode.HubToSink
+                };
+                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(pullDefinition));
+
+                var failTcpInfoLookup = true;
+                var sinkDatabase = await GetDatabase(sink.Database, sinkServer);
+                sinkDatabase.ReplicationLoader.ForTestingPurposesOnly().SelectPullReplicationRemoteUrls = (_, _, remoteUrls) =>
+                    failTcpInfoLookup ? ["http://127.0.0.1:1234"] : remoteUrls;
+
+                var pullReplication = new PullReplicationAsSink(hub.Database, $"ConnectionString-{hub.Database}", definitionName)
+                {
+                    Mode = PullReplicationMode.HubToSink
+                };
+                var sinkTask = await AddWatcherToReplicationTopology(sink, pullReplication, hub.Urls);
+
+                Assert.True(WaitForValue(() => HasHubToSinkReconnectQueued(sinkDatabase, sinkTask.TaskId), true, timeout),
+                    "Expected the sink to queue a HubToSink reconnect attempt after the first outgoing TCP info lookup fails.");
+
+                var queuedDestination = GetQueuedHubToSinkDestination(sinkDatabase, sinkTask.TaskId);
+                Assert.NotNull(queuedDestination);
+
+                var outgoingConnectorStarts = 0;
+                void CountHubToSinkConnector(DatabaseOutgoingReplicationHandler handler)
+                {
+                    if (handler is OutgoingPullReplicationHandlerAsSink &&
+                        handler.Destination is PullReplicationAsSink { TaskId: var destinationTaskId, Mode: PullReplicationMode.HubToSink } &&
+                        destinationTaskId == sinkTask.TaskId)
+                    {
+                        Interlocked.Increment(ref outgoingConnectorStarts);
+                    }
+                }
+
+                sinkDatabase.ReplicationLoader.OutgoingReplicationAdded += CountHubToSinkConnector;
+                try
+                {
+                    failTcpInfoLookup = false;
+                    sinkDatabase.ReplicationLoader.AddAndStartOutgoingReplication(queuedDestination);
+
+                    using (var session = hub.OpenSession())
+                    {
+                        session.Store(new User { Name = "after-handoff" }, "users/after-handoff");
+                        session.SaveChanges();
+                    }
+
+                    Assert.True(WaitForDocument<User>(sink, "users/after-handoff", u => u.Name == "after-handoff", timeout), sink.Identifier);
+                    Assert.True(WaitForValue(() => CountIncomingHubToSinkPullHandlers(sinkDatabase, sinkTask.TaskId), 1, timeout) == 1,
+                        "Expected the sink to complete a successful outgoing-to-incoming HubToSink handoff.");
+
+                    Assert.Equal(1, WaitForValue(() => Volatile.Read(ref outgoingConnectorStarts), 1, timeout));
+
+                    var connectorStartsAfterHandoff = Volatile.Read(ref outgoingConnectorStarts);
+                    Assert.False(WaitForValue(() => Volatile.Read(ref outgoingConnectorStarts) > connectorStartsAfterHandoff, true, reconnectTimerObservationTimeout),
+                        "The reconnect timer should not open another HubToSink outgoing connector after a successful handoff.");
+
+                    Assert.Equal(1, CountIncomingHubToSinkPullHandlers(sinkDatabase, sinkTask.TaskId));
+                    Assert.Equal(0, CountOutgoingHubToSinkPullHandlers(sinkDatabase, sinkTask.TaskId));
+                }
+                finally
+                {
+                    sinkDatabase.ReplicationLoader.OutgoingReplicationAdded -= CountHubToSinkConnector;
+                }
             }
         }
 
@@ -1684,9 +2076,37 @@ namespace SlowTests.Server.Replication
 
         private static bool HasIncomingHubToSinkPullHandler(Raven.Server.Documents.DocumentDatabase database, long taskId)
         {
+            return GetIncomingHubToSinkPullHandler(database, taskId) != null;
+        }
+
+        private static int CountIncomingHubToSinkPullHandlers(Raven.Server.Documents.DocumentDatabase database, long taskId)
+        {
             return database.ReplicationLoader.IncomingHandlers
                 .OfType<IncomingPullReplicationHandlerAsSink>()
-                .Any(x => x.IncomingPullReplicationParams.TaskId == taskId && x.IncomingPullReplicationParams.Mode == PullReplicationMode.HubToSink);
+                .Count(x => x.IncomingPullReplicationParams.TaskId == taskId && x.IncomingPullReplicationParams.Mode == PullReplicationMode.HubToSink);
+        }
+
+        private static IncomingPullReplicationHandlerAsSink GetIncomingHubToSinkPullHandler(Raven.Server.Documents.DocumentDatabase database, long taskId)
+        {
+            return database.ReplicationLoader.IncomingHandlers
+                .OfType<IncomingPullReplicationHandlerAsSink>()
+                .FirstOrDefault(x => x.IncomingPullReplicationParams.TaskId == taskId && x.IncomingPullReplicationParams.Mode == PullReplicationMode.HubToSink);
+        }
+
+        private static int CountOutgoingHubToSinkPullHandlers(Raven.Server.Documents.DocumentDatabase database, long taskId)
+        {
+            return database.ReplicationLoader.OutgoingHandlers
+                .OfType<OutgoingPullReplicationHandlerAsSink>()
+                .Count(x => x.Destination is PullReplicationAsSink { TaskId: var destinationTaskId, Mode: PullReplicationMode.HubToSink } &&
+                            destinationTaskId == taskId);
+        }
+
+        private static OutgoingPullReplicationHandlerAsSink GetOutgoingSinkToHubPullHandler(Raven.Server.Documents.DocumentDatabase database, long taskId)
+        {
+            return database.ReplicationLoader.OutgoingHandlers
+                .OfType<OutgoingPullReplicationHandlerAsSink>()
+                .FirstOrDefault(x => x.Destination is PullReplicationAsSink { TaskId: var destinationTaskId, Mode: PullReplicationMode.SinkToHub } &&
+                                     destinationTaskId == taskId);
         }
 
         private static bool HasHubToSinkReconnectQueued(Raven.Server.Documents.DocumentDatabase database, long taskId)

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -411,6 +411,127 @@ namespace SlowTests.Server.Replication
         }
 
         [RavenFact(RavenTestCategory.Replication)]
+        public async Task DisableHubToSinkPullReplicationOnSinkShouldDropIncomingHandler()
+        {
+            DoNotReuseServer();
+
+            var hubPort = GetReservedPort();
+            var hubSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = $"http://127.0.0.1:{hubPort}",
+                [RavenConfiguration.GetKey(x => x.Core.PublicServerUrl)] = $"http://localhost:{hubPort}"
+            };
+
+            var definitionName = $"pull-replication {GetDatabaseName()}";
+            var connectionStringName = $"ConnectionString-{definitionName}";
+            const int timeout = 10_000;
+
+            using (var sinkServer = GetNewServer())
+            using (var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = hubSettings }))
+            using (var sink = GetDocumentStore(new Options { Server = sinkServer }))
+            using (var hub = GetDocumentStore(new Options { Server = hubServer }))
+            {
+                var sinkDatabase = await GetDatabase(sink.Database, sinkServer);
+                // The sink connects to the hub through the bound URL, but the hub advertises PublicServerUrl
+                // in the handshake. URL-based cleanup cannot treat those strings as the task identity.
+                sinkDatabase.ReplicationLoader.ForTestingPurposesOnly().SelectPullReplicationRemoteUrls = (_, _, _) => hub.Urls;
+
+                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(definitionName)
+                {
+                    Mode = PullReplicationMode.HubToSink
+                }));
+
+                await sink.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Name = connectionStringName,
+                    Database = hub.Database,
+                    TopologyDiscoveryUrls = hub.Urls
+                }));
+
+                var sinkTask = await sink.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink(hub.Database, connectionStringName, definitionName)
+                {
+                    Mode = PullReplicationMode.HubToSink
+                }));
+
+                using (var session = hub.OpenSession())
+                {
+                    session.Store(new User { Name = "before-disable" }, "users/before-disable");
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(sink, "users/before-disable", u => u.Name == "before-disable", timeout), sink.Identifier);
+
+                Assert.True(WaitForValue(() => HasIncomingHubToSinkPullHandler(sinkDatabase, sinkTask.TaskId), true, timeout),
+                    "Expected an active IncomingPullReplicationHandlerAsSink before disabling the sink task.");
+
+                await sink.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(sinkTask.TaskId, OngoingTaskType.PullReplicationAsSink, disable: true));
+
+                Assert.False(WaitForValue(() => HasIncomingHubToSinkPullHandler(sinkDatabase, sinkTask.TaskId), false, timeout),
+                    "Disabling the HubToSink pull replication task on the sink should dispose the active incoming pull handler.");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task SuccessfulHubToSinkPullReplicationHandoffShouldClearQueuedReconnect()
+        {
+            DoNotReuseServer();
+
+            var customSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.RetryReplicateAfter)] = "60",
+                [RavenConfiguration.GetKey(x => x.Replication.RetryMaxTimeout)] = "1"
+            };
+
+            var definitionName = $"pull-replication {GetDatabaseName()}";
+            const int timeout = 20_000;
+
+            using (var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings }))
+            using (var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings }))
+            using (var sink = GetDocumentStore(new Options { Server = sinkServer }))
+            using (var hub = GetDocumentStore(new Options { Server = hubServer }))
+            {
+                var pullDefinition = new PullReplicationDefinition(definitionName)
+                {
+                    Mode = PullReplicationMode.HubToSink
+                };
+                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(pullDefinition));
+
+                var failTcpInfoLookup = true;
+                var sinkDatabase = await GetDatabase(sink.Database, sinkServer);
+                sinkDatabase.ReplicationLoader.ForTestingPurposesOnly().SelectPullReplicationRemoteUrls = (_, _, remoteUrls) =>
+                    failTcpInfoLookup ? ["http://127.0.0.1:1234"] : remoteUrls;
+
+                var pullReplication = new PullReplicationAsSink(hub.Database, $"ConnectionString-{hub.Database}", definitionName)
+                {
+                    Mode = PullReplicationMode.HubToSink
+                };
+                var sinkTask = await AddWatcherToReplicationTopology(sink, pullReplication, hub.Urls);
+
+                Assert.True(WaitForValue(() => HasHubToSinkReconnectQueued(sinkDatabase, sinkTask.TaskId), true, timeout),
+                    "Expected the sink to queue a HubToSink reconnect attempt after the first outgoing TCP info lookup fails.");
+
+                var queuedDestination = GetQueuedHubToSinkDestination(sinkDatabase, sinkTask.TaskId);
+                Assert.NotNull(queuedDestination);
+
+                failTcpInfoLookup = false;
+                sinkDatabase.ReplicationLoader.AddAndStartOutgoingReplication(queuedDestination);
+
+                using (var session = hub.OpenSession())
+                {
+                    session.Store(new User { Name = "after-handoff" }, "users/after-handoff");
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument<User>(sink, "users/after-handoff", u => u.Name == "after-handoff", timeout), sink.Identifier);
+                Assert.True(WaitForValue(() => HasIncomingHubToSinkPullHandler(sinkDatabase, sinkTask.TaskId), true, timeout),
+                    "Expected the sink to complete a successful outgoing-to-incoming HubToSink handoff.");
+
+                Assert.False(HasHubToSinkReconnectQueued(sinkDatabase, sinkTask.TaskId),
+                    "A successful HubToSink handoff should clear the queued reconnect for the same sink task.");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
         public async Task DisablePullReplicationOnHub()
         {
             DebuggerAttachedTimeout.DisableLongTimespan = true;
@@ -1559,6 +1680,23 @@ namespace SlowTests.Server.Replication
                     catch { /* cancelled */ }
                 }
             });
+        }
+
+        private static bool HasIncomingHubToSinkPullHandler(Raven.Server.Documents.DocumentDatabase database, long taskId)
+        {
+            return database.ReplicationLoader.IncomingHandlers
+                .OfType<IncomingPullReplicationHandlerAsSink>()
+                .Any(x => x.IncomingPullReplicationParams.TaskId == taskId && x.IncomingPullReplicationParams.Mode == PullReplicationMode.HubToSink);
+        }
+
+        private static bool HasHubToSinkReconnectQueued(Raven.Server.Documents.DocumentDatabase database, long taskId)
+        {
+            return database.ReplicationLoader.ReconnectQueue.OfType<PullReplicationAsSink>().Any(x => x.TaskId == taskId && x.Mode == PullReplicationMode.HubToSink);
+        }
+
+        private static PullReplicationAsSink GetQueuedHubToSinkDestination(Raven.Server.Documents.DocumentDatabase database, long taskId)
+        {
+            return database.ReplicationLoader.ReconnectQueue.OfType<PullReplicationAsSink>().FirstOrDefault(x => x.TaskId == taskId && x.Mode == PullReplicationMode.HubToSink);
         }
 
         private class AsyncGate

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -37,52 +37,6 @@ namespace SlowTests.Server.Replication
         {
         }
 
-        [RavenFact(RavenTestCategory.Replication)]
-        public async Task DisposingPullReplicationAsHubBeforeStartShouldNotThrow()
-        {
-            var definitionName = $"pull-replication {GetDatabaseName()}";
-
-            using (var store = GetDocumentStore())
-            {
-                var database = await GetDocumentDatabaseInstanceFor(store);
-                var initialRequest = new ReplicationInitialRequest
-                {
-                    PullReplicationDefinitionName = definitionName,
-                    Database = store.Database,
-                    SourceUrl = store.Urls[0],
-                    Info = new TcpConnectionInfo
-                    {
-                        Url = store.Urls[0],
-                        Urls = store.Urls,
-                        NodeTag = Server.ServerStore.NodeTag
-                    }
-                };
-
-                var pullReplicationDefinition = new PullReplicationDefinition(definitionName)
-                {
-                    Mode = PullReplicationMode.HubToSink,
-                    TaskId = 1
-                };
-
-                var toPullReplicationAsHub = typeof(PullReplicationDefinition).GetMethod("ToPullReplicationAsHub",
-                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-                Assert.NotNull(toPullReplicationAsHub);
-                var pullReplicationAsHub = toPullReplicationAsHub.Invoke(pullReplicationDefinition, new object[] { initialRequest, pullReplicationDefinition.TaskId });
-
-                var outgoingPullReplicationHandlerAsHubType = typeof(OutgoingPullReplicationHandler).Assembly.GetType(
-                    "Raven.Server.Documents.Replication.Outgoing.OutgoingPullReplicationHandlerAsHub",
-                    throwOnError: true);
-                var handler = Assert.IsAssignableFrom<IDisposable>(Activator.CreateInstance(
-                    outgoingPullReplicationHandlerAsHubType,
-                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic,
-                    binder: null,
-                    args: new[] { database.ReplicationLoader, database, pullReplicationAsHub, initialRequest.Info },
-                    culture: null));
-
-                handler.Dispose();
-            }
-        }
-
         [RavenTheory(RavenTestCategory.Replication)]
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanDefinePullReplication(Options options)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26851

### Additional description

Fixes two HubToSink pull-replication cleanup gaps on the sink side.

First, disabling the sink-side HubToSink pull replication task now drops the active `IncomingPullReplicationHandlerAsSink` by pull task identity instead of relying only on runtime URL matching.

Second, a successful HubToSink outgoing-to-incoming handoff clears the stale outgoing reconnect state for that destination. This prevents an old queued reconnect from creating a duplicate outgoing connector while the long-lived incoming HubToSink channel is already active.

Also covers live activation of `PullReplicationCompositeChangeVectors` when the sink observes the feature change before the hub. In that order, the sink-side incoming handler is reset intentionally, so the sink now starts a fresh outgoing connector to reopen the HubToSink channel.

This PR intentionally does not include the follow-up race-condition hardening from the separate PR.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required`
- [x] No UI work is needed
