### PR TITLE
RavenDB-26882 Honor per-table Disabled flag in CDC Sink (skip initial load and change capture)

### DIFF
--- a/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
@@ -449,8 +449,9 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
     }
 
     /// <summary>
-    /// Collects all configured tables (including embedded tables recursively) as a flat list
-    /// of TableInfo instances with schema, name, and primary key columns.
+    /// Collects the active configured tables (including embedded tables recursively) as a flat list
+    /// of TableInfo instances with schema, name, and primary key columns. Disabled root tables - and
+    /// their embedded tables - are excluded, so they are neither initial-loaded nor change-captured.
     /// </summary>
     /// <param name="defaultSchema">Default schema when SourceTableSchema is null (e.g., "public" for PostgreSQL, "dbo" for SQL Server).</param>
     public List<TableInfo> CollectAllTablesFlat(string defaultSchema)
@@ -458,6 +459,9 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
         var tables = new List<TableInfo>();
         foreach (var table in Tables)
         {
+            if (table.Disabled)
+                continue;
+
             tables.Add(new TableInfo
             {
                 Schema = string.IsNullOrEmpty(table.SourceTableSchema) ? defaultSchema : table.SourceTableSchema,

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
@@ -19,6 +19,7 @@ public class CdcSinkDocumentProcessor
 {
     private readonly CdcSinkConfiguration _config;
     private readonly string _defaultSchema;
+    private readonly bool _includeDisabledTables;
     private readonly Dictionary<(string Schema, string Table), CdcSinkTableProcessor> _tableIndex;
 
     internal RavenLogger Logger { get; set; }
@@ -28,14 +29,25 @@ public class CdcSinkDocumentProcessor
     /// </summary>
     public PatchRequest CombinedPatchRequest { get; }
 
-    public CdcSinkDocumentProcessor(CdcSinkConfiguration config, string defaultSchema = "")
+    /// <param name="includeDisabledTables">
+    /// When false (runtime default), tables marked <see cref="CdcSinkTableConfig.Disabled"/> are not registered,
+    /// so their streamed rows resolve to no processor and are discarded. Replay (<see cref="Commands.CdcSinkBatchCommand"/>)
+    /// and the test/preview endpoint pass true because they must resolve every configured table regardless of state.
+    /// </param>
+    public CdcSinkDocumentProcessor(CdcSinkConfiguration config, string defaultSchema = "", bool includeDisabledTables = false)
     {
         _config = config;
         _defaultSchema = defaultSchema;
+        _includeDisabledTables = includeDisabledTables;
         _tableIndex = new Dictionary<(string, string), CdcSinkTableProcessor>(TableKeyComparer.Instance);
 
         foreach (var table in config.Tables)
         {
+            // A disabled table is excluded from the runtime mapping: no processor is registered, so its rows
+            // are discarded during streaming and it is never initial-loaded (see CollectAllTablesFlat).
+            if (table.Disabled && _includeDisabledTables == false)
+                continue;
+
             // IsNullOrEmpty rather than `??` so callers that supply "" (empty) get the same
             // default-schema substitution as null. The test endpoint resolves SourceTableSchema
             // via string.IsNullOrEmpty before looking up tables in _tableIndex; this keeps the
@@ -85,6 +97,10 @@ public class CdcSinkDocumentProcessor
 
         foreach (var table in _config.Tables)
         {
+            // Skip patches for disabled tables that weren't registered above - no op will reference them.
+            if (table.Disabled && _includeDisabledTables == false)
+                continue;
+
             var schema = string.IsNullOrEmpty(table.SourceTableSchema) ? _defaultSchema : table.SourceTableSchema;
 
             if (table.Patch != null)

--- a/src/Raven.Server/Documents/CdcSink/Commands/CdcSinkBatchCommand.cs
+++ b/src/Raven.Server/Documents/CdcSink/Commands/CdcSinkBatchCommand.cs
@@ -1650,7 +1650,9 @@ public sealed class CdcSinkBatchCommand : DocumentMergedTransactionCommand
             // Prefer the schema persisted in the Dto — during tx-log replay the live process may be
             // gone, so re-deriving from it would yield "" and mis-key the rebuilt processors.
             var defaultSchema = DefaultSchema ?? process?.DefaultSchema ?? "";
-            var docProcessor = new CdcSinkDocumentProcessor(config, defaultSchema);
+            // includeDisabledTables: a batch persisted while a table was enabled may be replayed after the
+            // table was disabled - the replay must still resolve that table's processor to restore the ops.
+            var docProcessor = new CdcSinkDocumentProcessor(config, defaultSchema, includeDisabledTables: true);
 
             var ops = new List<CdcSinkDocumentOp>(Ops.Count);
             for (int i = 0; i < Ops.Count; i++)

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -407,6 +407,10 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
         var result = new List<CdcSinkEmbeddedTableConfig>();
         foreach (var root in rootTables)
         {
+            // A disabled root table isn't captured, so don't touch its embedded tables' source-side REPLICA IDENTITY.
+            if (root.Disabled)
+                continue;
+
             CdcSinkConfiguration.ForEachEmbeddedTable(root.EmbeddedTables, e =>
             {
                 if (e.OnDelete?.IgnoreDeletes == true)

--- a/src/Raven.Server/Documents/CdcSink/Test/CdcSinkTestRunner.cs
+++ b/src/Raven.Server/Documents/CdcSink/Test/CdcSinkTestRunner.cs
@@ -53,7 +53,9 @@ namespace Raven.Server.Documents.CdcSink.Test
                 return result;
             }
 
-            var docProcessor = new CdcSinkDocumentProcessor(configuration, defaultSchema);
+            // includeDisabledTables: the test endpoint is a dry-run mapping preview that is independent of
+            // whether the table is enabled for import, so a disabled table must still be resolvable here.
+            var docProcessor = new CdcSinkDocumentProcessor(configuration, defaultSchema, includeDisabledTables: true);
             var tableSchema = string.IsNullOrEmpty(targetTable.SourceTableSchema) ? defaultSchema : targetTable.SourceTableSchema;
             var processor = docProcessor.GetProcessor(tableSchema, targetTable.SourceTableName);
             if (processor == null)

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkDisabledTableTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkDisabledTableTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Operations.CdcSink;
+using Raven.Server.Documents.CdcSink;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.CdcSink
+{
+    public class CdcSinkDisabledTableTests : RavenTestBase
+    {
+        public CdcSinkDisabledTableTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // Two root tables, each with an embedded table. The "products" root can be toggled disabled.
+        private static CdcSinkConfiguration BuildConfig(bool productsDisabled, string productsPatch = null)
+        {
+            return new CdcSinkConfiguration
+            {
+                Name = "test-config",
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = "public",
+                        SourceTableName = "orders",
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "order_id", Name = "OrderId" },
+                            new CdcColumnMapping { Column = "customer_name", Name = "CustomerName" }
+                        },
+                        PrimaryKeyColumns = new List<string> { "order_id" },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = "public",
+                                SourceTableName = "order_lines",
+                                PropertyName = "Lines",
+                                Columns = new List<CdcColumnMapping>
+                                {
+                                    new CdcColumnMapping { Column = "line_id", Name = "LineId" }
+                                },
+                                PrimaryKeyColumns = new List<string> { "line_id" },
+                                JoinColumns = new List<string> { "order_id" },
+                                Type = CdcSinkRelationType.Array
+                            }
+                        }
+                    },
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Products",
+                        SourceTableSchema = "public",
+                        SourceTableName = "products",
+                        Disabled = productsDisabled,
+                        Patch = productsPatch,
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "product_id", Name = "ProductId" }
+                        },
+                        PrimaryKeyColumns = new List<string> { "product_id" },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = "public",
+                                SourceTableName = "product_tags",
+                                PropertyName = "Tags",
+                                Columns = new List<CdcColumnMapping>
+                                {
+                                    new CdcColumnMapping { Column = "tag_id", Name = "TagId" }
+                                },
+                                PrimaryKeyColumns = new List<string> { "tag_id" },
+                                JoinColumns = new List<string> { "product_id" },
+                                Type = CdcSinkRelationType.Array
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void CollectAllTablesFlat_ExcludesDisabledRootTableAndItsEmbeddedTables()
+        {
+            // Initial load and every provider's change-capture setup enumerate tables through
+            // CollectAllTablesFlat, so a disabled table must not appear there.
+            var disabled = BuildConfig(productsDisabled: true).CollectAllTablesFlat("public")
+                .Select(t => t.TableName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            Assert.Contains("orders", disabled);
+            Assert.Contains("order_lines", disabled);
+            Assert.DoesNotContain("products", disabled);
+            Assert.DoesNotContain("product_tags", disabled);
+
+            var enabled = BuildConfig(productsDisabled: false).CollectAllTablesFlat("public")
+                .Select(t => t.TableName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            Assert.Contains("products", enabled);
+            Assert.Contains("product_tags", enabled);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void DocumentProcessor_DoesNotRegisterDisabledTable()
+        {
+            var processor = new CdcSinkDocumentProcessor(BuildConfig(productsDisabled: true), "public");
+
+            Assert.True(processor.TryGetProcessor("public", "orders", out _));
+            Assert.True(processor.TryGetProcessor("public", "order_lines", out _));
+
+            Assert.False(processor.TryGetProcessor("public", "products", out _));
+            Assert.False(processor.TryGetProcessor("public", "product_tags", out _));
+            Assert.Throws<InvalidOperationException>(() => processor.GetProcessor("public", "products"));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void DocumentProcessor_RegistersDisabledTable_WhenIncludeDisabledTablesRequested()
+        {
+            // Replay (CdcSinkBatchCommand) and the test/preview endpoint must resolve every configured
+            // table regardless of state, so they opt back in via includeDisabledTables.
+            var processor = new CdcSinkDocumentProcessor(BuildConfig(productsDisabled: true), "public", includeDisabledTables: true);
+
+            Assert.True(processor.TryGetProcessor("public", "products", out _));
+            Assert.True(processor.TryGetProcessor("public", "product_tags", out _));
+            Assert.NotNull(processor.GetProcessor("public", "products"));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void ProcessRow_DiscardsRowForDisabledTable()
+        {
+            var processor = new CdcSinkDocumentProcessor(BuildConfig(productsDisabled: true), "public");
+            using var context = JsonOperationContext.ShortTermSingleUse();
+
+            var row = new CdcSinkRow
+            {
+                TableSchema = "public",
+                TableName = "products",
+                Operation = CdcSinkOperation.Upsert,
+                Data = new object[] { 1 }
+            };
+
+            // A streamed row for a disabled table resolves to no processor and is dropped.
+            Assert.Null(processor.ProcessRow(row, context));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void CombinedPatchRequest_ExcludesDisabledTablePatch()
+        {
+            const string patch = "this.Touched = true;";
+
+            // Only the disabled table has a patch → nothing to dispatch at runtime.
+            var runtime = new CdcSinkDocumentProcessor(BuildConfig(productsDisabled: true, productsPatch: patch), "public");
+            Assert.Null(runtime.CombinedPatchRequest);
+
+            // Replay/preview keep the patch so already-created ops can still dispatch it.
+            var replay = new CdcSinkDocumentProcessor(BuildConfig(productsDisabled: true, productsPatch: patch), "public", includeDisabledTables: true);
+            Assert.NotNull(replay.CombinedPatchRequest);
+
+            // When enabled, the patch is available for runtime too.
+            var enabled = new CdcSinkDocumentProcessor(BuildConfig(productsDisabled: false, productsPatch: patch), "public");
+            Assert.NotNull(enabled.CombinedPatchRequest);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26882/CDC-TableDisabled-isnt-respected

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
