### PR TITLE
RavenDB-26891 Add temporary debug info to ControlCharacterOnIdentifiers_WhenUpgrade test

### DIFF
--- a/test/InterversionTests/ControlCharacterTests.cs
+++ b/test/InterversionTests/ControlCharacterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Raven.Client.Documents.Indexes.Counters;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Server.Config;
 using Raven.Server.Utils;
 using Tests.Infrastructure;
@@ -138,22 +140,57 @@ public class ControlCharacterTests  : MixedClusterTestBase
                 Assert.Equal(1, counter.Value);
             }
 
-            var indexResult = await session.Query<CounterIndex.Result, CounterIndex>().Select(x => new
+            try
             {
-                x.Name,
-            }).SingleAsync();
-            //Should be `counterName` but we decided to not deal with that and reject control characters in new databases 
-            Assert.True(indexResult.Name == counterName || indexResult.Name == escapedCounterName);
+                var indexResult = (await session.Query<CounterIndex.Result, CounterIndex>().Select(x => new
+                {
+                    x.Name,
+                }).SingleAsync());
+                //Should be `counterName` but we decided to not deal with that and reject control characters in new databases
+                Assert.True(indexResult.Name == counterName || indexResult.Name == escapedCounterName);
+            }
+            catch (IndexDoesNotExistException)
+            {
+                // RavenDB-26891 DEBUG: capture which node failed, and retry the actual query for up to a minute to see whether the index comes back.
+                var names = await stores[i].Maintenance.SendAsync(new GetIndexNamesOperation(0, int.MaxValue));
+                var indexesVisibleAtFailure = names.Contains(counterIndex.IndexName);
+
+                var sw = Stopwatch.StartNew();
+                var recovered = false;
+                Exception lastError = null;
+                while (sw.Elapsed < TimeSpan.FromMinutes(1))
+                {
+                    try
+                    {
+                        using var retrySession = stores[i].OpenAsyncSession();
+                        await retrySession.Query<CounterIndex.Result, CounterIndex>().Select(x => new { x.Name }).SingleAsync();
+                        recovered = true;
+                        break;
+                    }
+                    catch (Exception e)
+                    {
+                        lastError = e;
+                    }
+
+                    await Task.Delay(500);
+                }
+
+                throw new InvalidOperationException(
+                    $"[RavenDB-26891] CounterIndex query threw IndexDoesNotExist on node i={i} url={stores[i].Urls[0]}. " +
+                    $"GetIndexNames-saw-it-at-failure={indexesVisibleAtFailure}; query-recovered={recovered} after {sw.ElapsedMilliseconds}ms; " +
+                    $"lastError={lastError?.GetType().Name}: {lastError?.Message}");
+            }
             
+
             var resetIndexCommand = new ResetIndexOperation.ResetIndexCommand(counterIndex.IndexName, IndexResetMode.InPlace);
             await stores[i].Commands().ExecuteAsync(resetIndexCommand);
             await Indexes.WaitForIndexingAsync(stores[i]);
-            indexResult = await session.Query<CounterIndex.Result, CounterIndex>().Select(x => new
+            var indexResultAfterReset = await session.Query<CounterIndex.Result, CounterIndex>().Select(x => new
             {
                 x.Name,
             }).SingleAsync();
-            //Should be `counterName` but we decided to not deal with that and reject control characters in new databases 
-            Assert.True(indexResult.Name == counterName || indexResult.Name == escapedCounterName); 
+            //Should be `counterName` but we decided to not deal with that and reject control characters in new databases
+            Assert.True(indexResultAfterReset.Name == counterName || indexResultAfterReset.Name == escapedCounterName);
             
             
             var timeSeries = await session.TimeSeriesFor(testObj, timeSeriesName).GetAsync();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26891

### Additional description

ControlCharacterOnIdentifiers_WhenUpgrade_ShouldSuccessToBackup failed intermittently on Jenkins with IndexDoesNotExistException on the CounterIndex query, right after the upgrade in the test flow.                                                            
                                                                                                                                                                                                                                            
Status                                                                                                                                                                                                                                    
I couldn't reproduce it locally. 
From the investigation, it looks like a test-level issue rather than a server bug, but I want to verify that before fixing it.                                                                     
                                                                                                                                                                                                                                            
  This PR                                                                                                                                                                                                                                   
  Adds temporary debug info. 
When the query throws IndexDoesNotExist, the test records which node it happened on and retries the query for up to a minute to see whether the index comes back. 
The details go into the failure message.     
                                                                                                                                                                                                                                            
  I'll use the next failing run to confirm the cause, then replace this with the real fix.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Additional Test Info

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
