### PR TITLE
[Custom] - RavenDB-26764 & RavenDB-26903

### DIFF
--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -478,13 +478,16 @@ namespace Raven.Server.Documents
         {
             var (fst, snd) = SplitCounterDocument(context, values, dbIds, originalNames);
 
-            using (Slice.From(context.Allocator, changeVector, out var cv))
+            var firstEtag = context.DocumentDatabase.DocumentsStorage.GenerateNextEtag();
+            var firstChangeVector = ChangeVector.MergeWithNewDatabaseChangeVector(context, new ChangeVector(changeVector, context), firstEtag);
+
+            using (Slice.From(context.Allocator, firstChangeVector, out var cv))
             using (DocumentIdWorker.GetStringPreserveCase(context, collectionName.Name, out Slice collectionSlice))
             {
                 using (table.Allocate(out TableValueBuilder tvb))
                 {
                     tvb.Add(countersGroupKey);
-                    tvb.Add(Bits.SwapBytes(context.DocumentDatabase.DocumentsStorage.GenerateNextEtag()));
+                    tvb.Add(Bits.SwapBytes(firstEtag));
                     tvb.Add(cv);
                     tvb.Add(fst.BasePointer, fst.Size);
                     tvb.Add(collectionSlice);
@@ -1073,6 +1076,9 @@ namespace Raven.Server.Documents
                             }
 
                             var etag = _documentsStorage.GenerateNextEtag();
+                            if (putCountersData.Modified)
+                                changeVectorToSave = ChangeVector.MergeWithNewDatabaseChangeVector(context, changeVectorToSave, etag);
+
                             using (Slice.From(context.Allocator, changeVectorToSave, out var cv))
                             using (DocumentIdWorker.GetStringPreserveCase(context, collectionName.Name, out Slice collectionSlice))
                             using (table.Allocate(out TableValueBuilder tvb))

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
@@ -54,7 +54,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
 
         RavenAwsS3Client.FillMetadata(multipartRequest.Metadata, _metadata);
 
-        var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken);
+        var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken).ConfigureAwait(false);
         _uploadId = initiateResponse.UploadId;
         _partNumber = 1;
         _partEtags = new List<PartETag>();
@@ -67,7 +67,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
 
     public async Task UploadPartAsync(Stream stream)
     {
-        await UploadPartAsync(stream, stream.Length);
+        await UploadPartAsync(stream, stream.Length).ConfigureAwait(false);
     }
 
     public async Task UploadPartAsync(Stream stream, long size)
@@ -90,7 +90,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
                     _progress?.UploadProgress.UpdateUploaded(args.IncrementTransferred);
                     _progress?.OnUploadProgress?.Invoke();
                 }
-            }, _cancellationToken);
+            }, _cancellationToken).ConfigureAwait(false);
 
         _partEtags.Add(new PartETag(uploadResponse.PartNumber.GetValueOrDefault(), uploadResponse.ETag));
     }
@@ -110,6 +110,6 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
                 Key = _key,
                 PartETags = _partEtags
             },
-            _cancellationToken);
+            _cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AzureMultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AzureMultiPartUploader.cs
@@ -60,7 +60,7 @@ public class AzureMultiPartUploader : IMultiPartUploader
                 _progress.UploadProgress.SetUploaded(uploadedSoFar + value);
                 _progress.OnUploadProgress?.Invoke();
             })
-        }, _cancellationToken);
+        }, _cancellationToken).ConfigureAwait(false);
     }
 
     public void CompleteUpload()
@@ -73,6 +73,6 @@ public class AzureMultiPartUploader : IMultiPartUploader
         await _blockBlobClient.CommitBlockListAsync(_base64BlockIds, new CommitBlockListOptions
         {
             Metadata = _metadata
-        }, _cancellationToken);
+        }, _cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1039,7 +1039,7 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        private static ExternalReplicationState GetExternalReplicationState(ServerStore server, string database, long taskId, TransactionOperationContext context)
+        public static ExternalReplicationState GetExternalReplicationState(ServerStore server, string database, long taskId, TransactionOperationContext context)
         {
             var stateBlittable = server.Cluster.Read(context, ExternalReplicationState.GenerateItemName(database, taskId));
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -917,7 +917,7 @@ namespace Raven.Server.Documents.TimeSeries
             private ChangeVector _currentChangeVector;
             public ChangeVector ChangeVector => _currentChangeVector;
 
-            public bool ResolvedSegment { get; set; }
+            public bool ResolvedSegment;
 
             private AllocatedMemoryData _clonedReadonlySegment;
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -917,6 +917,8 @@ namespace Raven.Server.Documents.TimeSeries
             private ChangeVector _currentChangeVector;
             public ChangeVector ChangeVector => _currentChangeVector;
 
+            public bool ResolvedSegment { get; set; }
+
             private AllocatedMemoryData _clonedReadonlySegment;
 
             private TimeSeriesSegmentHolder(
@@ -1133,7 +1135,10 @@ namespace Raven.Server.Documents.TimeSeries
                     return;
 
                 _currentEtag = _tss._documentsStorage.GenerateNextEtag();
-                _currentChangeVector = ChangeVector.Merge(ReadOnlyChangeVector, ChangeVectorFromReplication, _context);
+                var mergedChangeVector = ChangeVector.Merge(ReadOnlyChangeVector, ChangeVectorFromReplication, _context);
+                _currentChangeVector = ResolvedSegment
+                    ? ChangeVector.MergeWithNewDatabaseChangeVector(_context, mergedChangeVector, _currentEtag)
+                    : mergedChangeVector;
 
                 if (segment.RecomputeRequired)
                     segment = segment.Recompute(_context.Allocator);
@@ -1241,6 +1246,7 @@ namespace Raven.Server.Documents.TimeSeries
                 ulong status)
             {
                 AppendExistingSegment(splitSegment);
+                ResolvedSegment = false;
 
                 splitSegment.Initialize(currentValues.Length);
 
@@ -1966,6 +1972,7 @@ namespace Raven.Server.Documents.TimeSeries
                     }
 
                     bool segmentChanged = false;
+                    timeSeriesSegment.ResolvedSegment = false;
 
                     using (var enumerator = readOnlySegment.GetEnumerator(context.Allocator))
                     {
@@ -1991,6 +1998,9 @@ namespace Raven.Server.Documents.TimeSeries
                                     if (compare.HasFlag(CompareResult.Merge) == false &&
                                         currentTime == current?.Timestamp)
                                     {
+                                        if (compare.HasFlag(CompareResult.Equal) == false)
+                                            timeSeriesSegment.ResolvedSegment = true;
+
                                         reader.MoveNext();
                                         current = reader.Current;
                                     }
@@ -2139,20 +2149,35 @@ namespace Raven.Server.Documents.TimeSeries
             if (isIncrement && EnsureNumberOfValues(localValues.Length, ref remote) == false)
                 return CompareResult.Remote;
 
-            if (localValues.Length != remote.Values.Length)
+            var localCount = TrimmedLength(localValues);
+            var remoteCount = TrimmedLength(remote.Values.Span);
+
+            if (localCount != remoteCount)
             {
                 // larger number of values wins
-                if (localValues.Length > remote.Values.Length)
+                if (localCount > remoteCount)
                     return CompareResult.Local;
 
                 return CompareResult.Remote;
             }
 
             var compare = localValues.SequenceCompareTo(remote.Values.Span);
-            if (compare >= 0)
+            if (compare > 0)
                 return CompareResult.Local;
 
+            if (compare == 0)
+                return CompareResult.Equal;
+
             return CompareResult.Remote;
+        }
+
+        private static int TrimmedLength(Span<double> values)
+        {
+            var length = values.Length;
+            while (length > 0 && double.IsNaN(values[length - 1]))
+                length--;
+
+            return length;
         }
 
         private static CompareResult SelectSmallerValue(Span<double> localValues, SingleResult remote)
@@ -2170,8 +2195,11 @@ namespace Raven.Server.Documents.TimeSeries
             }
 
             var compare = localValues.SequenceCompareTo(remote.Values.Span);
