### PR TITLE
RavenDB-26911 - Wrong Exception for Agent query targets a non-existing index

### DIFF
--- a/src/Raven.Client/Exceptions/AiExceptions.cs
+++ b/src/Raven.Client/Exceptions/AiExceptions.cs
@@ -80,4 +80,15 @@ namespace Raven.Client.Exceptions
         {
         }
     }
+
+    public sealed class QueryToolFailedException : AiException
+    {
+        public QueryToolFailedException(string message) : base(message)
+        {
+        }
+
+        public QueryToolFailedException(string message, Exception e) : base(message, e)
+        {
+        }
+    }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -78,6 +78,10 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 {
                     throw;
                 }
+                catch (QueryToolFailedException)
+                {
+                    throw;
+                }
                 catch (AttachmentDoesNotExistException)
                 {
                     throw;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -1275,7 +1275,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
                         // Failed sub-request with no body (e.g. query against a non-existing index -> 404).
                         // Synthesize a schema to surface the real failure instead of dereferencing a null result.
-                        var (requestUrl, request) = TryGetRequestAndUrl(context, reqs, index);
+                        var (requestUrl, request) = GetRequestAndUrl(context, reqs, index);
                         var msg = $"The request to '{requestUrl}' failed with status code {statusCode} and returned an empty response body. Request: {request}";
 
                         var schema = new ExceptionDispatcher.ExceptionSchema
@@ -1293,11 +1293,9 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         }
     }
 
-    private static (string Url, string Request) TryGetRequestAndUrl(JsonOperationContext context, DynamicJsonArray reqs, int index)
+    private static (string Url, string Request) GetRequestAndUrl(JsonOperationContext context, DynamicJsonArray reqs, int index)
     {
-        if (reqs == null || index < 0 || index >= reqs.Items.Count || reqs.Items[index] is not DynamicJsonValue request)
-            return (null, null);
-
+        var request = reqs.Items[index] as DynamicJsonValue;
         var reqBjro = context.ReadObject(request, "ai-agent/failed-request");
         reqBjro.TryGet(nameof(GetRequest.Url), out string url);
         return (url, reqBjro.ToString());

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -1170,6 +1170,11 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                             // Missing parameter detected in sub-agent execution
                             throw;
                         }
+                        catch (QueryToolFailedException)
+                        {
+                            // A query tool failed inside the sub-agent (e.g. a non-existing index) - surface it to the user
+                            throw;
+                        }
                         catch (Exception e)
                         {
                             result.Messages.Add(context.ReadObject(
@@ -1184,7 +1189,18 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                         }
                         break;
                     case AiAgentToolQuery:
-                        var requestResult = getRequestResult.Invoke();
+                    {
+                        BlittableJsonReaderObject requestResult;
+                        try
+                        {
+                            requestResult = getRequestResult.Invoke();
+                        }
+                        catch (Exception e)
+                        {
+                            // Wrap query failures (e.g. a non-existing index) so they propagate to the user instead of being swallowed into a tool message.
+                            throw new QueryToolFailedException($"Query tool '{currentCall.Name}' failed to execute. (Query - Id: {currentCall.Id})", e);
+                        }
+
                         if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
                             throw new InvalidOperationException($"Query output is missing the '{nameof(QueryResult.Results)}' field. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
 
@@ -1196,6 +1212,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                                 [ChatCompletionClient.Constants.ResponseFields.Content] = GetToolResultContent(queryResult)
                             }, "tool-call/response"));
                         break;
+                    }
                     default:
                         throw new InvalidOperationException(
                             $"Type mismatch for tool '{currentCall.Name}' in sub-conversation '{conversationId}'. " +
@@ -1256,12 +1273,10 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                         if (requestResult != null)
                             throw ExceptionDispatcher.Get(requestResult, (HttpStatusCode)statusCode);
 
-                        // A failed sub-request can come back with a null body (for example, a query against a
-                        // non-existing index returns 404 with no result). There's no server-side ExceptionSchema
-                        // to deserialize in that case, so build a fitting one ourselves - otherwise we'd throw
-                        // while trying to deserialize a null result instead of surfacing the real failure.
-                        var (requestUrl, requestContent) = TryGetRequestUrlAndContent(reqs, index);
-                        var msg = $"The request to '{requestUrl}' failed with status code {statusCode} and returned an empty response body. Request: {requestContent}";
+                        // Failed sub-request with no body (e.g. query against a non-existing index -> 404).
+                        // Synthesize a schema to surface the real failure instead of dereferencing a null result.
+                        var (requestUrl, request) = TryGetRequestAndUrl(context, reqs, index);
+                        var msg = $"The request to '{requestUrl}' failed with status code {statusCode} and returned an empty response body. Request: {request}";
 
                         var schema = new ExceptionDispatcher.ExceptionSchema
                         {
@@ -1278,36 +1293,14 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         }
     }
 
