### PR TITLE
RavenDB-26862 - Optimize database creation by lazily allocating MeterMetric buckets and skipping unnecessary license-limit checks

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -329,7 +329,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertStaticIndexesCount(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, Table items, string type)
     {
-        if (databaseRecord.Indexes == null || databaseRecord.Indexes.Count == 0)
+        if (databaseRecord.Indexes is null or { Count: 0 })
             return;
 
         var maxStaticIndexesPerDatabase = licenseStatus.MaxNumberOfStaticIndexesPerDatabase;
@@ -360,7 +360,7 @@ public sealed partial class ClusterStateMachine
     {
         var maxAutoIndexesPerDatabase = licenseStatus.MaxNumberOfAutoIndexesPerDatabase;
 
-        if (databaseRecord.AutoIndexes == null || databaseRecord.AutoIndexes.Count == 0)
+        if (databaseRecord.AutoIndexes is null or { Count: 0 })
             return;
 
         if (maxAutoIndexesPerDatabase is >= 0 && databaseRecord.AutoIndexes.Count > maxAutoIndexesPerDatabase)
@@ -490,7 +490,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertSorters(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, Table items, string type)
     {
-        if (databaseRecord.Sorters == null || databaseRecord.Sorters.Count == 0)
+        if (databaseRecord.Sorters is null or { Count: 0 })
             return;
 
         var maxCustomSortersPerDatabase = licenseStatus.MaxNumberOfCustomSortersPerDatabase;
@@ -518,7 +518,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertAnalyzers(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, Table items, string type)
     {
-        if (databaseRecord.Analyzers == null || databaseRecord.Analyzers.Count == 0)
+        if (databaseRecord.Analyzers is null or { Count: 0 })
             return;
 
         var maxAnalyzersPerDatabase = licenseStatus.MaxNumberOfCustomAnalyzersPerDatabase;
@@ -943,7 +943,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertPullReplicationAsSinkLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.SinkPullReplications.Count == 0)
+        if (databaseRecord.SinkPullReplications is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -960,7 +960,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertPullReplicationAsHubLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.HubPullReplications.Count == 0)
+        if (databaseRecord.HubPullReplications is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -977,7 +977,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertExternalReplicationLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand = null)
     {
-        if (databaseRecord.ExternalReplications.Count == 0 && updateDatabaseCommand == null)
+        if (databaseRecord.ExternalReplications is null or { Count: 0 } && updateDatabaseCommand == null)
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1021,7 +1021,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertRavenEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.RavenEtls.Count == 0)
+        if (databaseRecord.RavenEtls is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1038,7 +1038,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertSqlEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.SqlEtls.Count == 0)
+        if (databaseRecord.SqlEtls is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1055,7 +1055,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertOlapEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.OlapEtls.Count == 0)
+        if (databaseRecord.OlapEtls is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1072,7 +1072,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertQueueEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.QueueEtls.Count == 0)
+        if (databaseRecord.QueueEtls is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1089,7 +1089,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertElasticSearchEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.ElasticSearchEtls.Count == 0)
+        if (databaseRecord.ElasticSearchEtls is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1106,7 +1106,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertSnowflakeEtl(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.SnowflakeEtls.Count == 0)
+        if (databaseRecord.SnowflakeEtls is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1123,7 +1123,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertEmbeddingsGeneration(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.AiConnectionStrings.Count == 0 || databaseRecord.EmbeddingsGenerations.Count == 0)
+        if (databaseRecord.AiConnectionStrings is null or { Count: 0 } || databaseRecord.EmbeddingsGenerations is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1150,7 +1150,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertGenAi(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.GenAis.Count == 0)
+        if (databaseRecord.GenAis is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1167,7 +1167,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertAiAgent(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.AiAgents.Count == 0)
+        if (databaseRecord.AiAgents is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1184,7 +1184,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertTimeSeriesConfigurationLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.TimeSeries == null || databaseRecord.TimeSeries.Collections.Count == 0)
+        if (databaseRecord.TimeSeries == null || databaseRecord.TimeSeries.Collections == null || databaseRecord.TimeSeries.Collections.Count == 0)
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
@@ -1220,7 +1220,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertAdditionalAssembliesFromNuGetLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.Indexes == null || databaseRecord.Indexes.Count == 0)
+        if (databaseRecord.Indexes is null or { Count: 0 })
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -946,13 +946,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.SinkPullReplications is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasPullReplicationAsSink)
             return;
 
         if (databaseRecord.SinkPullReplications.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.PullReplicationAsSink, "Your license doesn't support adding Sink Replication feature.");
@@ -963,13 +963,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.HubPullReplications is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasPullReplicationAsHub)
             return;
 
         if (databaseRecord.HubPullReplications.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.PullReplicationAsHub, "Your license doesn't support adding Hub Replication feature.");
@@ -1024,13 +1024,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.RavenEtls is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasRavenEtl)
             return;
 
         if (databaseRecord.RavenEtls.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.RavenEtl, "Your license doesn't support adding Raven ETL feature.");
@@ -1041,13 +1041,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.SqlEtls is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasSqlEtl)
             return;
 
         if (databaseRecord.SqlEtls.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.SqlEtl, "Your license doesn't support adding SQL ETL feature.");
@@ -1058,13 +1058,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.OlapEtls is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasOlapEtl)
             return;
 
         if (databaseRecord.OlapEtls.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.OlapEtl, "Your license doesn't support adding Olap ETL feature.");
@@ -1075,13 +1075,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.QueueEtls is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasQueueEtl)
             return;
 
         if (databaseRecord.QueueEtls.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.QueueEtl, "Your license doesn't support adding Queue ETL feature.");