-            if (compare <= 0)
+            if (compare < 0)
                 return CompareResult.Local;
+
+            if (compare == 0)
+                return CompareResult.Equal;
 
             return CompareResult.Remote;
         }

--- a/test/FastTests/Issues/RavenDB-26903.cs
+++ b/test/FastTests/Issues/RavenDB-26903.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Raven.Server.Documents.PeriodicBackup.DirectUpload;
+using Tests.Infrastructure;
+using Xunit;
+using ITestOutputHelper = Xunit.ITestOutputHelper;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_26903 : NoDisposalNeeded
+    {
+        public RavenDB_26903(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // Backups run the smuggler under AsyncHelpers.RunSyncWithSynchronization, which installs a
+        // single-threaded ExclusiveSynchronizationContext on the dedicated backup thread and pumps it
+        // only while the smuggler is executing. A multipart upload part is started (fire-and-forget)
+        // during that run, and the final in-flight part is awaited later in DirectUploadStream.Dispose.
+        //
+        // If the cloud upload awaits capture that synchronization context (the default ConfigureAwait(true)),
+        // the part's completion continuation is posted back to the context after its message loop has already
+        // ended, so it can never run. DirectUploadStream.Dispose then blocks forever on that task, hanging the
+        // dedicated backup thread.
+        //
+        // This test reproduces the exact lifecycle with the real AwsS3MultiPartUploader and a fake S3 client
+        // (no network): a context that captures continuations but never runs them, an upload started under it,
+        // and a blocking wait afterwards. It times out (fails) unless the uploader uses ConfigureAwait(false).
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public void DirectUpload_multipart_upload_must_not_capture_the_backup_synchronization_context()
+        {
+            var client = new AsyncCompletingS3Client();
+            var uploader = new AwsS3MultiPartUploader(client, bucketName: "bucket", storageClass: S3StorageClass.Standard,
+                progress: null, key: "key", metadata: new Dictionary<string, string>(), cancellationToken: default);
+
+            // Initialize() runs without a synchronization context (fast path), exactly like during backup setup.
+            uploader.Initialize();
+
+            using var stream = new MemoryStream(new byte[1024]);
+
+            var context = new NonPumpingSynchronizationContext();
+            var previous = SynchronizationContext.Current;
+
+            Task uploadTask;
+            SynchronizationContext.SetSynchronizationContext(context);
+            try
+            {
+                // Mirrors StartUploadTask() running on the backup thread while the ExclusiveSynchronizationContext
+                // is current: the upload is kicked off here but not awaited.
+                uploadTask = uploader.UploadPartAsync(stream);
+            }
+            finally
+            {
+                // The smuggler finishes and the message loop ends -> the context is no longer pumped,
+                // just like when RunSyncWithSynchronization returns.
+                SynchronizationContext.SetSynchronizationContext(previous);
+            }
+
+            // Mirrors DirectUploadStream.Dispose blocking on the last in-flight part. If the part's continuation
+            // was captured by 'context' (which is no longer pumped), the task never completes and this times out.
+            var completed = uploadTask.Wait(TimeSpan.FromSeconds(10));
+
+            Assert.True(completed,
+                "The multipart upload task never completed: its continuation was captured by the backup " +
+                "synchronization context and orphaned once the message loop ended. The cloud upload awaits " +
+                "must use ConfigureAwait(false).");
+        }
+
+        // A synchronization context that captures posted continuations but never executes them - modeling the
+        // backup's ExclusiveSynchronizationContext after its message loop has stopped pumping.
+        private sealed class NonPumpingSynchronizationContext : SynchronizationContext
+        {
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                // Intentionally drop the continuation: nothing pumps this context anymore.
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override SynchronizationContext CreateCopy() => this;
+        }
+
+        // Fake S3 client whose async operations complete asynchronously on the thread pool (no network).
+        // It uses ConfigureAwait(false) internally so that its OWN completion does not depend on the test's
+        // non-pumping context - only the production uploader's ConfigureAwait behavior is under test.
+        private sealed class AsyncCompletingS3Client : AmazonS3Client
+        {
+            public AsyncCompletingS3Client()
+                : base(new BasicAWSCredentials("test", "test"), new AmazonS3Config { ServiceURL = "https://localhost:1" })
+            {
+            }
+
+            public override async Task<InitiateMultipartUploadResponse> InitiateMultipartUploadAsync(InitiateMultipartUploadRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                return new InitiateMultipartUploadResponse { UploadId = "test-upload-id" };
+            }
+
+            public override async Task<UploadPartResponse> UploadPartAsync(UploadPartRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+                return new UploadPartResponse { PartNumber = 1, ETag = "\"test-etag\"" };
+            }
+
+            public override async Task<CompleteMultipartUploadResponse> CompleteMultipartUploadAsync(CompleteMultipartUploadRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                return new CompleteMultipartUploadResponse();
+            }
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB-21381.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21381.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FastTests.Utils;
 using Raven.Client;
 using Raven.Client.Documents.Operations.Revisions;
@@ -64,13 +65,21 @@ namespace SlowTests.Issues
                 Assert.Contains(DocumentFlags.DeleteRevision.ToString(), revisionsMetadata2[0].GetString(Constants.Documents.Metadata.Flags));
             }
 
-            var dbName = store.Database;
-            if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+            DocumentDatabase database;
+            switch (options.DatabaseMode)
             {
-                var shardNumber = await Sharding.GetShardNumberForAsync(store, user1.Id);
-                dbName = ShardHelper.ToShardName(store.Database, shardNumber);
+                case RavenDatabaseMode.Single:
+                    database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                    break;
+                case RavenDatabaseMode.Sharded:
+                    var shardNumber = await Sharding.GetShardNumberForAsync(store, user1.Id);
+                    var dbName = ShardHelper.ToShardName(store.Database, shardNumber);
+                    database = await Sharding.GetAnyShardDocumentDatabaseInstanceFor(dbName);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+
             }
-            var database = await Databases.GetDocumentDatabaseInstanceFor(store, dbName);
 
             // Delete the last revision (the 'Delete Revision')
             using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))