-    private static (string Url, string Content) TryGetRequestUrlAndContent(DynamicJsonArray reqs, int index)
+    private static (string Url, string Request) TryGetRequestAndUrl(JsonOperationContext context, DynamicJsonArray reqs, int index)
     {
-        if (reqs == null || index < 0 || index >= reqs.Items.Count)
+        if (reqs == null || index < 0 || index >= reqs.Items.Count || reqs.Items[index] is not DynamicJsonValue request)
             return (null, null);
 
-        if (reqs.Items[index] is not DynamicJsonValue request)
-            return (null, null);
-
-        string url = null;
-        string content = null;
-
-        foreach (var (name, value) in request.Properties)
-        {
-            if (name == nameof(GetRequest.Url))
-            {
-                url = value as string;
-            }
-            else if (name == nameof(GetRequest.Content) && value is DynamicJsonValue contentObject)
-            {
-                foreach (var (contentName, contentValue) in contentObject.Properties)
-                {
-                    content ??= string.Empty;
-                    if (content.Length > 0)
-                        content += ", ";
-                    content += $"{contentName}: {contentValue}";
-                }
-            }
-        }
-
-        return (url, content);
+        var reqBjro = context.ReadObject(request, "ai-agent/failed-request");
+        reqBjro.TryGet(nameof(GetRequest.Url), out string url);
+        return (url, reqBjro.ToString());
     }
 
     public async Task<AiInternalConversationResult> HandleRequestAsync(

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -1243,17 +1243,71 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                 var response = (BlittableJsonReaderObject)results[i];
                 if (response.TryGet(nameof(GetResponse.StatusCode), out int statusCode) == false)
                     throw new InvalidOperationException("Missing status code");
-                if (response.TryGet(nameof(GetResponse.Result), out BlittableJsonReaderObject requestResult) is false)
+
+                response.TryGet(nameof(GetResponse.Result), out BlittableJsonReaderObject requestResult);
+                if (statusCode == 200 && requestResult == null)
                     throw new InvalidOperationException("Missing Result from query request output");
 
+                var index = i;
                 yield return (() =>
                 {
                     if (statusCode != 200)
-                        throw ExceptionDispatcher.Get(requestResult, (HttpStatusCode)statusCode);
+                    {
+                        if (requestResult != null)
+                            throw ExceptionDispatcher.Get(requestResult, (HttpStatusCode)statusCode);
+
+                        // A failed sub-request can come back with a null body (for example, a query against a
+                        // non-existing index returns 404 with no result). There's no server-side ExceptionSchema
+                        // to deserialize in that case, so build a fitting one ourselves - otherwise we'd throw
+                        // while trying to deserialize a null result instead of surfacing the real failure.
+                        var (requestUrl, requestContent) = TryGetRequestUrlAndContent(reqs, index);
+                        var msg = $"The request to '{requestUrl}' failed with status code {statusCode} and returned an empty response body. Request: {requestContent}";
+
+                        var schema = new ExceptionDispatcher.ExceptionSchema
+                        {
+                            Url = requestUrl,
+                            Type = typeof(RavenException).FullName,
+                            Message = msg,
+                            Error = msg
+                        };
+                        throw ExceptionDispatcher.Get(schema, (HttpStatusCode)statusCode);
+                    }
                     return requestResult;
                 }, i);
             }
         }