@@ -1092,13 +1092,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.ElasticSearchEtls is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasElasticSearchEtl)
             return;
 
         if (databaseRecord.ElasticSearchEtls.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.ElasticSearchEtl, "Your license doesn't support adding Elastic Search ETL feature.");
@@ -1109,13 +1109,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.SnowflakeEtls is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasSnowflakeEtl)
             return;
 
         if (databaseRecord.SnowflakeEtls.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.SnowflakeEtl, "Your license doesn't support using the Snowflake ETL feature.");
@@ -1126,13 +1126,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.AiConnectionStrings is null or { Count: 0 } || databaseRecord.EmbeddingsGenerations is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasEmbeddingsGeneration)
             return;
 
         if (databaseRecord.EmbeddingsGenerations.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         foreach (var config in databaseRecord.EmbeddingsGenerations)
@@ -1153,13 +1153,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.GenAis is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasGenAi)
             return;
 
         if (databaseRecord.GenAis.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.GenAi, "Your license doesn't support using the AI Generation feature.");
@@ -1170,13 +1170,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.AiAgents is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasAiAgent)
             return;
 
         if (databaseRecord.AiAgents.All(x => x.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.AiAgent, "Your license doesn't support using the AI Agent feature.");
@@ -1187,13 +1187,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.TimeSeries == null || databaseRecord.TimeSeries.Collections == null || databaseRecord.TimeSeries.Collections.Count == 0)
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasTimeSeriesRollupsAndRetention)
             return;
 
         if (databaseRecord.TimeSeries.Collections.All(x => x.Value.Disabled))
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.TimeSeriesRollupsAndRetention, "Your license doesn't support adding Time Series Rollups And Retention feature.");
@@ -1204,15 +1204,15 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.DocumentsCompression == null)
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasDocumentsCompression)
             return;
 
         if (databaseRecord.DocumentsCompression.CompressAllCollections == false &&
             databaseRecord.DocumentsCompression.CompressRevisions == false &&
             databaseRecord.DocumentsCompression.Collections.Length == 0)
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.DocumentsCompression, "Your license doesn't support adding Documents Compression feature.");
@@ -1223,13 +1223,13 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.Indexes is null or { Count: 0 })
             return;
 
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
         if (licenseStatus.HasAdditionalAssembliesFromNuGet)
             return;
 
         if (LicenseManager.HasAdditionalAssembliesFromNuGet(databaseRecord.Indexes) == false)
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         throw new LicenseLimitException(LimitType.AdditionalAssembliesFromNuGet, "Your license doesn't support Additional Assemblies From NuGet feature.");

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -1305,58 +1305,58 @@ public sealed partial class ClusterStateMachine
 
     private void AssertToggleTaskStateLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand)
     {
+        if (updateDatabaseCommand is not ToggleTaskStateCommand ttsc)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (updateDatabaseCommand != null && updateDatabaseCommand is ToggleTaskStateCommand ttsc)
+        switch (ttsc.TaskType)
         {
-            switch (ttsc.TaskType)
-            {
-                case OngoingTaskType.Replication:
-                    AssertExternalReplicationLicenseLimits(databaseRecord, licenseStatus, context, updateDatabaseCommand);
-                    break;
-                case OngoingTaskType.RavenEtl:
-                    AssertRavenEtlLicenseLimits(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.SqlEtl:
-                    AssertSqlEtlLicenseLimits(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.OlapEtl:
-                    AssertOlapEtlLicenseLimits(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.ElasticSearchEtl:
-                    AssertElasticSearchEtlLicenseLimits(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.QueueEtl:
-                    AssertQueueEtlLicenseLimits(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.SnowflakeEtl:
-                    AssertSnowflakeEtl(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.Backup:
-                    AssertPeriodicBackupLicenseLimits(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.PullReplicationAsHub:
-                    AssertPullReplicationAsHubLicenseLimits(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.PullReplicationAsSink:
-                    AssertPullReplicationAsSinkLicenseLimits(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.QueueSink:
-                    AssertQueueSink(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.CdcSink:
-                    AssertCdcSink(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.EmbeddingsGeneration:
-                    AssertEmbeddingsGeneration(databaseRecord, licenseStatus, context);
-                    break;
-                case OngoingTaskType.GenAi:
-                    AssertGenAi(databaseRecord, licenseStatus, context);
-                    break;
-                default:
-                    return;
-            }
+            case OngoingTaskType.Replication:
+                AssertExternalReplicationLicenseLimits(databaseRecord, licenseStatus, context, updateDatabaseCommand);
+                break;
+            case OngoingTaskType.RavenEtl:
+                AssertRavenEtlLicenseLimits(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.SqlEtl:
+                AssertSqlEtlLicenseLimits(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.OlapEtl:
+                AssertOlapEtlLicenseLimits(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.ElasticSearchEtl:
+                AssertElasticSearchEtlLicenseLimits(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.QueueEtl:
+                AssertQueueEtlLicenseLimits(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.SnowflakeEtl:
+                AssertSnowflakeEtl(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.Backup:
+                AssertPeriodicBackupLicenseLimits(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.PullReplicationAsHub:
+                AssertPullReplicationAsHubLicenseLimits(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.PullReplicationAsSink:
+                AssertPullReplicationAsSinkLicenseLimits(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.QueueSink:
+                AssertQueueSink(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.CdcSink:
+                AssertCdcSink(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.EmbeddingsGeneration:
+                AssertEmbeddingsGeneration(databaseRecord, licenseStatus, context);
+                break;
+            case OngoingTaskType.GenAi:
+                AssertGenAi(databaseRecord, licenseStatus, context);
+                break;
+            default:
+                return;
         }
     }
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -329,7 +329,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertStaticIndexesCount(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, Table items, string type)
     {
-        if (databaseRecord.Indexes == null)
+        if (databaseRecord.Indexes == null || databaseRecord.Indexes.Count == 0)
             return;
 
         var maxStaticIndexesPerDatabase = licenseStatus.MaxNumberOfStaticIndexesPerDatabase;
@@ -360,7 +360,7 @@ public sealed partial class ClusterStateMachine
     {
         var maxAutoIndexesPerDatabase = licenseStatus.MaxNumberOfAutoIndexesPerDatabase;
 
-        if (databaseRecord.AutoIndexes == null)
+        if (databaseRecord.AutoIndexes == null || databaseRecord.AutoIndexes.Count == 0)
             return;
 
         if (maxAutoIndexesPerDatabase is >= 0 && databaseRecord.AutoIndexes.Count > maxAutoIndexesPerDatabase)
@@ -490,6 +490,9 @@ public sealed partial class ClusterStateMachine
 
     private void AssertSorters(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, Table items, string type)
     {
+        if (databaseRecord.Sorters == null || databaseRecord.Sorters.Count == 0)
+            return;
+
         var maxCustomSortersPerDatabase = licenseStatus.MaxNumberOfCustomSortersPerDatabase;
         if (maxCustomSortersPerDatabase is >= 0 && databaseRecord.Sorters.Count > maxCustomSortersPerDatabase)
         {
@@ -515,6 +518,9 @@ public sealed partial class ClusterStateMachine
 
     private void AssertAnalyzers(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, Table items, string type)
     {
+        if (databaseRecord.Analyzers == null || databaseRecord.Analyzers.Count == 0)
+            return;
+
         var maxAnalyzersPerDatabase = licenseStatus.MaxNumberOfCustomAnalyzersPerDatabase;
         if (maxAnalyzersPerDatabase is >= 0 && databaseRecord.Analyzers.Count > maxAnalyzersPerDatabase)
         {
@@ -937,13 +943,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertPullReplicationAsSinkLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.SinkPullReplications.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasPullReplicationAsSink)
-            return;
-
-        if (databaseRecord.SinkPullReplications.Count == 0)
             return;
 
         if (databaseRecord.SinkPullReplications.All(x => x.Disabled))
@@ -954,13 +960,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertPullReplicationAsHubLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.HubPullReplications.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasPullReplicationAsHub)
-            return;
-
-        if (databaseRecord.HubPullReplications.Count == 0)
             return;
 
         if (databaseRecord.HubPullReplications.All(x => x.Disabled))
@@ -971,6 +977,9 @@ public sealed partial class ClusterStateMachine
 
     private void AssertExternalReplicationLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand = null)
     {
+        if (databaseRecord.ExternalReplications.Count == 0 && updateDatabaseCommand == null)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
@@ -1012,13 +1021,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertRavenEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.RavenEtls.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasRavenEtl)
-            return;
-
-        if (databaseRecord.RavenEtls.Count == 0)
             return;
 
         if (databaseRecord.RavenEtls.All(x => x.Disabled))
@@ -1029,13 +1038,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertSqlEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.SqlEtls.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasSqlEtl)
-            return;
-
-        if (databaseRecord.SqlEtls.Count == 0)
             return;
 
         if (databaseRecord.SqlEtls.All(x => x.Disabled))
@@ -1046,13 +1055,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertOlapEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.OlapEtls.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasOlapEtl)
-            return;
-
-        if (databaseRecord.OlapEtls.Count == 0)
             return;
 
         if (databaseRecord.OlapEtls.All(x => x.Disabled))
@@ -1063,13 +1072,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertQueueEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.QueueEtls.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasQueueEtl)
-            return;
-
-        if (databaseRecord.QueueEtls.Count == 0)
             return;
 
         if (databaseRecord.QueueEtls.All(x => x.Disabled))
@@ -1080,13 +1089,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertElasticSearchEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.ElasticSearchEtls.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasElasticSearchEtl)
-            return;
-
-        if (databaseRecord.ElasticSearchEtls.Count == 0)
             return;
 
         if (databaseRecord.ElasticSearchEtls.All(x => x.Disabled))
@@ -1097,13 +1106,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertSnowflakeEtl(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.SnowflakeEtls.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasSnowflakeEtl)
-            return;
-
-        if (databaseRecord.SnowflakeEtls.Count == 0)
             return;
 
         if (databaseRecord.SnowflakeEtls.All(x => x.Disabled))
@@ -1114,13 +1123,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertEmbeddingsGeneration(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.AiConnectionStrings.Count == 0 || databaseRecord.EmbeddingsGenerations.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasEmbeddingsGeneration)
-            return;
-
-        if (databaseRecord.AiConnectionStrings.Count == 0 || databaseRecord.EmbeddingsGenerations.Count == 0)
             return;
 
         if (databaseRecord.EmbeddingsGenerations.All(x => x.Disabled))
@@ -1141,13 +1150,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertGenAi(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.GenAis.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasGenAi)
-            return;
-
-        if (databaseRecord.GenAis.Count == 0)
             return;
 
         if (databaseRecord.GenAis.All(x => x.Disabled))
@@ -1158,13 +1167,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertAiAgent(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.AiAgents.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasAiAgent)
-            return;
-
-        if (databaseRecord.AiAgents.Count == 0)
             return;
 
         if (databaseRecord.AiAgents.All(x => x.Disabled))
@@ -1175,16 +1184,16 @@ public sealed partial class ClusterStateMachine
 
     private void AssertTimeSeriesConfigurationLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.TimeSeries == null || databaseRecord.TimeSeries.Collections.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasTimeSeriesRollupsAndRetention)
             return;
 
-        if (databaseRecord.TimeSeries == null)
-            return;
-
-        if (databaseRecord.TimeSeries.Collections.Count == 0 || databaseRecord.TimeSeries.Collections.All(x => x.Value.Disabled))
+        if (databaseRecord.TimeSeries.Collections.All(x => x.Value.Disabled))
             return;
 
         throw new LicenseLimitException(LimitType.TimeSeriesRollupsAndRetention, "Your license doesn't support adding Time Series Rollups And Retention feature.");
@@ -1192,13 +1201,13 @@ public sealed partial class ClusterStateMachine
 
     private void AssertDocumentsCompressionLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.DocumentsCompression == null)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
         if (licenseStatus.HasDocumentsCompression)
-            return;
-
-        if (databaseRecord.DocumentsCompression == null)
             return;
 
         if (databaseRecord.DocumentsCompression.CompressAllCollections == false &&
@@ -1211,6 +1220,9 @@ public sealed partial class ClusterStateMachine
 
     private void AssertAdditionalAssembliesFromNuGetLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.Indexes == null || databaseRecord.Indexes.Count == 0)
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 

--- a/src/Raven.Server/Utils/Metrics/MeterMetric.cs
+++ b/src/Raven.Server/Utils/Metrics/MeterMetric.cs
@@ -28,7 +28,17 @@ namespace Raven.Server.Utils.Metrics
 
         // Ring-buffer of aggregated quanta. Each bucket carries its quantum start timestamp so readers can
         // distinguish fresh from wrapped/stale data without scanning or zeroing the whole array.
-        private readonly Bucket[] _buckets = new Bucket[BucketCount];
+        private Bucket[] _buckets;
+
+        private Bucket[] EnsureBuckets()
+        {
+            // Lazy Create
+            if (_buckets is not null)
+                return _buckets;
+
+            var created = new Bucket[BucketCount];
+            return Interlocked.CompareExchange(ref _buckets, created, null) ?? created;
+        }
 
         private long _count;
         private readonly long _startTime;
@@ -122,9 +132,10 @@ namespace Raven.Server.Utils.Metrics
             var bucketSeconds = BucketDurationNanoseconds / (double)Clock.NanosecondsInSecond;
 
             var buckets = new List<(long Start, double Rate)>();
-            for (int i = 0; i < BucketCount; i++)
+            var ring = _buckets;
+            for (int i = 0; ring != null && i < BucketCount; i++)
             {
-                ref var bucket = ref _buckets[i];
+                ref var bucket = ref ring[i];
                 var start = Volatile.Read(ref bucket.Start);
                 if (start == 0)
                     continue;
@@ -162,11 +173,13 @@ namespace Raven.Server.Utils.Metrics
         // This ensures no thread observes half-initialized state. The loop runs only at quantum boundaries.
         private void AddToBucket(long timestamp, long value, long duration)
         {
+            var buckets = EnsureBuckets();
+
             var quantum = timestamp / BucketDurationNanoseconds;
             var bucketStart = quantum * BucketDurationNanoseconds;
             var index = (int)(quantum % BucketCount);
 
-            ref var bucket = ref _buckets[index];
+            ref var bucket = ref buckets[index];
 
             const long ClaimedStart = -1; // sentinel: bucket claimed for reinitialization
 
@@ -243,16 +256,20 @@ namespace Raven.Server.Utils.Metrics
 
         private long Accumulate(long windowNs, out long totalDuration, out long bucketsExamined)
         {
+            totalDuration = 0L;
+            bucketsExamined = 0L;
+
+            var buckets = _buckets;
+            if (buckets == null)
+                return 0L; // lazy buffer not allocated => no samples recorded yet
+
             var now = _now();
             var lowerBound = now - windowNs;
 
             var total = 0L;
-            totalDuration = 0L;
-            bucketsExamined = 0L;
-
             for (int i = 0; i < BucketCount; i++)
             {
-                ref var bucket = ref _buckets[i];
+                ref var bucket = ref buckets[i];
                 // Skip buckets that were never initialised or fully pre-date the window. Only buckets whose
                 // quantum overlaps the requested range contribute to the final aggregates.
                 var start = Volatile.Read(ref bucket.Start);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26862/Github-issue-Performance-degradation-RavenTestDriver-GetDocumentStore-between-5.4-and-7.2

### Additional description
Issue:
This test has slowed down in (7.2 comparing 5.4)
```
[InProcess]
public class RavenDBBenchmark
{
    [Benchmark]
    public void CreateDocumentStores()
    {
        var testDriver = new NoLicenseTestDriver();
        for (int i = 0; i < 10; i++)
        {
            var store = testDriver.GetDocumentStore();
            store.Dispose();
        }

        testDriver.Dispose();
    }
}

public class NoLicenseTestDriver : RavenTestDriver
{
    static NoLicenseTestDriver()
    {
        ConfigureServer(new TestServerOptions
        {
            Licensing = new ServerOptions.LicensingOptions
            {
                ThrowOnInvalidOrMissingLicense = false
            }
        });
    }

    public IDocumentStore GetDocumentStore() => base.GetDocumentStore();
}
```
Solution:
speeds up the `GetDocumentStore()` (database create) path by lazily allocating `MeterMetric` bucket ring-buffer on first `Mark()` instead of eagerly per meter (removing the ~2.7 MB/DB LOH churn and its Gen2 stalls), and by short-circuiting the cluster license-limit assertions to skip the costly `CanAssertLicenseLimits` checks when the database record has no indexes, sorters, analyzers, replications, or ETLs.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
