### PR TITLE
RavenDB-26876 Propagate normal-tx recreate after cluster-wide delete

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -654,7 +654,7 @@ namespace Raven.Server.Documents
             {
                 foreach (var existingConflict in conflicts)
                 {
-                    status = ChangeVectorUtils.GetConflictStatus(context.GetChangeVector(changeVector), context.GetChangeVector(existingConflict.ChangeVector));
+                    status = context.DocumentDatabase.DocumentsStorage.GetConflictStatusForVersion(context, changeVector, existingConflict.ChangeVector);
                     if (status == ConflictStatus.Conflict)
                     {
                         ConflictManager.AssertChangeVectorNotNull(existingConflict.ChangeVector);

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2561,24 +2561,14 @@ namespace Raven.Server.Documents
         {
             var remoteChangeVector = context.GetChangeVector(remote);
             var localChangeVector = context.GetChangeVector(local);
+
+            // TRXN adds no ordering beyond RAFT; stripping it avoids false conflicts between cluster-tx and normal CVs.
+            remoteChangeVector = remoteChangeVector.StripTrxnTags(context);
+            localChangeVector = localChangeVector.StripTrxnTags(context);
+
             var originalStatus = ChangeVectorUtils.GetConflictStatus(remoteChangeVector, localChangeVector, mode: mode);
-
-            // conflicts for document with cluster tx have a special treatment in case of conflict
-            // because in some cases newer document in a normal tx can be conflicted with an older document/tombstone that was created in cluster tx
-            // so we should pick the newer version
-
-            // our local change vector is           RAFT:2, TRXN:10
-            // case 1: incoming change vector A:10, RAFT:3          -> update    (although it is a conflict) 
-            // case 2: incoming change vector A:10, RAFT:2          -> update    (although it is a conflict)
-            // case 3: incoming change vector A:10, RAFT:1          -> already merged
-            var partOfClusterTx = false;
-            var clusterTransactionId = DocumentDatabase.ClusterTransactionId;
-            if (string.IsNullOrEmpty(clusterTransactionId) == false)
-            {
-                partOfClusterTx = remote?.Contains(clusterTransactionId) == true || local?.Contains(clusterTransactionId) == true;
-            }
-
-            if (originalStatus == ConflictStatus.Conflict && (HasUnusedDatabaseIds() || partOfClusterTx))
+            
+            if (originalStatus == ConflictStatus.Conflict && HasUnusedDatabaseIds())
             {
                 // We need to distinguish between few cases here
                 // let's assume that node C was removed
@@ -2594,10 +2584,7 @@ namespace Raven.Server.Documents
                 // case 2: incoming change vector A:10, B:11, C:10 -> conflict              (original: conflict, after: conflict)
                 // case 3: incoming change vector A:11, B:10, C:10 -> update                (original: update, after: already merged)
                 // case 4: incoming change vector A:11, B:12, C:10 -> update                (original: conflict, after: update)
-
-                remoteChangeVector = remoteChangeVector.StripTrxnTags(context);
-                localChangeVector = localChangeVector.StripTrxnTags(context);
-
+              
                 remoteChangeVector.TryRemoveIds(UnusedDatabaseIds, context, out remoteChangeVector);
                 var skipValidation = localChangeVector.TryRemoveIds(UnusedDatabaseIds, context, out localChangeVector);
                 context.SkipChangeVectorValidation |= skipValidation;

--- a/test/SlowTests.Issues/Issues/RavenDB-26295/FilteredPullDualClusterFirstAndSecondHopTests.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26295/FilteredPullDualClusterFirstAndSecondHopTests.cs
@@ -800,7 +800,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
         var nodeCCounterAfterLocalChange = lab.GetFilteredRoundTripCounter(LabNode.C, counterName);
         var nodeCDbCvAfterLocalChange = lab.GetDatabaseChangeVector(LabNode.C);
 
-        AssertReplicatedItemKeptSourceChangeVector(filteredPassReceiveSide, "counter increment from filtered counter", nodeCCounter.ChangeVector, nodeACounterAfterLocalChange.ChangeVector, nodeCCounterAfterLocalChange.ChangeVector);
+        AssertReplicatedCounterIsCausalSuccessorOfSource(filteredPassReceiveSide, "counter increment from filtered counter", nodeCCounter.ChangeVector, nodeACounterAfterLocalChange.ChangeVector, nodeCCounterAfterLocalChange.ChangeVector);
         AssertLocalChangeIsCausalSuccessor(filteredPassReceiveSide, "counter increment from filtered counter", nodeCCounter.ChangeVector, nodeACounterAfterLocalChange.ChangeVector);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "counter after local increment replicated from node A", nodeCCounterAfterLocalChange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "counter after local increment replicated from node A", nodeCCounterAfterLocalChange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1737,10 +1737,41 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
         Assert.True(
             string.Equals(replicatedChangeVector, sourceChangeVector, StringComparison.Ordinal),
             $"Expected {itemDescription} to keep the exact source item CV when ordinary internal replication sends it from {NodeTag(filteredPassReceiveSide, LabNode.A)} to {NodeTag(filteredPassReceiveSide, LabNode.C)}. " +
-            $"A different CV means {NodeTag(filteredPassReceiveSide, LabNode.C)} had to merge or rewrite the item instead of applying it as a clean successor. " +
-            $"versionStatusAgainstFilteredPredecessor={status}, sourceCV='{sourceChangeVector ?? "<null>"}', replicatedCV='{replicatedChangeVector ?? "<null>"}', " +
-            $"filteredPredecessorCV='{filteredPredecessorChangeVector ?? "<null>"}', sourceVersion='{sourceVersion ?? "<null>"}', " +
-            $"filteredPredecessorVersion='{filteredPredecessorVersion ?? "<null>"}'.");
+            $"{Environment.NewLine}A different CV means {NodeTag(filteredPassReceiveSide, LabNode.C)} had to merge or rewrite the item instead of applying it as a clean successor. " +
+            $"{Environment.NewLine}versionStatusAgainstFilteredPredecessor={status}, " +
+            $"{Environment.NewLine}sourceCV='{sourceChangeVector ?? "<null>"}', " +
+            $"{Environment.NewLine}replicatedCV='{replicatedChangeVector ?? "<null>"}', " +
+            $"{Environment.NewLine}filteredPredecessorCV='{filteredPredecessorChangeVector ?? "<null>"}', " +
+            $"{Environment.NewLine}sourceVersion='{sourceVersion ?? "<null>"}', " +
+            $"{Environment.NewLine}filteredPredecessorVersion='{filteredPredecessorVersion ?? "<null>"}'.");
+    }
+
+    private static void AssertReplicatedCounterIsCausalSuccessorOfSource(
+        ClusterSide filteredPassReceiveSide,
+        string itemDescription,
+        string filteredPredecessorChangeVector,
+        string sourceChangeVector,
+        string replicatedChangeVector)
+    {
+        // Counters merge into counter-group documents on the receiver, so unlike documents the receiver
+        // may rewrite the group and stamp a fresh local change vector entry even when the incoming state
+        // fully dominates the local one. The only consequence is one extra (harmless) replication hop for
+        // the rewritten group, so we require the replicated Version to causally cover the source Version
+        // instead of demanding the exact source item CV.
+        var sourceVersion = GetVersionChangeVector(sourceChangeVector);
+        var replicatedVersion = GetVersionChangeVector(replicatedChangeVector);
+        var status = ChangeVectorUtils.GetConflictStatus(sourceVersion, replicatedVersion);
+
+        Assert.True(
+            status == ConflictStatus.AlreadyMerged,
+            $"Expected {itemDescription} on {NodeTag(filteredPassReceiveSide, LabNode.C)} to causally cover the source item Version when ordinary internal replication sends it from {NodeTag(filteredPassReceiveSide, LabNode.A)} to {NodeTag(filteredPassReceiveSide, LabNode.C)}. " +
+            $"{Environment.NewLine}A status other than AlreadyMerged means {NodeTag(filteredPassReceiveSide, LabNode.C)} lost or diverged from part of the source counter state instead of merging it as a clean successor. " +
+            $"{Environment.NewLine}status(sourceVersion vs replicatedVersion)={status}, " +
+            $"{Environment.NewLine}sourceCV='{sourceChangeVector ?? "<null>"}', " +
+            $"{Environment.NewLine}replicatedCV='{replicatedChangeVector ?? "<null>"}', " +
+            $"{Environment.NewLine}filteredPredecessorCV='{filteredPredecessorChangeVector ?? "<null>"}', " +
+            $"{Environment.NewLine}sourceVersion='{sourceVersion ?? "<null>"}', " +
+            $"{Environment.NewLine}replicatedVersion='{replicatedVersion ?? "<null>"}'.");
     }
 
     private static void AssertClientRevisionHistoryContainsOnlyExpectedRevisions(

--- a/test/SlowTests/Cluster/RavenDB_22502.cs
+++ b/test/SlowTests/Cluster/RavenDB_22502.cs
@@ -3,12 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FastTests.Utils;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Sharding;
+using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.ServerWide.Maintenance;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Server;
@@ -303,6 +307,387 @@ namespace SlowTests.Cluster
                     Assert.Equal(ConflictStatus.Update, status);
                 }
             }
+        }
+
+        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Replication | RavenTestCategory.ClusterTransactions)]
+        public async Task RecreateAfterClusterWideDeleteWithCleanedTombstoneShouldPropagate()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
+            var database = GetDatabaseName();
+            await CreateDatabaseInCluster(database, replicationFactor: 2, leader.WebUrl);
+
+            var other = nodes.Single(n => n != leader);
+
+            using var storeA = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { leader.WebUrl },
+                Conventions = { DisableTopologyUpdates = true } // pin all writes to node A
+            }.Initialize();
+
+            using var storeB = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { other.WebUrl },
+                Conventions = { DisableTopologyUpdates = true } // read node B directly
+            }.Initialize();
+
+            // 1. cluster-tx create -> CV {RAFT, TRXN}, flag FromClusterTransaction (on both nodes via Raft)
+            using (var session = storeA.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new Person { Name = "Old" }, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            // 2. cluster-tx delete -> tombstone {RAFT, TRXN} with FromClusterTransaction on BOTH nodes
+            using (var session = storeA.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                session.Delete("foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            // advance the etag past the tombstone (so the cleaner may remove it) and confirm the
+            // delete fully replicated to B before we touch the cleaner
+            using (var session = storeA.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Person { Name = "marker" }, "marker/1");
+                await session.SaveChangesAsync();
+            }
+            Assert.True(await WaitForDocumentInClusterAsync<Person>(nodes, database, "marker/1",
+                p => p != null, TimeSpan.FromSeconds(30)));
+
+            var dbA = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+
+            // 3. clean the DOCUMENT tombstone on node A ONLY (B keeps its cluster-tx tombstone)
+            Assert.True(await WaitForValueAsync(async () =>
+            {
+                await dbA.TombstoneCleaner.ExecuteCleanup();
+                using (dbA.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(ctx, "foo/bar", out var lowerId))
+                    return dbA.DocumentsStorage.GetDocumentOrTombstone(ctx, lowerId).Tombstone == null;
+            }, expectedVal: true, timeout: 30_000));
+
+            // 4. normal-tx recreate on A. No tombstone to inherit from -> CV is built from the
+            //    TRXN-stripped database CV, so the recreate's CV has NO TRXN entry.
+            using (var session = storeA.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Person { Name = "New" }, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            // 5. The recreate must propagate to B.
+            var name = await WaitForValueAsync(async () =>
+            {
+                using var session = storeB.OpenAsyncSession();
+                var p = await session.LoadAsync<Person>("foo/bar");
+                return p?.Name;
+            }, expectedVal: "New", timeout: 30_000);
+
+            Assert.Equal("New", name); // FAILS: B stays deleted (name == null)
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [true])]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [false])]
+        public async Task DeleteClusterWideAndNormalRecrateShouldPropagate(Options options, bool revisions)
+        {
+            using var src = GetDocumentStore(options);
+            using var dst = GetDocumentStore(options);
+
+            if (revisions)
+            {
+                await RevisionsHelper.SetupRevisionsAsync(src);
+                await RevisionsHelper.SetupRevisionsAsync(dst);
+            }
+
+            using (var session = src.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                var user1 = new Person()
+                {
+                    Name = "Old",
+                };
+                await session.StoreAsync(user1, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = src.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                session.Delete("foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            var cleanupState1 = await CompareExchangeTombstoneCleanerTestHelper.Clean(nodes: [Server], src.Database, ignoreClustrTrx: true);
+            Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState1);
+
+            await SetupReplicationAsync(src, dst);
+            await EnsureReplicatingAsync(src, dst);
+
+            using (var session = src.OpenAsyncSession())
+            {
+                var user1 = new Person()
+                {
+                    Name = "New",
+                };
+                await session.StoreAsync(user1, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            await EnsureReplicatingAsync(src, dst);
+
+            using (var session = dst.OpenAsyncSession())
+            {
+                var p = await session.LoadAsync<Person>("foo/bar");
+                Assert.NotNull(p);
+                Assert.Equal("New", p.Name);
+            }
+
+            using (var session = src.OpenAsyncSession())
+            {
+                var p = await session.LoadAsync<Person>("foo/bar");
+                p.Name = "New2";
+                await session.SaveChangesAsync();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.Replication)]
+        public async Task DeleteClusterWideAndNormalRecrateShouldPropagateInternally()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
+            var database = GetDatabaseName();
+            await CreateDatabaseInCluster(database, 2, leader.WebUrl);
+
+            using var store = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { leader.WebUrl },
+                Conventions = { DisableTopologyUpdates = true }
+            }.Initialize();
+
+            // hold internal replication from the leader to its sibling
+            using var breakRepl = await BreakReplication(leader.ServerStore, database);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user1 = new Person()
+                {
+                    Name = "Old",
+                };
+                await session.StoreAsync(user1, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide
+            }))
+            {
+                session.Delete("foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            // release replication after the second write
+            breakRepl.Mend();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user1 = new Person()
+                {
+                    Name = "New",
+                };
+                await session.StoreAsync(user1, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            Assert.True(await WaitForDocumentInClusterAsync<Person>(nodes, database, "foo/bar",
+                p => p != null && p.Name == "New", TimeSpan.FromSeconds(30)));
+        }
+
+        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Replication | RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterWideWriteBackToRecreatedDocWithTombstonedGuardShouldSucceed()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
+            var database = GetDatabaseName();
+            await CreateDatabaseInCluster(database, replicationFactor: 2, leader.WebUrl);
+
+            using var store = new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { leader.WebUrl },
+                Conventions = { DisableTopologyUpdates = true }
+            }.Initialize();
+
+            // cluster-tx create -> live atomic guard
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new Person { Name = "Old" }, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            // cluster-tx delete -> document and atomic guard tombstoned
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                session.Delete("foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Person { Name = "marker" }, "marker/1");
+                await session.SaveChangesAsync();
+            }
+            Assert.True(await WaitForDocumentInClusterAsync<Person>(nodes, database, "marker/1",
+                p => p != null, TimeSpan.FromSeconds(30)));
+
+            // drain the document tombstone so the recreate is born without a TRXN tag. Tombstone cleanup
+            // has no client API, so this is the only server-side step; the marker write above advanced the
+            // etag and confirmed the delete replicated, which makes the tombstone eligible for removal.
+            var db = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+            await db.TombstoneCleaner.ExecuteCleanup();
+
+            // normal-tx recreate -> live doc whose CV lacks TRXN; its atomic guard is still a tombstone
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Person { Name = "New" }, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            // the recreate (over a cleaned tombstone) has no TRXN tag
+            using (var session = store.OpenAsyncSession())
+            {
+                var recreated = await session.LoadAsync<Person>("foo/bar");
+                Assert.DoesNotContain("TRXN", session.Advanced.GetChangeVectorFor(recreated));
+            }
+
+            // a cluster-wide write-back to the recreated doc must succeed: the doc has no TRXN, so the guard
+            // CAS uses index 0, and the deleted guard (treated as absent) accepts it.
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var p = await session.LoadAsync<Person>("foo/bar");
+                Assert.NotNull(p);
+                p.Name = "Updated";
+                await session.SaveChangesAsync(); // must not throw ConcurrencyException
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var p = await session.LoadAsync<Person>("foo/bar");
+                Assert.Equal("Updated", p.Name);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.ClusterTransactions)]
+        public async Task ExistingConflictResolvedByRecreate_ExternalReplication()
+        {
+            Options NoAutoResolve() => new Options
+            {
+                ModifyDatabaseRecord = record => record.ConflictSolverConfig = new ConflictSolver
+                {
+                    ResolveToLatest = false,
+                    ResolveByCollection = new Dictionary<string, ScriptResolver>()
+                }
+            };
+            using var src = GetDocumentStore(NoAutoResolve());
+            using var dst = GetDocumentStore(NoAutoResolve());
+
+            // (a) src: cluster-tx create -> CV {RAFT, TRXN}
+            using (var session = src.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new Person { Name = "src-val" }, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            // (b) dst: an independent cluster-tx create in a different lineage -> CV {RAFT, TRXN}
+            using (var session = dst.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new Person { Name = "dst-val" }, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            // (c) replicate src->dst first: the two diverge, so dst stores them as a conflict (resolver disabled).
+            var srcToDst = await SetupReplicationAsync(src, dst);
+            var srcToDstTaskId = srcToDst.Single().TaskId;
+
+            var conflicts = WaitUntilHasConflict(dst, "foo/bar", count: 2);
+            Assert.Equal(2, conflicts.Length);
+            // both stored conflict entries derive from a cluster-tx, so both carry TRXN
+            Assert.All(conflicts, c => Assert.Contains("TRXN", c.ChangeVector));
+
+            // now teach src dst's RAFT lineage (dst->src). src also stores the conflict (resolver off), which is
+            // what we want: src's database CV absorbs dst's RAFT entry, so src's later recreate dominates BOTH
+            // lineages. Wait until src is conflicted (i.e. it has seen dst's lineage) before building the recreate.
+            await SetupReplicationAsync(dst, src);
+            WaitUntilHasConflict(src, "foo/bar", count: 2);
+
+            // (d) DELETE src->dst so only the FINAL recreate (not the intermediate delete tombstone) reaches dst.
+            // Deleting (rather than disabling) also frees the tombstone cleaner: a disabled outgoing destination
+            // still pins the minimal confirmed etag and would block the cleanup below.
+            await DeleteOngoingTask(src as DocumentStore, srcToDstTaskId, OngoingTaskType.Replication);
+
+            // delete foo/bar on src (normal tx), advance the etag + clean src's tombstone, then recreate (normal tx).
+            // With no tombstone to inherit from, the recreate is born from src's TRXN-stripped database CV ->
+            // its CV covers both lineages but has NO TRXN.
+            using (var session = src.OpenAsyncSession())
+            {
+                session.Delete("foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = src.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Person { Name = "marker" }, "marker/1");
+                await session.SaveChangesAsync();
+            }
+
+            var srcDb = await Databases.GetDocumentDatabaseInstanceFor(src);
+            Assert.True(await WaitForValueAsync(async () =>
+            {
+                await srcDb.TombstoneCleaner.ExecuteCleanup();
+                using (srcDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(ctx, "foo/bar", out var lowerId))
+                    return srcDb.DocumentsStorage.GetDocumentOrTombstone(ctx, lowerId).Tombstone == null;
+            }, expectedVal: true, timeout: 30_000));
+
+            using (var session = src.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Person { Name = "resolved" }, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            // tripwire: the recreate must have lost its TRXN tag (no tombstone to inherit from), otherwise it
+            // would carry TRXN and would not exercise the TRXN-stripping bug in the existing-conflicts loop.
+            using (var session = src.OpenAsyncSession())
+            {
+                var recreated = await session.LoadAsync<Person>("foo/bar");
+                Assert.DoesNotContain("TRXN", session.Advanced.GetChangeVectorFor(recreated));
+            }
+
+            // (e) Re-add src->dst. The recreate must resolve dst's stored conflict and converge to "resolved".
+            // src's foo/bar tombstone was cleaned, so only the live "resolved" doc replicates.
+            await SetupReplicationAsync(src, dst);
+
+            var name = await WaitForValueAsync(async () =>
+            {
+                using var session = dst.OpenAsyncSession();
+                try
+                {
+                    var p = await session.LoadAsync<Person>("foo/bar");
+                    return p?.Name;
+                }
+                catch (Raven.Client.Exceptions.Documents.DocumentConflictException)
+                {
+                    return "<conflicted>";
+                }
+            }, expectedVal: "resolved", timeout: 60_000);
+
+            Assert.Equal("resolved", name);
         }
         private static void ModifyTopology(Options original, Options @new)
         {

--- a/test/SlowTests/Server/Documents/Revisions/RevisionAttachmentRemoteParametersTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionAttachmentRemoteParametersTests.cs
@@ -59,8 +59,8 @@ namespace SlowTests.Server.Documents.Revisions
                     var remoteParams = new RemoteAttachmentParameters(identifier, remoteAt) { Flags = RemoteAttachmentFlags.Remote };
                     database.DocumentsStorage.AttachmentsStorage.PutAttachment(
                         ctx, docId, attachmentName, contentType, base64Hash, size: 1L,
-                        remoteParams: remoteParams, expectedChangeVector: null, stream: null,
-                        updateDocument: true, extractCollectionName: true);
+                        remoteParams: remoteParams, expectedChangeVector: null, stream: null, streamAlreadyInRemoteStorage : true,
+                        updateDocument: true, extractCollectionName: true, source: AttachmentsStorage.AttachmentSource.None);
                     tx.Commit();
                 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26876

### Additional description

A document deleted in a cluster transaction and then recreated normally could disappear
on replication.

Why: when RavenDB checks two versions of a document for a conflict, it was including the
cluster-transaction (TRXN) marker in the comparison. That marker can exist on one node's
copy but not the other's, which made two versions of the same document look like a
conflict when they weren't — and the loser was the newer (recreated) document.

Fix: ignore the TRXN marker when checking for conflicts.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

- Stripping `TRXN` at comparison time keeps the recreated-document CV shape identical to previous versions, so a mixed-version cluster during a rolling upgrade and existing on-disk data resolve consistently — both the strip-keeping and strip-removing variants now compare to the same result. 

- The new tombstone-index behavior is scoped to atomic-guard keys (`rvn-atomic/*`), so regular compare-exchange GET behavior for user keys is unchanged.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
