### PR TITLE
RavenDB-23119 - Fix failing test ClusterTransactionRequestWithRevisions

### DIFF
--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -1039,8 +1039,7 @@ namespace SlowTests.Cluster
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
 
                 // bring our SUT node down, but we still have a cluster and can execute cluster transaction.
-                var server = Servers[1];
-                var result1 = await DisposeServerAndWaitForFinishOfDisposalAsync(server);
+                var result1 = await DisposeServerAndWaitForFinishOfDisposalAsync(Servers[1]);
 
                 const string id = "foo/bar/2";
                 using (var session = leaderStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
@@ -1073,6 +1072,23 @@ namespace SlowTests.Cluster
                     session.Advanced.WaitForIndexesAfterSaveChanges();
                     await session.SaveChangesAsync();
                 }
+
+                long committedRaftIndex = 0;
+                foreach (var server in Servers)
+                {
+                    if (server == Servers[0] || server == Servers[1])
+                        continue;
+
+                    if (server.ServerStore.Disposed || server.ServerStore.Engine.CurrentState == RachisState.Passive)
+                        continue;
+
+                    using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        committedRaftIndex = Math.Max(committedRaftIndex, server.ServerStore.Engine.GetLastCommitIndex(ctx));
+                    }
+                }
+                await Servers[0].ServerStore.Cluster.WaitForIndexNotification(committedRaftIndex, TimeSpan.FromSeconds(15));
 
                 // bring more nodes down, so only one node is left
                 var task2 = DisposeServerAndWaitForFinishOfDisposalAsync(Servers[2]);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23119/SlowTests.Cluster.ClusterTransactionTests.ClusterTransactionRequestWithRevisionsoptions-DatabaseMode-Single-SearchEngineMode

### Additional description
```
             Scenario:
               1. Dispose `Server[1]`. 
               2. Execute the cluster transactions:
               
                  * Store Compare Exchange `"usernames/ayende"`.
                  * Store documents `"foo/bar"` and `"foo/bar/2"`.
                  * Delete `"foo/bar/2"`.
               3. The cluster transaction Raft entries are appended, committed, and applied by a majority (e.g. `Server[2]`, `Server[3]`, `Server[4]`). 
               4. `Server[0]` is lagging and does **not** receive those Raft entries before the next step. 
               5. Dispose `Server[2]`, `Server[3]`, and `Server[4]`. 
               6. Revive `Server[1]`. 
               
               At this point, the only remaining source for catch-up is `Server[0]`, but it is stale and does not have the cluster transaction Raft entries, so `Server[1]` cannot receive them. 
```

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
