### PR TITLE
RavenDB-26411: fixed Fix GenAI retry handling and per-request timeouts

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
@@ -24,6 +24,8 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
     private readonly EtlProcessStatistics _statistics;
     private readonly GenAiStatsScope _scope;
 
+    internal static readonly TimeSpan RefreshDelay = TimeSpan.FromMinutes(10);
+
     public GenAiBatchPatchCommand(
         List<GenAiResultItem> items,
         PatchRequest patchRequest,
@@ -45,7 +47,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
 
     protected override long ExecuteCmd(DocumentsOperationContext context)
     {
-        var hashes = new Dictionary<string, (Document Doc, List<string> Hashes)>();
+        var hashes = new Dictionary<string, (Document Doc, List<string> Hashes, bool Refresh)>();
 
         using (var statsScope = _scope.For(GenAiOperations.ApplyUpdateScript))
         {
@@ -58,14 +60,17 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
                     if (item.ContextOutput.IsCached)
                         statsScope.TotalCachedContexts++;
 
-                    if (item.UpdateHash == false)
-                        continue;
-                    
                     ref var tuple = ref CollectionsMarshal.GetValueRefOrAddDefault(hashes, item.DocumentId, out var exists);
                     if (exists is false)
                     {
                         Document document = GetCurrentDocument(context, item.DocumentId);
-                        tuple = (document, []);
+                        tuple = (document, [], false);
+                    }
+
+                    if (item.UpdateHash == false)
+                    {
+                        tuple.Refresh = true;
+                        continue;
                     }
 
                     if (tuple.Doc is null)
@@ -105,15 +110,16 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
                 }
             }
 
-            // update metadata for each doc in same transaction
-            foreach (var (id, (doc, allHashes)) in hashes)
+            var refreshAt = context.DocumentDatabase.Time.GetUtcNow().Add(RefreshDelay);
+            foreach (var (id, (doc, allHashes, refresh)) in hashes)
             {
-                // this indicates that there was an error in the update script
-                // and that we should not update this document
-                if (allHashes.Count is 0)
+                if (doc is null)
                     continue;
 
-                UpdateHashesInMetadata(id, doc.Data, _taskIdentifier, allHashes, context);
+                if (allHashes.Count == 0 && refresh == false)
+                    continue;
+
+                UpdateMetadata(id, doc.Data, _taskIdentifier, allHashes, refresh ? refreshAt : null, context);
             }
 
             return statsScope.TotalUpdates;
@@ -131,73 +137,37 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
         return context.ReadObject(djv, item.DocumentId);
     }
 
-    internal static BlittableJsonReaderObject UpdateHashesInMetadata(string id, BlittableJsonReaderObject doc, string taskIdentifier, List<string> allHashes, DocumentsOperationContext context)
+    internal static BlittableJsonReaderObject UpdateMetadata(string id, BlittableJsonReaderObject doc, string taskIdentifier, List<string> allHashes, DateTime? refreshAt, DocumentsOperationContext context)
     {
         if (doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false)
         {
-            // no metadata at all (shouldn't happen)
+            if (allHashes.Count == 0 && refreshAt.HasValue == false)
+                return doc;
+
+            var newMetadata = new DynamicJsonValue();
+            if (allHashes.Count > 0)
+                newMetadata[Constants.Documents.Metadata.GenAiHashes] = new DynamicJsonValue { [taskIdentifier] = allHashes };
+            if (refreshAt.HasValue)
+                newMetadata[Constants.Documents.Metadata.Refresh] = refreshAt.Value;
 
             doc.Modifications = new DynamicJsonValue(doc)
             {
-                [Constants.Documents.Metadata.Key] = new DynamicJsonValue
-                {
-                    [Constants.Documents.Metadata.GenAiHashes] = new DynamicJsonValue
-                    {
-                        [taskIdentifier] = allHashes
-                    }
-                }
+                [Constants.Documents.Metadata.Key] = newMetadata
             };
         }
-
-        else if (metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashes) == false)
-        {
-            // no hashes section
-
-            metadata.Modifications = new DynamicJsonValue(metadata)
-            {
-                [Constants.Documents.Metadata.GenAiHashes] = new DynamicJsonValue
-                {
-                    [taskIdentifier] = allHashes
-                }
-            };
-            doc.Modifications = new DynamicJsonValue(doc)
-            {
-                [Constants.Documents.Metadata.Key] = metadata
-            };
-        }
-
         else
         {
-            // we already have the hashes section, need to modify it
+            var changed = allHashes.Count > 0 && TryUpdateHashesIfNeeded(metadata, taskIdentifier, allHashes);
 
-            if (hashes.TryGet(taskIdentifier, out BlittableJsonReaderArray existingHashes) && existingHashes != null && 
-                existingHashes.Length == allHashes.Count)
+            if (refreshAt.HasValue && metadata.TryGet(Constants.Documents.Metadata.Refresh, out object _) == false)
             {
-                bool needToUpdate = false;
-
-                foreach (var hash in existingHashes)
-                {
-                    if (allHashes.Contains(hash.ToString())) 
-                        continue;
-
-                    // we have a new hash that is not in the existing hashes
-                    needToUpdate = true;
-                    break;
-                }
-
-                if (needToUpdate == false)
-                    return doc; // we already have the hashes for this task, no need to update
+                metadata.Modifications ??= new DynamicJsonValue(metadata);
+                metadata.Modifications[Constants.Documents.Metadata.Refresh] = refreshAt.Value;
+                changed = true;
             }
 
-            hashes.Modifications = new DynamicJsonValue(hashes)
-            {
-                [taskIdentifier] = allHashes
-            };
-
-            metadata.Modifications = new DynamicJsonValue(metadata)
-            {
-                [Constants.Documents.Metadata.GenAiHashes] = hashes
-            };
+            if (changed == false)
+                return doc;
 
             doc.Modifications = new DynamicJsonValue(doc)
             {
@@ -206,13 +176,49 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
         }
 
         using (var old = doc)
-        {
             doc = context.ReadObject(old, id);
-        }
 
         context.DocumentDatabase.DocumentsStorage.Put(context, id, expectedChangeVector: null, doc);
 
         return doc;
+    }
+
+    private static bool TryUpdateHashesIfNeeded(BlittableJsonReaderObject metadata, string taskIdentifier, List<string> allHashes)
+    {
+        if (metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashes) == false)
+        {
+            metadata.Modifications ??= new DynamicJsonValue(metadata);
+            metadata.Modifications[Constants.Documents.Metadata.GenAiHashes] = new DynamicJsonValue
+            {
+                [taskIdentifier] = allHashes
+            };
+            return true;
+        }
+
+        if (hashes.TryGet(taskIdentifier, out BlittableJsonReaderArray existingHashes) && existingHashes != null &&
+            existingHashes.Length == allHashes.Count)
+        {
+            var needToUpdate = false;
+            foreach (var hash in existingHashes)
+            {
+                if (allHashes.Contains(hash.ToString()))
+                    continue;
+
+                needToUpdate = true;
+                break;
+            }
+
+            if (needToUpdate == false)
+                return false;
+        }
+
+        hashes.Modifications = new DynamicJsonValue(hashes)
+        {
+            [taskIdentifier] = allHashes
+        };
+        metadata.Modifications ??= new DynamicJsonValue(metadata);
+        metadata.Modifications[Constants.Documents.Metadata.GenAiHashes] = hashes;
+        return true;
     }
 
     private Document GetCurrentDocument(DocumentsOperationContext context, string id)

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
@@ -112,15 +112,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
 
             var refreshAt = context.DocumentDatabase.Time.GetUtcNow().Add(RefreshDelay);
             foreach (var (id, (doc, allHashes, refresh)) in hashes)