--- a/test/SlowTests.Issues/Issues/RavenDB_15437.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15437.cs
@@ -77,7 +77,6 @@ namespace SlowTests.Issues
                 dbA.ReplicationLoader.DebugWaitAndRunReplicationOnce.Set();
                 dbA.ReplicationLoader.DebugWaitAndRunReplicationOnce = null;
 
-                await SetupReplicationAsync(storeA, storeB);
                 await EnsureReplicatingAsync(storeA, storeB);
 
                 await SetupReplicationAsync(storeB, storeA);

--- a/test/SlowTests.Issues/Issues/RavenDB_15538.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15538.cs
@@ -153,7 +153,7 @@ namespace SlowTests.Issues
                         }
                         // Replication from source to firstDestination
                         await SetupReplicationAsync(source, firstDestination);
-                        await EnsureReplicatingAsync(source, firstDestination);
+                        await EnsureReplicatingAsync(source, firstDestination, server);
 
                         var stats = await GetDatabaseStatisticsAsync(source, servers: servers);
                         Assert.True(await WaitForValueAsync(async () => await AssertReplicationAsync(firstDestination, firstDestination.Database, stats, servers), true, reasonableWaitTime, 333));
@@ -165,7 +165,7 @@ namespace SlowTests.Issues
                             await session.SaveChangesAsync();
                         }
 
-                        await EnsureReplicatingAsync(source, firstDestination);
+                        await EnsureReplicatingAsync(source, firstDestination, server);
 
                         stats = await GetDatabaseStatisticsAsync(source, servers: servers);
                         Assert.True(await WaitForValueAsync(async () => await AssertReplicationAsync(firstDestination, firstDestination.Database, stats, servers), true, reasonableWaitTime, 333));

--- a/test/SlowTests/Client/Attachments/RavenDB_20601.cs
+++ b/test/SlowTests/Client/Attachments/RavenDB_20601.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Client.Attachments
         public RavenDB_20601(ITestOutputHelper output) : base(output)
         {
         }
-        [RavenFact(RavenTestCategory.Attachments)]
+        [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.Replication | RavenTestCategory.ClusterTransactions)]
         public async Task ConflictOfClusterTxDocumentWithAttachment()
         {
             var co = new ServerCreationOptions
@@ -38,7 +38,7 @@ namespace SlowTests.Client.Attachments
                 }
 
                 await SetupReplicationAsync(store1, store2);
-                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2, server);
 
                 var d = await BreakReplication(server.ServerStore, store1.Database);
                 using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
@@ -64,11 +64,11 @@ namespace SlowTests.Client.Attachments
 
                 d.Mend();
 
-                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2, server);
             }
         }
 
-        [RavenFact(RavenTestCategory.Attachments)]
+        [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.Replication | RavenTestCategory.ClusterTransactions)]
         public async Task ConflictOfTwoClusterTxAndAttachment()
         {
             using (var store1 = GetDocumentStore())
@@ -112,7 +112,7 @@ namespace SlowTests.Client.Attachments
             }
         }
 
-        [RavenFact(RavenTestCategory.Attachments)]
+        [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.Replication | RavenTestCategory.ClusterTransactions)]
         public async Task ConflictOfClusterTxDocumentWithAttachment2()
         {
             var co = new ServerCreationOptions
@@ -137,7 +137,7 @@ namespace SlowTests.Client.Attachments
 
                 await SetupReplicationAsync(store1, store2);
 
-                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2, server);
                 var d = await BreakReplication(server.ServerStore, store1.Database);
                 using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
                 {
@@ -177,7 +177,7 @@ namespace SlowTests.Client.Attachments
 
                 d.Mend();
 
-                await EnsureReplicatingAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2, server);
             }
         }
     }

