### PR TITLE
RavenDB-26885 The Databases view shows that we have 0 documents and the database is 0 bytes in size

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.spec.tsx
@@ -8,6 +8,7 @@ import { DatabasesStubs } from "test/stubs/DatabasesStubs";
 const {
     Single,
     Cluster,
+    ClusterViewedFromUnrelatedNode,
     Sharded,
     DifferentNodeStates,
     WithLoadErrorOnSingleNode,
@@ -50,6 +51,16 @@ describe("DatabasesPage", function () {
         await screen.findByText(/Manage group/i);
 
         await screen.findByText("9 Indexing errors");
+    });
+
+    it("can render cluster database stats when current node is not part of database group", async () => {
+        const { screen } = rtlRender(<ClusterViewedFromUnrelatedNode />);
+
+        await screen.findByText(/Manage group/i);
+
+        expect(await screen.findAllByText("7 Bytes")).not.toHaveLength(0);
+        expect(await screen.findAllByText("1,024")).not.toHaveLength(0);
+        expect(screen.queryByText("0 Bytes")).not.toBeInTheDocument();
     });
 
     it("can render load error on single node", async () => {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.stories.tsx
@@ -20,14 +20,14 @@ export default {
     },
 } satisfies Meta<typeof DatabasesPage>;
 
-function commonInit() {
+function commonInit(localNodeTag = "A", nodeTags = ["A", "B", "C"]) {
     const { cluster } = mockStore;
-    cluster.with_Cluster();
+    cluster.with_Cluster(nodeTags, localNodeTag);
 
     const { accessManager } = mockStore;
     accessManager.with_securityClearance("ClusterAdmin");
 
-    clusterTopologyManager.default.localNodeTag = ko.pureComputed(() => "A");
+    clusterTopologyManager.default.localNodeTag = ko.pureComputed(() => localNodeTag);
 }
 
 function getDatabaseNamesForNode(nodeTag: string, dto: DatabaseSharedInfo): string[] {
@@ -52,6 +52,18 @@ export const Cluster: StoryFn<typeof DatabasesPage> = () => {
     commonInit();
 
     const value = mockStore.databases.with_Cluster();
+
+    mockServices.databasesService.withGetDatabasesState((tag) => getDatabaseNamesForNode(tag, value));
+
+    return <DatabasesPage />;
+};
+
+export const ClusterViewedFromUnrelatedNode: StoryFn<typeof DatabasesPage> = () => {
+    commonInit("D", ["A", "B", "C", "D"]);
+
+    const value = mockStore.databases.with_Cluster((db) => {
+        db.currentNode.isRelevant = false;
+    });
 
     mockServices.databasesService.withGetDatabasesState((tag) => getDatabaseNamesForNode(tag, value));
 

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.spec.tsx
@@ -80,6 +80,38 @@ describe("ValidDatabasePropertiesPanel", () => {
                 expect(getLocalGeneralInfo(dbStates, "B").totalDocuments).toBe(20);
             });
 
+            it("can get values from a remote node when local node is not part of database group", () => {
+                const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
+                    getDatabaseLocalInfo({
+                        status: "failure",
+                        location: { nodeTag: "A" },
+                        documentsCount: 10,
+                        totalSize: { SizeInBytes: 1, HumaneSize: "1 B" },
+                        tempBuffersSize: { SizeInBytes: 2, HumaneSize: "2 B" },
+                    }),
+                    getDatabaseLocalInfo({
+                        status: "success",
+                        location: { nodeTag: "B" },
+                        documentsCount: 20,
+                        totalSize: { SizeInBytes: 3, HumaneSize: "3 B" },
+                        tempBuffersSize: { SizeInBytes: 4, HumaneSize: "4 B" },
+                    }),
+                    getDatabaseLocalInfo({
+                        status: "success",
+                        location: { nodeTag: "C" },
+                        documentsCount: 30,
+                        totalSize: { SizeInBytes: 5, HumaneSize: "5 B" },
+                        tempBuffersSize: { SizeInBytes: 6, HumaneSize: "6 B" },
+                    }),
+                ];
+
+                const info = getLocalGeneralInfo(dbStates, "D");
+
+                expect(info.hasLocalNodeAllData).toBe(true);
+                expect(info.totalDocuments).toBe(20);
+                expect(info.totalSizeWithTempBuffers).toBe(7);
+            });
+
             it("can get total size", () => {
                 const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
                     getDatabaseLocalInfo({

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
@@ -336,14 +336,17 @@ function getLocalGeneralInfo(
     dbStates: locationAwareLoadableData<DatabaseLocalInfo>[],
     localNodeTag: string
 ): LocalGeneralInfo {
-    const allShards = new Set(
-        dbStates.filter((x) => x.location.nodeTag === localNodeTag).map((x) => x.location.shardNumber ?? -1)
+    const localDbStates = dbStates.filter((x) => x.location.nodeTag === localNodeTag);
+    const hasLocalLocations = localDbStates.length > 0;
+    const expectedShardKeys = new Set(
+        (hasLocalLocations ? localDbStates : dbStates).map((x) => x.location.shardNumber ?? -1)
     );
 
-    const localDbStatesWithoutErrors = dbStates.filter(
-        (x) => x.location.nodeTag === localNodeTag && x.status === "success" && !x.data?.loadError
-    );
-    const hasLocalNodeAllData = localDbStatesWithoutErrors.length === allShards.size;
+    // When the current node does not host this database, use the first healthy node in topology order.
+    const dbStatesToUse = hasLocalLocations ? localDbStates : getFirstAvailableDbStatesByShard(dbStates);
+    const localDbStatesWithoutErrors = dbStatesToUse.filter((x) => x.status === "success" && !x.data?.loadError);
+    const availableShardKeys = new Set(localDbStatesWithoutErrors.map((x) => x.location.shardNumber ?? -1));
+    const hasLocalNodeAllData = expectedShardKeys.size > 0 && availableShardKeys.size === expectedShardKeys.size;
 
     const totalSizeWithTempBuffers = sumBy(
         localDbStatesWithoutErrors,
@@ -361,6 +364,20 @@ function getLocalGeneralInfo(
         totalDocuments,
         backupStatus,
     };
+}
+
+function getFirstAvailableDbStatesByShard(
+    dbStates: locationAwareLoadableData<DatabaseLocalInfo>[]
+): locationAwareLoadableData<DatabaseLocalInfo>[] {
+    const shardKeys = Array.from(new Set(dbStates.map((x) => x.location.shardNumber ?? -1)));
+
+    return shardKeys
+        .map((shardKey) =>
+            dbStates.find(
+                (x) => (x.location.shardNumber ?? -1) === shardKey && x.status === "success" && !x.data?.loadError
+            )
+        )
+        .filter(Boolean);
 }
 
 export const exportedForTesting = {

--- a/src/Raven.Studio/typescript/test/mocks/store/MockClusterManager.ts
+++ b/src/Raven.Studio/typescript/test/mocks/store/MockClusterManager.ts
@@ -15,24 +15,17 @@ export class MockClusterManager {
         globalDispatch(clusterActions.serverStateLoaded({ passive }));
     }
 
-    with_Cluster() {
+    with_Cluster(nodeTags = ["A", "B", "C"], localNodeTag = "A") {
         globalDispatch(
-            clusterActions.nodesLoaded([
-                {
-                    nodeTag: "A",
-                    serverUrl: "https://a.server-url.com",
-                },
-                {
-                    nodeTag: "B",
-                    serverUrl: "https://b.server-url.com",
-                },
-                {
-                    nodeTag: "C",
-                    serverUrl: "https://c.server-url.com",
-                },
-            ])
+            clusterActions.nodesLoaded(
+                nodeTags.map((nodeTag) => ({
+                    nodeTag,
+                    serverUrl: `https://${nodeTag.toLowerCase()}.server-url.com`,
+                    type: "Member",
+                }))
+            )
         );
-        globalDispatch(clusterActions.localNodeTagLoaded("A"));
+        globalDispatch(clusterActions.localNodeTagLoaded(localNodeTag));
     }
 
     with_Single() {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26885

### Additional description

When the current node does not host a database, use the first healthy node

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
