### PR TITLE
RavenDB-26903 - Fix backup hang on cloud direct upload (S3/Azure) after `RunSyncWithSynchronization` change

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
@@ -54,7 +54,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
 
         RavenAwsS3Client.FillMetadata(multipartRequest.Metadata, _metadata);
 
-        var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken);
+        var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken).ConfigureAwait(false);
         _uploadId = initiateResponse.UploadId;
         _partNumber = 1;
         _partEtags = new List<PartETag>();
@@ -67,7 +67,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
 
     public async Task UploadPartAsync(Stream stream)
     {
-        await UploadPartAsync(stream, stream.Length);
+        await UploadPartAsync(stream, stream.Length).ConfigureAwait(false);
     }
 
     public async Task UploadPartAsync(Stream stream, long size)
@@ -90,7 +90,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
                     _progress?.UploadProgress.UpdateUploaded(args.IncrementTransferred);
                     _progress?.OnUploadProgress?.Invoke();
                 }
-            }, _cancellationToken);
+            }, _cancellationToken).ConfigureAwait(false);
 
         _partEtags.Add(new PartETag(uploadResponse.PartNumber.GetValueOrDefault(), uploadResponse.ETag));
     }
@@ -110,6 +110,6 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
                 Key = _key,
                 PartETags = _partEtags
             },
-            _cancellationToken);
+            _cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AzureMultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AzureMultiPartUploader.cs
@@ -60,7 +60,7 @@ public class AzureMultiPartUploader : IMultiPartUploader
                 _progress.UploadProgress.SetUploaded(uploadedSoFar + value);
                 _progress.OnUploadProgress?.Invoke();
             })
-        }, _cancellationToken);
+        }, _cancellationToken).ConfigureAwait(false);
     }
 
     public void CompleteUpload()
@@ -73,6 +73,6 @@ public class AzureMultiPartUploader : IMultiPartUploader
         await _blockBlobClient.CommitBlockListAsync(_base64BlockIds, new CommitBlockListOptions
         {
             Metadata = _metadata
-        }, _cancellationToken);
+        }, _cancellationToken).ConfigureAwait(false);
     }
 }