--- a/test/SlowTests/Client/Counters/RavenDB_26766.cs
+++ b/test/SlowTests/Client/Counters/RavenDB_26766.cs
@@ -1,0 +1,182 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.Counters
+{
+    public class RavenDB_26766 : ReplicationTestBase
+    {
+        public RavenDB_26766(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const string DocId = "users/ayende";
+        private const string CounterName = "Likes";
+
+        [RavenFact(RavenTestCategory.Counters | RavenTestCategory.Replication)]
+        public async Task MergedCounterValueMustNotBeStrandedByChangeVectorGate()
+        {
+            using var a = GetDocumentStore();
+            using var b = GetDocumentStore();
+            using var c = GetDocumentStore();
+
+            foreach (var store in new[] { a, b, c })
+            {
+                using var session = store.OpenSession();
+                session.Store(new { Name = "Oren" }, DocId);
+                session.SaveChanges();
+            }
+
+            foreach (var store in new[] { a, b, c })
+            {
+                using var session = store.OpenSession();
+                session.CountersFor(DocId).Increment(CounterName, 1);
+                session.SaveChanges();
+            }
+
+            using (var session = c.OpenSession())
+            {
+                session.Store(new { }, "carrier/c");
+                session.SaveChanges();
+            }
+
+            using var cOut = await GetReplicationManagerAsync(c, c.Database, RavenDatabaseMode.Single,
+                new ReplicationManager.ReplicationOptions { BreakReplicationOnStart = true, MaxItemsCount = 1 });
+
+            var links = new[] { (a, b), (b, a), (a, c), (b, c), (c, a), (c, b) };
+            foreach (var (from, to) in links) // full mesh; c->a, c->b blocked by the gate, everything else flows
+                await SetupReplicationAsync(from, to);
+
+            Assert.True(await WaitForValueAsync(() => CounterAt(c) == 3 && CounterAt(a) == 2 && CounterAt(b) == 2, true, timeout: 30_000),
+                $"phase 1 not reached: A={Fmt(CounterAt(a))} B={Fmt(CounterAt(b))} C={Fmt(CounterAt(c))} (want A=2,B=2,C=3)");
+
+            var carrierDelivered = await WaitForValueAsync(() =>
+            {
+                cOut.ReplicateOnce(DocId);
+                return HasDoc(a, "carrier/c") && HasDoc(b, "carrier/c");
+            }, true);
+
+            Assert.True(carrierDelivered, "carrier doc was not delivered to A and B");
+
+            cOut.ReplicateOnce(DocId); // C now evaluates its merged counter-group row under the armed cv -> gated
+
+            cOut.Mend();
+            foreach (var (from, to) in links)
+                EnsureReplicating(from, to);
+
+            var r = await WaitForValueAsync(() => CounterAt(a) == 3 && CounterAt(b) == 3 && CounterAt(c) == 3, true);
+
+            Assert.True(r, "merged counter value stranded by the change-vector send gate (PutCounters :1075) - divergence: " +
+                           $"A={Fmt(CounterAt(a))} B={Fmt(CounterAt(b))} C={Fmt(CounterAt(c))} (expected all 3)");
+        }
+
+        [RavenFact(RavenTestCategory.Counters | RavenTestCategory.Replication)]
+        public async Task MergedCounterValuesMustNotBeStrandedWhenGroupSplits()
+        {
+            const int counterCount = 48; // enough that a 3-dbId merge on C grows the group past 2KB and SPLITS
+            var names = Enumerable.Range(0, counterCount).Select(i => "C" + i.ToString("D3")).ToArray();
+
+            using var a = GetDocumentStore();
+            using var b = GetDocumentStore();
+            using var c = GetDocumentStore();
+
+            foreach (var store in new[] { a, b, c })
+            {
+                using var session = store.OpenSession();
+                session.Store(new { Name = "Oren" }, DocId);
+                session.SaveChanges();
+            }
+
+            foreach (var store in new[] { a, b, c })
+            {
+                using var session = store.OpenSession();
+                var cf = session.CountersFor(DocId);
+                foreach (var n in names)
+                    cf.Increment(n, 1);
+                session.SaveChanges();
+            }
+
+            using (var session = c.OpenSession())
+            {
+                session.Store(new { }, "carrier/c");
+                session.SaveChanges();
+            }
+
+            using var cOut = await GetReplicationManagerAsync(c, c.Database, RavenDatabaseMode.Single,
+                new ReplicationManager.ReplicationOptions { BreakReplicationOnStart = true, MaxItemsCount = 1 });
+
+            var links = new[] { (a, b), (b, a), (a, c), (b, c), (c, a), (c, b) };
+            foreach (var (from, to) in links) // full mesh; c->a, c->b blocked by the gate, everything else flows
+                await SetupReplicationAsync(from, to);
+
+            Assert.True(await WaitForValueAsync(() =>
+                    CounterSum(c, names) == 3 * counterCount &&
+                    CounterSum(a, names) == 2 * counterCount &&
+                    CounterSum(b, names) == 2 * counterCount, true, timeout: 30_000),
+                $"phase 1 not reached: A={CounterSum(a, names)} B={CounterSum(b, names)} C={CounterSum(c, names)} " +
+                $"(want A={2 * counterCount},B={2 * counterCount},C={3 * counterCount})");
+
+            var carrierDelivered = await WaitForValueAsync(() =>
+            {
+                cOut.ReplicateOnce(DocId);
+                return HasDoc(a, "carrier/c") && HasDoc(b, "carrier/c");
+            }, true);
+
+            Assert.True(carrierDelivered, "carrier doc was not delivered to A and B");
+
+            cOut.ReplicateOnce(DocId);
+
+            cOut.Mend();
+            foreach (var (from, to) in links)
+                EnsureReplicating(from, to);
+
+            var r = await WaitForValueAsync(() =>
+                AllCountersEqual(a, names, 3) && AllCountersEqual(b, names, 3) && AllCountersEqual(c, names, 3), true);
+
+            Assert.True(r, "merged counter value(s) stranded by the change-vector send gate on the >2KB split path - " +
+                        "the first sub-group row (SplitCounterGroup) carries a plain-union cv with no fresh local component: " +
+                        $"A stranded=[{StrandedNames(a, names)}] B stranded=[{StrandedNames(b, names)}] (expected all 3)");
+        }
+
+        private static long? CounterAt(DocumentStore store)
+        {
+            using var session = store.OpenSession();
+            return session.CountersFor(DocId).Get(CounterName);
+        }
+
+        private static bool HasDoc(DocumentStore store, string id)
+        {
+            using var session = store.OpenSession();
+            return session.Load<object>(id) != null;
+        }
+
+        private static long CounterSum(DocumentStore store, string[] names)
+        {
+            using var session = store.OpenSession();
+            var all = session.CountersFor(DocId).GetAll();
+            return names.Sum(n => all != null && all.TryGetValue(n, out var v) ? v ?? 0 : 0);
+        }
+
+        private static bool AllCountersEqual(DocumentStore store, string[] names, long expected)
+        {
+            using var session = store.OpenSession();
+            var all = session.CountersFor(DocId).GetAll();
+            return all != null && names.All(n => all.TryGetValue(n, out var v) && v == expected);
+        }
+
+        private static string StrandedNames(DocumentStore store, string[] names)
+        {
+            using var session = store.OpenSession();
+            var all = session.CountersFor(DocId).GetAll();
+            return string.Join(",", names
+                .Where(n => !(all != null && all.TryGetValue(n, out var v) && v == 3))
+                .Select(n => n + "=" + (all != null && all.TryGetValue(n, out var v) ? Fmt(v) : "null"))
+                .Take(10));
+        }
+
+        private static string Fmt(long? v) => v?.ToString() ?? "null";
+    }
+}

--- a/test/SlowTests/Client/Counters/RavenDB_26766.cs
+++ b/test/SlowTests/Client/Counters/RavenDB_26766.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Tests.Infrastructure;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SlowTests.Client.Counters
 {

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB_26710.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB_26710.cs
@@ -1,0 +1,350 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Server.Documents.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.TimeSeries.Issues
+{
+    public class RavenDB_26710 : ReplicationTestBase
+    {
+        public RavenDB_26710(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const string DocId = "users/ayende";
+        private const string TsName = "Heartrate";
+
+        [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Replication)]
+        public async Task MultiValueSameTimestampConflictMustConvergeAcrossNodes()
+        {
+            const int span = 200;
+            var baseline = RavenTestHelper.UtcToday;
+            using var a = GetDocumentStore();
+            using var b = GetDocumentStore();
+
+            foreach (var store in new[] { a, b })
+            {
+                using var session = store.OpenSession();
+                session.Store(new { Name = "Oren" }, DocId);
+                session.SaveChanges();
+            }
+
+            using (var session = a.OpenSession()) // 32 values, LOW base -> wins by value-count
+            {
+                for (int t = 0; t < span; t++)
+                    session.TimeSeriesFor(DocId, TsName).Append(baseline.AddMinutes(t),
+                        Enumerable.Range(0, 32).Select(k => 1_000_000d + t + k).ToArray(), "src");
+                session.SaveChanges();
+            }
+
+            using (var session = b.OpenSession()) // 8 values, HIGH base -> must LOSE (count comes first)
+            {
+                for (int t = 0; t < span; t++)
+                    session.TimeSeriesFor(DocId, TsName).Append(baseline.AddMinutes(t),
+                        Enumerable.Range(0, 8).Select(k => 2_000_000d + t + k).ToArray(), "src");
+                session.SaveChanges();
+            }
+
+            await SetupReplicationAsync(a, b);
+            await SetupReplicationAsync(b, a);
+            EnsureReplicating(a, b);
+            EnsureReplicating(b, a);
+
+            int[] ca = null, cb = null;
+            // correct result: every timestamp keeps the 32-value entry on BOTH nodes
+            var converged = await WaitForValueAsync(() =>
+            {
+                ca = ValueCountsPerTimestamp(a);
+                cb = ValueCountsPerTimestamp(b);
+                return ca.SequenceEqual(cb) && ca.All(c => c == 32);
+            }, true);
+
+            Assert.True(converged,
+                "multi-value conflict did not converge to the count-winner. " +
+                $"A value-counts: [{string.Join(",", ca.Distinct().OrderBy(x => x))}]  " +
+                $"B value-counts: [{string.Join(",", cb.Distinct().OrderBy(x => x))}]  (expected all 32)");
+        }
+
+        [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Replication, Skip = "RavenDB-26710 no apparent data loss/inconsistency")]
+        public async Task ThreeNodesCollision_DeterministicRepro()
+        {
+            var t0 = RavenTestHelper.UtcToday;
+            using var a = GetDocumentStore();
+            using var b = GetDocumentStore();
+            using var c = GetDocumentStore();
+
+            using (var s = a.OpenSession())
+            {
+                s.Store(new { Name = "Oren" }, DocId); 
+                s.TimeSeriesFor(DocId, TsName).Append(t0.AddDays(0), new[] { 10d }, "src"); 
+                s.TimeSeriesFor(DocId, TsName).Append(t0.AddDays(24), new[] { 11d }, "src"); 
+                s.SaveChanges();
+            }
+            using (var s = b.OpenSession())
+            {
+                s.Store(new { Name = "Oren" }, DocId); 
+                s.TimeSeriesFor(DocId, TsName).Append(t0.AddDays(24), new[] { 1000d }, "src"); 
+                s.TimeSeriesFor(DocId, TsName).Append(t0.AddDays(25), new[] { 1001d }, "src"); 
+                s.SaveChanges();
+            }
+            using (var s = c.OpenSession())
+            {
+                s.Store(new { Name = "Oren" }, DocId); 
+                s.TimeSeriesFor(DocId, TsName).Append(t0.AddDays(24), new[] { 500d }, "src"); 
+                s.TimeSeriesFor(DocId, TsName).Append(t0.AddDays(25), new[] { 1001d }, "src"); 
+                s.SaveChanges();
+            }
+
+            async Task<IReplicationManager> Mgr(DocumentStore s) => await GetReplicationManagerAsync(s, s.Database, RavenDatabaseMode.Single,
+                new ReplicationManager.ReplicationOptions { BreakReplicationOnStart = true, MaxItemsCount = 100 });
+            using var mgrA = await Mgr(a);
+            using var mgrB = await Mgr(b);
+            using var mgrC = await Mgr(c);
+            await SetupReplicationAsync(b, a);
+            await SetupReplicationAsync(c, b);
+            await SetupReplicationAsync(a, c);
+
+            async Task<string> StateOf(DocumentStore dest)
+            {
+                var s = await dest.Operations.SendAsync(new GetSegmentsSummaryOperation(DocId, TsName, t0.AddMinutes(-1), t0.AddDays(40)));
+                return string.Join("|", s.Results.OrderBy(z => z.StartTime).Select(z => $"{z.StartTime.Ticks}:{z.ChangeVector}"));
+            }
+            async Task Step(IReplicationManager m, DocumentStore dest)
+            {
+                var before = await StateOf(dest);
+                m.ReplicateOnce(DocId);
+                await AssertWaitForValueAsync(async () => await StateOf(dest) != before, true, interval: 50);
+            }
+
+            await Step(mgrB, a);  // B->A: A adopts B, SPLITS into the pair (seg1[day0,day24] + seg2[day25]), sharing B, distinct owns
+            await Step(mgrC, b);  // C->B: C's @day24 loses inside B's spanning segment -> B's own climbs
+            await Step(mgrA, c);  // A->C: C captures A's pair (high own + stale B) via its spanning [day24,day25] segment
+            await Step(mgrB, a);  // B->A: B's spanning segment delivers climbed B to the pair (now differs ONLY in own)
+            await SetupReplicationAsync(c, a); // wire c->a only now (see per-database note above)
+
+            var before = await StateOf(a); // C->A: C's spanning segment collapses the pair's own -> identical CV
+            await AssertWaitForValueAsync(async () =>
+            {
+                mgrC.ReplicateOnce(DocId);
+                return await StateOf(a) != before;
+            }, true, interval: 50);
+
+            var summary = await a.Operations.SendAsync(new GetSegmentsSummaryOperation(DocId, TsName, t0.AddMinutes(-1), t0.AddDays(40)));
+            var collisions = summary.Results.GroupBy(s => s.ChangeVector).Where(g => g.Count() > 1)
+                .Select(g => $"cv shared by {g.Count()} segments at day+{string.Join(", day+", g.Select(s => $"{(int)(s.StartTime - t0).TotalDays}[{s.NumberOfLiveEntries}]"))}")
+                .ToList();
+
+            var message = $"{collisions.Count} within-node change-vector collision(s) on node A:" + Environment.NewLine +
+                          string.Join(Environment.NewLine, collisions);
+
+            Assert.True(collisions.Count == 0, message);
+        }
+
+        [RavenTheory(RavenTestCategory.TimeSeries | RavenTestCategory.Replication)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SameTimestampMustNotHaveDifferentValuesAcrossNodes(bool withDeletes)
+        {
+            var stores = await BuildConflictingMeshAsync(numberOfNodes: 3, span: 3000, withDeletes: withDeletes);
+            var divergences = await PollForFrozenValueDivergencesAsync(stores);
+            Assert.True(divergences.Count == 0, $"{divergences.Count} timestamp(s) have different values across nodes:" + Environment.NewLine +
+                                                string.Join(Environment.NewLine, divergences.Take(15)));
+        }
+
+        private async Task<DocumentStore[]> BuildConflictingMeshAsync(int numberOfNodes, int span, bool withDeletes)
+        {
+            var n = numberOfNodes;
+            var stores = new DocumentStore[n];
+            for (int i = 0; i < n; i++)
+                stores[i] = GetDocumentStore();
+
+            var baseline = RavenTestHelper.UtcToday;
+
+            for (int node = 0; node < n; node++)
+            {
+                using var session = stores[node].OpenSession();
+                session.Store(new { Name = "Oren" }, DocId);
+                for (int t = 0; t < span; t++)
+                {
+                    var minute = node + t;
+                    var arity = node == n / 2 ? 6 : 1; // a MIDDLE node wins by value-count
+                    var values = new double[arity];
+                    for (int k = 0; k < arity; k++)
+                        values[k] = node * 1_000_000d + minute + k;
+
+                    session.TimeSeriesFor(DocId, TsName).Append(baseline.AddMinutes(minute), values, "src");
+                }
+
+                session.SaveChanges();
+            }
+
+            if (withDeletes)
+            {
+                for (int node = 0; node < n; node++)
+                {
+                    using var session = stores[node].OpenSession();
+                    var start = node * 120 + 20;
+                    session.TimeSeriesFor(DocId, TsName)
+                        .Delete(baseline.AddMinutes(start), baseline.AddMinutes(start + 50));
+                    session.SaveChanges();
+                }
+            }
+
+            for (int i = 0; i < n; i++)
+                for (int j = 0; j < n; j++)
+                    if (i != j)
+                        await SetupReplicationAsync(stores[i], stores[j]);
+
+            for (int i = 0; i < n; i++)
+                for (int j = 0; j < n; j++)
+                    if (i != j)
+                        EnsureReplicating(stores[i], stores[j]);
+
+            return stores;
+        }
+
+        private static async Task<List<string>> PollForFrozenValueDivergencesAsync(DocumentStore[] stores)
+        {
+            List<string> divergences = null;
+            for (int attempt = 0; attempt < 30; attempt++)
+            {
+                divergences = ComputeValueDivergences(stores);
+                if (divergences.Count == 0)
+                    return divergences;
+
+                await Task.Delay(1000);
+            }
+
+            return divergences;
+        }
+
+        private static List<string> ComputeValueDivergences(DocumentStore[] stores)
+        {
+            var perNode = new List<Dictionary<DateTime, double[]>>();
+            foreach (var store in stores)
+            {
+                using var session = store.OpenSession();
+                perNode.Add(session.TimeSeriesFor(DocId, TsName)
+                    .Get()?
+                    .ToDictionary(e => e.Timestamp, e => e.Values) ?? new Dictionary<DateTime, double[]>());
+            }
+
+            var divergences = new List<string>();
+            foreach (var ts in perNode.SelectMany(m => m.Keys).Distinct().OrderBy(t => t))
+            {
+                var renderings = new HashSet<string>();
+                for (int i = 0; i < stores.Length; i++)
+                    renderings.Add(perNode[i].TryGetValue(ts, out var v) ? string.Join(",", v) : "<missing>");
+
+                if (renderings.Count > 1)
+                    divergences.Add($"  {ts:O}: " + string.Join(" | ", Enumerable.Range(0, stores.Length).Select(i =>
+                        $"{(char)('A' + i)}={(perNode[i].TryGetValue(ts, out var v) ? string.Join(",", v) : "<missing>")}")));
+            }
+
+            return divergences;
+        }
+
+        [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Replication)]
+        public async Task WinningValueMustNotBeStrandedByChangeVectorGate()
+        {
+            var td = RavenTestHelper.UtcToday;
+            var te = td.AddDays(40); // > ~24.85d segment window => a SEPARATE segment from td (the carrier)
+
+            using var a = GetDocumentStore();
+            using var b = GetDocumentStore();
+            using var c = GetDocumentStore();
+
+            foreach (var store in new[] { a, b, c })
+            {
+                using var session = store.OpenSession();
+                session.Store(new { Name = "Oren" }, DocId);
+                session.SaveChanges();
+            }
+
+            using (var session = a.OpenSession())
+            {
+                session.TimeSeriesFor(DocId, TsName).Append(td, new[] { 50d }, "src");
+                session.SaveChanges();
+            }
+
+            using (var session = b.OpenSession())
+            {
+                session.TimeSeriesFor(DocId, TsName).Append(td, new[] { 50d }, "src");
+                session.SaveChanges();
+            }
+
+            using (var session = c.OpenSession()) // 100 at td (must win), then 7 at te (the carrier, written AFTER td)
+            {
+                session.TimeSeriesFor(DocId, TsName).Append(td, new[] { 100d }, "src");
+                session.TimeSeriesFor(DocId, TsName).Append(te, new[] { 7d }, "src");
+                session.SaveChanges();
+            }
+
+            using var cOut = await GetReplicationManagerAsync(c, c.Database, RavenDatabaseMode.Single,
+                new ReplicationManager.ReplicationOptions { BreakReplicationOnStart = true, MaxItemsCount = 1 });
+
+            var links = new[] { (a, b), (b, a), (a, c), (b, c), (c, a), (c, b) };
+            foreach (var (from, to) in links) // full mesh; c->a, c->b are blocked by the gate, everything else flows
+                await SetupReplicationAsync(from, to);
+
+            Assert.True(await WaitForValueAsync(async () =>
+                    await CvComponentsAt(a, td) >= 2 &&   // A merged B's 50   -> {A,B}
+                    await CvComponentsAt(b, td) >= 2 &&   // B merged A's 50   -> {A,B}
+                    await CvComponentsAt(c, td) >= 3 &&   // C merged both 50s -> {A,B,C}
+                    ValueAt(c, td) == 100d, true, timeout: 30_000),
+                "phase 1 did not reach the kept-local union state on C (A=" + Fmt(ValueAt(a, td)) +
+                " B=" + Fmt(ValueAt(b, td)) + " C=" + Fmt(ValueAt(c, td)) + ")");
+
+            var carrierDelivered = await WaitForValueAsync(() =>
+            {
+                cOut.ReplicateOnce(DocId);
+                return ValueAt(a, te) == 7d && ValueAt(b, te) == 7d;
+            }, true);
+
+            Assert.True(carrierDelivered, "carrier (te=7) was not delivered to A and B");
+
+            cOut.ReplicateOnce(DocId);
+
+            cOut.Mend();
+            foreach (var (from, to) in links)
+                EnsureReplicating(from, to);
+
+            var r = await WaitForValueAsync(() => ValueAt(a, td) == 100d && ValueAt(b, td) == 100d && ValueAt(c, td) == 100d, true);
+
+            Assert.True(r, "winning value (100) was stranded on C by the change-vector send gate - permanent divergence at td: " +
+                        $"A={Fmt(ValueAt(a, td))} B={Fmt(ValueAt(b, td))} C={Fmt(ValueAt(c, td))} (expected all 100)");
+        }
+
+        private static double? ValueAt(DocumentStore store, DateTime t)
+        {
+            using var session = store.OpenSession();
+            var entry = session.TimeSeriesFor(DocId, TsName).Get()?
+                .FirstOrDefault(e => e.Timestamp == t);
+            return entry?.Values.FirstOrDefault();
+        }
+
+        private static async Task<int> CvComponentsAt(DocumentStore store, DateTime baseline)
+        {
+            var summary = await store.Operations.SendAsync(
+                new GetSegmentsSummaryOperation(DocId, TsName, baseline.AddMinutes(-1), baseline.AddMinutes(1)));
+            var cv = summary.Results?.FirstOrDefault(s => Math.Abs((s.StartTime - baseline).TotalMinutes) < 1)?.ChangeVector;
+            return cv?.Split(',').Length ?? 0;
+        }
+
+        private static string Fmt(double? v) => v?.ToString() ?? "null";
+
+        private static int[] ValueCountsPerTimestamp(DocumentStore store)
+        {
+            using var session = store.OpenSession();
+            return session.TimeSeriesFor(DocId, TsName)
+                .Get()
+                .Select(e => e.Values.Length)
+                .ToArray();
+        }
+    }
+}

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB_26710.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB_26710.cs
@@ -6,7 +6,6 @@ using Raven.Client.Documents;
 using Raven.Server.Documents.Operations;
 using Tests.Infrastructure;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SlowTests.Client.TimeSeries.Issues
 {

--- a/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
@@ -507,7 +507,7 @@ namespace SlowTests.Server.Documents.TimeSeries
                            }))
                 {
                     await SetupReplicationAsync(store1, store2);
-                    await EnsureReplicatingAsync(store1, store2);
+                    await WaitForMarkerAsync(store1, store2);
                 }
             }
         }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -24,6 +24,7 @@ using Raven.Server;
 using Raven.Server.Commercial;
 using Raven.Server.Config;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Replication;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -143,18 +144,19 @@ namespace Tests.Infrastructure
             }
         }
 