-            {
-                if (doc is null)
-                    continue;
-
-                if (allHashes.Count == 0 && refresh == false)
-                    continue;
-
-                UpdateMetadata(id, doc.Data, _taskIdentifier, allHashes, refresh ? refreshAt : null, context);
-            }
+                UpdateMetadata(id, doc?.Data, _taskIdentifier, allHashes, refresh ? refreshAt : null, context);
 
             return statsScope.TotalUpdates;
         }
@@ -139,11 +131,13 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
 
     internal static BlittableJsonReaderObject UpdateMetadata(string id, BlittableJsonReaderObject doc, string taskIdentifier, List<string> allHashes, DateTime? refreshAt, DocumentsOperationContext context)
     {
+        // no document, or nothing to write (no hashes and no @refresh) - nothing to persist
+        if (doc == null || (allHashes.Count == 0 && refreshAt.HasValue == false))
+            return null;
+
+        var changed = false;
         if (doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false)
         {
-            if (allHashes.Count == 0 && refreshAt.HasValue == false)
-                return doc;
-
             var newMetadata = new DynamicJsonValue();
             if (allHashes.Count > 0)
                 newMetadata[Constants.Documents.Metadata.GenAiHashes] = new DynamicJsonValue { [taskIdentifier] = allHashes };
@@ -154,10 +148,11 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
             {
                 [Constants.Documents.Metadata.Key] = newMetadata
             };
+            changed = true;
         }
         else
         {
-            var changed = allHashes.Count > 0 && TryUpdateHashesIfNeeded(metadata, taskIdentifier, allHashes);
+            changed = allHashes.Count > 0 && TryUpdateHashesIfNeeded(metadata, taskIdentifier, allHashes);
 
             if (refreshAt.HasValue && metadata.TryGet(Constants.Documents.Metadata.Refresh, out object _) == false)
             {
@@ -166,17 +161,19 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
                 changed = true;
             }
 
-            if (changed == false)
-                return doc;
-
-            doc.Modifications = new DynamicJsonValue(doc)
+            if (changed)
             {
-                [Constants.Documents.Metadata.Key] = metadata
-            };
+                doc.Modifications = new DynamicJsonValue(doc)
+                {
+                    [Constants.Documents.Metadata.Key] = metadata
+                };
+            }
         }
 
-        using (var old = doc)
-            doc = context.ReadObject(old, id);
+        if (changed == false)
+            return doc;
+
+        doc = context.ReadObject(doc, id);
 
         context.DocumentDatabase.DocumentsStorage.Put(context, id, expectedChangeVector: null, doc);
 

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -157,10 +157,21 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         // Prevent database unloading during long-running AI operations
         using (Database.PreventFromUnloadingByIdleOperations())
         using (EnterLoadStep(TaskErrorStep.ModelInference))
