### PR TITLE
RavenDB-26910 Defer sparse-region hole-punch to after the data-file sync

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -708,8 +708,8 @@ namespace Voron.Impl.Journal
             }
 
             private LastFlushState _lastFlushed = LastFlushState.Empty;
-            // touched only under _flushingLock
-            private readonly List<(long Start, long Count)> _pendingSparseRegions = new();
+            // free-space-tree sections with freed space pending a hole-punch; touched only under _flushingLock
+            private readonly HashSet<long> _pendingSparseSections = new();
             private long _totalWrittenButUnsyncedBytes;
             private bool _ignoreLockAlreadyTaken;
             private Action<LowLevelTransaction> _updateJournalStateAfterFlush;
@@ -888,8 +888,17 @@ namespace Voron.Impl.Journal
                         throw;
                     }
 
-                    if (currentState.SparseRegions is { Count: > 0 } regionsToPunchAfterSync)
-                        _pendingSparseRegions.AddRange(regionsToPunchAfterSync);
+                    if (currentState.SparseRegions is { Count: > 0 } freedRegions)
+                    {
+                        foreach (var (start, count) in freedRegions)
+                        {
+                            for (var section = start / FreeSpaceHandling.NumberOfPagesInSection;
+                                 section <= (start + count - 1) / FreeSpaceHandling.NumberOfPagesInSection; section++)
+                            {
+                                _pendingSparseSections.Add(section);
+                            }
+                        }
+                    }
 
                     _waj._env.SuggestSyncDataFile();
                 }
@@ -1519,24 +1528,15 @@ namespace Voron.Impl.Journal
             // Space reclamation only (cf. DisableSparseRegions), so failures are swallowed and never fail the sync.
             private void ApplyPendingSparseRegions()
             {
-                if (_pendingSparseRegions.Count == 0)
+                if (_pendingSparseSections.Count == 0)
                     return;
 
                 try
                 {
-                    // re-validate against the live free-space tree: a page reused (allocated) since it was freed is no longer free here, so it's excluded and never zeroed
-                    var sections = new HashSet<long>();
-                    foreach (var (start, count) in _pendingSparseRegions)
-                    {
-                        for (var section = start / FreeSpaceHandling.NumberOfPagesInSection;
-                             section <= (start + count - 1) / FreeSpaceHandling.NumberOfPagesInSection;
-                             section++)
-                            sections.Add(section);
-                    }
-
                     using (var readTx = _waj._env.ReadTransaction())
                     {
-                        var stillFree = _waj._env.FreeSpaceHandling.GetSparseRegions(readTx.LowLevelTransaction, sections);
+                        // re-validate against the live free-space tree: a page reused (allocated) since it was freed is no longer free here, so it's excluded and never zeroed
+                        var stillFree = _waj._env.FreeSpaceHandling.GetSparseRegions(readTx.LowLevelTransaction, _pendingSparseSections);
                         if (stillFree.Count > 0)
                         {
                             MarkSparseRegionsInDataFile(stillFree);
@@ -1554,7 +1554,7 @@ namespace Voron.Impl.Journal
                 }
                 finally
                 {
-                    _pendingSparseRegions.Clear();
+                    _pendingSparseSections.Clear();
                 }
             }
 

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -837,7 +837,7 @@ namespace Voron.Impl.Journal
                             return; // nothing to do
                     }
 
-                    _forTestingPurposes?.OnApplyLogsToDataFile_AfterSparseRegionsSet_BeforeWritingToDataFile?.Invoke();
+                    _forTestingPurposes?.OnApplyLogsToDataFile_BeforeWritingToDataFile?.Invoke();
 
 
                     Debug.Assert(_applyLogsToDataFileStateFromPreviousFailedAttempt is { Record: not null, Buffers: not null });
@@ -1208,7 +1208,7 @@ namespace Voron.Impl.Journal
 
                 internal Action OnApplyLogsToDataFileUnderFlushingLock;
 
-                internal Action OnApplyLogsToDataFile_AfterSparseRegionsSet_BeforeWritingToDataFile;
+                internal Action OnApplyLogsToDataFile_BeforeWritingToDataFile;
 
                 internal Action OnWaitForJournalStateToBeUpdated_BeforeAssigning_updateJournalStateAfterFlush;
 

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -883,6 +883,18 @@ namespace Voron.Impl.Journal
 
                     Interlocked.Add(ref TotalCommittedSinceLastFlushPages, -currentTotalCommittedSinceLastFlushPages);
 
+                    // update pending _before_ ApplyJournalStateAfterFlush: that method can re-enter on this thread and run a queued sync's
+                    // punch (WaitForJournalStateToBeUpdated -> RunTaskIfNotAlreadyRan), so pending must already include this flush's frees
+                    // and exclude the pages it just wrote
+                    if (currentState.SparseRegions is { Count: > 0 } freedRegions)
+                    {
+                        _pendingSparseRegions.AddRange(freedRegions);
+                        StorageEnvironment.MergeSparseRegions(_pendingSparseRegions);
+                    }
+
+                    if (flushedPageRanges != null)
+                        SubtractRanges(_pendingSparseRegions, flushedPageRanges);
+
                     try
                     {
                         ApplyJournalStateAfterFlush(token, currentState.Buffers, currentState.Record, dataPagerState, byteStringContext);
@@ -891,18 +903,6 @@ namespace Voron.Impl.Journal
                     {
                         _failedToUpdateJournalState = true;
                         throw;
-                    }
-
-                    if (currentState.SparseRegions is { Count: > 0 } freedRegions)
-                    {
-                        _pendingSparseRegions.AddRange(freedRegions);
-                        StorageEnvironment.MergeSparseRegions(_pendingSparseRegions);
-                    }
-
-                    if (flushedPageRanges != null)
-                    {
-                        // a freed page that a later transaction reused gets written by a flush - it must not be punched
-                        SubtractRanges(_pendingSparseRegions, flushedPageRanges);
                     }
 
                     _waj._env.SuggestSyncDataFile();
@@ -930,6 +930,8 @@ namespace Voron.Impl.Journal
                 Pager.State dataPagerState,
                 ByteStringContext byteStringContext)
             {
+                _forTestingPurposes?.OnApplyJournalStateAfterFlush?.Invoke();
+
                 // the idea here is that even though we need to run the journal through its state update under the transaction lock
                 // we don't actually have to do that in our own transaction, what we'll do is to setup things so if there is a running
                 // write transaction, we'll piggy back on its commit to complete our process, without interrupting its work
@@ -1211,6 +1213,8 @@ namespace Voron.Impl.Journal
                 internal Action OnWaitForJournalStateToBeUpdated_BeforeAssigning_updateJournalStateAfterFlush;
 
                 internal Action OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush;
+
+                internal Action OnApplyJournalStateAfterFlush;
             }
 
             // This can take a LONG time, and it needs to run concurrently with the

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -30,6 +30,7 @@ using Sparrow.Threading;
 using Voron.Data.BTrees;
 using Voron.Exceptions;
 using Voron.Impl.FileHeaders;
+using Voron.Impl.FreeSpace;
 using Voron.Impl.Paging;
 using Voron.Impl.Scratch;
 using Voron.Logging;
@@ -707,6 +708,8 @@ namespace Voron.Impl.Journal
             }
 
             private LastFlushState _lastFlushed = LastFlushState.Empty;