-        public async Task EnsureReplicatingAsync(IDocumentStore src, IDocumentStore dst)
+        public async Task WaitForMarkerAsync(IDocumentStore src, IDocumentStore dst)
         {
             var sharding = await Sharding.GetShardingConfigurationAsync(src);
             if (sharding == null)
             {
                 var id = "marker/" + Guid.NewGuid();
-                using (var s = src.OpenSession())
+                using (var s = src.OpenSession(src.Database))
                 {
                     s.Store(new { }, id);
                     s.SaveChanges();
                 }
-                Assert.NotNull(await WaitForDocumentToReplicateAsync<object>(dst, id, 15 * 1000));
+
+                Assert.NotNull(await WaitForDocumentToReplicateAsync<object>(dst, id, TimeSpan.FromSeconds(30)));
                 return;
             }
 
@@ -162,16 +164,81 @@ namespace Tests.Infrastructure
             {
                 var database = ShardHelper.ToShardName(src.Database, shardNumber);
                 var id = $"marker/{Guid.NewGuid()}${Sharding.GetRandomIdForShard(sharding, shardNumber)}";
-
                 using (var s = src.OpenSession(database))
                 {
                     s.Store(new { }, id);
                     s.SaveChanges();
                 }
 
-                var r = await Replication.WaitForDocumentToReplicateAsync<object>(dst, id, 30 * 1000);
-                Assert.NotNull(r);
+                Assert.NotNull(await WaitForDocumentToReplicateAsync<object>(dst, id, TimeSpan.FromSeconds(30)));
             }
+        }
+
+        public async Task EnsureReplicatingAsync(IDocumentStore src, IDocumentStore dst, RavenServer server = null)
+        {
+            var sharding = await Sharding.GetShardingConfigurationAsync(src);
+            if (sharding == null)
+            {
+                var srcDb = await Databases.GetDocumentDatabaseInstanceFor(server, src);
+                await EnsureReplicatingAndAckedAsync(srcDb, src, dst, src.Database, "marker/" + Guid.NewGuid(), timeoutMs: 15 * 1000);
+                return;
+            }
+
+            foreach (var shardNumber in sharding.Shards.Keys)
+            {
+                var srcServers = server == null ? GetServers().Where(s => src.Urls.Contains(s.WebUrl)).ToList() : [server];
+                if (srcServers.Count == 0)
+                    throw new InvalidOperationException("Source server not found, do you use a custom server?");
+
+                var database = ShardHelper.ToShardName(src.Database, shardNumber);
+                var shardDb = await Sharding.GetAnyShardDocumentDatabaseInstanceFor(database, srcServers);
+                var id = $"marker/{Guid.NewGuid()}${Sharding.GetRandomIdForShard(sharding, shardNumber)}";
+                await EnsureReplicatingAndAckedAsync(shardDb, src, dst, database, id, timeoutMs: 30 * 1000);
+            }
+        }
+
+        private async Task EnsureReplicatingAndAckedAsync(DocumentDatabase srcDb, IDocumentStore src, IDocumentStore dst, string database, string markerId, int timeoutMs)
+        {
+            long lastEtagBefore = 0;
+            using (srcDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+                lastEtagBefore = srcDb.DocumentsStorage.ReadLastEtag(ctx.Transaction.InnerTransaction);
+
+            using (var s = src.OpenSession(database))
+            {
+                s.Store(new { }, markerId);
+                s.SaveChanges();
+            }
+
+            Assert.NotNull(await WaitForDocumentToReplicateAsync<object>(dst, markerId, timeoutMs));
+            var r = await WaitForValueAsync(() => GetMinimalEtagForExternalReplication(srcDb) >= lastEtagBefore, true);
+            Assert.True(r, $"'{srcDb.Name}' did not get the replication ack from '{dst.Database}' up to etag {lastEtagBefore} (current: {GetMinimalEtagForExternalReplication(srcDb)}).");
+        }
+
+        private long GetMinimalEtagForExternalReplication(DocumentDatabase database)
+        {
+            var minEtag = long.MaxValue;
+            var server = database.ServerStore;
+            using (server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var dbRecord = server.Cluster.ReadRawDatabaseRecord(ctx, database.Name);
+                var externals = dbRecord.ExternalReplications;
+                if (externals != null)
+                {
+                    foreach (var external in externals)
+                    {
+                        if (external.Disabled)
+                            continue;
+
+                        var state = ReplicationLoader.GetExternalReplicationState(server, database.Name, external.TaskId, ctx);
+                        var myEtag = ChangeVectorUtils.GetEtagById(state.SourceChangeVector, database.DbBase64Id);
+                        minEtag = Math.Min(myEtag, minEtag);
+                    }
+                }
+            }
+
+            return minEtag;
         }
 
         protected static async Task<T> WaitForDocumentToReplicateAsync<T>(IDocumentStore store, string id, TimeSpan timeout)

--- a/test/Tests.Infrastructure/RavenTestBase.Databases.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Databases.cs
@@ -30,9 +30,19 @@ public partial class RavenTestBase
             _parent = parent ?? throw new ArgumentNullException(nameof(parent));
         }
 