-        using (var cts = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken))
         {
-            cts.CancelAfter(Database.Configuration.Ai.GenAiSendToModelTimeout.AsTimeSpan);
-            exceptions = SendToModel(results, context, scope, cts.Token);
+            exceptions = SendToModel(results, context, scope, CancellationToken);
+        }
+
+        var batch = AnalyzeAttemptedBatch(results);
+
+        if (batch.AllAttemptedFailedNonDeterministically)
+        {
+            LoadErrorStep = TaskErrorStep.ModelInference;
+            _maxConcurrency = 1;
+
+            if (exceptions?.Count > 0)
+                throw new AggregateException(exceptions).ExtractSingleInnerException();
+
+            throw new InvalidOperationException("The whole attempted GenAI batch failed without a captured exception.");
         }
 
         using (EnterLoadStep(TaskErrorStep.Persistence))
@@ -168,17 +179,17 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
             ApplyUpdateScript(results, scope);
         }
 
-        if (exceptions?.Count > 0)
+        // Whole attempted failures were handled above by throwing.
+        // If this is only a partial transient failure, persist successful/handled items,
+        // but back off instead of increasing concurrency.
+        if (batch.HasNonDeterministicFailures)
         {
-            LoadErrorStep = TaskErrorStep.ModelInference;
             _maxConcurrency = 1;
-            throw new AggregateException(exceptions).ExtractSingleInnerException();
         }
-
         // we had no errors, re-raise max concurrency slowly
-        if (_maxConcurrency < Configuration.MaxConcurrency &&
-            // we had sufficient changes to actually use the current limit  
-            results.Count >= _maxConcurrency)
+        else if (_maxConcurrency < Configuration.MaxConcurrency &&
+                 // we had sufficient changes to actually use the current limit
+                 results.Count >= _maxConcurrency)
         {
             _maxConcurrency++;
         }
@@ -186,7 +197,34 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         return results.Count;
     }
 