+            // touched only under _flushingLock
+            private readonly List<(long Start, long Count)> _pendingSparseRegions = new();
             private long _totalWrittenButUnsyncedBytes;
             private bool _ignoreLockAlreadyTaken;
             private Action<LowLevelTransaction> _updateJournalStateAfterFlush;
@@ -835,14 +838,6 @@ namespace Voron.Impl.Journal
                             return; // nothing to do
                     }
 
-                    if(_applyLogsToDataFileStateFromPreviousFailedAttempt.SparseRegions is {Count: > 0} sparseRegionsToFlush)
-                    {
-                        // This needs to happen _before_ we actually write to the disk
-                        // because we _first_ zero a range and then we may write data to that range (filling some of it up).
-                        // That is fine, and means that we don't need to track re-uses. 
-                        MarkSparseRegionsInDataFile(sparseRegionsToFlush);
-                    }
-
                     _forTestingPurposes?.OnApplyLogsToDataFile_AfterSparseRegionsSet_BeforeWritingToDataFile?.Invoke();
 
 
@@ -892,7 +887,10 @@ namespace Voron.Impl.Journal
                         _failedToUpdateJournalState = true;
                         throw;
                     }
-                    
+
+                    if (currentState.SparseRegions is { Count: > 0 } regionsToPunchAfterSync)
+                        _pendingSparseRegions.AddRange(regionsToPunchAfterSync);
+
                     _waj._env.SuggestSyncDataFile();
                 }
                 finally
@@ -1262,6 +1260,9 @@ namespace Voron.Impl.Journal
                     if (parent._waj._env.Disposed)
                         return false;
 
+                    // runs here because the file is now synced (clean) and we hold _flushingLock - the deferred punch's two preconditions (RavenDB-26910)
+                    parent.ApplyPendingSparseRegions();
+
                     Interlocked.Add(ref parent._totalWrittenButUnsyncedBytes, -_currentTotalWrittenBytes);
 
                     var ignoreLastSyncJournalMissing = false;
@@ -1512,6 +1513,49 @@ namespace Voron.Impl.Journal
                 Interlocked.Add(ref _totalWrittenButUnsyncedBytes, written);
 
                 return dataPagerState;
+            }
+
+            // Caller must hold _flushingLock and have synced first - punching a clean section is much cheaper on Windows (RavenDB-26910).
+            // Space reclamation only (cf. DisableSparseRegions), so failures are swallowed and never fail the sync.
+            private void ApplyPendingSparseRegions()
+            {
+                if (_pendingSparseRegions.Count == 0)
+                    return;
+
+                try
+                {
+                    // re-validate against the live free-space tree: a page reused (allocated) since it was freed is no longer free here, so it's excluded and never zeroed
+                    var sections = new HashSet<long>();
+                    foreach (var (start, count) in _pendingSparseRegions)
+                    {
+                        for (var section = start / FreeSpaceHandling.NumberOfPagesInSection;
+                             section <= (start + count - 1) / FreeSpaceHandling.NumberOfPagesInSection;
+                             section++)
+                            sections.Add(section);
+                    }
+
+                    using (var readTx = _waj._env.ReadTransaction())
+                    {
+                        var stillFree = _waj._env.FreeSpaceHandling.GetSparseRegions(readTx.LowLevelTransaction, sections);
+                        if (stillFree.Count > 0)
+                        {
+                            MarkSparseRegionsInDataFile(stillFree);
+
+                            // punch shrinks the physical (on-disk) size, not the allocated/logical size; refresh the cached value reports read
+                            var dataPagerState = _waj._env.CurrentStateRecord.DataPagerState;
+                            dataPagerState.TotalPhysicalSpace = _waj._env.DataPager.GetFileSize(dataPagerState).PhysicalSize;
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (_waj._logger.IsWarnEnabled)
+                        _waj._logger.Warn("Failed to punch deferred sparse regions after sync; disk space reclamation skipped for this cycle.", e);
+                }
+                finally
+                {
+                    _pendingSparseRegions.Clear();
+                }
             }
 
             private void MarkSparseRegionsInDataFile(List<(long Start, long Count)> sparseRegions)

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -30,7 +30,6 @@ using Sparrow.Threading;
 using Voron.Data.BTrees;
 using Voron.Exceptions;
 using Voron.Impl.FileHeaders;
-using Voron.Impl.FreeSpace;
 using Voron.Impl.Paging;
 using Voron.Impl.Scratch;
 using Voron.Logging;
@@ -708,8 +707,8 @@ namespace Voron.Impl.Journal
             }
 
             private LastFlushState _lastFlushed = LastFlushState.Empty;
-            // free-space-tree sections with freed space pending a hole-punch; touched only under _flushingLock
-            private readonly HashSet<long> _pendingSparseSections = new();
+            // touched only under _flushingLock
+            private readonly List<(long Start, long Count)> _pendingSparseRegions = new();
             private long _totalWrittenButUnsyncedBytes;
             private bool _ignoreLockAlreadyTaken;
             private Action<LowLevelTransaction> _updateJournalStateAfterFlush;
@@ -845,10 +844,11 @@ namespace Voron.Impl.Journal
                     var currentTotalCommittedSinceLastFlushPages = TotalCommittedSinceLastFlushPages;
 
                     Pager.State dataPagerState;
+                    List<(long Start, long Count)> flushedPageRanges;
                     try
                     {
                         byteStringContext = new ByteStringContext(SharedMultipleUseFlag.None);
-                        dataPagerState = ApplyPagesToDataFileFromScratch(_applyLogsToDataFileStateFromPreviousFailedAttempt);
+                        dataPagerState = ApplyPagesToDataFileFromScratch(_applyLogsToDataFileStateFromPreviousFailedAttempt, out flushedPageRanges);
                     }
                     catch (Exception e) when (e is OutOfMemoryException or EarlyOutOfMemoryException)
                     {
@@ -890,14 +890,14 @@ namespace Voron.Impl.Journal
 
                     if (currentState.SparseRegions is { Count: > 0 } freedRegions)
                     {
-                        foreach (var (start, count) in freedRegions)
-                        {
-                            for (var section = start / FreeSpaceHandling.NumberOfPagesInSection;
-                                 section <= (start + count - 1) / FreeSpaceHandling.NumberOfPagesInSection; section++)
-                            {
-                                _pendingSparseSections.Add(section);
-                            }
-                        }
+                        _pendingSparseRegions.AddRange(freedRegions);
+                        StorageEnvironment.MergeSparseRegions(_pendingSparseRegions);
+                    }
+
+                    if (flushedPageRanges != null)
+                    {
+                        // a freed page that a later transaction reused gets written by a flush - it must not be punched
+                        SubtractRanges(_pendingSparseRegions, flushedPageRanges);
                     }
 
                     _waj._env.SuggestSyncDataFile();
@@ -1475,7 +1475,7 @@ namespace Voron.Impl.Journal
                 }
             }
 
