### PR TITLE
RavenDB-26785 Don't dispose landlord-cached database in test

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19922.cs
+++ b/test/SlowTests/Issues/RavenDB-19922.cs
@@ -58,11 +58,8 @@ namespace SlowTests.Issues
 
                 long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
 
-                string tag1;
-                using (var db = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database))
-                {
-                    tag1 = db.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
-                }
+                var db = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                string tag1 = db.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
 
                 CheckDecisionLog(leaderServer, new MentorNode(tag1, config.Name).ReasonForDecisionLog);
                 
@@ -73,10 +70,8 @@ namespace SlowTests.Issues
                 string tag2 = "";
                 await WaitForValueAsync(async () =>
                 {
-                    using (var db = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database))
-                    {
-                        tag2 = db.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
-                    }
+                    var dbi = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                    tag2 = dbi.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
                     return tag1.Equals(tag2);
                 }, false);
 

--- a/test/SlowTests/RavenDB-21679.cs
+++ b/test/SlowTests/RavenDB-21679.cs
@@ -178,7 +178,7 @@ namespace SlowTests
                 {
                     Assert.NotNull(stream);
 
-                    using (DocumentDatabase database = Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName2).Result)
+                    var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName2);
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     using (var source = new StreamSource(stream, context, database.Name, new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.ValidUser)))
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26785

### Additional description
The DocumentDatabase retrieved from the cache of the DatabasesLandlord should not be disposed.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test fix

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed
- [x] Not relevant

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No
- [x] Not relevant

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
