### PR TITLE
RavenDB-26865 Quill - UI improvements

### DIFF
--- a/src/Raven.AiAppliance.Web/src/api/generated/server-api.ts
+++ b/src/Raven.AiAppliance.Web/src/api/generated/server-api.ts
@@ -705,7 +705,8 @@ export interface components {
         JsonElement: unknown;
         LoginRequest: {
             apiKey: string;
-        };        MapRequest: {
+        };
+        MapRequest: {
             /** Format: int64 */
             taskId?: null | number;
             disabled?: null | boolean;

--- a/src/Raven.AiAppliance.Web/src/components/data/copyable-code.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/data/copyable-code.tsx
@@ -1,0 +1,28 @@
+import { Copy } from "lucide-react";
+import { Button } from "@/components/shadcn/ui/button";
+import { cn, copyToClipboard } from "@/lib/utils";
+
+export function CopyableCode({ code, copyLabel, className }: { code: string; copyLabel: string; className?: string }) {
+    return (
+        <div className="relative min-w-0">
+            <pre
+                className={cn(
+                    "rounded-lg border bg-muted/50 py-2 pr-10 pl-3 text-xs break-all whitespace-pre-wrap",
+                    className,
+                )}
+            >
+                <code>{code}</code>
+            </pre>
+            <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="absolute top-1.5 right-1.5"
+                aria-label={copyLabel}
+                onClick={() => copyToClipboard(code)}
+            >
+                <Copy className="size-3.5" aria-hidden="true" />
+            </Button>
+        </div>
+    );
+}

--- a/src/Raven.AiAppliance.Web/src/components/data/expandable-text.stories.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/data/expandable-text.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ExpandableText } from "./expandable-text";
+
+const LONG_TEXT =
+    "You are a customer support assistant for an e-commerce platform. " +
+    "You can answer questions about products, orders, shipping, and returns. " +
+    "Always be concise, friendly, and accurate. When you are unsure, ask a clarifying " +
+    "question instead of guessing. Never invent order details or prices; rely only on " +
+    "the data available through your tools.";
+
+const meta = {
+    title: "Components/Expandable Text",
+    component: ExpandableText,
+    decorators: [
+        (Story) => (
+            <div className="max-w-md p-6">
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        maxLines: 3,
+        className: "text-sm text-muted-foreground",
+    },
+} satisfies Meta<typeof ExpandableText>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: { children: LONG_TEXT },
+};
+
+export const Short: Story = {
+    args: { children: "A short prompt that fits comfortably within the line limit." },
+};

--- a/src/Raven.AiAppliance.Web/src/components/data/expandable-text.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/data/expandable-text.tsx
@@ -1,0 +1,65 @@
+import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/components/shadcn/ui/button";
+
+type ExpandableTextProps = {
+    children: ReactNode;
+    maxLines?: number;
+    className?: string;
+};
+
+export function ExpandableText({ children, maxLines = 3, className }: ExpandableTextProps) {
+    const contentRef = useRef<HTMLDivElement>(null);
+    const [isExpanded, setIsExpanded] = useState(false);
+    const [canExpand, setCanExpand] = useState(false);
+
+    // Overflow can only be known after layout. Measure before the browser paints so the
+    // toggle is present in the first frame instead of flashing in late, and re-check on
+    // resize. Skip while expanded — nothing is clamped then, and the toggle stays visible
+    // because it was the user who expanded it.
+    useLayoutEffect(() => {
+        const element = contentRef.current;
+        if (!element || isExpanded) {
+            return;
+        }
+
+        const measure = () => setCanExpand(element.scrollHeight > element.clientHeight + 1);
+        measure();
+
+        const observer = new ResizeObserver(measure);
+        observer.observe(element);
+        return () => observer.disconnect();
+    }, [children, maxLines, isExpanded]);
+
+    const clampStyle: CSSProperties | undefined = isExpanded
+        ? undefined
+        : { display: "-webkit-box", WebkitBoxOrient: "vertical", WebkitLineClamp: maxLines, overflow: "hidden" };
+
+    return (
+        <div className="flex flex-col items-start">
+            <div ref={contentRef} style={clampStyle} className={className}>
+                {children}
+            </div>
+            {(canExpand || isExpanded) && (
+                <Button
+                    variant="link"
+                    className="mt-1 h-auto gap-1 p-0 text-xs font-medium"
+                    onClick={() => setIsExpanded((expanded) => !expanded)}
+                    aria-expanded={isExpanded}
+                >
+                    {isExpanded ? (
+                        <>
+                            Show less
+                            <ChevronUp />
+                        </>
+                    ) : (
+                        <>
+                            Show more
+                            <ChevronDown />
+                        </>
+                    )}
+                </Button>
+            )}
+        </div>
+    );
+}

--- a/src/Raven.AiAppliance.Web/src/components/data/expandable-text.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/data/expandable-text.tsx
@@ -36,7 +36,7 @@ export function ExpandableText({ children, maxLines = 3, className }: Expandable
         : { display: "-webkit-box", WebkitBoxOrient: "vertical", WebkitLineClamp: maxLines, overflow: "hidden" };
 
     return (
-        <div className="flex flex-col items-start">
+        <div className="flex flex-col items-end">
             <div ref={contentRef} style={clampStyle} className={className}>
                 {children}
             </div>

--- a/src/Raven.AiAppliance.Web/src/components/data/inline-code.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/data/inline-code.tsx
@@ -1,0 +1,5 @@
+import type { PropsWithChildren } from "react";
+
+export function InlineCode({ children }: PropsWithChildren) {
+    return <code className="rounded bg-muted px-1 py-0.5 font-mono">{children}</code>;
+}

--- a/src/Raven.AiAppliance.Web/src/components/shadcn/ui/collapsible.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/shadcn/ui/collapsible.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { Collapsible as CollapsiblePrimitive } from "radix-ui";
+
+function Collapsible({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+    return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Trigger>) {
+    return <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />;
+}
+
+function CollapsibleContent({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Content>) {
+    return <CollapsiblePrimitive.Content data-slot="collapsible-content" {...props} />;
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/src/Raven.AiAppliance.Web/src/components/table/use-auto-size-columns.ts
+++ b/src/Raven.AiAppliance.Web/src/components/table/use-auto-size-columns.ts
@@ -1,0 +1,119 @@
+import { useLayoutEffect, type RefObject } from "react";
+import type { ColumnSizingState, Table as ReactTable } from "@tanstack/react-table";
+
+const CELL_PADDING_X = 16;
+const RESIZER_WIDTH = 4;
+const CELL_MIN_WIDTH = 30;
+const CELL_MAX_WIDTH = 300;
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+}
+
+// Measures a cell's intrinsic content width, ignoring the column's current width so that
+// truncated text still reports how wide it wants to be. The temporary style changes are
+// reverted before the browser paints (this only runs inside useLayoutEffect).
+function measureContentWidth(cell: HTMLElement): number {
+    const content = cell.firstElementChild;
+    if (!content) {
+        return 0;
+    }
+
+    const { width, maxWidth } = cell.style;
+    cell.style.width = "max-content";
+    cell.style.maxWidth = "none";
+    const measured = content.scrollWidth;
+    cell.style.width = width;
+    cell.style.maxWidth = maxWidth;
+
+    return measured;
+}
+
+// Widest content across the column's header and (virtualized) body cells.
+function measureColumnWidth(container: HTMLElement, columnId: string): number {
+    const cells = container.querySelectorAll<HTMLElement>(`[data-column-id="${CSS.escape(columnId)}"]`);
+
+    let widest = 0;
+    cells.forEach((cell) => {
+        widest = Math.max(widest, measureContentWidth(cell) + CELL_PADDING_X + RESIZER_WIDTH);
+    });
+    return widest;
+}
+
+function computeColumnSizing<TData>(
+    table: ReactTable<TData>,
+    container: HTMLElement,
+    containerWidth: number,
+): ColumnSizingState {
+    const sizing: ColumnSizingState = {};
+    const resizableIds: string[] = [];
+    let totalWidth = 0;
+
+    for (const column of table.getVisibleLeafColumns()) {
+        // Columns that opt out of resizing (e.g. the checkbox column) keep their configured width.
+        if (!column.getCanResize()) {
+            totalWidth += column.getSize();
+            continue;
+        }
+
+        const width = clamp(measureColumnWidth(container, column.id), CELL_MIN_WIDTH, CELL_MAX_WIDTH);
+        sizing[column.id] = width;
+        totalWidth += width;
+        resizableIds.push(column.id);
+    }
+
+    // Grow columns to fill any leftover space so the table always spans its container.
+    const freeSpace = containerWidth - totalWidth;
+    if (freeSpace > 0 && resizableIds.length > 0) {
+        const cappedId = resizableIds.find((id) => sizing[id] === CELL_MAX_WIDTH);
+        if (cappedId) {
+            // A capped column most likely holds the long content, so let it absorb the slack.
+            sizing[cappedId] += freeSpace;
+        } else {
+            const share = Math.floor(freeSpace / resizableIds.length);
+            for (const id of resizableIds) {
+                sizing[id] += share;
+            }
+        }
+    }
+
+    return sizing;
+}
+
+/**
+ * Sizes each column to fit its content after layout, then keeps it in sync when the container
+ * resizes or web fonts finish loading. Columns that opt out of resizing keep their configured width.
+ */
+export function useAutoSizeColumns<TData>(
+    table: ReactTable<TData>,
+    containerRef: RefObject<HTMLDivElement | null>,
+    rowCount: number,
+) {
+    useLayoutEffect(() => {
+        const container = containerRef.current;
+        if (!container || rowCount === 0) {
+            return;
+        }
+
+        const resize = () => table.setColumnSizing(computeColumnSizing(table, container, container.clientWidth));
+
+        resize();
+
+        // Web fonts (the mono cells) can finish loading after the first pass, which would leave
+        // columns sized to the narrower fallback metrics. Re-measure once fonts are ready.
+        let cancelled = false;
+        document.fonts?.ready.then(() => {
+            if (!cancelled) {
+                resize();
+            }
+        });
+
+        const observer = new ResizeObserver(resize);
+        observer.observe(container);
+
+        return () => {
+            cancelled = true;
+            observer.disconnect();
+        };
+    }, [table, containerRef, rowCount]);
+}

--- a/src/Raven.AiAppliance.Web/src/components/table/use-auto-size-columns.ts
+++ b/src/Raven.AiAppliance.Web/src/components/table/use-auto-size-columns.ts
@@ -65,10 +65,11 @@ function computeColumnSizing<TData>(
     // Grow columns to fill any leftover space so the table always spans its container.
     const freeSpace = containerWidth - totalWidth;
     if (freeSpace > 0 && resizableIds.length > 0) {
-        const cappedId = resizableIds.find((id) => sizing[id] === CELL_MAX_WIDTH);
-        if (cappedId) {
-            // A capped column most likely holds the long content, so let it absorb the slack.
-            sizing[cappedId] += freeSpace;
+        const cappedIds = resizableIds.filter((id) => sizing[id] === CELL_MAX_WIDTH);
+        if (cappedIds.length > 0) {
+            cappedIds.forEach((id) => {
+                sizing[id] += Math.floor(freeSpace / cappedIds.length);
+            });
         } else {
             const share = Math.floor(freeSpace / resizableIds.length);
             for (const id of resizableIds) {
@@ -109,7 +110,7 @@ export function useAutoSizeColumns<TData>(
         });
 
         const observer = new ResizeObserver(resize);
-        observer.observe(container);
+        observer.observe(container, { box: "content-box" });
 
         return () => {
             cancelled = true;

--- a/src/Raven.AiAppliance.Web/src/components/table/virtual-data-table.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/table/virtual-data-table.tsx
@@ -2,10 +2,11 @@
 // https://github.com/TanStack/table/issues/5567
 "use no memo";
 
-import { useRef } from "react";
-import { flexRender, type Table as ReactTable } from "@tanstack/react-table";
+import { useRef, type CSSProperties, type ReactNode } from "react";
+import { flexRender, type Header, type Table as ReactTable } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/ui/table";
+import { useAutoSizeColumns } from "@/components/table/use-auto-size-columns";
 import { cn } from "@/lib/utils";
 
 const DEFAULT_TABLE_HEIGHT_IN_PX = 360;
@@ -22,6 +23,12 @@ interface VirtualDataTableProps<TData> {
     rowHeightInPx?: number;
     getCellClassName?: (cellId: string) => string;
     getRowState?: (rowId: string) => string;
+    /** Floating content laid over the table region, e.g. a selection toolbar pinned to the bottom edge. */
+    overlay?: ReactNode;
+}
+
+function getColumnStyle(size: number): CSSProperties {
+    return { width: size, flexGrow: 0, flexShrink: 0 };
 }
 
 export function VirtualDataTable<TData>({
@@ -34,7 +41,16 @@ export function VirtualDataTable<TData>({
     rowHeightInPx = DEFAULT_ROW_HEIGHT_IN_PX,
     getCellClassName,
     getRowState,
+    overlay,
 }: VirtualDataTableProps<TData>) {
+    // Enable resizing for the whole table so the drag handles and content-based auto-sizing
+    // work without every caller having to opt in.
+    table.setOptions((prev) => ({
+        ...prev,
+        enableColumnResizing: true,
+        columnResizeMode: "onChange",
+    }));
+
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rows = table.getRowModel().rows;
 
@@ -45,9 +61,11 @@ export function VirtualDataTable<TData>({
         overscan,
     });
 
+    useAutoSizeColumns(table, tableContainerRef, rows.length);
+
     if (rows.length === 0) {
         return (
-            <div className={cn("overflow-hidden rounded-lg border", className)}>
+            <div className={cn("min-w-0 overflow-hidden rounded-lg border", className)}>
                 <table className="w-full caption-bottom text-sm">
                     <VirtualTableHeader table={table} />
                     <TableBody>
@@ -63,9 +81,10 @@ export function VirtualDataTable<TData>({
     }
 
     return (
-        <div className={cn("overflow-hidden rounded-lg border", className)}>
-            <div ref={tableContainerRef} className="overflow-auto" style={{ height: heightInPx }}>
-                <table className="grid w-full caption-bottom text-sm">
+        // min-w-0 lets the table shrink inside flex/grid parents instead of forcing them to overflow.
+        <div className={cn("relative min-w-0", className)}>
+            <div ref={tableContainerRef} className="overflow-auto rounded-lg border" style={{ height: heightInPx }}>
+                <table className="grid min-w-full caption-bottom text-sm" style={{ width: table.getTotalSize() }}>
                     <VirtualTableHeader table={table} />
                     <TableBody
                         className="relative grid"
@@ -95,12 +114,16 @@ export function VirtualDataTable<TData>({
                                     {row.getVisibleCells().map((cell) => (
                                         <TableCell
                                             key={cell.id}
-                                            className={cn("flex items-center", getCellClassName?.(cell.id))}
-                                            style={{
-                                                width: cell.column.getSize(),
-                                            }}
+                                            data-column-id={cell.column.id}
+                                            className={cn(
+                                                "flex items-center overflow-hidden",
+                                                getCellClassName?.(cell.id),
+                                            )}
+                                            style={getColumnStyle(cell.column.getSize())}
                                         >
-                                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                            <span className="truncate">
+                                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                            </span>
                                         </TableCell>
                                     ))}
                                 </TableRow>
@@ -109,6 +132,7 @@ export function VirtualDataTable<TData>({
                     </TableBody>
                 </table>
             </div>
+            {overlay}
         </div>
     );
 }
@@ -121,18 +145,35 @@ function VirtualTableHeader<TData>({ table }: { table: ReactTable<TData> }) {
                     {headerGroup.headers.map((header) => (
                         <TableHead
                             key={header.id}
-                            className="flex items-center"
-                            style={{
-                                width: header.getSize(),
-                            }}
+                            data-column-id={header.column.id}
+                            className="group relative flex items-center overflow-hidden"
+                            style={getColumnStyle(header.getSize())}
                         >
-                            {header.isPlaceholder
-                                ? null
-                                : flexRender(header.column.columnDef.header, header.getContext())}
+                            <span className="truncate">
+                                {header.isPlaceholder
+                                    ? null
+                                    : flexRender(header.column.columnDef.header, header.getContext())}
+                            </span>
+                            {header.column.getCanResize() && <ColumnResizer header={header} />}
                         </TableHead>
                     ))}
                 </TableRow>
             ))}
         </TableHeader>
+    );
+}
+
+function ColumnResizer<TData>({ header }: { header: Header<TData, unknown> }) {
+    return (
+        <div
+            role="separator"
+            aria-orientation="vertical"
+            onMouseDown={header.getResizeHandler()}
+            onTouchStart={header.getResizeHandler()}
+            className={cn(
+                "absolute top-0 right-0 h-full w-1 cursor-col-resize touch-none bg-border opacity-0 transition-opacity select-none group-hover:opacity-100",
+                header.column.getIsResizing() && "bg-primary opacity-100",
+            )}
+        />
     );
 }

--- a/src/Raven.AiAppliance.Web/src/index.css
+++ b/src/Raven.AiAppliance.Web/src/index.css
@@ -279,6 +279,30 @@
         caret-color: var(--color-foreground);
     }
 
+    /* Native number steppers ignore our class-based dark mode (we never set color-scheme),
+       so the up/down arrows render dark-on-dark and vanish on dark inputs. Scope color-scheme
+       to number inputs to recolor the steppers without touching scrollbars or other controls. */
+    input[type="number"] {
+        color-scheme: light;
+    }
+
+    .dark input[type="number"] {
+        color-scheme: dark;
+    }
+
+    input[type="number"]::-webkit-inner-spin-button,
+    input[type="number"]::-webkit-outer-spin-button {
+        margin-left: 0.25rem;
+        opacity: 0.6;
+    }
+
+    input[type="number"]:hover::-webkit-inner-spin-button,
+    input[type="number"]:focus-within::-webkit-inner-spin-button,
+    input[type="number"]:hover::-webkit-outer-spin-button,
+    input[type="number"]:focus-within::-webkit-outer-spin-button {
+        opacity: 1;
+    }
+
     ::-webkit-scrollbar {
         width: 10px;
         height: 10px;

--- a/src/Raven.AiAppliance.Web/src/mocks/setup-mocks.ts
+++ b/src/Raven.AiAppliance.Web/src/mocks/setup-mocks.ts
@@ -122,7 +122,7 @@ export const discoveryWithAllStates: DiscoverResponse = {
                     isCdcCapturable: true,
                 },
             ],
-            primaryKeyColumns: ["Id"],
+            primaryKeyColumns: ["Id", "TenantId", "ExternalReferenceId", "RegionCode"],
             foreignKeys: [],
             isCdcEnabled: true,
             warnings: [],

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-channel-detail.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-channel-detail.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/shadcn/ui/button";
 import { appRoutes } from "@/lib/app-routes";
 import { CHANNEL_TYPE_LABELS } from "@/lib/channel-type-labels";
 import { ChannelActiveLinks } from "@/pages/apps/channels/channel-active-links";
+import { EmbedLinkApiDocs } from "@/pages/apps/channels/embed-link-api-docs";
 import { GenerateEmbedLinkDialog } from "@/pages/apps/channels/generate-embed-link-dialog";
 import { SectionCard } from "@/pages/apps/section-card";
 
@@ -67,24 +68,31 @@ export function AppChannelDetail() {
                             </div>
 
                             {isIFrame ? (
-                                <SectionCard
-                                    title="Active links"
-                                    action={
-                                        <GenerateEmbedLinkDialog
-                                            slug={slug}
-                                            agentId={channel.agentId}
-                                            displayName={channel.displayName}
-                                            parameterNames={agent?.parameters ?? []}
-                                            trigger={
-                                                <Button size="sm" variant="outline" disabled={!channel.enabled}>
-                                                    Generate link
-                                                </Button>
-                                            }
-                                        />
-                                    }
-                                >
-                                    <ChannelActiveLinks slug={slug} widgetId={channel.widgetId} />
-                                </SectionCard>
+                                <>
+                                    <EmbedLinkApiDocs
+                                        slug={slug}
+                                        agentId={channel.agentId}
+                                        parameterNames={agent?.parameters ?? []}
+                                    />
+                                    <SectionCard
+                                        title="Active links"
+                                        action={
+                                            <GenerateEmbedLinkDialog
+                                                slug={slug}
+                                                agentId={channel.agentId}
+                                                displayName={channel.displayName}
+                                                parameterNames={agent?.parameters ?? []}
+                                                trigger={
+                                                    <Button size="sm" variant="outline" disabled={!channel.enabled}>
+                                                        Generate link
+                                                    </Button>
+                                                }
+                                            />
+                                        }
+                                    >
+                                        <ChannelActiveLinks slug={slug} widgetId={channel.widgetId} />
+                                    </SectionCard>
+                                </>
                             ) : (
                                 <Alert>Embed links apply to web widget channels only.</Alert>
                             )}

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/channel-active-links-columns.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/channel-active-links-columns.tsx
@@ -1,0 +1,112 @@
+/* eslint-disable react-refresh/only-export-components */
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { Copy, Eye, Trash2 } from "lucide-react";
+import type { EmbedLinkSummaryResponse } from "@/api/generated/server-api";
+import { Badge } from "@/components/shadcn/ui/badge";
+import { Button } from "@/components/shadcn/ui/button";
+import { copyToClipboard, formatDateTime } from "@/lib/utils";
+import { buildEmbedUrl } from "@/pages/apps/channels/embed-link-utils";
+import { PreviewEmbedLinkDialog } from "@/pages/apps/channels/preview-embed-link-dialog";
+import { RevokeEmbedLinkDialog } from "@/pages/apps/channels/revoke-embed-link-dialog";
+
+export function createActiveLinkColumns(slug: string): ColumnDef<EmbedLinkSummaryResponse>[] {
+    return [
+        {
+            accessorKey: "token",
+            header: "Token",
+            cell: ({ getValue }) => (
+                <span className="font-mono text-xs" title={getValue<string>()}>
+                    {getValue<string>()}
+                </span>
+            ),
+        },
+        {
+            id: "parameters",
+            header: "Parameters",
+            cell: ({ row }) => <LinkParameters parameters={row.original.parameters} />,
+        },
+        {
+            accessorKey: "createdAt",
+            header: "Created",
+            cell: ({ row }) => <span className="text-muted-foreground">{formatDateTime(row.original.createdAt)}</span>,
+        },
+        {
+            accessorKey: "expiresAt",
+            header: "Expires",
+            cell: ({ row }) => <span className="text-muted-foreground">{formatDateTime(row.original.expiresAt)}</span>,
+        },
+        {
+            id: "usage",
+            header: "Usage",
+            cell: ({ row }) => (
+                <span className="text-muted-foreground tabular-nums">
+                    {row.original.invocationCount.toLocaleString()} / {row.original.maxInvocations.toLocaleString()}
+                </span>
+            ),
+        },
+        {
+            id: "actions",
+            header: "",
+            size: 120,
+            enableResizing: false,
+            cell: ({ row }) => <LinkActions slug={slug} link={row.original} />,
+        },
+    ];
+}
+
+function LinkActions({ slug, link }: { slug: string; link: EmbedLinkSummaryResponse }) {
+    return (
+        <div className="flex items-center gap-1">
+            <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`Copy embed link ${link.token}`}
+                title="Copy link"
+                onClick={() => copyToClipboard(buildEmbedUrl(link.token))}
+            >
+                <Copy className="size-3.5" aria-hidden="true" />
+            </Button>
+            <PreviewEmbedLinkDialog
+                slug={slug}
+                link={link}
+                trigger={
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label={`Preview embed link ${link.token}`}
+                        title="Preview link"
+                    >
+                        <Eye className="size-3.5" aria-hidden="true" />
+                    </Button>
+                }
+            />
+            <RevokeEmbedLinkDialog
+                slug={slug}
+                token={link.token}
+                trigger={
+                    <Button variant="ghost" size="icon-sm" aria-label={`Revoke link ${link.token}`} title="Revoke link">
+                        <Trash2 className="size-3.5" aria-hidden="true" />
+                    </Button>
+                }
+            />
+        </div>
+    );
+}
+
+function LinkParameters({ parameters }: { parameters: Record<string, string> }) {
+    const entries = Object.entries(parameters);
+    if (entries.length === 0) {
+        return <span className="text-muted-foreground">—</span>;
+    }
+
+    return (
+        <span className="flex gap-1.5">
+            {entries.map(([name, value]) => (
+                <Badge key={name} variant="secondary" className="font-mono font-normal">
+                    {name}: {value}
+                </Badge>
+            ))}
+        </span>
+    );
+}

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/channel-active-links.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/channel-active-links.tsx
@@ -1,19 +1,31 @@
+/* eslint-disable react-hooks/incompatible-library */
+"use no memo";
+
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Copy, Eye, Trash2 } from "lucide-react";
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
-import { Badge } from "@/components/shadcn/ui/badge";
-import { Button } from "@/components/shadcn/ui/button";
-import { TableCell, TableRow } from "@/components/shadcn/ui/table";
-import { formatDateTime, copyToClipboard } from "@/lib/utils";
-import { SectionTable } from "@/pages/apps/section-card";
-import { buildEmbedUrl } from "@/pages/apps/channels/embed-link-utils";
-import { PreviewEmbedLinkDialog } from "@/pages/apps/channels/preview-embed-link-dialog";
-import { RevokeEmbedLinkDialog } from "@/pages/apps/channels/revoke-embed-link-dialog";
+import { VirtualDataTable } from "@/components/table/virtual-data-table";
+import { createActiveLinkColumns } from "@/pages/apps/channels/channel-active-links-columns";
 
 export function ChannelActiveLinks({ slug, widgetId }: { slug: string; widgetId: string }) {
     const linksQuery = useQuery(api.queries.embedLinks.list(slug));
-    const links = (linksQuery.data ?? []).filter((link) => link.widgetId === widgetId);
+
+    // react-table (and its row models) want stable references across renders; "use no memo" opts this
+    // file out of the React Compiler, so the data and columns are memoized explicitly.
+    const links = useMemo(
+        () => (linksQuery.data ?? []).filter((link) => link.widgetId === widgetId),
+        [linksQuery.data, widgetId],
+    );
+    const columns = useMemo(() => createActiveLinkColumns(slug), [slug]);
+
+    const table = useReactTable({
+        columns,
+        data: links,
+        getCoreRowModel: getCoreRowModel(),
+        getRowId: (link) => link.token,
+    });
 
     return (
         <ApiState
@@ -23,85 +35,12 @@ export function ChannelActiveLinks({ slug, widgetId }: { slug: string; widgetId:
             onRetry={() => void linksQuery.refetch()}
             loadingLabel="Loading links..."
         >
-            <SectionTable
-                headers={["Token", "Parameters", "Created", "Expires", "Usage", ""]}
-                isEmpty={links.length === 0}
+            <VirtualDataTable
+                table={table}
+                columnCount={columns.length}
                 emptyMessage="No active links. Generate one to embed this agent for a specific user."
-            >
-                {links.map((link) => (
-                    <TableRow key={link.token}>
-                        <TableCell className="font-mono text-xs" title={link.token}>
-                            {link.token.slice(0, 8)}…
-                        </TableCell>
-                        <TableCell>
-                            <LinkParameters parameters={link.parameters} />
-                        </TableCell>
-                        <TableCell className="text-muted-foreground">{formatDateTime(link.createdAt)}</TableCell>
-                        <TableCell className="text-muted-foreground">{formatDateTime(link.expiresAt)}</TableCell>
-                        <TableCell className="text-muted-foreground tabular-nums">
-                            {link.invocationCount.toLocaleString()} / {link.maxInvocations.toLocaleString()}
-                        </TableCell>
-                        <TableCell className="text-right">
-                            <div className="flex items-center justify-end gap-1">
-                                <Button
-                                    variant="ghost"
-                                    size="icon-sm"
-                                    aria-label={`Copy embed link ${link.token}`}
-                                    title="Copy link"
-                                    onClick={() => copyToClipboard(buildEmbedUrl(link.token))}
-                                >
-                                    <Copy className="size-3.5" aria-hidden="true" />
-                                </Button>
-                                <PreviewEmbedLinkDialog
-                                    slug={slug}
-                                    link={link}
-                                    trigger={
-                                        <Button
-                                            variant="ghost"
-                                            size="icon-sm"
-                                            aria-label={`Preview embed link ${link.token}`}
-                                            title="Preview link"
-                                        >
-                                            <Eye className="size-3.5" aria-hidden="true" />
-                                        </Button>
-                                    }
-                                />
-                                <RevokeEmbedLinkDialog
-                                    slug={slug}
-                                    token={link.token}
-                                    trigger={
-                                        <Button
-                                            variant="ghost"
-                                            size="icon-sm"
-                                            aria-label={`Revoke link ${link.token}`}
-                                            title="Revoke link"
-                                        >
-                                            <Trash2 className="size-3.5" aria-hidden="true" />
-                                        </Button>
-                                    }
-                                />
-                            </div>
-                        </TableCell>
-                    </TableRow>
-                ))}
-            </SectionTable>
+                className="bg-card"
+            />
         </ApiState>
-    );
-}
-
-function LinkParameters({ parameters }: { parameters: Record<string, string> }) {
-    const entries = Object.entries(parameters);
-    if (entries.length === 0) {
-        return <span className="text-muted-foreground">—</span>;
-    }
-
-    return (
-        <div className="flex flex-wrap gap-1.5">
-            {entries.map(([name, value]) => (
-                <Badge key={name} variant="secondary" className="font-mono font-normal">
-                    {name}: {value}
-                </Badge>
-            ))}
-        </div>
     );
 }

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/embed-link-api-docs.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/embed-link-api-docs.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { CopyableCode } from "@/components/data/copyable-code";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/shadcn/ui/collapsible";
+import {
+    buildMintEmbedLinkUrl,
+    DEFAULT_MAX_INVOCATIONS,
+    DEFAULT_TTL_SECONDS,
+    MAX_INVOCATIONS,
+    MAX_TTL_SECONDS,
+    MIN_INVOCATIONS,
+    MIN_TTL_SECONDS,
+} from "@/pages/apps/channels/embed-link-utils";
+import { InlineCode } from "@/components/data/inline-code";
+
+const OPEN_STORAGE_KEY = "quill-embed-api-docs-open";
+
+function readIsOpen() {
+    return localStorage.getItem(OPEN_STORAGE_KEY) !== "false";
+}
+
+type EmbedLinkApiDocsProps = {
+    slug: string;
+    agentId: string;
+    parameterNames: string[];
+};
+
+export function EmbedLinkApiDocs({ slug, agentId, parameterNames }: EmbedLinkApiDocsProps) {
+    const hasParameters = parameterNames.length > 0;
+    const request = buildRequestSnippet(slug, agentId, parameterNames);
+
+    const [isOpen, setIsOpen] = useState(readIsOpen);
+
+    const onOpenChange = (open: boolean) => {
+        localStorage.setItem(OPEN_STORAGE_KEY, String(open));
+        setIsOpen(open);
+    };
+
+    const fields = [
+        { name: "agentId", description: "The agent this channel is bound to (already filled in)." },
+        {
+            name: "ttlSeconds",
+            description: `Link lifetime in seconds, ${MIN_TTL_SECONDS}–${MAX_TTL_SECONDS.toLocaleString()} (default ${DEFAULT_TTL_SECONDS.toLocaleString()}).`,
+        },
+        {
+            name: "maxInvocations",
+            description: `Chats allowed before the link stops, ${MIN_INVOCATIONS}–${MAX_INVOCATIONS.toLocaleString()} (default ${DEFAULT_MAX_INVOCATIONS}).`,
+        },
+        ...(hasParameters
+            ? [
+                  {
+                      name: "parameters",
+                      description: `Values bound into the link for this agent (${parameterNames.join(", ")}); omitting a required one returns 400.`,
+                  },
+              ]
+            : []),
+    ];
+
+    return (
+        <Collapsible open={isOpen} onOpenChange={onOpenChange} className="rounded-md border bg-surface2 p-4">
+            <h2 className="text-sm font-semibold">
+                <CollapsibleTrigger className="group flex w-full items-center justify-between gap-3 rounded-sm text-left focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none">
+                    Generate links via the API
+                    <ChevronDown
+                        className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
+                        aria-hidden="true"
+                    />
+                </CollapsibleTrigger>
+            </h2>
+
+            <CollapsibleContent className="mt-4 grid gap-4">
+                <p className="text-sm text-muted-foreground">
+                    Mint links from your own backend by POSTing to the embed-links endpoint, authenticated with your
+                    operator key in the <InlineCode>X-Api-Key</InlineCode> header. The app and agent are already filled
+                    in below — swap in your <InlineCode>QUILL_API_KEY</InlineCode>
+                    {hasParameters ? " and the parameter values" : ""}.
+                </p>
+
+                <CopyableCode code={request} copyLabel="Copy API request" />
+
+                <dl className="grid gap-2 text-sm">
+                    {fields.map((field) => (
+                        <div key={field.name} className="grid gap-x-3 sm:grid-cols-[8rem_1fr]">
+                            <dt className="font-mono text-xs font-medium">{field.name}</dt>
+                            <dd className="text-muted-foreground">{field.description}</dd>
+                        </div>
+                    ))}
+                </dl>
+
+                <p className="text-xs text-muted-foreground">
+                    The response returns a <InlineCode>url</InlineCode> — use it as-is in an{" "}
+                    <InlineCode>&lt;iframe src&gt;</InlineCode>. It is served only on the public embed host.
+                </p>
+            </CollapsibleContent>
+        </Collapsible>
+    );
+}
+
+function buildRequestSnippet(slug: string, agentId: string, parameterNames: string[]) {
+    const body: Record<string, unknown> = {
+        agentId,
+        ttlSeconds: DEFAULT_TTL_SECONDS,
+        maxInvocations: DEFAULT_MAX_INVOCATIONS,
+    };
+    if (parameterNames.length > 0) {
+        body.parameters = Object.fromEntries(parameterNames.map((name) => [name, "<value>"]));
+    }
+
+    const indentedBody = JSON.stringify(body, null, 2)
+        .split("\n")
+        .map((line, index) => (index === 0 ? line : `  ${line}`))
+        .join("\n");
+
+    return [
+        "curl -X POST \\",
+        `  "${buildMintEmbedLinkUrl(slug)}" \\`,
+        `  -H "X-Api-Key: <your QUILL_API_KEY>" \\`,
+        `  -H "Content-Type: application/json" \\`,
+        `  -d '${indentedBody}'`,
+    ].join("\n");
+}

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/embed-link-api-docs.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/embed-link-api-docs.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { CopyableCode } from "@/components/data/copyable-code";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/shadcn/ui/collapsible";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/ui/tabs";
 import {
     buildMintEmbedLinkUrl,
     DEFAULT_MAX_INVOCATIONS,
@@ -14,9 +15,16 @@ import {
 import { InlineCode } from "@/components/data/inline-code";
 
 const OPEN_STORAGE_KEY = "quill-embed-api-docs-open";
+const SHELL_STORAGE_KEY = "quill-embed-api-docs-shell";
+
+type Shell = "bash" | "powershell";
 
 function readIsOpen() {
     return localStorage.getItem(OPEN_STORAGE_KEY) !== "false";
+}
+
+function readShell(): Shell {
+    return localStorage.getItem(SHELL_STORAGE_KEY) === "powershell" ? "powershell" : "bash";
 }
 
 type EmbedLinkApiDocsProps = {
@@ -27,13 +35,20 @@ type EmbedLinkApiDocsProps = {
 
 export function EmbedLinkApiDocs({ slug, agentId, parameterNames }: EmbedLinkApiDocsProps) {
     const hasParameters = parameterNames.length > 0;
-    const request = buildRequestSnippet(slug, agentId, parameterNames);
+    const requests = buildRequestSnippets(slug, agentId, parameterNames);
 
     const [isOpen, setIsOpen] = useState(readIsOpen);
+    const [shell, setShell] = useState<Shell>(readShell);
 
     const onOpenChange = (open: boolean) => {
         localStorage.setItem(OPEN_STORAGE_KEY, String(open));
         setIsOpen(open);
+    };
+
+    const onShellChange = (value: string) => {
+        const next = value as Shell;
+        localStorage.setItem(SHELL_STORAGE_KEY, next);
+        setShell(next);
     };
 
     const fields = [
@@ -57,7 +72,7 @@ export function EmbedLinkApiDocs({ slug, agentId, parameterNames }: EmbedLinkApi
     ];
 
     return (
-        <Collapsible open={isOpen} onOpenChange={onOpenChange} className="rounded-md border bg-surface2 p-4">
+        <Collapsible open={isOpen} onOpenChange={onOpenChange} className="rounded-md border bg-card p-4">
             <h2 className="text-sm font-semibold">
                 <CollapsibleTrigger className="group flex w-full items-center justify-between gap-3 rounded-sm text-left focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none">
                     Generate links via the API
@@ -76,7 +91,18 @@ export function EmbedLinkApiDocs({ slug, agentId, parameterNames }: EmbedLinkApi
                     {hasParameters ? " and the parameter values" : ""}.
                 </p>
 
-                <CopyableCode code={request} copyLabel="Copy API request" />
+                <Tabs value={shell} onValueChange={onShellChange} className="gap-3">
+                    <TabsList>
+                        <TabsTrigger value="bash">macOS / Linux</TabsTrigger>
+                        <TabsTrigger value="powershell">Windows (PowerShell)</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="bash">
+                        <CopyableCode code={requests.bash} copyLabel="Copy API request" />
+                    </TabsContent>
+                    <TabsContent value="powershell">
+                        <CopyableCode code={requests.powershell} copyLabel="Copy API request" />
+                    </TabsContent>
+                </Tabs>
 
                 <dl className="grid gap-2 text-sm">
                     {fields.map((field) => (
@@ -96,7 +122,7 @@ export function EmbedLinkApiDocs({ slug, agentId, parameterNames }: EmbedLinkApi
     );
 }
 
-function buildRequestSnippet(slug: string, agentId: string, parameterNames: string[]) {
+function buildRequestSnippets(slug: string, agentId: string, parameterNames: string[]) {
     const body: Record<string, unknown> = {
         agentId,
         ttlSeconds: DEFAULT_TTL_SECONDS,
@@ -111,11 +137,21 @@ function buildRequestSnippet(slug: string, agentId: string, parameterNames: stri
         .map((line, index) => (index === 0 ? line : `  ${line}`))
         .join("\n");
 
-    return [
-        "curl -X POST \\",
-        `  "${buildMintEmbedLinkUrl(slug)}" \\`,
-        `  -H "X-Api-Key: <your QUILL_API_KEY>" \\`,
-        `  -H "Content-Type: application/json" \\`,
-        `  -d '${indentedBody}'`,
-    ].join("\n");
+    const url = buildMintEmbedLinkUrl(slug);
+
+    // bash continues lines with "\", PowerShell with a backtick; PowerShell also needs curl.exe so
+    // it doesn't resolve to the Invoke-WebRequest alias on Windows PowerShell 5.1.
+    const snippet = (curl: string, continuation: string) =>
+        [
+            `${curl} -X POST ${continuation}`,
+            `  "${url}" ${continuation}`,
+            `  -H "X-Api-Key: <your QUILL_API_KEY>" ${continuation}`,
+            `  -H "Content-Type: application/json" ${continuation}`,
+            `  -d '${indentedBody}'`,
+        ].join("\n");
+
+    return {
+        bash: snippet("curl", "\\"),
+        powershell: snippet("curl.exe", "`"),
+    };
 }

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/embed-link-preview.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/embed-link-preview.tsx
@@ -1,5 +1,5 @@
 import { Copy, ExternalLink } from "lucide-react";
-import { Button } from "@/components/shadcn/ui/button";
+import { CopyableCode } from "@/components/data/copyable-code";
 import { Field, FieldLabel } from "@/components/shadcn/ui/field";
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/shadcn/ui/input-group";
 import { formatDateTime, copyToClipboard } from "@/lib/utils";
@@ -51,21 +51,7 @@ export function EmbedLinkPreview({ url, token, expiresAt, maxInvocations }: Embe
 
             <Field>
                 <FieldLabel>Embed snippet</FieldLabel>
-                <div className="relative min-w-0">
-                    <pre className="rounded-lg border bg-muted/50 py-2 pr-10 pl-3 text-xs break-all whitespace-pre-wrap">
-                        <code>{iframeSnippet}</code>
-                    </pre>
-                    <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        className="absolute top-1.5 right-1.5"
-                        aria-label="Copy embed snippet"
-                        onClick={() => copyToClipboard(iframeSnippet)}
-                    >
-                        <Copy className="size-3.5" aria-hidden="true" />
-                    </Button>
-                </div>
+                <CopyableCode code={iframeSnippet} copyLabel="Copy embed snippet" />
             </Field>
 
             <p className="text-xs text-muted-foreground">

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/embed-link-preview.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/embed-link-preview.tsx
@@ -5,26 +5,13 @@ import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "
 import { formatDateTime, copyToClipboard } from "@/lib/utils";
 
 type EmbedLinkPreviewProps = {
-    /** Absolute, paste-ready embed URL for the customer's cross-origin <iframe src>. */
     url: string;
-    /** The opaque bearer token — drives the relative inline preview. */
-    token: string;
     expiresAt: string;
     maxInvocations: number;
 };
 
-/**
- * The minted-link result view shared by the "Generate embed link" dialog and the
- * per-link preview dialog: the paste-ready URL (copy + open), the iframe snippet,
- * the TTL/cap line, and an inline live preview. Renders its own grid container, so
- * place a sibling footer next to it inside a `DialogContent`.
- */
-export function EmbedLinkPreview({ url, token, expiresAt, maxInvocations }: EmbedLinkPreviewProps) {
+export function EmbedLinkPreview({ url, expiresAt, maxInvocations }: EmbedLinkPreviewProps) {
     const iframeSnippet = `<iframe src="${url}" width="400" height="600"></iframe>`;
-    // The url is absolute (paste-ready for the customer). The inline preview loads the
-    // token relatively so it works behind the dev /embed proxy and same-origin in
-    // production, regardless of the absolute host the URL points at.
-    const previewUrl = `/embed/${token}`;
 
     return (
         <div className="grid min-w-0 gap-4">
@@ -48,26 +35,15 @@ export function EmbedLinkPreview({ url, token, expiresAt, maxInvocations }: Embe
                     </InputGroupAddon>
                 </InputGroup>
             </Field>
-
             <Field>
                 <FieldLabel>Embed snippet</FieldLabel>
                 <CopyableCode code={iframeSnippet} copyLabel="Copy embed snippet" />
             </Field>
-
             <p className="text-xs text-muted-foreground">
                 Expires {formatDateTime(expiresAt)} · up to {maxInvocations.toLocaleString()} chats.
             </p>
-
-            {/* Rendered at the widget's real 400px width (matching the snippet) so the preview
-                looks exactly as embedded. The embed page styles itself light-only, so the
-                backdrop stays white in dark mode too.
-                KNOWN LIMITATION (RavenDB-26775): this previews the *real* minted token, so
-                sending a message here spends one of the link's invocations and pins its
-                single server-owned conversation — the end user then inherits that history and
-                a reduced budget. Merely opening the preview is harmless (only POST /chat
-                counts). A dedicated un-counted preview surface is deferred. */}
             <iframe
-                src={previewUrl}
+                src={url}
                 title="Embed preview"
                 className="mx-auto h-[min(600px,55vh)] w-full max-w-[400px] rounded-lg border bg-white"
             />

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/embed-link-utils.ts
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/embed-link-utils.ts
@@ -2,16 +2,34 @@
  *  public.* subdomain only, so swap the operator host's leading label (dashboard.* / api.*) for
  *  public.* — falling back to the current origin when there is no subdomain to swap (dev/localhost). */
 export function buildEmbedUrl(token: string) {
-    return `${publicOrigin()}/embed/${token}`;
+    return `${originForSubdomain("public")}/embed/${token}`;
 }
 
-function publicOrigin() {
+/** Builds the absolute embed-links mint endpoint shown in the "Generate links via the API" docs. The
+ *  API is served on the api.* subdomain, so swap the operator host's leading label for api.* — falling
+ *  back to the current origin when there is no subdomain to swap (dev/localhost), where /api is local. */
+export function buildMintEmbedLinkUrl(slug: string) {
+    return `${originForSubdomain("api")}/api/apps/${encodeURIComponent(slug)}/embed-links`;
+}
+
+// Swaps the operator host's leading label (dashboard.* / api.*) for the given subdomain, falling back
+// to the current origin when there is no subdomain to swap (dev/localhost / bare IP).
+function originForSubdomain(label: string) {
     const { protocol, hostname, port } = window.location;
     const isIpV4 = /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname);
     const dot = hostname.indexOf(".");
     if (dot <= 0 || isIpV4) {
         return window.location.origin;
     }
-    const publicHost = `public.${hostname.slice(dot + 1)}`;
-    return `${protocol}//${publicHost}${port ? `:${port}` : ""}`;
+    const host = `${label}.${hostname.slice(dot + 1)}`;
+    return `${protocol}//${host}${port ? `:${port}` : ""}`;
 }
+
+// Server-enforced bounds for minting embed links (see the embed-links mint contract). Shared by the
+// generate dialog (range validation + defaults) and the API docs (documented ranges + example body).
+export const MIN_TTL_SECONDS = 60;
+export const MAX_TTL_SECONDS = 2_592_000;
+export const MIN_INVOCATIONS = 1;
+export const MAX_INVOCATIONS = 1_000_000;
+export const DEFAULT_TTL_SECONDS = 3_600;
+export const DEFAULT_MAX_INVOCATIONS = 100;

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
@@ -230,13 +230,7 @@ export function GenerateEmbedLinkDialog({
 function MintedLink({ result, onGenerateAnother }: { result: MintEmbedLinkResponse; onGenerateAnother: () => void }) {
     return (
         <>
-            <EmbedLinkPreview
-                url={result.url}
-                token={result.token}
-                expiresAt={result.expiresAt}
-                maxInvocations={result.maxInvocations}
-            />
-
+            <EmbedLinkPreview url={result.url} expiresAt={result.expiresAt} maxInvocations={result.maxInvocations} />
             <DialogFooter>
                 <Button type="button" variant="secondary" onClick={onGenerateAnother}>
                     Generate another

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
@@ -22,6 +22,13 @@ import {
 import { FormInput } from "@/components/form/form-input";
 import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
 import { EmbedLinkPreview } from "@/pages/apps/channels/embed-link-preview";
+import {
+    DEFAULT_MAX_INVOCATIONS,
+    MAX_INVOCATIONS,
+    MAX_TTL_SECONDS,
+    MIN_INVOCATIONS,
+    MIN_TTL_SECONDS,
+} from "@/pages/apps/channels/embed-link-utils";
 
 type GenerateEmbedLinkDialogProps = {
     slug: string;
@@ -33,13 +40,6 @@ type GenerateEmbedLinkDialogProps = {
     trigger: ReactNode;
 };
 
-// Server-enforced bounds (see the embed-links mint contract). Mirrored here so the
-// form surfaces range errors before the request rather than after a 400.
-const MIN_TTL_SECONDS = 60;
-const MAX_TTL_SECONDS = 2_592_000;
-const MIN_INVOCATIONS = 1;
-const MAX_INVOCATIONS = 1_000_000;
-const DEFAULT_MAX_INVOCATIONS = 100;
 const DEFAULT_TTL_PRESET = "3600";
 
 const ttlPresetSchema = z.enum(["3600", "14400", "86400", "604800", "custom"]);

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/preview-embed-link-dialog.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/preview-embed-link-dialog.tsx
@@ -22,16 +22,6 @@ type PreviewEmbedLinkDialogProps = {
     trigger: ReactNode;
 };
 
-/**
- * Re-opens the minted-link result view for an already-generated link, so the
- * operator can copy its URL/snippet and see a live preview without minting again.
- * The summary doesn't carry the absolute URL, so we rebuild it from the token.
- *
- * Sending a message in the live preview spends a real invocation server-side (see
- * embed-link-preview.tsx), so the link's usage count goes stale while the dialog is
- * open. There's no cross-origin signal from the iframe, so we refresh the list when
- * the dialog closes to pick up any invocations spent during the preview.
- */
 export function PreviewEmbedLinkDialog({ slug, link, trigger }: PreviewEmbedLinkDialogProps) {
     const [isOpen, setIsOpen] = useState(false);
     const queryClient = useQueryClient();
@@ -57,7 +47,6 @@ export function PreviewEmbedLinkDialog({ slug, link, trigger }: PreviewEmbedLink
 
                 <EmbedLinkPreview
                     url={buildEmbedUrl(link.token)}
-                    token={link.token}
                     expiresAt={link.expiresAt}
                     maxInvocations={link.maxInvocations}
                 />

--- a/src/Raven.AiAppliance.Web/src/pages/apps/section-card.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/section-card.tsx
@@ -3,7 +3,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 
 export function SectionCard({ title, action, children }: { title: string; action?: ReactNode; children: ReactNode }) {
     return (
-        <section>
+        <section className="min-w-0">
             <div className="mb-4 flex items-center justify-between gap-3">
                 <h2 className="text-sm font-semibold">{title}</h2>
                 {action}

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/connect/import-config-dialog.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/connect/import-config-dialog.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { toast } from "sonner";
 import { UploadIcon } from "lucide-react";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Button } from "@/components/shadcn/ui/button";
@@ -36,13 +35,7 @@ export function ImportConfigDialog({ disabled }: ImportConfigDialogProps) {
     };
 
     const handleFileSelected = (file: File) => {
-        importMutation.mutate(file, {
-            onSuccess: () => {
-                setIsOpen(false);
-                importMutation.reset();
-                toast.success("Configuration imported");
-            },
-        });
+        importMutation.mutate(file);
     };
 
     return (

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { useFormContext } from "react-hook-form";
+import { toast } from "sonner";
 import type { DiscoverResponse } from "@/api/generated/server-api";
 import { api } from "@/api/api";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
@@ -78,6 +79,8 @@ export function useImportConfig() {
             }
         },
         onSuccess: ({ config, formTables, discoverResult, schemas }) => {
+            toast.success("Configuration imported");
+
             const verifySchemaTables = config.tables.map((table) => ({
                 sourceTableSchema: table.sourceTableSchema ?? null,
                 sourceTableName: table.sourceTableName ?? "",

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/verify/verified-tables-table.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/verify/verified-tables-table.tsx
@@ -57,35 +57,36 @@ export function VerifiedTablesTable({
 
     return (
         <TooltipProvider>
-            <div className={cn("relative", selectedCount > 0 && "mb-4")}>
-                <VirtualDataTable
-                    table={table}
-                    columnCount={VERIFIED_COLUMNS.length}
-                    emptyMessage="No tables match the current filter."
-                    heightInPx={300}
-                    getRowState={(rowId) => (rowSelection[rowId] ? "selected" : "")}
-                />
-                {selectedCount > 0 && (
-                    <div className="absolute bottom-0 left-1/2 flex -translate-x-1/2 translate-y-1/2 items-center gap-2.5 rounded-full border bg-card px-4 py-2 text-sm shadow-md">
-                        <span className="whitespace-nowrap text-muted-foreground">
-                            {selectedCount} out of {totalTableCount} tables selected
-                        </span>
-                        {!disabled && (
-                            <>
-                                <div className="h-4 w-px bg-border" />
-                                <button
-                                    type="button"
-                                    className="flex items-center gap-1.5 whitespace-nowrap text-foreground transition-colors hover:text-muted-foreground"
-                                    onClick={() => onRowSelectionChange({})}
-                                >
-                                    <XIcon className="size-3.5" aria-hidden="true" />
-                                    Deselect all
-                                </button>
-                            </>
-                        )}
-                    </div>
-                )}
-            </div>
+            <VirtualDataTable
+                table={table}
+                columnCount={VERIFIED_COLUMNS.length}
+                emptyMessage="No tables match the current filter."
+                heightInPx={300}
+                className={cn(selectedCount > 0 && "mb-4")}
+                getRowState={(rowId) => (rowSelection[rowId] ? "selected" : "")}
+                overlay={
+                    selectedCount > 0 && (
+                        <div className="absolute bottom-0 left-1/2 flex -translate-x-1/2 translate-y-1/2 items-center gap-2.5 rounded-full border bg-card px-4 py-2 text-sm shadow-md">
+                            <span className="whitespace-nowrap text-muted-foreground">
+                                {selectedCount} out of {totalTableCount} tables selected
+                            </span>
+                            {!disabled && (
+                                <>
+                                    <div className="h-4 w-px bg-border" />
+                                    <button
+                                        type="button"
+                                        className="flex items-center gap-1.5 whitespace-nowrap text-foreground transition-colors hover:text-muted-foreground"
+                                        onClick={() => onRowSelectionChange({})}
+                                    >
+                                        <XIcon className="size-3.5" aria-hidden="true" />
+                                        Deselect all
+                                    </button>
+                                </>
+                            )}
+                        </div>
+                    )
+                }
+            />
         </TooltipProvider>
     );
 }

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-columns.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-columns.tsx
@@ -11,10 +11,9 @@ const TABLE_NAME_COLUMN: ColumnDef<DiscoverTableResponse> = {
     accessorFn: (table) => getTableLabel(table),
     header: "Table name",
     id: "tableName",
-    size: 300,
     cell: ({ row, getValue }) => (
-        <span className="flex items-center gap-1.5 font-mono">
-            {getValue<string>()}
+        <span className="flex min-w-0 items-center gap-1.5 font-mono">
+            <span className="truncate">{getValue<string>()}</span>
             {row.original.warnings.length > 0 && (
                 <Tooltip>
                     <TooltipTrigger asChild>
@@ -38,7 +37,6 @@ const PRIMARY_KEY_COLUMN: ColumnDef<DiscoverTableResponse> = {
     accessorFn: (table) => table.primaryKeyColumns.join(", "),
     header: "Primary key",
     id: "primaryKey",
-    size: 100,
     cell: ({ getValue }) => <span className="font-mono">{getValue<string>()}</span>,
 };
 
@@ -46,7 +44,6 @@ const COLUMNS_COUNT_COLUMN: ColumnDef<DiscoverTableResponse> = {
     accessorFn: (table) => table.columns.length,
     header: "Columns count",
     id: "columnsCount",
-    size: 130,
     cell: ({ getValue }) => <span className="tabular-nums">{getValue<number>()}</span>,
 };
 
@@ -71,6 +68,7 @@ export const VERIFIED_COLUMNS: ColumnDef<DiscoverTableResponse>[] = [
         ),
         enableSorting: false,
         enableHiding: false,
+        enableResizing: false,
         size: 40,
     },
     TABLE_NAME_COLUMN,

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/add-capability-wizard.stories.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/add-capability-wizard.stories.tsx
@@ -8,6 +8,7 @@ import { api } from "@/api/api";
 import { FormWizard } from "@/components/form/wizard/form-wizard";
 import { preventEnterKeySubmission } from "@/lib/form-utils";
 import { sampleAgentSuggestion } from "@/mocks/apps-mocks";
+import { aiConnectionStringsMocks } from "@/mocks/ai-connection-strings-mocks";
 import { channelsMocks } from "@/mocks/channels-mocks";
 import { AddCapabilityWizard } from "./add-capability-wizard";
 import { suggestionToAgentConfiguration } from "./agent-config-form";
@@ -106,6 +107,12 @@ export const ChooseCapability: Story = {
 
 export const ConnectProvider: Story = {
     render: () => <CapabilityWizardAtStep initialStep="connection" />,
+};
+
+// No connection strings yet: the step hides the selector and shows only the "Add" button.
+export const ConnectProviderEmpty: Story = {
+    render: () => <CapabilityWizardAtStep initialStep="connection" />,
+    parameters: { msw: { handlers: { aiConnectionStrings: [aiConnectionStringsMocks.list({ items: [] })] } } },
 };
 
 export const CreateAgent: Story = {

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/connect/connect-provider-step.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/connect/connect-provider-step.tsx
@@ -7,11 +7,11 @@ import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wiz
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
 import { AddAiConnectionString } from "@/components/ai-connection-string/add-ai-connection-string";
 import { FormCombobox } from "@/components/form/form-combobox";
+import { Field, FieldLabel } from "@/components/shadcn/ui/field";
 
 export function ConnectProviderStep({ isBusy }: WizardBodyComponentProps) {
     const { slug = "" } = useParams();
-    const { control, setValue } = useFormContext<AgentFormData>();
-
+    const { control } = useFormContext<AgentFormData>();
     const connectionStringsQuery = useQuery(api.queries.aiConnectionStrings.list(slug));
     const items = connectionStringsQuery.data?.items ?? [];
 
@@ -23,32 +23,47 @@ export function ConnectProviderStep({ isBusy }: WizardBodyComponentProps) {
             onRetry={connectionStringsQuery.refetch}
             loadingLabel="Loading connection strings..."
         >
-            <div className="flex items-end gap-3">
-                <FormCombobox
-                    control={control}
-                    name="connection.connectionStringName"
-                    label="Connection string"
-                    className="flex-1"
-                    placeholder={items.length > 0 ? "Select..." : "No connection strings yet"}
-                    disabled={isBusy || items.length === 0}
-                    options={items.map((item) => ({
-                        value: item.name,
-                        label: `${item.name} · ${item.provider}`,
-                    }))}
-                    addons={
-                        <AddAiConnectionString
-                            slug={slug}
-                            modelType="Chat"
-                            onCreated={(name) =>
-                                setValue("connection.connectionStringName", name, {
-                                    shouldValidate: true,
-                                    shouldDirty: true,
-                                })
-                            }
-                        />
-                    }
-                />
-            </div>
+            {items.length === 0 ? (
+                <Field>
+                    <FieldLabel>Connection string</FieldLabel>
+                    <div>
+                        <AddButton slug={slug} />
+                    </div>
+                </Field>
+            ) : (
+                <div className="flex items-end gap-3">
+                    <FormCombobox
+                        control={control}
+                        name="connection.connectionStringName"
+                        label="Connection string"
+                        className="flex-1"
+                        placeholder="Select..."
+                        disabled={isBusy}
+                        options={items.map((item) => ({
+                            value: item.name,
+                            label: `${item.name} · ${item.provider}`,
+                        }))}
+                        addons={<AddButton slug={slug} />}
+                    />
+                </div>
+            )}
         </ApiState>
+    );
+}
+
+function AddButton({ slug }: { slug: string }) {
+    const { setValue } = useFormContext<AgentFormData>();
+
+    return (
+        <AddAiConnectionString
+            slug={slug}
+            modelType="Chat"
+            onCreated={(name) =>
+                setValue("connection.connectionStringName", name, {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                })
+            }
+        />
     );
 }

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/agent-suggestion-tab.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/steps/review/agent-suggestion-tab.tsx
@@ -4,7 +4,7 @@ import { Sparkles } from "lucide-react";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
+import { ExpandableText } from "@/components/data/expandable-text";
 import { FormTextarea } from "@/components/form/form-textarea";
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
 import { SuggestionPicker } from "@/pages/setup/add-capability-wizard/suggestion-picker";
@@ -36,18 +36,11 @@ export function AgentSuggestionTab() {
                     <SummaryRow label="Agent name">{config.name || "—"}</SummaryRow>
                     <SummaryRow label="System prompt">
                         {systemPrompt ? (
-                            <TooltipProvider>
-                                <Tooltip>
-                                    <TooltipTrigger asChild>
-                                        <span className="block max-w-md cursor-default">{systemPrompt}</span>
-                                    </TooltipTrigger>
-                                    <TooltipContent className="max-w-sm whitespace-normal">
-                                        {systemPrompt}
-                                    </TooltipContent>
-                                </Tooltip>
-                            </TooltipProvider>
+                            <ExpandableText maxLines={3} className="text-justify text-sm whitespace-pre-wrap">
+                                {systemPrompt}
+                            </ExpandableText>
                         ) : (
-                            "—"
+                            <span className="text-sm text-muted-foreground">—</span>
                         )}
                     </SummaryRow>
                     <SummaryRow label="Connection string">{connectionStringName || "—"}</SummaryRow>
@@ -106,7 +99,7 @@ function PromptEditor() {
 
 function SummaryRow({ label, children }: { label: string; children: ReactNode }) {
     return (
-        <div className="flex min-h-12 items-center justify-between gap-4 py-3">
+        <div className="flex min-h-12 items-center justify-between gap-12 py-3">
             <span className="shrink-0 text-sm font-medium">{label}</span>
             <div className="flex min-w-0 justify-end text-sm">{children}</div>
         </div>

--- a/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/suggestion-picker.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/setup/add-capability-wizard/suggestion-picker.tsx
@@ -15,7 +15,7 @@ export function SuggestionPicker() {
     const selectedIndex = useWatch({ control, name: "create.selectedIndex" });
 
     return (
-        <div className="grid gap-3 md:grid-cols-3">
+        <div className="grid grid-flow-col gap-3">
             {suggestions.map((config, index) => {
                 const isSelected = mode === "ai" && index === selectedIndex;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26865

### Additional description

Added:
- virtual table auto sizing
- CopyableCode
- ExpandableText
- InlineCode
- Collapsible
- iframe link API instructions

Fixed:
- number input styling
- empty connection string selector
- import success toast
- large system prompt preview
- iframe public link

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