-        public Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(IDocumentStore store, string database = null)
+        public async Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(IDocumentStore store, string database = null)
         {
-            return _parent.Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database ?? database));
+            var topology = record.Topology;
+            foreach (var server in _parent.GetServers())
+            {
+                if (topology.RelevantFor(server.ServerStore.NodeTag))
+                {
+                    return await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
+                }
+            }
+
+            throw new InvalidOperationException($"Could not find a suitable server for database '{database ?? store.Database}'.");
         }
 
         public Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(string node, string database)
@@ -43,6 +53,9 @@ public partial class RavenTestBase
 
         public Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(RavenServer server, IDocumentStore store, string database = null)
         {
+            if (server == null)
+                return GetDocumentDatabaseInstanceFor(store, database);
+
             return server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
         }
 

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -378,7 +378,7 @@ public partial class RavenTestBase
             {
                 foreach (var task in server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourcesStore(shardDatabase))
                 {
-                    if(await task == null)
+                    if (await task == null)
                         continue;
 
                     return task.Result;


### PR DESCRIPTION
This fix is on top of 7.2.4 version

Fixes active/active (bidirectional) replication divergence for time series and counters, where a colliding change-vector component could strand a value on one node.

- **RavenDB-26765 / RavenDB-26710 (time series):** mint a fresh CV component on the resolved segment so a within-node CV collision can't strand a winning value; plus a non-commutative-merge fix in `SelectLargestValue` (`TrimmedLength` / `CompareResult.Equal`).
- **RavenDB-26766 (counters):** mint a fresh CV component when a counter group is modified / split, so the first sub-group can't strand.
- **RavenDB-26903:** fix backup hang on cloud direct upload: opt upload I/O out of the backup thread's synchronization context.