### PR TITLE
RavenDB-26796 0 Add debug info to 'SubAgent2OpenActionTools2Agents' and 'SubAgent2OpenActionTools_DepthOf3'

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Raven.Client.Documents;
 using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
@@ -813,50 +816,72 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
         };
         userAgent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var userAgent1Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1, MoviesSampleObject.Instance)).Identifier;
+        var sb = new StringBuilder();
+        try
+        {
+            var chat = store.AI.Conversation(userAgent1Id, "chats/",
+                new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
+            chat.Handle<ChangeUserNameSampleRequest, ActionToolResult>("user-info-agent-2a/ChangeUserName", async (r) =>
+            {
+                var res = (await ChangeUserNameAsync(store, r)) as ActionToolResult;
+                sb.AppendLine($"*Tool-ChangeUserName : Req={r?.ToString()} Res={res?.ToString()}*");
+                return res;
+            });
+            chat.Handle<RateToolSampleRequest, ActionToolResult>("user-info-agent-2a/RateMovie", async (r) =>
+            {
+                var res = await RateMovieAsync(store, "Users/1", r) as ActionToolResult;
+                sb.AppendLine($"*Tool-RateMovie : Req={r?.ToString()} Res={res?.ToString()}*");
+                return res;
+            });
+            chat.Handle<AddMovieToWatchedListSampleRequest, ActionToolResult>("user-info-agent-2b/AddToMovieWatchedList", async (r) =>
+            {
+                var res = await AddMovieAsync(store, "Users/1", r) as ActionToolResult;
+                sb.AppendLine($"*Tool-AddMovieToWatchedList : Req={r?.ToString()} Res={res?.ToString()}*");
+                return res;
+            });
 
-        var chat = store.AI.Conversation(userAgent1Id, "chats/",
-            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
-        chat.Handle<ChangeUserNameSampleRequest, ActionToolResult>("user-info-agent-2a/ChangeUserName", async (r) =>
-        {
-            var res = (await ChangeUserNameAsync(store, r)) as ActionToolResult;
-            // Console.WriteLine(res.Answer);
-            return res;
-        });
-        chat.Handle<RateToolSampleRequest, ActionToolResult>("user-info-agent-2a/RateMovie", async (r) =>
-        {
-            var res = await RateMovieAsync(store, "Users/1", r) as ActionToolResult;
-            // Console.WriteLine(res.Answer);
-            return res;
-        });
-        chat.Handle<AddMovieToWatchedListSampleRequest, ActionToolResult>("user-info-agent-2b/AddToMovieWatchedList", async (r) =>
-        {
-            var res = await AddMovieAsync(store, "Users/1", r) as ActionToolResult;
-            return res;
-        });
+            chat.SetUserPrompt("Please rate the movie \"Toy Story\" as 5, add the movie Nixon and Sudden Death to my watched list, change my name from 'Shahar Hikri' to 'Aviv Rachmani', and also please add Sudden Death to my watched list");
+            var r = await chat.RunAsync<MoviesSampleObject>();
+            Assert.Equal(AiConversationResult.Done, r.Status);
 
-        chat.SetUserPrompt("Please rate the movie \"Toy Story\" as 5, add the movie Nixon and Sudden Death to my watched list, change my name from 'Shahar Hikri' to 'Aviv Rachmani', and also please add Sudden Death to my watched list");
-        var r = await chat.RunAsync<MoviesSampleObject>();
-        Assert.Equal(AiConversationResult.Done, r.Status);
+            using (var session = store.OpenAsyncSession())
+            {
+                var u = await session.LoadAsync<User>("Users/1");
 
-        using (var session = store.OpenAsyncSession())
-        {
-            var u = await session.LoadAsync<User>("Users/1");
-            Assert.Equal("Aviv Rachmani", u.Name);
-            Assert.Equal(5, u.WatchedMovies.Count);
+                sb.AppendLine(u.ToString());
+                var newRatings = (await session.Query<Rating>().ToListAsync())
+                    .Where(x => Rates.Any(y => y.Id == x.Id) == false);
+                sb.AppendLine(string.Join(",", newRatings));
+
+                Assert.Equal("Aviv Rachmani", u.Name);
+                Assert.Equal(5, u.WatchedMovies.Count);
+            }
+
+            Assert.Equal(Rates.Count + 1, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
+
+            chat.SetUserPrompt("Please rate the movie \"Toy Story\" as 4, add the movie Casino and Sudden Death to my watched list, change my name from 'Aviv Rachmani' to 'Omer Adam'");
+            r = await chat.RunAsync<MoviesSampleObject>();
+            Assert.Equal(AiConversationResult.Done, r.Status);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var u = await session.LoadAsync<User>("Users/1");
+
+                sb.AppendLine(u.ToString());
+                var newRatings = (await session.Query<Rating>().ToListAsync())
+                    .Where(x => Rates.Any(y => y.Id == x.Id) == false);
+                sb.AppendLine(string.Join(",", newRatings));
+
+                Assert.Equal("Omer Adam", u.Name);
+                Assert.Equal(6, u.WatchedMovies.Count);
+            }
+
+            Assert.Equal(Rates.Count + 2, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
         }
-        Assert.Equal(Rates.Count + 1, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
-
-        chat.SetUserPrompt("Please rate the movie \"Toy Story\" as 4, add the movie Casino and Sudden Death to my watched list, change my name from 'Aviv Rachmani' to 'Omer Adam'");
-        r = await chat.RunAsync<MoviesSampleObject>();
-        Assert.Equal(AiConversationResult.Done, r.Status);
-
-        using (var session = store.OpenAsyncSession())
+        catch (Exception e)
         {
-            var u = await session.LoadAsync<User>("Users/1");
-            Assert.Equal("Omer Adam", u.Name);
-            Assert.Equal(6, u.WatchedMovies.Count);
+            throw new AggregateException(sb.ToString(), e);
         }
-        Assert.Equal(Rates.Count + 2, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Raven.Client.Documents;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI;
@@ -172,42 +174,64 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenDB_24887_Base(outp
         userAgent0.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var userAgent0Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent0, MoviesSampleObject.Instance)).Identifier;
 
-        var chat = store.AI.Conversation(userAgent0Id, "chats/",
-            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
-        chat.Handle<ChangeUserNameSampleRequest, ActionToolResult>("user-info-agent-1/user-info-agent-2/ChangeUserName", async (r) =>
+        var sb = new StringBuilder();
+        try
         {
-            var res = (await ChangeUserNameAsync(store, r)) as ActionToolResult;
-            // Console.WriteLine(res.Answer);
-            return res;
-        });
-        chat.Handle<RateToolSampleRequest, ActionToolResult>("user-info-agent-1/user-info-agent-2/RateMovie", async (r) =>
-        {
-            var res = await RateMovieAsync(store, "Users/1", r) as ActionToolResult;
-            // Console.WriteLine(res.Answer);
-            return res;
-        });
+            var chat = store.AI.Conversation(userAgent0Id, "chats/",
+                new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
+            chat.Handle<ChangeUserNameSampleRequest, ActionToolResult>("user-info-agent-1/user-info-agent-2/ChangeUserName", async (r) =>
+            {
+                var res = (await ChangeUserNameAsync(store, r)) as ActionToolResult;
+                sb.AppendLine($"*Tool-ChangeUserName : Req={r?.ToString()} Res={res?.ToString()}*");
+                return res;
+            });
+            chat.Handle<RateToolSampleRequest, ActionToolResult>("user-info-agent-1/user-info-agent-2/RateMovie", async (r) =>
+            {
+                var res = await RateMovieAsync(store, "Users/1", r) as ActionToolResult;
+                sb.AppendLine($"*Tool-RateMovie : Req={r?.ToString()} Res={res?.ToString()}*");
+                return res;
+            });
 
-        chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 5 and change my name from 'Shahar Hikri' to 'Aviv Rachmani'?");
-        var r = await chat.RunAsync<MoviesSampleObject>();
-        Assert.Equal(AiConversationResult.Done, r.Status);
+            chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 5 and change my name from 'Shahar Hikri' to 'Aviv Rachmani'?");
+            var r = await chat.RunAsync<MoviesSampleObject>();
+            Assert.Equal(AiConversationResult.Done, r.Status);
 
-        using (var session = store.OpenAsyncSession())
-        {
-            var u = await session.LoadAsync<User>("Users/1");
-            Assert.Equal("Aviv Rachmani", u.Name);
+            using (var session = store.OpenAsyncSession())
+            {
+                var u = await session.LoadAsync<User>("Users/1");
+
+                sb.AppendLine(u.ToString());
+                var newRatings = (await session.Query<Rating>().ToListAsync())
+                    .Where(x => Rates.Any(y => y.Id == x.Id) == false);
+                sb.AppendLine(string.Join(",", newRatings));
+
+                Assert.Equal("Aviv Rachmani", u.Name);
+            }
+
+            Assert.Equal(Rates.Count + 1, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
+
+            chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 4 and change my name from 'Aviv Rachmani' to 'Omer Adam'?");
+            r = await chat.RunAsync<MoviesSampleObject>();
+            Assert.Equal(AiConversationResult.Done, r.Status);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var u = await session.LoadAsync<User>("Users/1");
+
+                sb.AppendLine(u.ToString());
+                var newRatings = (await session.Query<Rating>().ToListAsync())
+                    .Where(x => Rates.Any(y => y.Id == x.Id) == false);
+                sb.AppendLine(string.Join(",", newRatings));
+
+                Assert.Equal("Omer Adam", u.Name);
+            }
+
+            Assert.Equal(Rates.Count + 2, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
         }
-        Assert.Equal(Rates.Count + 1, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
-
-        chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 4 and change my name from 'Aviv Rachmani' to 'Omer Adam'?");
-        r = await chat.RunAsync<MoviesSampleObject>();
-        Assert.Equal(AiConversationResult.Done, r.Status);
-
-        using (var session = store.OpenAsyncSession())
+        catch (Exception e)
         {
-            var u = await session.LoadAsync<User>("Users/1");
-            Assert.Equal("Omer Adam", u.Name);
+            throw new AggregateException(sb.ToString(), e);
         }
-        Assert.Equal(Rates.Count + 2, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_Base.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_Base.cs
@@ -31,6 +31,9 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             public string Id { get; set; }
             public string Name { get; set; }
             public HashSet<string> WatchedMovies { get; set; }
+
+            public override string ToString()
+                => $"User - Id: {Id}, Name: {Name}, WatchedMovies: [{string.Join(", ", WatchedMovies ?? new HashSet<string>())}]";
         }
 
         internal class Rating
@@ -40,6 +43,10 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             public string MovieId { get; set; }
             public double RatingValue { get; set; }
             public DateTime TimeStamp { get; set; }
+
+            public override string ToString()
+                => $"Rating - Id: {Id}, UserId: {UserId}, MovieId: {MovieId}, RatingValue: {RatingValue}, TimeStamp: {TimeStamp}";
+            
         }
 
         internal class Chat
@@ -90,6 +97,11 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             public string MovieName { get; set; }
             public double RateValue { get; set; }
+
+            public override string ToString()
+            {
+                return $"{{\"MovieName\": \"{MovieName}\", \"RateValue\": {RateValue}}}";
+            }
         }
 
         internal class AddMovieToWatchedListSampleRequest
@@ -100,12 +112,22 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             };
 
             public string MovieName { get; set; }
+
+            public override string ToString()
+            {
+                return $"{{\"MovieName\": \"{MovieName}\"}}";
+            }
         }
 
         internal class ActionToolResult
         {
             public bool IsSuccessful { get; set; }
             public string Answer { get; set; }
+
+            public override string ToString()
+            {
+                return $"{{\"IsSuccessful\": {IsSuccessful.ToString().ToLower()}, \"Answer\": \"{Answer}\"}}";
+            }
         }
 
         internal class ChangeUserNameSampleRequest
@@ -120,6 +142,11 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             public string UserId { get; set; }
             public string NewUserName { get; set; }
             public string OldUserName { get; set; }
+
+            public override string ToString()
+            {
+                return $"{{\"UserId\": \"{UserId}\", \"OldUserName\": \"{OldUserName}\", \"NewUserName\": \"{NewUserName}\"}}";
+            }
         }
 
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26796/SlowTests.Server.Documents.AI.AiAgent.RavenDB248873.SubAgent2OpenActionToolsDepthOf3options-DatabaseMode-Single-config

https://issues.hibernatingrhinos.com/issue/RavenDB-26820/SlowTests.Server.Documents.AI.AiAgent.RavenDB248872.SubAgent2OpenActionTools2Agentsoptions-DatabaseMode-Single-config

### Additional description

Couldn't reproduce.
Add relevant debug info for future failures.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
