### PR TITLE
RavenDB-26780 - CDC Sink: fix /cdc-sink/performance endpoint stats collection

### DIFF
--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -55,6 +55,8 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
 
     private CdcSinkStatsAggregator _lastStats;
 
+    private int _statsId;
+
     private readonly ConcurrentQueue<CdcSinkStatsAggregator> _lastCdcSinkStats = new();
 
     protected readonly CdcSinkDocumentProcessor DocumentProcessor;
@@ -438,22 +440,42 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         // We *intentionally* submit the command here, even if we have no entries
         // to update the checkpoint and table load state in a timely manner
 
-        var command = new Commands.CdcSinkBatchCommand(
-            Database, ops, Configuration.Name, checkpoint,
-            tableLoadUpdates: tableLoadUpdates,
-            patchRequest: DocumentProcessor.CombinedPatchRequest,
-            statsScope: null, statistics: Statistics, logger: Logger,
-            grouper: grouper, defaultSchema: DefaultSchema);
+        // Per-batch stats aggregator, mirroring the ETL/QueueSink stats lifecycle: chain the
+        // start time off the previous batch, open a scope the batch command records into,
+        // start the timer and register it as the latest (and in the ring buffer), then
+        // Complete() once the batch finishes. CreateScope() returns an unstarted scope, so
+        // Start() it here to begin timing at batch submission rather than at construction.
+        var statsAggregator = new CdcSinkStatsAggregator(Interlocked.Increment(ref _statsId), _lastStats);
+        var stats = statsAggregator.CreateScope();
 
-        var start = Stopwatch.GetTimestamp();
-        await Database.TxMerger.Enqueue(command);
+        statsAggregator.Start();
+        stats.Start();
+        AddPerformanceStats(statsAggregator);
 
-        LastBatchTime = Database.Time.GetUtcNow();
-        if (checkpoint != null)
-            LastCheckpoint = checkpoint;
+        try
+        {
+            var command = new Commands.CdcSinkBatchCommand(
+                Database, ops, Configuration.Name, checkpoint,
+                tableLoadUpdates: tableLoadUpdates,
+                patchRequest: DocumentProcessor.CombinedPatchRequest,
+                statsScope: stats, statistics: Statistics, logger: Logger,
+                grouper: grouper, defaultSchema: DefaultSchema);
 
-        if (Logger.IsDebugEnabled)
-            Logger.Debug($"[{Name}] SubmitBatch: {command.ProcessedSuccessfully} ops persisted in {Stopwatch.GetElapsedTime(start).TotalMilliseconds:#,#} ms, checkpoint={checkpoint ?? "(none)"}");
+            var start = Stopwatch.GetTimestamp();
+            await Database.TxMerger.Enqueue(command);
+
+            LastBatchTime = Database.Time.GetUtcNow();
+            if (checkpoint != null)
+                LastCheckpoint = checkpoint;
+
+            if (Logger.IsDebugEnabled)
+                Logger.Debug($"[{Name}] SubmitBatch: {command.ProcessedSuccessfully} ops persisted in {Stopwatch.GetElapsedTime(start).TotalMilliseconds:#,#} ms, checkpoint={checkpoint ?? "(none)"}");
+        }
+        finally
+        {
+            stats.Dispose();
+            statsAggregator.Complete();
+        }
 
         Database.CdcSinkLoader.OnBatchCompleted(Configuration.Name, Name, Statistics);
         return (checkpoint, ops.Count);

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
@@ -171,6 +171,61 @@ namespace SlowTests.Server.Documents.CdcSink
         }
 
         [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
+        public async Task InitialLoad_FeedsPerformanceStats()
+        {
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE employees (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    name VARCHAR(200) NOT NULL,
+                    department VARCHAR(200) NOT NULL
+                )");
+
+            ExecuteMySql(connectionString, "INSERT INTO employees (name, department) VALUES ('Alice', 'Engineering')");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-mysql-performance-stats",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Employees",
+                        SourceTableSchema = schemaName,
+                        SourceTableName = "employees",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "name", Name = "Name" },
+                            new CdcColumnMapping { Column = "department", Name = "Department" }
+                        }
+                    }
+                }
+            };
+
+            AddCdcSink(store, config);
+            
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                return (await session.LoadAsync<Employee>("Employees/1"))?.Name;
+            }, "Alice", timeout: 60_000);
+
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            var process = db.CdcSinkLoader.Processes.Single(p => p.Name == config.Name);
+            
+            var perf = process.GetPerformanceStats();
+            Assert.NotEmpty(perf);
+            Assert.Contains(perf, s => s.Started != default);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
         public async Task CdcStreaming_Insert()
         {
             using var store = GetDocumentStore();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26780/CDC-Sink-performance-stats-always-empty-also-consider-a-cdc-sink-progress-endpoint

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