-    private List<Exception> SendToModel(List<GenAiResultItem> items, JsonOperationContext context, GenAiStatsScope scope, CancellationToken batchToken)
+    private readonly record struct AttemptedBatch(int AttemptedCount, int NonDeterministicFailures)
+    {
+        public bool HasNonDeterministicFailures => NonDeterministicFailures > 0;
+
+        public bool AllAttemptedFailedNonDeterministically => AttemptedCount > 0 && NonDeterministicFailures == AttemptedCount;
+    }
+
+    private static AttemptedBatch AnalyzeAttemptedBatch(List<GenAiResultItem> results)
+    {
+        var attempted = 0;
+        var nonDeterministicFailures = 0;
+        foreach (var item in results)
+        {
+            if (item.ContextOutput.IsCached)
+                continue; // cached items were not attempted in this batch
+
+            attempted++;
+            if (item.UpdateHash == false)
+                nonDeterministicFailures++;
+        }
+
+        return new AttemptedBatch(attempted, nonDeterministicFailures);
+    }
+
+    internal static bool IsWholeAttemptedBatchFailure(List<GenAiResultItem> results) =>
+        AnalyzeAttemptedBatch(results).AllAttemptedFailedNonDeterministically;
+
+    private List<Exception> SendToModel(List<GenAiResultItem> items, JsonOperationContext context, GenAiStatsScope scope, CancellationToken shutdown)
     {
         using (var statsScope = scope.For(GenAiOperations.LoadToModel))
         {
@@ -206,7 +244,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 }
 
                 // this is how we ensure that we don't have too many outstanding tasks 
-                var idx = Task.WaitAny(executingTasks, CancellationToken);
+                var idx = Task.WaitAny(executingTasks, shutdown);
                 statsScope.TotalSentToModel++;
 
                 string json = item.ContextOutput.Context.ToString();
@@ -233,7 +271,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 handler.SetClient(_chatCompletionClient);
                 try
                 {
-                    task = handler.HandleRequestAsync(batchToken);
+                    task = handler.HandleRequestAsync(Database.Configuration.Ai.GenAiSendToModelTimeout.AsTimeSpan, shutdown);
                 }
                 catch (Exception e)
                 {
@@ -249,7 +287,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
 
             try
             {
-                Task.WaitAll(executingTasks, CancellationToken); // only the pending tasks remain here
+                Task.WaitAll(executingTasks, shutdown); // only the pending tasks remain here
             }
             catch (Exception)
             {
@@ -506,8 +544,15 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                         context.DocumentDatabase.DocumentsStorage.Put(context, document!.Id, expectedChangeVector: null, document.Data);
                     }
 
+                    var refresh = false;
                     foreach (var item in items)
                     {
+                        if (item.UpdateHash == false)
+                        {
+                            refresh = true;
+                            continue;
+                        }
+
                         hashes.Add(item.ContextOutput.AiHash);
 
                         if (item.ModelOutput is null)
@@ -539,17 +584,32 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                     }
 
 
+                    DateTime? refreshAt = refresh
+                        ? context.DocumentDatabase.Time.GetUtcNow().Add(GenAiBatchPatchCommand.RefreshDelay)
+                        : null;
+
                     if (lastPatch != null)
                     {
                         status = lastPatch.PatchResult.Status;
-                        debugActions = lastPatch?.DebugActions;
-                        debugOutput = lastPatch?.DebugOutput;
+                        debugActions = lastPatch.DebugActions;
+                        debugOutput = lastPatch.DebugOutput;
+                    }
 
-                        if (lastPatch?.PatchResult?.ModifiedDocument != null)
-                        {
-                            outputDocument = GenAiBatchPatchCommand.UpdateHashesInMetadata(document.Id, lastPatch.PatchResult.ModifiedDocument, Configuration.Identifier,
-                                hashes, context);
-                        }
+                    // Clone stored document data because UpdateMetadata may dispose the blittable it receives.
+                    // ModifiedDocument is already an owned patch result and can be passed directly.
+                    BlittableJsonReaderObject documentToUpdate = lastPatch?.PatchResult?.ModifiedDocument;
+                    if (documentToUpdate == null && (hashes.Count > 0 || refreshAt.HasValue))
+                        documentToUpdate = document?.Data?.Clone(context);
+
+                    if ((hashes.Count > 0 || refreshAt.HasValue) && documentToUpdate != null)
+                    {
+                        outputDocument = GenAiBatchPatchCommand.UpdateMetadata(
+                            document.Id,
+                            documentToUpdate,
+                            Configuration.Identifier,
+                            hashes,
+                            refreshAt,
+                            context);
                     }
 
                     break;

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -113,8 +113,10 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
 
     protected override void EnterFallbackMode(Exception e, DateTime? lastErrorTime)
     {
-        if (e is AggregateException ae &&
-            ae.InnerExceptions.OfType<RateLimitException>().FirstOrDefault() is { } rateLimitException)
+        var rateLimitException = e as RateLimitException ??
+                                 (e as AggregateException)?.Flatten().InnerExceptions.OfType<RateLimitException>().FirstOrDefault();
+
+        if (rateLimitException != null)
         {
             FallbackTime = rateLimitException.RetryAfter;
             return;
@@ -177,6 +179,14 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         using (EnterLoadStep(TaskErrorStep.Persistence))
         {
             ApplyUpdateScript(results, scope);
+        }
+
+        if (exceptions?.OfType<RateLimitException>().Any() == true)
+        {
+            LoadErrorStep = TaskErrorStep.ModelInference;
+            _maxConcurrency = 1;
+
+            throw new AggregateException(exceptions).ExtractSingleInnerException();
         }
 
         // Whole attempted failures were handled above by throwing.
@@ -595,22 +605,13 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                         debugOutput = lastPatch.DebugOutput;
                     }
 
-                    // Clone stored document data because UpdateMetadata may dispose the blittable it receives.
-                    // ModifiedDocument is already an owned patch result and can be passed directly.
-                    BlittableJsonReaderObject documentToUpdate = lastPatch?.PatchResult?.ModifiedDocument;
-                    if (documentToUpdate == null && (hashes.Count > 0 || refreshAt.HasValue))
-                        documentToUpdate = document?.Data?.Clone(context);
-
-                    if ((hashes.Count > 0 || refreshAt.HasValue) && documentToUpdate != null)
-                    {
-                        outputDocument = GenAiBatchPatchCommand.UpdateMetadata(
-                            document.Id,
-                            documentToUpdate,
-                            Configuration.Identifier,
-                            hashes,
-                            refreshAt,
-                            context);
-                    }
+                    outputDocument = GenAiBatchPatchCommand.UpdateMetadata(
+                        document?.Id,
+                        lastPatch?.PatchResult?.ModifiedDocument ?? document?.Data,
+                        Configuration.Identifier,
+                        hashes,
+                        refreshAt,
+                        context);
 
                     break;
                 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/GenAiConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/GenAiConversationHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.AI;
@@ -12,14 +13,15 @@ internal class GenAiConversationHandler(ServerStore server, DocumentDatabase dat
 {
     private readonly DocumentDatabase _database = database;
 
-    public async Task<GenAiHandlerResult> HandleRequestAsync(CancellationToken token)
+    public async Task<GenAiHandlerResult> HandleRequestAsync(TimeSpan cancelAfter, CancellationToken shutdown)
     {
+        using var token = new OperationCancelToken(cancelAfter, shutdown);
         using var _ = _database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
 
         // the parameters is a BlittableJsonReaderObject which use a shared underlying context that is not thread safe, so we need to clone it for concurrent read
         _request.Parameters = _request.Parameters?.CloneForConcurrentRead(context);
 
-        var response = await HandleRequestAsync(context, token);
+        var response = await HandleRequestAsync(context, token.Token);
         var result = new GenAiHandlerResult
         {
             Response = response.Response.ToString(), 

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
@@ -422,7 +422,7 @@ this.Comments[idx].IsBlocked = $output.Blocked;";
     [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task GenAi_LoadError_AuthFailure_ShouldOnlyTrackSuccess(Options options, GenAiConfiguration config)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
 
         store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
@@ -444,22 +444,19 @@ this.Comments[idx].IsSpam = $output.Blocked;";
         store.Maintenance.Send(new AddGenAiOperation(config));
         var db = await GetDatabase(store.Database);
 
-        var etlProcess = db.EtlLoader.Processes.FirstOrDefault() as GenAiTask;
-        Assert.NotNull(etlProcess);
+        GenAiTask etlProcess = null;
+        Assert.True(await WaitForValueAsync(() =>
+        {
+            etlProcess = db.EtlLoader.Processes.OfType<GenAiTask>().FirstOrDefault();
+            return Task.FromResult(etlProcess != null);
+        }, true, timeout: 15_000), "GenAi ETL process was not loaded in time");
 
         var chatCompletionClient = etlProcess.GetChatCompletionClient();
-        var enteredOnce = 0;
-        var blockEtlMre = new AsyncManualResetEvent();
 
         chatCompletionClient.ForTestingPurposesOnly().SimulateFailureAsync = ctx =>
         {
-            if (ctx.Contains("alex"))
-            {
-                if (Interlocked.CompareExchange(ref enteredOnce, 1, 0) == 0)
-                    throw new UnsuccessfulAiRequestException("Unauthorized", HttpStatusCode.Unauthorized) { RequestId = "fake-request-id" };
-
-                return blockEtlMre.WaitAsync(TimeSpan.FromSeconds(60));
-            }
+            if (ctx.Contains("alex") && ctx.Contains("AI Agent Parameters:") == false)
+                throw new UnsuccessfulAiRequestException("Unauthorized", HttpStatusCode.Unauthorized) { RequestId = "fake-request-id" };
 
             return Task.CompletedTask;
         };
@@ -488,17 +485,25 @@ this.Comments[idx].IsSpam = $output.Blocked;";
         Assert.NotEmpty(errors);
         Assert.Contains("Unauthorized", errors.First().Error);
 
+        Assert.True(await WaitForValueAsync(async () =>
+        {
+            using var session = store.OpenAsyncSession();
+            var d = await session.LoadAsync<BlittableJsonReaderObject>(docId);
+            return d != null
+                   && d.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject m)
+                   && m.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject h)
+                   && h.TryGet(config.Identifier, out BlittableJsonReaderArray arr) && arr.Length == 1;
+        }, true, timeout: 30_000), "only the successful context should be hashed");
+
         using (var session = store.OpenSession())
         {
             var doc = session.Load<BlittableJsonReaderObject>(docId);
             Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
-            Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
-            Assert.True(hashesSection.TryGet(config.Identifier, out BlittableJsonReaderArray hashes));
 
-            // Only one comment should have succeeded
-            Assert.Equal(1, hashes.Length);
+            // the failed context is parked via @refresh so only it will be retried later
+            Assert.True(metadata.TryGet(Constants.Documents.Metadata.Refresh, out object _));
 
-            // assert that the update phase was executed only for comment #2
+            // only the successful context (comment #2) was patched
             Assert.True(doc.TryGet(nameof(GenAiBasics.Post.Comments), out BlittableJsonReaderArray comments));
             Assert.Equal(2, comments.Length);
 
@@ -512,45 +517,12 @@ this.Comments[idx].IsSpam = $output.Blocked;";
             Assert.True(comment2.TryGet("IsSpam", out bool _));
         }
 
-        blockEtlMre.Set();
-
-        // assert that next ETL batch starts from 0 etag
-        var state = EtlProcess.GetProcessState(db, config.Name, config.Transforms[0].Name);
-        var lastProcessedEtag = state.GetLastProcessedEtag(db.DbBase64Id, Server.ServerStore.NodeTag);
-        Assert.Equal(0, lastProcessedEtag);
-
-        // assert that the comment with model failure is processed in the next ETL batch
-        var etlDone = Etl.WaitForEtlToComplete(store);
-
-        Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(60)));
-
-        using (var session = store.OpenSession())
+        // a partial failure commits the successful context and advances the checkpoint -
+        // we do not reprocess the whole batch from etag 0
+        Assert.True(await WaitForValueAsync(() =>
         {
-            var doc = session.Load<BlittableJsonReaderObject>(docId);
-            Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
-            Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
-            Assert.True(hashesSection.TryGet(config.Identifier, out BlittableJsonReaderArray hashes));
-
-            // now both contexts should have their hash in metadata
-            Assert.Equal(2, hashes.Length);
-
-            // assert that the update phase was executed for comment #2
-            Assert.True(doc.TryGet(nameof(GenAiBasics.Post.Comments), out BlittableJsonReaderArray comments));
-            Assert.Equal(2, comments.Length);
-
-            var comment1 = comments[0] as BlittableJsonReaderObject;
-            var comment2 = comments[1] as BlittableJsonReaderObject;
-
-            Assert.NotNull(comment1);
-            Assert.NotNull(comment2);
-
-            Assert.True(comment1.TryGet("IsSpam", out bool _));
-            Assert.True(comment1.TryGet("IsSpam", out bool _));
-        }
-
-        // assert that next ETL batch will NOT start from 0 etag
-        state = EtlProcess.GetProcessState(db, config.Name, config.Transforms[0].Name);
-        lastProcessedEtag = state.GetLastProcessedEtag(db.DbBase64Id, Server.ServerStore.NodeTag);
-        Assert.True(lastProcessedEtag > 0);
+            var state = EtlProcess.GetProcessState(db, config.Name, config.Transforms[0].Name);
+            return Task.FromResult(state.GetLastProcessedEtag(db.DbBase64Id, Server.ServerStore.NodeTag) > 0);
+        }, true, timeout: 30_000), "partial success should advance the ETL checkpoint");
     }
 }

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiStats.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiStats.cs
@@ -375,13 +375,7 @@ this.Comments[idx].IsSpam = $output.Blocked;
         Assert.Equal(1, modelScope.ModelCallFailures);
 
         var updatePhaseStats = loadDetails.Operations.FirstOrDefault(x => x.Name == GenAiOperations.ApplyUpdateScript) as GenAiPerformanceOperation;
-        Assert.NotNull(updatePhaseStats);
-
-        // nothing should be patched 
-        Assert.Equal(1, updatePhaseStats.NumberOfContextObjects);
-        Assert.Equal(0, updatePhaseStats.TotalUpdates);
-        Assert.Equal(0, updatePhaseStats.TotalCachedContexts);
-        Assert.Equal(0, updatePhaseStats.UpdateFailures);
+        Assert.Null(updatePhaseStats);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_26184.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_26184.cs
@@ -1,0 +1,186 @@
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Config;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues
+{
+    // RavenDB-26184 / RavenDB-26411 - GenAI ETL failure handling.
+    //
+    // Deterministic failures (too-many-tokens, refusal) write @gen-ai-hashes and never retry. Non-deterministic
+    // failures are decided at the batch level: a partial batch parks the failed items via @refresh (no hash, no throw,
+    // successes commit); a whole attempted batch that failed is thrown before any @refresh is stamped, letting the ETL
+    // fallback/backoff handle it. Cached/already-hashed items never make a whole-attempted-batch failure look partial.
+    public class RavenDB_26184(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        private const string Marker = "ZZZMARKER";
+
+        [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Ai)]
+        public void IsWholeAttemptedBatchFailure_CountsOnlyAttemptedItems()
+        {
+            Assert.False(GenAiTask.IsWholeAttemptedBatchFailure([Sent(failed: false), Sent(failed: true)])); // partial
+            Assert.True(GenAiTask.IsWholeAttemptedBatchFailure([Sent(failed: true), Sent(failed: true)]));    // whole attempted batch
+            Assert.True(GenAiTask.IsWholeAttemptedBatchFailure([Cached(), Sent(failed: true)]));              // cached excluded -> whole
+            Assert.False(GenAiTask.IsWholeAttemptedBatchFailure([Sent(failed: false), Sent(failed: false)])); // whole batch handled (e.g. deterministic) -> no throw
+            Assert.False(GenAiTask.IsWholeAttemptedBatchFailure([Sent(failed: false)]));                      // success only
+            Assert.False(GenAiTask.IsWholeAttemptedBatchFailure([Cached()]));                                 // nothing attempted
+            Assert.False(GenAiTask.IsWholeAttemptedBatchFailure([]));
+            return;
+
+            static GenAiResultItem Sent(bool failed) => new() { UpdateHash = failed == false, ContextOutput = new ContextOutput { IsCached = false } };
+            static GenAiResultItem Cached() => new() { UpdateHash = true, ContextOutput = new ContextOutput { IsCached = true } };
+        }
+
+        // Partial batch: one document succeeds, one fails non-deterministically (times out). The success is hashed, the
+        // failure is parked via @refresh (no hash), and the batch commits (no throw).
+        [RavenTheory(RavenTestCategory.Etl | RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task PartialBatch_HashesSuccess_ParksFailure_NoThrow(Options options, GenAiConfiguration config)
+        {
+            const int perCallDelayMs = 6_000;
+            const int timeoutInSec = 3;
+
+            options.ModifyDatabaseRecord = record =>
+                record.Settings[RavenConfiguration.GetKey(x => x.Ai.GenAiSendToModelTimeout)] = timeoutInSec.ToString();
+
+            using var store = GetDocumentStore(options);
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+            ConfigureGenAi(config, "partial-batch");
+            config.MaxConcurrency = 2; // keep both documents in one batch
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            var etlProcess = await WaitForGenAiProcessAsync(store);
+            etlProcess.GetChatCompletionClient().ForTestingPurposesOnly().SimulateFailureAsync = async msg =>
+            {
+                if (msg.Contains(Marker) && msg.Contains("AI Agent Parameters:") == false)
+                    await Task.Delay(perCallDelayMs); // only the marked document times out
+            };
+
+            const string okDoc = "posts/1";
+            const string failDoc = "posts/2";
+            using (var session = store.OpenSession())
+            {
+                session.Store(new GenAiBasics.Post([new GenAiBasics.Comment("a normal comment", "author") { Id = "1" }], "title", "body"), okDoc);
+                session.Store(new GenAiBasics.Post([new GenAiBasics.Comment($"{Marker} times out", "author") { Id = "1" }], "title", "body"), failDoc);
+                session.SaveChanges();
+            }
+
+            Assert.True(await WaitForValueAsync(() => HasSuccessHashAsync(store, okDoc, config.Identifier), true, timeout: 30_000),
+                "the successful document should be hashed");
+            Assert.False(await HasRefreshAsync(store, okDoc), "a successful document must not be parked via @refresh");
+            Assert.True(await WaitForRefreshAsync(store, failDoc), "the non-deterministic failure should be parked via @refresh");
+            Assert.False(await HasSuccessHashAsync(store, failDoc, config.Identifier), "a parked failure must not be hashed");
+        }
+
+        // Whole attempted batch fails non-deterministically (a single document that times out): it is thrown (ETL
+        // fallback) and NOT parked - no @refresh is stamped, no hash. Once the model recovers, it is hashed.
+        [RavenTheory(RavenTestCategory.Etl | RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task WholeBatchFailure_Throws_DoesNotPark_ThenRecovers(Options options, GenAiConfiguration config)
+        {
+            const int perCallDelayMs = 6_000;
+            const int timeoutInSec = 3;
+
+            options.ModifyDatabaseRecord = record =>
+                record.Settings[RavenConfiguration.GetKey(x => x.Ai.GenAiSendToModelTimeout)] = timeoutInSec.ToString();
+
+            using var store = GetDocumentStore(options);
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+            ConfigureGenAi(config, "whole-batch");
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            var etlProcess = await WaitForGenAiProcessAsync(store);
+            var failing = new StrongBox<bool>(true);
+            var modelCalls = 0;
+            etlProcess.GetChatCompletionClient().ForTestingPurposesOnly().SimulateFailureAsync = async msg =>
+            {
+                if (msg.Contains(Marker) && msg.Contains("AI Agent Parameters:") == false)
+                {
+                    Interlocked.Increment(ref modelCalls);
+                    if (Volatile.Read(ref failing.Value))
+                        await Task.Delay(perCallDelayMs);
+                }
+            };
+
+            const string docId = "posts/1";
+            StoreMarkedPost(store, docId, "times out");
+
+            Assert.True(await WaitForValueAsync(() => Task.FromResult(Volatile.Read(ref modelCalls) >= 1), true, timeout: 30_000),
+                "the document should be attempted");
+
+            // a whole attempted batch failure throws before stamping @refresh, so the document is neither parked nor hashed
+            Assert.False(await HasRefreshAsync(store, docId), "a whole-attempted-batch non-deterministic failure must not stamp @refresh");
+            Assert.False(await HasSuccessHashAsync(store, docId, config.Identifier), "a failed document must not be hashed");
+
+            Volatile.Write(ref failing.Value, false);
+            Assert.True(await WaitForValueAsync(() => HasSuccessHashAsync(store, docId, config.Identifier), true, timeout: 60_000),
+                "after the model recovers, the document should be hashed");
+        }
+
+        private static void StoreMarkedPost(Raven.Client.Documents.IDocumentStore store, string docId, string comment)
+        {
+            using var session = store.OpenSession();
+            session.Store(new GenAiBasics.Post([new GenAiBasics.Comment($"{Marker} {comment}", "author") { Id = "1" }], "title", "body"), docId);
+            session.SaveChanges();
+        }
+
+        private static Task<bool> WaitForRefreshAsync(Raven.Client.Documents.IDocumentStore store, string docId)
+            => WaitForValueAsync(() => HasRefreshAsync(store, docId), true, timeout: 30_000);
+
+        private static async Task<bool> HasRefreshAsync(Raven.Client.Documents.IDocumentStore store, string docId)
+        {
+            using var session = store.OpenAsyncSession();
+            var doc = await session.LoadAsync<BlittableJsonReaderObject>(docId);
+            return doc != null &&
+                   doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) &&
+                   metadata.TryGet(Constants.Documents.Metadata.Refresh, out object _);
+        }
+
+        private static void ConfigureGenAi(GenAiConfiguration config, string identifier)
+        {
+            config.Prompt = "Reply with the given text unchanged.";
+            config.Collection = "Posts";
+            config.SampleObject = JsonConvert.SerializeObject(new { Result = "text" });
+            config.UpdateScript = @"const idx = this.Comments.findIndex(c => c.Id == $input.Id);
+this.Comments[idx].Result = $output.Result;";
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script = "for (const comment of this.Comments) ai.genContext({Text: comment.Text, Id: comment.Id});"
+            };
+            config.MaxConcurrency = 1;
+            config.Identifier = identifier;
+        }
+
+        private async Task<GenAiTask> WaitForGenAiProcessAsync(Raven.Client.Documents.IDocumentStore store)
+        {
+            var db = await GetDatabase(store.Database);
+            GenAiTask etlProcess = null;
+            Assert.True(await WaitForValueAsync(() =>
+            {
+                etlProcess = db.EtlLoader.Processes.OfType<GenAiTask>().FirstOrDefault();
+                return Task.FromResult(etlProcess != null);
+            }, true, timeout: 15_000), "GenAi ETL process was not loaded in time");
+            return etlProcess;
+        }
+
+        private static async Task<bool> HasSuccessHashAsync(Raven.Client.Documents.IDocumentStore store, string docId, string identifier)
+        {
+            using var session = store.OpenAsyncSession();
+            var doc = await session.LoadAsync<BlittableJsonReaderObject>(docId);
+            return doc != null &&
+                   doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) &&
+                   metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashes) &&
+                   hashes.TryGet(identifier, out BlittableJsonReaderArray arr) && arr.Length > 0;
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_26411.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_26411.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Config;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues
+{
+    public class RavenDB_26411(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        // The GenAi 'SendToModel' timeout must apply per request (per document), not once across the whole batch.
+        // Each model call is delayed so a single call fits its own window but two sequential calls do not fit one
+        // shared batch window; with a per-batch deadline the 2nd document is starved and cancelled, with a
+        // per-request deadline both succeed.
+        [RavenTheory(RavenTestCategory.Etl | RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task GenAi_SendToModelTimeout_ShouldBeAppliedPerRequest_NotPerBatch(Options options, GenAiConfiguration config)
+        {
+            const int perCallDelayMs = 8_000;
+            const int timeoutInSec = 15;
+            const string marker = "ZZZMARKER";
+
+            // The invariant that makes this test meaningful: a single call fits its own window (delay < timeout),
+            // but two sequential calls would NOT fit a single shared batch window (timeout < 2*delay). Asserted so a
+            // future tweak can't silently stop distinguishing a per-request timeout from a per-batch one.
+            Assert.True(perCallDelayMs < timeoutInSec * 1000 && timeoutInSec * 1000 < 2 * perCallDelayMs,
+                "test invariant: perCallDelay < timeout < 2*perCallDelay");
+
+            options.ModifyDatabaseRecord = record =>
+                record.Settings[RavenConfiguration.GetKey(x => x.Ai.GenAiSendToModelTimeout)] = timeoutInSec.ToString();
+
+            using var store = GetDocumentStore(options);
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            config.Prompt = "Reply with the given text unchanged.";
+            config.Collection = "Posts";
+            config.SampleObject = JsonConvert.SerializeObject(new { Result = "text" });
+            config.UpdateScript = @"const idx = this.Comments.findIndex(c => c.Id == $input.Id);
+this.Comments[idx].Result = $output.Result;";
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script = "for (const comment of this.Comments) ai.genContext({Text: comment.Text, Id: comment.Id});"
+            };
+            config.MaxConcurrency = 1; // sequential, so the per-request vs per-batch difference is observable
+            config.Identifier = "per-request-timeout";
+
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            // EtlLoader populates the process asynchronously after AddGenAiOperation, so wait for it.
+            var db = await GetDatabase(store.Database);
+            GenAiTask etlProcess = null;
+            Assert.True(await WaitForValueAsync(() =>
+            {
+                etlProcess = db.EtlLoader.Processes.OfType<GenAiTask>().FirstOrDefault();
+                return Task.FromResult(etlProcess != null);
+            }, true, timeout: 15_000), "GenAi ETL process was not loaded in time");
+
+            // Delay each model call once. Only the user-content message carries the marker; the "AI Agent Parameters:"
+            // message also interpolates it, so we skip that. Assumes the task has no Queries/tools (a tool iteration
+            // would re-serialize the prompt and delay twice).
+            etlProcess.GetChatCompletionClient().ForTestingPurposesOnly().SimulateFailureAsync = async msg =>
+            {
+                if (msg.Contains(marker) && msg.Contains("AI Agent Parameters:") == false)
+                    await Task.Delay(perCallDelayMs);
+            };
+
+            const string docId = "posts/1";
+            using (var session = store.OpenSession())
+            {
+                session.Store(new GenAiBasics.Post([
+                    new GenAiBasics.Comment($"{marker} first comment", "author") { Id = "1" },
+                    new GenAiBasics.Comment($"{marker} second comment", "author") { Id = "2" }
+                ], "title", "body"), docId);
+                session.SaveChanges();
+            }
+
+            // both contexts must be processed - the 2nd one must not be cancelled by a shared batch timeout
+            var processed = await WaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var doc = await session.LoadAsync<BlittableJsonReaderObject>(docId);
+                if (doc == null || doc.TryGet(nameof(GenAiBasics.Post.Comments), out BlittableJsonReaderArray comments) == false)
+                    return 0;
+
+                return comments.Cast<BlittableJsonReaderObject>().Count(c => c.TryGet("Result", out string _));
+            }, 2, timeout: 90_000);
+
+            Assert.Equal(2, processed);
+
+            // and there must be no load errors: a per-batch timeout would have logged a cancellation for the 2nd context
+            var errors = (await Etl.GetItemLoadErrorsAsync(store.Database, config)).ToList();
+            Assert.True(errors.Count == 0, $"Expected no load errors, but got: {string.Join(" | ", errors.Select(e => e.Error))}");
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26411/GenAI-Timeout-Issues-with-Large-Text-Processing
https://issues.hibernatingrhinos.com/issue/RavenDB-26184/GenAI-task-loops-indefinitely-on-batch-timeout-TaskCanceledException

### Additional description

Two fixes for how the GenAI ETL handles model-call failures (RavenDB-26411 + RavenDB-26184).

The send-to-model timeout used to be a single deadline for the whole batch, so documents near the end of the queue could get starved and cancelled before they were ever sent. Now each document gets its own timeout window.

Transient failures (timeouts, rate limits, etc.) used to retry the same documents forever and burn through tokens. Now we tell two kinds of failures apart: deterministic ones (too many tokens, refusal) just get hashed and skipped, while transient ones are decided per batch — if the whole batch failed we throw and let the normal ETL back-off retry it later, and if only some failed we keep the good results, park the failed docs with @refresh, and drop concurrency to 1.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