-            private Pager.State ApplyPagesToDataFileFromScratch(ApplyLogsToDataFileState state)
+            private Pager.State ApplyPagesToDataFileFromScratch(ApplyLogsToDataFileState state, out List<(long Start, long Count)> flushedPageRanges)
             {
                 long written = 0;
                 var sp = Stopwatch.StartNew();
@@ -1484,6 +1484,7 @@ namespace Voron.Impl.Journal
                 var currentStateRecord = _waj._env.CurrentStateRecord;
                 var dataPagerState = currentStateRecord.DataPagerState;
                 var record = state.Record;
+                flushedPageRanges = null;
                 using (var meter = options.IoMetrics.MeterIoRate(dataPager.FileName, IoMetrics.MeterType.DataFlush, 0))
                 {
                     var pagesBuffer = ArrayPool<Pal.page_to_write>.Shared.Rent(record.ScratchPagesTable.Count);
@@ -1493,6 +1494,14 @@ namespace Voron.Impl.Journal
                         Span<Pal.page_to_write> pages = GetSortedPages(ref txState, record, pagesBuffer, out written);
                         if (pages.IsEmpty)
                             return dataPagerState;
+
+                        if (state.SparseRegions is { Count: > 0 } || _pendingSparseRegions.Count > 0)
+                        {
+                            flushedPageRanges = new List<(long Start, long Count)>(pages.Length);
+                            foreach (var page in pages)
+                                flushedPageRanges.Add((page.page_num, page.count_of_pages));
+                        }
+
                         dataPager.EnsureContinuous(ref dataPagerState, pages[^1].page_num, pages[^1].count_of_pages);
                         (dataPagerState.TotalAllocatedSize, dataPagerState.TotalPhysicalSpace) = dataPager.GetFileSize(dataPagerState);
                         fixed (Pal.page_to_write* ptr = pages)
@@ -1525,27 +1534,20 @@ namespace Voron.Impl.Journal
             }
 
             // Caller must hold _flushingLock and have synced first - punching a clean section is much cheaper on Windows (RavenDB-26910).
-            // Space reclamation only (cf. DisableSparseRegions), so failures are swallowed and never fail the sync.
+            // Pending holds flushed frees (older than every reader, per the flush's uptoTxIdExclusive bound) minus pages later flushes rewrote.
+            // Space reclamation only (cf. DisableSparseRegions) - failures are swallowed and never fail the sync.
             private void ApplyPendingSparseRegions()
             {
-                if (_pendingSparseSections.Count == 0)
+                if (_pendingSparseRegions.Count == 0)
                     return;
 
                 try
                 {
-                    using (var readTx = _waj._env.ReadTransaction())
-                    {
-                        // re-validate against the live free-space tree: a page reused (allocated) since it was freed is no longer free here, so it's excluded and never zeroed
-                        var stillFree = _waj._env.FreeSpaceHandling.GetSparseRegions(readTx.LowLevelTransaction, _pendingSparseSections);
-                        if (stillFree.Count > 0)
-                        {
-                            MarkSparseRegionsInDataFile(stillFree);
+                    MarkSparseRegionsInDataFile(_pendingSparseRegions);
 
-                            // punch shrinks the physical (on-disk) size, not the allocated/logical size; refresh the cached value reports read
-                            var dataPagerState = _waj._env.CurrentStateRecord.DataPagerState;
-                            dataPagerState.TotalPhysicalSpace = _waj._env.DataPager.GetFileSize(dataPagerState).PhysicalSize;
-                        }
-                    }
+                    // the flush captured the file sizes before this deferred punch - refresh the physical size that storage reports read
+                    var dataPagerState = _waj._env.CurrentStateRecord.DataPagerState;
+                    dataPagerState.TotalPhysicalSpace = _waj._env.DataPager.GetFileSize(dataPagerState).PhysicalSize;
                 }
                 catch (Exception e)
                 {
@@ -1554,8 +1556,42 @@ namespace Voron.Impl.Journal
                 }
                 finally
                 {
-                    _pendingSparseSections.Clear();
+                    _pendingSparseRegions.Clear();
                 }
+            }
+
+            // both lists must be sorted by Start and non-overlapping
+            internal static void SubtractRanges(List<(long Start, long Count)> sparseRegions, List<(long Start, long Count)> flushedPageRanges)
+            {
+                if (sparseRegions.Count == 0 || flushedPageRanges.Count == 0)
+                    return;
+
+                var result = new List<(long Start, long Count)>(sparseRegions.Count);
+                int j = 0;
+                foreach ((long start, long count) in sparseRegions)
+                {
+                    long current = start;
+                    long end = start + count;
+
+                    while (j < flushedPageRanges.Count && flushedPageRanges[j].Start + flushedPageRanges[j].Count <= current)
+                    {
+                        j++;
+                    }
+
+                    for (int k = j; k < flushedPageRanges.Count && flushedPageRanges[k].Start < end; k++)
+                    {
+                        if (flushedPageRanges[k].Start > current)
+                            result.Add((current, flushedPageRanges[k].Start - current));
+
+                        current = Math.Max(current, flushedPageRanges[k].Start + flushedPageRanges[k].Count);
+                    }
+
+                    if (current < end)
+                        result.Add((current, end - current));
+                }
+
+                sparseRegions.Clear();
+                sparseRegions.AddRange(result);
             }
 
             private void MarkSparseRegionsInDataFile(List<(long Start, long Count)> sparseRegions)

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1567,27 +1567,57 @@ namespace Voron.Impl.Journal
                     return;
 
                 var result = new List<(long Start, long Count)>(sparseRegions.Count);
-                int j = 0;
-                foreach ((long start, long count) in sparseRegions)
-                {
-                    long current = start;
-                    long end = start + count;
 
-                    while (j < flushedPageRanges.Count && flushedPageRanges[j].Start + flushedPageRanges[j].Count <= current)
+                int i = 0;
+                int j = 0;
+
+                while (i < sparseRegions.Count)
+                {
+                    var (sStart, sCount) = sparseRegions[i];
+                    long sEnd = sStart + sCount;
+
+                    // no more flushed ranges left, the remaining sparse regions stay as-is
+                    if (j >= flushedPageRanges.Count)
                     {
+                        result.Add((sStart, sCount));
+                        i++;
+                        continue;
+                    }
+
+                    var (fStart, fCount) = flushedPageRanges[j];
+                    long fEnd = fStart + fCount;
+
+                    if (fEnd <= sStart)
+                    {
+                        // flushed range is entirely before the current sparse region
                         j++;
                     }
-
-                    for (int k = j; k < flushedPageRanges.Count && flushedPageRanges[k].Start < end; k++)
+                    else if (fStart >= sEnd)
                     {
-                        if (flushedPageRanges[k].Start > current)
-                            result.Add((current, flushedPageRanges[k].Start - current));
-
-                        current = Math.Max(current, flushedPageRanges[k].Start + flushedPageRanges[k].Count);
+                        // flushed range is entirely after the current sparse region
+                        result.Add((sStart, sCount));
+                        i++;
                     }
+                    else
+                    {
+                        // overlap - keep the non-overlapping left segment
+                        if (sStart < fStart)
+                        {
+                            result.Add((sStart, fStart - sStart));
+                        }
 
-                    if (current < end)
-                        result.Add((current, end - current));
+                        if (sEnd > fEnd)
+                        {
+                            // the sparse region extends past the flushed range - evaluate the remainder against the next flushed ranges
+                            sparseRegions[i] = (fEnd, sEnd - fEnd);
+                            j++;
+                        }
+                        else
+                        {
+                            // the sparse region is entirely consumed by this flushed range
+                            i++;
+                        }
+                    }
                 }
 
                 sparseRegions.Clear();

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -844,11 +844,16 @@ namespace Voron.Impl.Journal
                     var currentTotalCommittedSinceLastFlushPages = TotalCommittedSinceLastFlushPages;
 
                     Pager.State dataPagerState;
-                    List<(long Start, long Count)> flushedPageRanges;
+
+                    // the flushed page ranges are needed only when there are sparse regions to subtract them from
+                    List<(long Start, long Count)> flushedPageRanges = null;
+                    if (_applyLogsToDataFileStateFromPreviousFailedAttempt.SparseRegions is { Count: > 0 } || _pendingSparseRegions.Count > 0)
+                        flushedPageRanges = new List<(long Start, long Count)>();
+
                     try
                     {
                         byteStringContext = new ByteStringContext(SharedMultipleUseFlag.None);
-                        dataPagerState = ApplyPagesToDataFileFromScratch(_applyLogsToDataFileStateFromPreviousFailedAttempt, out flushedPageRanges);
+                        dataPagerState = ApplyPagesToDataFileFromScratch(_applyLogsToDataFileStateFromPreviousFailedAttempt, flushedPageRanges);
                     }
                     catch (Exception e) when (e is OutOfMemoryException or EarlyOutOfMemoryException)
                     {
@@ -1475,7 +1480,7 @@ namespace Voron.Impl.Journal
                 }
             }
 
-            private Pager.State ApplyPagesToDataFileFromScratch(ApplyLogsToDataFileState state, out List<(long Start, long Count)> flushedPageRanges)
+            private Pager.State ApplyPagesToDataFileFromScratch(ApplyLogsToDataFileState state, List<(long Start, long Count)> flushedPageRanges)
             {
                 long written = 0;
                 var sp = Stopwatch.StartNew();
@@ -1484,7 +1489,6 @@ namespace Voron.Impl.Journal
                 var currentStateRecord = _waj._env.CurrentStateRecord;
                 var dataPagerState = currentStateRecord.DataPagerState;
                 var record = state.Record;
-                flushedPageRanges = null;
                 using (var meter = options.IoMetrics.MeterIoRate(dataPager.FileName, IoMetrics.MeterType.DataFlush, 0))
                 {
                     var pagesBuffer = ArrayPool<Pal.page_to_write>.Shared.Rent(record.ScratchPagesTable.Count);
@@ -1495,9 +1499,8 @@ namespace Voron.Impl.Journal
                         if (pages.IsEmpty)
                             return dataPagerState;
 
-                        if (state.SparseRegions is { Count: > 0 } || _pendingSparseRegions.Count > 0)
+                        if (flushedPageRanges != null)
                         {
-                            flushedPageRanges = new List<(long Start, long Count)>(pages.Length);
                             foreach (var page in pages)
                                 flushedPageRanges.Add((page.page_num, page.count_of_pages));
                         }

--- a/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
+++ b/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Sparrow;
 using Sparrow.Platform;
 using Tests.Infrastructure;
@@ -109,9 +111,9 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
     [RavenFact(RavenTestCategory.Voron)]
     public unsafe void DeferredPunch_DoesNotZeroPageReusedInLaterFlushBatch()
     {
-        // RavenDB-26910: the hole-punch is deferred to the post-sync phase and re-validated against the live free-space tree.
-        // A page freed in one flush batch can be reused + written by a later batch before the deferred punch runs; the re-validation
-        // must exclude it so it is never zeroed. If the filter is removed (punching the stale pending regions directly), this fails.
+        // RavenDB-26910: the hole-punch is deferred to the post-sync phase. A page freed in one flush batch can be reused + written
+        // by a later batch before the punch runs; that later flush subtracts its writes from the pending regions (SubtractRanges),
+        // so the reused page is never zeroed. If the subtraction is removed, this fails.
         RequireFileBasedPager();
         Options.ManualFlushing = true;
         Options.ManualSyncing = true;
@@ -155,8 +157,8 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
         }
         Env.FlushLogToDataFile();
 
-        // now sync: batch N's deferred punch runs over a clean section, re-validated against the live free-space tree. The pages were
-        // reused by batch N+1, so they must be excluded from the punch and keep their content.
+        // now sync: batch N's deferred punch runs over a clean section. Batch N+1 rewrote these pages and subtracted them from the
+        // pending regions, so they are excluded from the punch and keep their content.
         using (var sync = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
             Assert.True(sync.SyncDataFile());
 
@@ -236,6 +238,100 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
             Assert.Equal(readerOverflowSize, page.OverflowSize);
             Assert.False(page.AsSpan(PageHeader.SizeOf, readerOverflowSize).ContainsAnyExcept((byte)3),
                 "Page freed by a transaction newer than the read tx was zeroed by the deferred sparse-region punch");
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void DeferredPunch_MidFlushPunchDoesNotZeroPageThisFlushRewrote()
+    {
+        // RavenDB-26910 (C1): the deferred punch can execute on the FLUSH thread, mid-flush. When a user write transaction holds
+        // the tx lock, WaitForJournalStateToBeUpdated times out acquiring it and calls RunTaskIfNotAlreadyRan, which executes a
+        // queued sync's UpdateDatabaseStateAfterSync (including the punch) while the flush - which already wrote a reallocated
+        // page - still holds _flushingLock. Pending must be reconciled (this flush's writes subtracted) BEFORE
+        // ApplyJournalStateAfterFlush, or that punch zeroes the just-written page. This test builds the real interleaving:
+        // a held write tx forces the flusher into the timeout branch, and a real SyncOperation gets its punch executed mid-flush.
+        RequireFileBasedPager();
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+
+        const int pages = 600; // > NumberOfFreePagesForSparseConsideration (512), so freeing the run yields a punchable region
+        const int overflowSize = pages * Constants.Storage.PageSize - PageHeader.SizeOf;
+
+        long p;
+        using (var tx = Env.WriteTransaction())
+        {
+            var page = tx.LowLevelTransaction.AllocatePage(pages);
+            page.Flags |= PageFlags.Overflow;
+            page.OverflowSize = overflowSize;
+            page.AsSpan(PageHeader.SizeOf, overflowSize).Fill(1);
+            p = page.PageNumber;
+            tx.Commit();
+        }
+        Env.FlushLogToDataFile();
+
+        // F1: free the run - its region enters _pendingSparseRegions and stays there (no sync yet)
+        using (var tx = Env.WriteTransaction())
+        {
+            for (int i = 0; i < pages; i++)
+                tx.LowLevelTransaction.FreePage(p + i);
+            tx.Commit();
+        }
+        Env.FlushLogToDataFile();
+
+        // reallocate the same run and write new content - flushed by F2 below
+        using (var tx = Env.WriteTransaction())
+        {
+            var page = tx.LowLevelTransaction.AllocatePage(pages);
+            Assert.Equal(p, page.PageNumber);
+            page.Flags |= PageFlags.Overflow;
+            page.OverflowSize = overflowSize;
+            page.AsSpan(PageHeader.SizeOf, overflowSize).Fill(2);
+            tx.Commit();
+        }
+
+        using (var txLockHeld = new ManualResetEventSlim())
+        using (var releaseTxLock = new ManualResetEventSlim())
+        using (var flushWrotePages = new ManualResetEventSlim())
+        {
+            // hold the write tx lock so F2's WaitForJournalStateToBeUpdated keeps timing out and runs the sync's tasks itself
+            var txHolder = Task.Run(() =>
+            {
+                using (Env.WriteTransaction())
+                {
+                    txLockHeld.Set();
+                    releaseTxLock.Wait(TimeSpan.FromSeconds(60));
+                }
+            });
+            Assert.True(txLockHeld.Wait(TimeSpan.FromSeconds(60)));
+
+            // fires on the flush thread after F2 wrote the reallocated page, right before it gets stuck on the tx lock
+            Env.Journal.Applicator.ForTestingPurposesOnly().OnApplyJournalStateAfterFlush += flushWrotePages.Set;
+
+            var flushTask = Task.Run(() => Env.FlushLogToDataFile());
+            try
+            {
+                Assert.True(flushWrotePages.Wait(TimeSpan.FromSeconds(60)), "expected F2 to write its pages and reach ApplyJournalStateAfterFlush");
+
+                // a real sync: its GatherInformationToStartSync and UpdateDatabaseStateAfterSync (punch included) cannot take
+                // _flushingLock, so both are executed by the stuck F2 flush thread via RunTaskIfNotAlreadyRan - the punch runs mid-flush
+                using (var sync = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+                    Assert.True(sync.SyncDataFile());
+            }
+            finally
+            {
+                releaseTxLock.Set();
+            }
+
+            Assert.True(flushTask.Wait(TimeSpan.FromSeconds(60)), "expected F2 to complete after the tx lock was released");
+            Assert.True(txHolder.Wait(TimeSpan.FromSeconds(60)));
+        }
+
+        using (var tx = Env.ReadTransaction())
+        {
+            var page = tx.LowLevelTransaction.GetPage(p);
+            Assert.Equal(overflowSize, page.OverflowSize);
+            Assert.False(page.AsSpan(PageHeader.SizeOf, overflowSize).ContainsAnyExcept((byte)2),
+                "Page rewritten by the in-progress flush was zeroed by the mid-flush deferred punch");
         }
     }
 

--- a/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
+++ b/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
@@ -5,6 +5,7 @@ using Sparrow.Platform;
 using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
+using Voron.Impl.Journal;
 using Xunit;
 
 namespace FastTests.Voron.NextGenPagers;
@@ -15,6 +16,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
     public unsafe void CanReleaseDiskSpaceBackToTheOperatingSystem()
     {
         Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
         var pages = new List<long>();
         using (var wtx = Env.WriteTransaction())
         {
@@ -76,6 +78,12 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
         Env.FlushLogToDataFile();
         Assert.Equal(128 * 1024 * 1024, Env.CurrentStateRecord.DataPagerState.TotalAllocatedSize);
 
+        // RavenDB-26910: hole-punching is deferred to the post-sync phase, so force a sync to actually reclaim the space
+        using (var syncOperation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+        {
+            Assert.True(syncOperation.SyncDataFile());
+        }
+
         (long allocatedSize, long physicalSize) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);
 
         // On Linux, we have to deal with hole punching being done on 4KB boundaries, but the file system is 
@@ -94,6 +102,69 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
             // MacOS is doing weird stuff here, because it is eagerly marking the file as sparse
             // so we'll just verify that we were able to save _some_ space.
             Assert.True((beforePhysicalSize - physicalSize) > 20*1024*1024);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public unsafe void DeferredPunch_DoesNotZeroPageReusedInLaterFlushBatch()
+    {
+        // RavenDB-26910: the hole-punch is deferred to the post-sync phase and re-validated against the live free-space tree.
+        // A page freed in one flush batch can be reused + written by a later batch before the deferred punch runs; the re-validation
+        // must exclude it so it is never zeroed. If the filter is removed (punching the stale pending regions directly), this fails.
+        RequireFileBasedPager();
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+
+        const int allocationSize = 600;
+        const int overflowSize = allocationSize * Constants.Storage.PageSize - PageHeader.SizeOf;
+
+        long pageNum;
+        using (var tx = Env.WriteTransaction())
+        {
+            var p = tx.LowLevelTransaction.AllocatePage(allocationSize);
+            p.Flags |= PageFlags.Overflow;
+            p.OverflowSize = overflowSize;
+            pageNum = p.PageNumber;
+            p.AsSpan(PageHeader.SizeOf, overflowSize).Fill(1);
+            tx.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+        using (var sync = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            Assert.True(sync.SyncDataFile());
+
+        // batch N: free the pages (records a sparse-region candidate), flush without syncing -> the punch is deferred, not yet done
+        using (var tx = Env.WriteTransaction())
+        {
+            for (int i = 0; i < allocationSize; i++)
+                tx.LowLevelTransaction.FreePage(pageNum + i);
+            tx.Commit();
+        }
+        Env.FlushLogToDataFile();
+
+        // batch N+1: reuse the same pages and write new content, flush -> the deferred punch from batch N has still not run
+        using (var tx = Env.WriteTransaction())
+        {
+            var p = tx.LowLevelTransaction.AllocatePage(allocationSize);
+            Assert.Equal(pageNum, p.PageNumber);
+            p.Flags |= PageFlags.Overflow;
+            p.OverflowSize = overflowSize;
+            p.AsSpan(PageHeader.SizeOf, overflowSize).Fill(2);
+            tx.Commit();
+        }
+        Env.FlushLogToDataFile();
+
+        // now sync: batch N's deferred punch runs over a clean section, re-validated against the live free-space tree. The pages were
+        // reused by batch N+1, so they must be excluded from the punch and keep their content.
+        using (var sync = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            Assert.True(sync.SyncDataFile());
+
+        using (var tx = Env.WriteTransaction())
+        {
+            var p = tx.LowLevelTransaction.GetPage(pageNum);
+            Assert.Equal(overflowSize, p.OverflowSize);
+            Assert.False(p.AsSpan(PageHeader.SizeOf, overflowSize).ContainsAnyExcept((byte)2),
+                "Reused page was zeroed by the deferred sparse-region punch");
         }
     }
 
@@ -168,6 +239,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
     public unsafe void StorageReport_ShouldReflectPhysicalDiskSpaceAfterHolePunching()
     {
         Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
         var pages = new List<long>();
         using (var wtx = Env.WriteTransaction())
         {
@@ -199,6 +271,12 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
         }
 
         Env.FlushLogToDataFile();
+
+        // RavenDB-26910: hole-punching is deferred to the post-sync phase, so force a sync to actually reclaim the space
+        using (var syncOperation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+        {
+            Assert.True(syncOperation.SyncDataFile());
+        }
 
         using var rtx = Env.ReadTransaction();
         var report = Env.GenerateReport(rtx);

--- a/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
+++ b/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
@@ -5,6 +5,7 @@ using Sparrow.Platform;
 using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
+using Voron.Impl.FreeSpace;
 using Voron.Impl.Journal;
 using Xunit;
 
@@ -169,6 +170,76 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
     }
 
     [RavenFact(RavenTestCategory.Voron)]
+    public void DeferredPunch_DoesNotZeroPagesStillReadByOlderReadTransaction()
+    {
+        // RavenDB-26910: a page freed by a transaction newer than an open read tx still has its last flushed content in
+        // the data file, and the reader resolves it from there - the deferred punch must not zero it (it may only cover
+        // frees older than every active read transaction, the same uptoTxIdExclusive bound the flush obeys)
+        RequireFileBasedPager();
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+
+        // the flushed free must push the section's free count above NumberOfFreePagesForSparseConsideration (512)
+        // to register a sparse candidate; the reader's run only needs to be a punchable >= 128 pages
+        const int sectionMatePages = 600;
+        const int readerPages = 256;
+        const int readerOverflowSize = readerPages * Constants.Storage.PageSize - PageHeader.SizeOf;
+
+        long sectionMate;
+        long readerPage;
+        using (var tx = Env.WriteTransaction())
+        {
+            var p1 = tx.LowLevelTransaction.AllocatePage(sectionMatePages);
+            p1.Flags |= PageFlags.Overflow;
+            p1.OverflowSize = sectionMatePages * Constants.Storage.PageSize - PageHeader.SizeOf;
+            sectionMate = p1.PageNumber;
+
+            var p2 = tx.LowLevelTransaction.AllocatePage(readerPages);
+            p2.Flags |= PageFlags.Overflow;
+            p2.OverflowSize = readerOverflowSize;
+            p2.AsSpan(PageHeader.SizeOf, readerOverflowSize).Fill(3);
+            readerPage = p2.PageNumber;
+
+            tx.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        // both runs must share a free-space section, so the flushed free below makes the whole section a punch candidate
+        Assert.Equal(sectionMate / FreeSpaceHandling.NumberOfPagesInSection,
+            (readerPage + readerPages - 1) / FreeSpaceHandling.NumberOfPagesInSection);
+
+        using (var tx = Env.WriteTransaction())
+        {
+            for (int i = 0; i < sectionMatePages; i++)
+                tx.LowLevelTransaction.FreePage(sectionMate + i);
+            tx.Commit();
+        }
+
+        // the free above is flushed, so its sparse region is pending the deferred punch
+        Env.FlushLogToDataFile();
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            // freed by a transaction newer than rtx
+            using (var tx = Env.WriteTransaction())
+            {
+                for (int i = 0; i < readerPages; i++)
+                    tx.LowLevelTransaction.FreePage(readerPage + i);
+                tx.Commit();
+            }
+
+            using (var sync = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+                Assert.True(sync.SyncDataFile());
+
+            var page = rtx.LowLevelTransaction.GetPage(readerPage);
+            Assert.Equal(readerOverflowSize, page.OverflowSize);
+            Assert.False(page.AsSpan(PageHeader.SizeOf, readerOverflowSize).ContainsAnyExcept((byte)3),
+                "Page freed by a transaction newer than the read tx was zeroed by the deferred sparse-region punch");
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
     public void WillReleaseFreeSpaceAfterRestart()
     {
         RequireFileBasedPager();
@@ -233,6 +304,107 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
         StorageEnvironment.MergeSparseRegions(inputSource);
 
         Assert.Equal(expectedResult , inputSource);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void SubtractRanges_ShouldRemoveFlushedPagesFromSparseRegions()
+    {
+        static void AssertSubtract(
+            List<(long Start, long Count)> sparseRegions,
+            List<(long Start, long Count)> flushedPageRanges,
+            List<(long Start, long Count)> expected)
+        {
+            WriteAheadJournal.JournalApplicator.SubtractRanges(sparseRegions, flushedPageRanges);
+            Assert.Equal(expected, sparseRegions);
+        }
+
+        // no overlap
+        AssertSubtract([(100, 50)], [(10, 20), (200, 30)], [(100, 50)]);
+
+        // touching boundaries are not overlaps
+        AssertSubtract([(100, 50)], [(80, 20), (150, 10)], [(100, 50)]);
+
+        // exact cover and superset remove the region entirely
+        AssertSubtract([(100, 50)], [(100, 50)], []);
+        AssertSubtract([(100, 50)], [(90, 100)], []);
+
+        // trim head, trim tail
+        AssertSubtract([(100, 50)], [(90, 20)], [(110, 40)]);
+        AssertSubtract([(100, 50)], [(140, 20)], [(100, 40)]);
+
+        // a flushed range strictly inside splits the region
+        AssertSubtract([(100, 50)], [(120, 10)], [(100, 20), (130, 20)]);
+
+        // multiple holes in one region
+        AssertSubtract([(100, 100)], [(110, 10), (150, 10), (190, 20)], [(100, 10), (120, 30), (160, 30)]);
+
+        // one flushed range spanning two regions must trim both
+        AssertSubtract([(100, 50), (200, 50)], [(140, 70)], [(100, 40), (210, 40)]);
+
+        // empty inputs
+        AssertSubtract([], [(100, 50)], []);
+        AssertSubtract([(100, 50)], [], [(100, 50)]);
+    }
+
+    [RavenTheory(RavenTestCategory.Voron)]
+    [InlineDataWithRandomSeed]
+    public void SubtractRanges_Fuzzy(int seed)
+    {
+        var random = new Random(seed);
+
+        for (int i = 0; i < 128; i++)
+        {
+            // merged pending regions cannot be adjacent (minGap 1); flushed page ranges can be (minGap 0)
+            var sparseRegions = GenerateSortedRanges(random, maxEntries: 24, minGap: 1, maxGap: 64, maxCount: 96);
+            var flushedPageRanges = GenerateSortedRanges(random, maxEntries: 48, minGap: 0, maxGap: 48, maxCount: 48);
+
+            var expected = SubtractByPage(sparseRegions, flushedPageRanges);
+
+            var actual = new List<(long Start, long Count)>(sparseRegions);
+            WriteAheadJournal.JournalApplicator.SubtractRanges(actual, flushedPageRanges);
+
+            Assert.Equal(expected, actual);
+        }
+
+        static List<(long Start, long Count)> GenerateSortedRanges(Random random, int maxEntries, int minGap, int maxGap, int maxCount)
+        {
+            var result = new List<(long Start, long Count)>();
+            long cursor = random.Next(0, 64);
+            int entries = random.Next(0, maxEntries + 1);
+            for (int i = 0; i < entries; i++)
+            {
+                long start = cursor + random.Next(minGap, maxGap + 1);
+                long count = random.Next(1, maxCount + 1);
+                result.Add((start, count));
+                cursor = start + count;
+            }
+            return result;
+        }
+
+        static List<(long Start, long Count)> SubtractByPage(List<(long Start, long Count)> regions, List<(long Start, long Count)> ranges)
+        {
+            var pages = new HashSet<long>();
+            foreach (var (start, count) in regions)
+                for (long page = start; page < start + count; page++)
+                    pages.Add(page);
+
+            foreach (var (start, count) in ranges)
+                for (long page = start; page < start + count; page++)
+                    pages.Remove(page);
+
+            var sorted = new List<long>(pages);
+            sorted.Sort();
+
+            var result = new List<(long Start, long Count)>();
+            foreach (long page in sorted)
+            {
+                if (result.Count > 0 && result[^1].Start + result[^1].Count == page)
+                    result[^1] = (result[^1].Start, result[^1].Count + 1);
+                else
+                    result.Add((page, 1));
+            }
+            return result;
+        }
     }
 
     [RavenFact(RavenTestCategory.Voron)]

--- a/test/SlowTests.Issues/Issues/RavenDB-25424.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25424.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using FastTests.Voron;
 using Tests.Infrastructure;
+using Voron.Impl.Journal;
 using Xunit;
 
 namespace SlowTests.Issues
@@ -14,6 +15,7 @@ namespace SlowTests.Issues
         public void CanHandleTransactionReleasingPagesWhileFlushing()
         {
             Options.ManualFlushing = true;
+            Options.ManualSyncing = true;
 
             const int AllocationSize= 600;
             const int OverflowSize = AllocationSize * Voron.Global.Constants.Storage.PageSize - Voron.PageHeader.SizeOf;
@@ -30,12 +32,12 @@ namespace SlowTests.Issues
             }
 
             bool alreadyRun = false;
-            Env.Journal.Applicator.ForTestingPurposesOnly().OnApplyLogsToDataFile_AfterSparseRegionsSet_BeforeWritingToDataFile += () =>
+            Env.Journal.Applicator.ForTestingPurposesOnly().OnApplyLogsToDataFile_BeforeWritingToDataFile += () =>
             {
                 if (alreadyRun)
                     return;
                 alreadyRun = true;
-                // this will be ignored, because we _already_ process spare regions
+                // committed while the flush is running - the next flush consumes this free and registers its sparse region for the deferred punch
                 using (var tx = Env.WriteTransaction())
                 {
                     for (int i = 0; i < AllocationSize; i++)
@@ -45,7 +47,7 @@ namespace SlowTests.Issues
                     tx.Commit();
                 }
 
-                // this will be flushed to disk, since we haven't gotten to it yet
+                // the reallocation is written by the next flush, which also subtracts these pages from the pending sparse regions
                 using (var tx = Env.WriteTransaction())
                 {
                     var p = tx.LowLevelTransaction.AllocatePage(AllocationSize);
@@ -60,8 +62,12 @@ namespace SlowTests.Issues
             // first run, to create the "race" with the transactions
             Env.FlushLogToDataFile();
 
-            // second run, forcing the sparse pages to be zeroed
+            // second run flushes the free + reallocation
             Env.FlushLogToDataFile();
+
+            // punch whatever is still pending - it must not touch the reallocated pages
+            using (var sync = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+                Assert.True(sync.SyncDataFile());
 
             using (var tx = Env.WriteTransaction())
             {

--- a/test/SlowTests/Voron/Issues/RavenDB_24327.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_24327.cs
@@ -384,9 +384,9 @@ public class RavenDB_24327 : StorageTest
             tx.Commit();
         }
 
-        // flush so it will mark sparse regions in the data file BUT also error before writing actual data
+        // flush and simulate an error before writing the actual data
 
-        Env.Journal.Applicator.ForTestingPurposesOnly().OnApplyLogsToDataFile_AfterSparseRegionsSet_BeforeWritingToDataFile += () =>
+        Env.Journal.Applicator.ForTestingPurposesOnly().OnApplyLogsToDataFile_BeforeWritingToDataFile += () =>
         {
             throw new IOException("Simulating error on flush");
         };

--- a/test/SlowTests/Voron/Issues/RavenDB_26344.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344.cs
@@ -9,6 +9,7 @@ using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Voron.Impl.Backup;
+using Voron.Impl.Journal;
 using Voron.Util.Settings;
 using Xunit;
 
@@ -81,6 +82,12 @@ public class RavenDB_26344 : StorageTest
 
         Env.FlushLogToDataFile();
 
+        // RavenDB-26910: hole-punching is deferred to the post-sync phase, so force a sync to actually reclaim the space
+        using (var syncOperation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+        {
+            Assert.True(syncOperation.SyncDataFile());
+        }
+
         (long allocatedAfter, long physicalAfter) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);
         Assert.Equal(allocatedBefore, allocatedAfter);
 
@@ -132,6 +139,12 @@ public class RavenDB_26344 : StorageTest
         }
 
         Env.FlushLogToDataFile();
+
+        // RavenDB-26910: hole-punching is deferred to the post-sync phase, so force a sync so the source file is actually sparse before backup
+        using (var syncOperation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+        {
+            Assert.True(syncOperation.SyncDataFile());
+        }
 
         // 3. Get the original file sizes for reference
         (long originalAllocated, long originalPhysical) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26910/Windows-performance-issue-with-making-sparse-regions

### Additional description

On Windows, punching a hole (`FSCTL_SET_ZERO_DATA`) over a range that still has dirty, unsynced pages forces NTFS to flush/reconcile those pages before it can deallocate the clusters, so the punch costs about as much as a full FlushFileBuffers - whereas over an already-synced (clean) section it is a cheap metadata operation. Running it during flush, over unsynced pages, is what made delete-by-query slow. Move the punch to the post-sync phase, under the flush lock and over a clean section, and re-validate each freed region against the live free-space tree so a page reused since it was freed is never zeroed.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