--- a/test/FastTests/Issues/RavenDB-26903.cs
+++ b/test/FastTests/Issues/RavenDB-26903.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Raven.Server.Documents.PeriodicBackup.DirectUpload;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_26903 : NoDisposalNeeded
+    {
+        public RavenDB_26903(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // Backups run the smuggler under AsyncHelpers.RunSyncWithSynchronization, which installs a
+        // single-threaded ExclusiveSynchronizationContext on the dedicated backup thread and pumps it
+        // only while the smuggler is executing. A multipart upload part is started (fire-and-forget)
+        // during that run, and the final in-flight part is awaited later in DirectUploadStream.Dispose.
+        //
+        // If the cloud upload awaits capture that synchronization context (the default ConfigureAwait(true)),
+        // the part's completion continuation is posted back to the context after its message loop has already
+        // ended, so it can never run. DirectUploadStream.Dispose then blocks forever on that task, hanging the
+        // dedicated backup thread.
+        //
+        // This test reproduces the exact lifecycle with the real AwsS3MultiPartUploader and a fake S3 client
+        // (no network): a context that captures continuations but never runs them, an upload started under it,
+        // and a blocking wait afterwards. It times out (fails) unless the uploader uses ConfigureAwait(false).
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public void DirectUpload_multipart_upload_must_not_capture_the_backup_synchronization_context()
+        {
+            var client = new AsyncCompletingS3Client();
+            var uploader = new AwsS3MultiPartUploader(client, bucketName: "bucket", storageClass: S3StorageClass.Standard,
+                progress: null, key: "key", metadata: new Dictionary<string, string>(), cancellationToken: default);
+
+            // Initialize() runs without a synchronization context (fast path), exactly like during backup setup.
+            uploader.Initialize();
+
+            using var stream = new MemoryStream(new byte[1024]);
+
+            var context = new NonPumpingSynchronizationContext();
+            var previous = SynchronizationContext.Current;
+
+            Task uploadTask;
+            SynchronizationContext.SetSynchronizationContext(context);
+            try
+            {
+                // Mirrors StartUploadTask() running on the backup thread while the ExclusiveSynchronizationContext
+                // is current: the upload is kicked off here but not awaited.
+                uploadTask = uploader.UploadPartAsync(stream);
+            }
+            finally
+            {
+                // The smuggler finishes and the message loop ends -> the context is no longer pumped,
+                // just like when RunSyncWithSynchronization returns.
+                SynchronizationContext.SetSynchronizationContext(previous);
+            }
+
+            // Mirrors DirectUploadStream.Dispose blocking on the last in-flight part. If the part's continuation
+            // was captured by 'context' (which is no longer pumped), the task never completes and this times out.
+            var completed = uploadTask.Wait(TimeSpan.FromSeconds(10));
+
+            Assert.True(completed,
+                "The multipart upload task never completed: its continuation was captured by the backup " +
+                "synchronization context and orphaned once the message loop ended. The cloud upload awaits " +
+                "must use ConfigureAwait(false).");
+        }
+
+        // A synchronization context that captures posted continuations but never executes them - modeling the
+        // backup's ExclusiveSynchronizationContext after its message loop has stopped pumping.
+        private sealed class NonPumpingSynchronizationContext : SynchronizationContext
+        {
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                // Intentionally drop the continuation: nothing pumps this context anymore.
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override SynchronizationContext CreateCopy() => this;
+        }
+
+        // Fake S3 client whose async operations complete asynchronously on the thread pool (no network).
+        // It uses ConfigureAwait(false) internally so that its OWN completion does not depend on the test's
+        // non-pumping context - only the production uploader's ConfigureAwait behavior is under test.
+        private sealed class AsyncCompletingS3Client : AmazonS3Client
+        {
+            public AsyncCompletingS3Client()
+                : base(new BasicAWSCredentials("test", "test"), new AmazonS3Config { ServiceURL = "https://localhost:1" })
+            {
+            }
+
+            public override async Task<InitiateMultipartUploadResponse> InitiateMultipartUploadAsync(InitiateMultipartUploadRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                return new InitiateMultipartUploadResponse { UploadId = "test-upload-id" };
+            }
+
+            public override async Task<UploadPartResponse> UploadPartAsync(UploadPartRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+                return new UploadPartResponse { PartNumber = 1, ETag = "\"test-etag\"" };
+            }
+
+            public override async Task<CompleteMultipartUploadResponse> CompleteMultipartUploadAsync(CompleteMultipartUploadRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                return new CompleteMultipartUploadResponse();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26903/Backups-hang-and-cannot-be-aborted

### Additional description

#### Summary

Fixes a hang in cloud **direct-upload** backups (Amazon S3 and Azure). The dedicated
backup thread gets stuck forever in `DirectUploadStream.Dispose`, blocked in
`AsyncHelpers.RunSync(() => _uploadTask)` waiting on a multipart upload task that
never completes. The backup never finishes or fails, and subsequent scheduled
backups for the task cannot proceed.

Observed stack (tail):
```
ManualResetEventSlim.Wait
Task.InternalWait
TaskAwaiter.HandleNonSuccessAndDebuggerNotification
AsyncHelpers.RunSync(Func<Task>)
DirectUploadStream`1.Dispose(bool)
Stream.Close()
BackupTask.CreateBackup(...)
```

#### Why this happened

This is a regression that was introduced here: https://github.com/ravendb/ravendb/pull/22720 - from the change that moved backup work onto the dedicated `BelowNormal`-priority thread by replacing `smuggler.ExecuteAsync().Wait()` with `AsyncHelpers.RunSyncWithSynchronization(...)`. 
That helper installs the single-threaded `ExclusiveSynchronizationContext` and pumps its message loop on the
dedicated thread so async continuations stay on it (with opt-in capture via the `CaptureContextOnAwait` flags on `AsyncBlittableJsonTextWriter` and `ZstdStream`).

The unintended side effect: with a `SynchronizationContext` now present, `await`
defaults to `ConfigureAwait(true)` and **captures** that context. The cloud
multipart uploaders (`AwsS3MultiPartUploader`, `AzureMultiPartUploader`) awaited the
SDK calls **without** `ConfigureAwait(false)`. This worked before, because the
backup ran with no synchronization context (`SynchronizationContext.Current == null`),
so the default behaved exactly like `ConfigureAwait(false)` and continuations ran on
the thread pool.

The deadlock sequence:

1. During the smuggler run (message loop active), a write triggers a fire-and-forget
   `UploadPartAsync(...)`. Its `await _client.UploadPartAsync(...)` captures the
   `ExclusiveSynchronizationContext`, because the writer keeps writes pinned to the
   dedicated thread.
2. The smuggler finishes; `RunSyncWithSynchronization` ends the message loop and
   returns. The context's pump is gone (this is why the hang stack shows the
   no-context fast path).
3. The `using` blocks unwind into `DirectUploadStream.Dispose`, which does a blocking
   `RunSync(() => _uploadTask)` on the last upload part.
4. The S3/Azure request completes on the wire, but its continuation is posted to the
   now-defunct context. Because it is a single dedicated thread — already blocked in
   `GetResult()` — nothing can ever dispatch that continuation. `_uploadTask` never
   completes and the thread blocks permanently.

So it is not a network/timeout problem and not thread-pool starvation: the task's
completion is stranded on a synchronization context whose pump has terminated.

#### Fix

Opt the upload I/O out of the captured context with `ConfigureAwait(false)`. Upload
continuations are I/O and were never meant to be pinned to the backup thread — only
JSON serialization and compression are (via the existing `CaptureContextOnAwait`
opt-in). This preserves the `BelowNormal` priority intent while letting upload tasks
complete independently of the message loop's lifetime.

- `AwsS3MultiPartUploader` — `InitializeAsync`, both `UploadPartAsync` overloads, `CompleteUploadAsync`
- `AzureMultiPartUploader` — `UploadPartAsync`, `CompleteUploadAsync`

The `MemoryStream` write in `WriteAsync` is left as-is: it completes synchronously and
never captures a context.

#### Scope

- Affects only cloud **direct-upload** backups where a multipart upload part is still
  in flight at dispose time. Direct upload targets S3 and Azure only, so there is no
  GCP path involved.

#### Tests

Added `RavenDB-26903` (FastTests, `BackupExportImport`). It drives the real
`AwsS3MultiPartUploader` with a fake `AmazonS3Client` (no network) and reproduces the
exact lifecycle: an upload started under a non-pumping `SynchronizationContext`, then
awaited after the loop has ended. The test times out (fails) without the fix and
passes with it.

Verified on this branch:

| State | Result | Duration |
|-------|--------|----------|
| Fix present | Passed | 168 ms |
| Fix reverted | Failed (timeout) | 10 s |

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