+    }
+
+    private static (string Url, string Content) TryGetRequestUrlAndContent(DynamicJsonArray reqs, int index)
+    {
+        if (reqs == null || index < 0 || index >= reqs.Items.Count)
+            return (null, null);
+
+        if (reqs.Items[index] is not DynamicJsonValue request)
+            return (null, null);
+
+        string url = null;
+        string content = null;
+
+        foreach (var (name, value) in request.Properties)
+        {
+            if (name == nameof(GetRequest.Url))
+            {
+                url = value as string;
+            }
+            else if (name == nameof(GetRequest.Content) && value is DynamicJsonValue contentObject)
+            {
+                foreach (var (contentName, contentValue) in contentObject.Properties)
+                {
+                    content ??= string.Empty;
+                    if (content.Length > 0)
+                        content += ", ";
+                    content += $"{contentName}: {contentValue}";
+                }
+            }
+        }
+
+        return (url, content);
     }
 
     public async Task<AiInternalConversationResult> HandleRequestAsync(

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26911.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26911.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_26911(ITestOutputHelper output) : RavenDB_24887_Base(output)
+    {
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task WrongIndexInQuery(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                foreach (var m in Movies)
+                    await session.StoreAsync(m);
+
+                foreach (var u in Users)
+                    await session.StoreAsync(u);
+
+                foreach (var r in Rates)
+                    await session.StoreAsync(r);
+
+                await session.SaveChangesAsync();
+            }
+
+            var userAgent = new AiAgentConfiguration("user-info-agent-1",
+                config.ConnectionStringName,
+                "Your role responsibility is to provide the user's name when requested OR change user name.")
+            {
+                Queries = new List<AiAgentToolQuery>()
+                {
+                    new AiAgentToolQuery
+                    {
+                        Name = "GetUserName",
+                        Description = "Get the user name",
+                        // wrong index: 'NonExistentIndex' does not exist in the database
+                        Query = "from index 'NonExistentIndex' " +
+                                "where id() = $userId " +
+                                "select Name",
+                        ParametersSampleObject = "{}"
+                    },
+                },
+                Actions = new List<AiAgentToolAction>()
+                {
+                    new AiAgentToolAction("ChangeUserName",
+                        "Updates the name of the current user interacting with the AI agent. have to send also the old name for validation.")
+                    {
+                        ParametersSampleObject = JsonConvert.SerializeObject(ChangeUserNameSampleRequest.Instance)
+                    },
+                }
+            };
+            userAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            var userAgentId = (await store.AI.CreateAgentAsync(userAgent, MoviesSampleObject.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(userAgentId, "chats/1",
+                new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
+            chat.Handle<ChangeUserNameSampleRequest, ActionToolResult>("ChangeUserName",
+                r => ChangeUserNameAsync(store, r));
+
+            chat.SetUserPrompt("What is my name?");
+            var e = await Assert.ThrowsAsync<AiException>(() => chat.RunAsync<MoviesSampleObject>(CancellationToken.None));
+            var msg =
+                "The request to '/databases/WrongIndexInQuery_1/queries' failed with status code 404 and returned an empty response body. Request: Query: from index 'NonExistentIndex' where id() = $userId select Name, QueryParameters: {\"userId\":\"Users/1\"}";
+            Assert.Contains(msg, e.Message);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26911.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26911.cs
@@ -25,14 +25,8 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             using (var session = store.OpenAsyncSession())
             {
-                foreach (var m in Movies)
-                    await session.StoreAsync(m);
-
                 foreach (var u in Users)
                     await session.StoreAsync(u);
-
-                foreach (var r in Rates)
-                    await session.StoreAsync(r);
 
                 await session.SaveChangesAsync();
             }
@@ -72,10 +66,158 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 r => ChangeUserNameAsync(store, r));
 
             chat.SetUserPrompt("What is my name?");
-            var e = await Assert.ThrowsAsync<AiException>(() => chat.RunAsync<MoviesSampleObject>(CancellationToken.None));
-            var msg =
-                "The request to '/databases/WrongIndexInQuery_1/queries' failed with status code 404 and returned an empty response body. Request: Query: from index 'NonExistentIndex' where id() = $userId select Name, QueryParameters: {\"userId\":\"Users/1\"}";
-            Assert.Contains(msg, e.Message);
+            var e = await Assert.ThrowsAsync<QueryToolFailedException>(() => chat.RunAsync<MoviesSampleObject>(CancellationToken.None));
+            Assert.Contains("failed with status code 404", e.Message);
+            Assert.Contains("NonExistentIndex", e.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task WrongIndexInSubAgentQuery(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                foreach (var u in Users)
+                    await session.StoreAsync(u);
+
+                await session.SaveChangesAsync();
+            }
+
+            // The sub-agent runs a query against an index that does not exist.
+            var userAgent = new AiAgentConfiguration("user-info-agent-1",
+                config.ConnectionStringName,
+                "Your role responsibility is to provide the user's name when requested.")
+            {
+                Queries = new List<AiAgentToolQuery>()
+                {
+                    new AiAgentToolQuery
+                    {
+                        Name = "GetUserName",
+                        Description = "Get the user name",
+                        // wrong index: 'NonExistentIndex' does not exist in the database
+                        Query = "from index 'NonExistentIndex' " +
+                                "where id() = $userId " +
+                                "select Name",
+                        ParametersSampleObject = "{}"
+                    },
+                }
+            };
+            userAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            var userAgentId = (await store.AI.CreateAgentAsync(userAgent, MoviesSampleObject.Instance)).Identifier;
+
+            // The root agent delegates the name lookup to the sub-agent above.
+            var rootAgent = new AiAgentConfiguration("root-agent-1",
+                config.ConnectionStringName,
+                "You are a User Profile Agent. When asked about the user's name, delegate to the sub-agent.")
+            {
+                SubAgents =
+                [
+                    new AiAgentToolSubAgent
+                    {
+                        Identifier = userAgentId,
+                        Description = "Get the user name."
+                    }
+                ]
+            };
+            rootAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            var rootAgentId = (await store.AI.CreateAgentAsync<MoviesSampleObject>(rootAgent, MoviesSampleObject.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(rootAgentId, "chats/1",
+                new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
+
+            chat.SetUserPrompt("What is my name?");
+
+            // The sub-agent's query failure must propagate all the way to the user
+            // (instead of being swallowed into a tool message for the model).
+            var e = await Assert.ThrowsAsync<QueryToolFailedException>(() => chat.RunAsync<MoviesSampleObject>(CancellationToken.None));
+            Assert.Contains("failed with status code 404", e.Message);
+            Assert.Contains("NonExistentIndex", e.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task WrongIndexInSubAgentQuery_ThreeLayers(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                foreach (var u in Users)
+                    await session.StoreAsync(u);
+
+                await session.SaveChangesAsync();
+            }
+
+            // Layer 3 (deepest): the only agent that actually runs a query, against an index that does not exist.
+            var lastSubAgent = new AiAgentConfiguration("last-sub-agent",
+                config.ConnectionStringName,
+                "Your role responsibility is to provide the user's name when requested.")
+            {
+                Queries = new List<AiAgentToolQuery>()
+                {
+                    new AiAgentToolQuery
+                    {
+                        Name = "GetUserName",
+                        Description = "Get the user name",
+                        // wrong index: 'NonExistentIndex' does not exist in the database
+                        Query = "from index 'NonExistentIndex' " +
+                                "where id() = $userId " +
+                                "select Name",
+                        ParametersSampleObject = "{}"
+                    },
+                }
+            };
+            lastSubAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            var lastSubAgentId = (await store.AI.CreateAgentAsync<MoviesSampleObject>(lastSubAgent, MoviesSampleObject.Instance)).Identifier;
+
+            // Layer 2 (middle): delegates the name lookup to the deepest agent.
+            var middleSubAgent = new AiAgentConfiguration("middle-sub-agent",
+                config.ConnectionStringName,
+                "Your role responsibility is to provide the user's name when requested. Delegate to the sub-agent.")
+            {
+                SubAgents =
+                [
+                    new AiAgentToolSubAgent
+                    {
+                        Identifier = lastSubAgentId,
+                        Description = "Get the user name."
+                    }
+                ]
+            };
+            middleSubAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            var middleSubAgentId = (await store.AI.CreateAgentAsync<MoviesSampleObject>(middleSubAgent, MoviesSampleObject.Instance)).Identifier;
+
+            // Layer 1 (root): delegates the name lookup to the middle agent.
+            var rootAgent = new AiAgentConfiguration("sub-agent-root",
+                config.ConnectionStringName,
+                "You are a User Profile Agent. When asked about the user's name, delegate to the sub-agent.")
+            {
+                SubAgents =
+                [
+                    new AiAgentToolSubAgent
+                    {
+                        Identifier = middleSubAgentId,
+                        Description = "Get the user name."
+                    }
+                ]
+            };
+            rootAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            var rootAgentId = (await store.AI.CreateAgentAsync<MoviesSampleObject>(rootAgent, MoviesSampleObject.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(rootAgentId, "chats/1",
+                new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
+
+            chat.SetUserPrompt("What is my name?");
+
+            // The query failure happens in the deepest sub-agent and must propagate up
+            // through every layer all the way to the user - exactly like WrongIndexInSubAgentQuery.
+            var e = await Assert.ThrowsAsync<QueryToolFailedException>(() => chat.RunAsync<MoviesSampleObject>(CancellationToken.None));
+            Assert.Contains("failed with status code 404", e.Message);
+            Assert.Contains("NonExistentIndex", e.Message);
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26911/Wrong-Exception-for-Agent-query-targets-a-non-existing-index

### Additional description

Server throws NRE when root agent runs a query on a non-existing index

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
