### PR TITLE
RavenDB-26887 Probe @SharedJournals, not the database journals, when deciding whether an index can share journals

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -624,11 +624,19 @@ namespace Raven.Server.Documents.Indexes
                 return;
             }
 
-            if (indexOptions.CanJournalsBeLinkedWith(documentDatabase.DocumentsStorage.Environment.Options) == false)
+            var sharedJournals = documentDatabase.IndexStore.SharedJournals;
+            if (sharedJournals == null)
+            {
+                if (logger.IsInfoEnabled)
+                    logger.Info($"Shared journals environment is not available for index '{name}'; running in unshared mode.");
+                return;
+            }
+
+            if (indexOptions.CanJournalsBeLinkedWith(sharedJournals.Env.Options) == false)
             {
                 if (logger.IsWarnEnabled)
                 {
-                    logger.Warn($"Unable to create hard links between '{documentDatabase.DocumentsStorage.Environment.Options.JournalPath}' and '{indexOptions.JournalPath}'. " +
+                    logger.Warn($"Unable to create hard links between '{sharedJournals.Env.Options.JournalPath}' and '{indexOptions.JournalPath}'. " +
                                 $"Shared journals mode is disabled for this index: {name}.");
                 }
                 return;

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -843,7 +843,9 @@ namespace Voron
 
             public override bool CanJournalsBeLinkedWith(StorageEnvironmentOptions other)
             {
-                return other is DirectoryStorageEnvironmentOptions && 
+                if (ForTestingPurposes?.SimulateCannotLinkJournals == true || other.ForTestingPurposes?.SimulateCannotLinkJournals == true)
+                    return false;
+                return other is DirectoryStorageEnvironmentOptions &&
                        CanJournalsBeLinkedWith(other.JournalPath, JournalPath);
             }
 
@@ -1154,7 +1156,9 @@ namespace Voron
 
             public override bool CanJournalsBeLinkedWith(StorageEnvironmentOptions other)
             {
-                return other is PureMemoryStorageEnvironmentOptions && 
+                if (ForTestingPurposes?.SimulateCannotLinkJournals == true || other.ForTestingPurposes?.SimulateCannotLinkJournals == true)
+                    return false;
+                return other is PureMemoryStorageEnvironmentOptions &&
                        CanJournalsBeLinkedWith(TempPath, other.TempPath);
             }
         }
@@ -1421,6 +1425,8 @@ namespace Voron
         internal sealed class TestingStuff
         {
             internal Action<long> BeforeLinkFiles;
+
+            internal bool SimulateCannotLinkJournals;
         }
     }
 }

--- a/test/SlowTests.Issues/Issues/RavenDB_26887.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26887.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26887 : RavenTestBase
+{
+    public RavenDB_26887(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task Indexes_open_unshared_instead_of_faulting_when_they_cannot_hard_link_to_SharedJournals()
+    {
+        using var store = GetDocumentStore(new Options { RunInMemory = false });
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        await database.IndexStore.InitializeSharedJournalsAsync();
+        Assert.NotNull(database.IndexStore.SharedJournals);
+
+        // Simulate the index journals not being hard-linkable to @SharedJournals - i.e. @SharedJournals sits on a
+        // different volume than the indexes (errno 17, "cannot move the file to a different disk drive"). The gate
+        // must probe @SharedJournals (not the database journals) and, finding it can't link, open each index in
+        // unshared mode instead of faulting it on the failed cross-device LinkFiles call.
+        database.IndexStore.SharedJournals.Env.Options.ForTestingPurposesOnly().SimulateCannotLinkJournals = true;
+
+        for (int i = 0; i < 3; i++)
+        {
+            await store.Maintenance.SendAsync(new PutIndexesOperation(new IndexDefinition
+            {
+                Name = $"Users/ByName_{i}",
+                Maps = { "from u in docs.Users select new { u.Name }" }
+            }));
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = "Joe" });
+            await session.SaveChangesAsync();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // The bug faulted every index here with IndexOpenException -> FaultyInMemoryIndex.
+        var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+        var faulty = stats.Indexes.Where(i => i.State == IndexState.Error || i.Type == IndexType.Faulty).ToList();
+        Assert.True(faulty.Count == 0, $"faulty indexes: {string.Join(", ", faulty.Select(f => $"{f.Name}({f.State}/{f.Type})"))}");
+
+        // Every index must run unshared (shared journals correctly disabled because it can't link to @SharedJournals).
+        // If the gate regresses to probing the database journals, these stay co-located on one volume, the probe
+        // passes, and the indexes come up as branches - so RootJournal would be non-null here.
+        var indexes = database.IndexStore.GetIndexes().ToList();
+        Assert.Equal(3, indexes.Count);
+        foreach (var idx in indexes)
+            Assert.Null(idx._environment.Options.RootJournal);
+
+        // Data is fully indexed and queryable.
+        foreach (var idx in indexes)
+        {
+            using var session = store.OpenAsyncSession();
+            var results = await session.Advanced.AsyncRawQuery<User>($"from index '{idx.Name}' where Name = 'Joe'").ToListAsync();
+            Assert.Equal(1, results.Count);
+        }
+    }
+}


### PR DESCRIPTION



### Issue link

Original: https://issues.hibernatingrhinos.com/issue/RavenDB-26887
Recreated: https://issues.hibernatingrhinos.com/issue/RavenDB-26886

### Additional description

The link is made index <-> @SharedJournals, but the gate probed against the database journal path. When the two weren't co-located (DB journals on a faster drive, or @SharedJournals relocated) the probe passed and the cross-device LinkFiles then faulted every index at open (errno 17; only the hard-link-limit fallback existed). Probe @SharedJournals directly: cross-volume layouts run unshared, sharing is kept when index and @SharedJournals share a volume. Adds a test-only SimulateCannotLinkJournals seam to reproduce it without a second volume.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
