### PR TITLE
RavenDB-26917 Quill - Customize iframe styles

### DIFF
--- a/src/Raven.AiAppliance.Web/src/api/api.ts
+++ b/src/Raven.AiAppliance.Web/src/api/api.ts
@@ -5,6 +5,7 @@ import { createAgentTestService } from "@/api/custom-services/agent-test-service
 import { createAppsQueries } from "@/api/queries/apps-queries";
 import { createAgentsQueries } from "@/api/queries/agents-queries";
 import { createChannelsQueries } from "@/api/queries/channels-queries";
+import { createWebWidgetQueries } from "@/api/queries/web-widget-queries";
 import { createEmbedLinksQueries } from "@/api/queries/embed-links-queries";
 import { createBootstrapQueries } from "@/api/queries/bootstrap-queries";
 import { createSetupQueries } from "@/api/queries/setup-queries";
@@ -22,6 +23,7 @@ export type ApiQueries = {
     apps: ReturnType<typeof createAppsQueries>;
     agents: ReturnType<typeof createAgentsQueries>;
     channels: ReturnType<typeof createChannelsQueries>;
+    webWidget: ReturnType<typeof createWebWidgetQueries>;
     embedLinks: ReturnType<typeof createEmbedLinksQueries>;
     setup: ReturnType<typeof createSetupQueries>;
     aiConnectionStrings: ReturnType<typeof createAiConnectionStringsQueries>;
@@ -52,6 +54,7 @@ export function createApi(options?: ApiClientOptions): Api {
             apps: createAppsQueries(services.apps),
             agents: createAgentsQueries(services.agents),
             channels: createChannelsQueries(services.channels),
+            webWidget: createWebWidgetQueries(services.iframe),
             embedLinks: createEmbedLinksQueries(services.embedLinks),
             setup: createSetupQueries(services.setup),
             aiConnectionStrings: createAiConnectionStringsQueries(services.aiConnectionStrings),

--- a/src/Raven.AiAppliance.Web/src/api/generated/server-api.ts
+++ b/src/Raven.AiAppliance.Web/src/api/generated/server-api.ts
@@ -293,6 +293,76 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/apps/{slug}/iframe/{widgetId}/customization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Returns a web-widget channel's own embed CSS plus the app default, for the styling editor. */
+        get: operations["iframe.getCustomization"];
+        /** @description Saves a web-widget channel's embed CSS. An empty body clears it so the channel falls back to the app default. */
+        put: operations["iframe.updateCustomization"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/apps/{slug}/iframe/default-customization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Returns the app-level default web-widget embed CSS applied to channels with no CSS of their own. */
+        get: operations["iframe.getDefaultCustomization"];
+        /** @description Saves the app-level default web-widget embed CSS. An empty body clears it. */
+        put: operations["iframe.updateDefaultCustomization"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/apps/{slug}/iframe/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Returns the inert web-widget preview document (base styles + sample bubbles) the dashboard frames to live-preview CSS edits. */
+        get: operations["iframe.preview"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/apps/{slug}/iframe/style-guide": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Returns the web-widget embed page's base CSS, used as the styling editor's starter template and "reset to default" content. */
+        get: operations["iframe.getStyleGuide"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/apps/{slug}/embed-links": {
         parameters: {
             query?: never;
@@ -1137,6 +1207,19 @@ export interface components {
             /** Format: int32 */
             embeddingsMaxConcurrentBatches?: null | number;
         };
+        IFrameCustomizationResponse: {
+            css: null | string;
+            defaultCss: null | string;
+        };
+        IFrameDefaultCustomizationResponse: {
+            css: null | string;
+        };
+        IFramePreviewResponse: {
+            html: string;
+        };
+        IFrameStyleGuideResponse: {
+            baseCss: string;
+        };
         JsonElement: unknown;
         LicensePlan: {
             slug: string;
@@ -1372,6 +1455,9 @@ export interface components {
             displayName: null | string;
             allowedOrigins: null | string[];
             enabled: null | boolean;
+        };
+        UpdateIFrameCustomizationRequest: {
+            css: null | string;
         };
         UsageGranularity: unknown;
         UsagePoint: {
@@ -2006,6 +2092,222 @@ export interface operations {
                 };
                 content: {
                     "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+        };
+    };
+    "iframe.getCustomization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+                widgetId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IFrameCustomizationResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    "iframe.updateCustomization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+                widgetId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateIFrameCustomizationRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IFrameCustomizationResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    "iframe.getDefaultCustomization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IFrameDefaultCustomizationResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    "iframe.updateDefaultCustomization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateIFrameCustomizationRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IFrameDefaultCustomizationResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    "iframe.preview": {
+        parameters: {
+            query?: {
+                title?: string;
+            };
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IFramePreviewResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    "iframe.getStyleGuide": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IFrameStyleGuideResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2915,6 +3217,10 @@ export type EmbedLinkSummaryResponse = components["schemas"]["EmbedLinkSummaryRe
 export type GoogleAIVersion = components["schemas"]["GoogleAIVersion"];
 export type GoogleSettings = components["schemas"]["GoogleSettings"];
 export type HuggingFaceSettings = components["schemas"]["HuggingFaceSettings"];
+export type IFrameCustomizationResponse = components["schemas"]["IFrameCustomizationResponse"];
+export type IFrameDefaultCustomizationResponse = components["schemas"]["IFrameDefaultCustomizationResponse"];
+export type IFramePreviewResponse = components["schemas"]["IFramePreviewResponse"];
+export type IFrameStyleGuideResponse = components["schemas"]["IFrameStyleGuideResponse"];
 export type JsonElement = components["schemas"]["JsonElement"];
 export type LicensePlan = components["schemas"]["LicensePlan"];
 export type LicenseResponse = components["schemas"]["LicenseResponse"];
@@ -2949,6 +3255,7 @@ export type TokensByAppResponse = components["schemas"]["TokensByAppResponse"];
 export type TopCapability = components["schemas"]["TopCapability"];
 export type TopTable = components["schemas"]["TopTable"];
 export type UpdateChannelRequest = components["schemas"]["UpdateChannelRequest"];
+export type UpdateIFrameCustomizationRequest = components["schemas"]["UpdateIFrameCustomizationRequest"];
 export type UsageGranularity = components["schemas"]["UsageGranularity"];
 export type UsagePoint = components["schemas"]["UsagePoint"];
 export type UsageWindow = components["schemas"]["UsageWindow"];
@@ -2994,6 +3301,14 @@ export const API_ENDPOINTS = {
         list: (slug: string) => `/apps/${encodeURIComponent(slug)}/embed-links`,
         mint: (slug: string) => `/apps/${encodeURIComponent(slug)}/embed-links`,
         revoke: (slug: string, token: string) => `/apps/${encodeURIComponent(slug)}/embed-links/${encodeURIComponent(token)}`,
+    },
+    iframe: {
+        getCustomization: (slug: string, widgetId: string) => `/apps/${encodeURIComponent(slug)}/iframe/${encodeURIComponent(widgetId)}/customization`,
+        getDefaultCustomization: (slug: string) => `/apps/${encodeURIComponent(slug)}/iframe/default-customization`,
+        getStyleGuide: (slug: string) => `/apps/${encodeURIComponent(slug)}/iframe/style-guide`,
+        preview: (slug: string) => `/apps/${encodeURIComponent(slug)}/iframe/preview`,
+        updateCustomization: (slug: string, widgetId: string) => `/apps/${encodeURIComponent(slug)}/iframe/${encodeURIComponent(widgetId)}/customization`,
+        updateDefaultCustomization: (slug: string) => `/apps/${encodeURIComponent(slug)}/iframe/default-customization`,
     },
     settings: {
         license: "/settings/license",
@@ -3064,6 +3379,14 @@ export function createServerApi(client: ApiClient) {
             list: (slug: string) => client.get<EmbedLinkSummaryResponse[], ApiErrorResponse>(API_ENDPOINTS.embedLinks.list(slug)),
             mint: (slug: string, request: MintEmbedLinkRequest) => client.post<MintEmbedLinkResponse, ApiErrorResponse>(API_ENDPOINTS.embedLinks.mint(slug), request),
             revoke: (slug: string, token: string) => client.delete<void, ApiErrorResponse>(API_ENDPOINTS.embedLinks.revoke(slug, token)),
+        },
+        iframe: {
+            getCustomization: (slug: string, widgetId: string) => client.get<IFrameCustomizationResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.getCustomization(slug, widgetId)),
+            getDefaultCustomization: (slug: string) => client.get<IFrameDefaultCustomizationResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.getDefaultCustomization(slug)),
+            getStyleGuide: (slug: string) => client.get<IFrameStyleGuideResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.getStyleGuide(slug)),
+            preview: (slug: string, searchParams?: { title?: string; }) => client.get<IFramePreviewResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.preview(slug), { searchParams }),
+            updateCustomization: (slug: string, widgetId: string, request: UpdateIFrameCustomizationRequest) => client.put<IFrameCustomizationResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.updateCustomization(slug, widgetId), request),
+            updateDefaultCustomization: (slug: string, request: UpdateIFrameCustomizationRequest) => client.put<IFrameDefaultCustomizationResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.updateDefaultCustomization(slug), request),
         },
         settings: {
             license: (searchParams?: { demoState?: string; }) => client.get<LicenseResponse>(API_ENDPOINTS.settings.license, { searchParams }),

--- a/src/Raven.AiAppliance.Web/src/api/queries/web-widget-queries.ts
+++ b/src/Raven.AiAppliance.Web/src/api/queries/web-widget-queries.ts
@@ -1,0 +1,31 @@
+import { queryOptions } from "@tanstack/react-query";
+import type { ServerApi } from "@/api/generated/server-api";
+
+const baseKey = "web-widget";
+
+export function createWebWidgetQueries(api: ServerApi["iframe"]) {
+    return {
+        customization: (slug: string, widgetId: string) =>
+            queryOptions({
+                queryKey: [baseKey, "customization", slug, widgetId],
+                queryFn: () => api.getCustomization(slug, widgetId),
+            }),
+        defaultCustomization: (slug: string) =>
+            queryOptions({
+                queryKey: [baseKey, "default-customization", slug],
+                queryFn: () => api.getDefaultCustomization(slug),
+            }),
+        preview: (slug: string, title?: string) =>
+            queryOptions({
+                queryKey: [baseKey, "preview", slug, title ?? ""],
+                queryFn: () => api.preview(slug, title ? { title } : undefined),
+            }),
+        styleGuide: (slug: string) =>
+            queryOptions({
+                queryKey: [baseKey, "style-guide", slug],
+                queryFn: () => api.getStyleGuide(slug),
+            }),
+    };
+}
+
+export type WebWidgetQueries = ReturnType<typeof createWebWidgetQueries>;

--- a/src/Raven.AiAppliance.Web/src/api/queries/web-widget-queries.ts
+++ b/src/Raven.AiAppliance.Web/src/api/queries/web-widget-queries.ts
@@ -3,11 +3,16 @@ import type { ServerApi } from "@/api/generated/server-api";
 
 const baseKey = "web-widget";
 
+// Prefix matching every web widget's customization in an app. `customization` is built from it so
+// the two can't drift, letting a default-styles save invalidate all channels at once (see below).
+const customizationsKey = (slug: string) => [baseKey, "customization", slug];
+
 export function createWebWidgetQueries(api: ServerApi["iframe"]) {
     return {
+        customizationsKey,
         customization: (slug: string, widgetId: string) =>
             queryOptions({
-                queryKey: [baseKey, "customization", slug, widgetId],
+                queryKey: [...customizationsKey(slug), widgetId],
                 queryFn: () => api.getCustomization(slug, widgetId),
             }),
         defaultCustomization: (slug: string) =>

--- a/src/Raven.AiAppliance.Web/src/components/ace-editor/ace-editor-action-utils.ts
+++ b/src/Raven.AiAppliance.Web/src/components/ace-editor/ace-editor-action-utils.ts
@@ -3,13 +3,26 @@ import type { Ace } from "ace-builds";
 import ace from "ace-builds/src-noconflict/ace";
 import type ReactAce from "react-ace";
 import "ace-builds/src-noconflict/ext-beautify";
+import "ace-builds/src-noconflict/mode-css";
 import { ACE_EDITOR_LINE_HEIGHT_IN_PX } from "@/components/ace-editor/ace-editor-constants";
 
 type BeautifyModule = {
     beautify: (session: Ace.EditSession) => void;
 };
 
+type CssModeModule = {
+    Mode: new () => Ace.SyntaxMode;
+};
+
 const beautify = ace.require("ace/ext/beautify") as BeautifyModule;
+const cssMode = ace.require("ace/mode/css") as CssModeModule;
+
+// Beautify a CSS string without a live editor, e.g. to pre-format server CSS before it fills the form.
+export function formatCss(css: string): string {
+    const session = ace.createEditSession(css, new cssMode.Mode());
+    beautify.beautify(session);
+    return session.getValue();
+}
 
 export function handleFormat(reactAce: RefObject<ReactAce | null>) {
     const session = reactAce.current?.editor.session;

--- a/src/Raven.AiAppliance.Web/src/components/form/form-ace-editor.tsx
+++ b/src/Raven.AiAppliance.Web/src/components/form/form-ace-editor.tsx
@@ -11,6 +11,7 @@ type FormAceEditorProps<TFieldValues extends FieldValues, TName extends FieldPat
         description?: ReactNode;
         editorName?: string;
         label?: ReactNode;
+        labelClassName?: string;
     };
 
 export function FormAceEditor<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>({
@@ -26,6 +27,7 @@ export function FormAceEditor<TFieldValues extends FieldValues, TName extends Fi
     readOnly,
     rules,
     shouldUnregister,
+    labelClassName,
     ...props
 }: FormAceEditorProps<TFieldValues, TName>) {
     const generatedId = useId();
@@ -45,7 +47,9 @@ export function FormAceEditor<TFieldValues extends FieldValues, TName extends Fi
 
     return (
         <Field className={className} data-invalid={invalid}>
-            <FieldLabel htmlFor={inputId}>{label}</FieldLabel>
+            <FieldLabel htmlFor={inputId} className={labelClassName}>
+                {label}
+            </FieldLabel>
             <AceEditor
                 aria-invalid={invalid}
                 mode={mode}

--- a/src/Raven.AiAppliance.Web/src/mocks/default-mocks.ts
+++ b/src/Raven.AiAppliance.Web/src/mocks/default-mocks.ts
@@ -7,6 +7,7 @@ import { bootstrapMocks } from "./bootstrap-mocks";
 import { channelsMocks } from "./channels-mocks";
 import { chatMocks } from "./chat-mocks";
 import { embedLinksMocks } from "./embed-links-mocks";
+import { iframeHandlers } from "./iframe-mocks";
 import { settingsMocks } from "./settings-mocks";
 import { setupMocks } from "./setup-mocks";
 import { statsMocks } from "./stats-mocks";
@@ -43,6 +44,7 @@ export const defaultApiMocks = {
     channels: [channelsMocks.list(), channelsMocks.create(), channelsMocks.update(), channelsMocks.delete()],
     chat: [chatMocks.stream()],
     embedLinks: [embedLinksMocks.list(), embedLinksMocks.mint(), embedLinksMocks.revoke()],
+    iframe: iframeHandlers(),
     settings: [settingsMocks.license(), settingsMocks.usage()],
     stats: [
         statsMocks.dashboard(),

--- a/src/Raven.AiAppliance.Web/src/mocks/iframe-mocks.ts
+++ b/src/Raven.AiAppliance.Web/src/mocks/iframe-mocks.ts
@@ -1,0 +1,119 @@
+import type {
+    IFrameCustomizationResponse,
+    IFrameDefaultCustomizationResponse,
+    IFramePreviewResponse,
+    IFrameStyleGuideResponse,
+} from "@/api/generated/server-api";
+import { apiHttp } from "./api-http";
+
+// The widget's base stylesheet as the server ships it (see EmbedEndpoints.WidgetBaseCss): the
+// generated :root variables followed by the layout rules, rule bodies on single lines. The editor
+// formats this on load, so keeping it unformatted here mirrors the real payload.
+export const SAMPLE_WIDGET_BASE_CSS = `:root {
+  --ai-bg: #ffffff;
+  --ai-fg: #0f172a;
+  --ai-border-color: #e2e8f0;
+  --ai-bubble-agent-bg: #f1f5f9;
+  --ai-user-bg: #2563eb;
+  --ai-user-fg: #ffffff;
+  --ai-input-border-color: #cbd5e1;
+  --ai-radius-bubble: 12px;
+  --ai-radius-control: 8px;
+  --ai-font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; background: var(--ai-bg); color: var(--ai-fg); font-family: var(--ai-font-family); }
+  #ai-chat { display: flex; flex-direction: column; height: 100%; }
+  #ai-chat-header { padding: 12px 16px; font-weight: 600; border-bottom: 1px solid var(--ai-border-color); }
+  #ai-chat-feed { flex: 1; overflow-y: auto; padding: 12px 16px; }
+  .row { margin: 6px 0; padding: 8px 12px; border-radius: var(--ai-radius-bubble); max-width: 80%; white-space: pre-wrap; }
+  .row.user { background: var(--ai-user-bg); color: var(--ai-user-fg); margin-left: auto; }
+  .row.agent { background: var(--ai-bubble-agent-bg); }
+  #ai-chat-form { display: flex; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--ai-border-color); }
+  #ai-chat-input { flex: 1; padding: 10px 12px; border: 1px solid var(--ai-input-border-color); border-radius: var(--ai-radius-control); font-size: 14px; }
+  #ai-chat-form button { padding: 10px 16px; border: 0; border-radius: var(--ai-radius-control); background: var(--ai-user-bg); color: var(--ai-user-fg); cursor: pointer; }`;
+
+// A saved channel customization, formatted the way an operator leaves it after editing.
+export const SAMPLE_CUSTOM_CSS = `:root {
+    --ai-user-bg: #16a34a;
+    --ai-radius-bubble: 4px;
+}
+#ai-chat-header {
+    background: #16a34a;
+    color: #ffffff;
+}`;
+
+// The app-level default a channel inherits when it has no CSS of its own.
+export const SAMPLE_DEFAULT_CSS = `:root {
+    --ai-user-bg: #7c3aed;
+    --ai-font-family: Georgia, "Times New Roman", serif;
+}`;
+
+// The inert preview document the dashboard frames (see EmbedEndpoints.PreviewHtmlTemplate): base
+// styles, an empty raven-custom slot the editor fills as the operator types, and sample bubbles.
+const SAMPLE_PREVIEW_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Website widget</title>
+<style>
+${SAMPLE_WIDGET_BASE_CSS}
+</style>
+<style id="raven-custom"></style>
+</head>
+<body>
+<div id="ai-chat">
+  <div id="ai-chat-header">Website widget</div>
+  <div id="ai-chat-feed">
+    <div class="row agent">Hi! I'm your AI assistant. How can I help you today?</div>
+    <div class="row user">What can you do?</div>
+    <div class="row agent">I can answer questions about your data and help you get things done — just ask.</div>
+  </div>
+  <form id="ai-chat-form" onsubmit="return false">
+    <input id="ai-chat-input" autocomplete="off" placeholder="Ask a question..." aria-label="Ask a question">
+    <button type="submit">Send</button>
+  </form>
+</div>
+</body>
+</html>`;
+
+export const iframeMocks = {
+    getCustomization: (
+        customization: IFrameCustomizationResponse = { css: SAMPLE_CUSTOM_CSS, defaultCss: SAMPLE_DEFAULT_CSS },
+    ) =>
+        apiHttp.get("/api/apps/{slug}/iframe/{widgetId}/customization", ({ response }) =>
+            response(200).json(customization),
+        ),
+    updateCustomization: (defaultCss: string | null = SAMPLE_DEFAULT_CSS) =>
+        apiHttp.put("/api/apps/{slug}/iframe/{widgetId}/customization", async ({ request, response }) => {
+            const body = await request.json();
+            return response(200).json({ css: body.css, defaultCss });
+        }),
+    getDefaultCustomization: (defaultCustomization: IFrameDefaultCustomizationResponse = { css: null }) =>
+        apiHttp.get("/api/apps/{slug}/iframe/default-customization", ({ response }) =>
+            response(200).json(defaultCustomization),
+        ),
+    updateDefaultCustomization: () =>
+        apiHttp.put("/api/apps/{slug}/iframe/default-customization", async ({ request, response }) => {
+            const body = await request.json();
+            return response(200).json({ css: body.css });
+        }),
+    preview: (preview: IFramePreviewResponse = { html: SAMPLE_PREVIEW_HTML }) =>
+        apiHttp.get("/api/apps/{slug}/iframe/preview", ({ response }) => response(200).json(preview)),
+    styleGuide: (styleGuide: IFrameStyleGuideResponse = { baseCss: SAMPLE_WIDGET_BASE_CSS }) =>
+        apiHttp.get("/api/apps/{slug}/iframe/style-guide", ({ response }) => response(200).json(styleGuide)),
+};
+
+// Happy-path handlers for every iframe endpoint (the story default). Because a story override
+// replaces the whole `iframe` array, spread this after a single overriding handler to change one
+// endpoint while keeping the rest — the override comes first, so it wins MSW's first-match.
+export function iframeHandlers() {
+    return [
+        iframeMocks.getCustomization(),
+        iframeMocks.updateCustomization(),
+        iframeMocks.getDefaultCustomization(),
+        iframeMocks.updateDefaultCustomization(),
+        iframeMocks.preview(),
+        iframeMocks.styleGuide(),
+    ];
+}

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-channel-detail.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-channel-detail.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Palette } from "lucide-react";
 import { Link, useParams } from "react-router";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
@@ -52,19 +52,34 @@ export function AppChannelDetail() {
                 {channelsQuery.data &&
                     (channel ? (
                         <div className="grid gap-5">
-                            <div className="grid gap-1">
-                                <div className="flex items-center gap-3">
-                                    <h2 className="text-lg font-semibold">{channel.displayName}</h2>
-                                    <StatusIndicator
-                                        tone={channel.enabled ? "positive" : "muted"}
-                                        label={channel.enabled ? "Connected" : "Disabled"}
-                                    />
+                            <div className="flex items-start justify-between gap-4">
+                                <div className="grid gap-1">
+                                    <div className="flex items-center gap-3">
+                                        <h2 className="text-lg font-semibold">{channel.displayName}</h2>
+                                        <StatusIndicator
+                                            tone={channel.enabled ? "positive" : "muted"}
+                                            label={channel.enabled ? "Connected" : "Disabled"}
+                                        />
+                                    </div>
+                                    <p className="text-sm text-muted-foreground">
+                                        {channel.type ? CHANNEL_TYPE_LABELS[channel.type] : "—"}
+                                        {agent?.name ? ` · ${agent.name}` : ""}
+                                        <span className="font-mono"> · {channel.widgetId}</span>
+                                    </p>
                                 </div>
-                                <p className="text-sm text-muted-foreground">
-                                    {channel.type ? CHANNEL_TYPE_LABELS[channel.type] : "—"}
-                                    {agent?.name ? ` · ${agent.name}` : ""}
-                                    <span className="font-mono"> · {channel.widgetId}</span>
-                                </p>
+                                {isIFrame && (
+                                    <Button asChild variant="outline" size="sm" className="shrink-0">
+                                        <Link
+                                            to={appRoutes.app(
+                                                slug,
+                                                `web-widget/${encodeURIComponent(channel.widgetId)}/customize`,
+                                            )}
+                                        >
+                                            <Palette aria-hidden="true" />
+                                            Customize appearance
+                                        </Link>
+                                    </Button>
+                                )}
                             </div>
 
                             {isIFrame ? (

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-channels.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-channels.tsx
@@ -1,6 +1,9 @@
-import { useParams } from "react-router";
+import { Palette } from "lucide-react";
+import { Link, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
+import { Button } from "@/components/shadcn/ui/button";
+import { appRoutes } from "@/lib/app-routes";
 import { DashboardStatCards, type DashboardStatCard } from "@/pages/dashboard/dashboard-stat-cards";
 import { AddChannelMenu } from "@/pages/apps/channels/add-channel-menu";
 import { ChannelGroups } from "@/pages/apps/channel-groups";
@@ -20,7 +23,15 @@ export function AppChannels() {
                 <p className="max-w-prose text-sm text-muted-foreground">
                     Channels are the surfaces end users reach your agents through.
                 </p>
-                <AddChannelMenu slug={slug} label="New channel" />
+                <div className="flex shrink-0 items-center gap-2">
+                    <Button asChild variant="outline">
+                        <Link to={appRoutes.app(slug, "web-widget/default-customize")}>
+                            <Palette aria-hidden="true" />
+                            Edit default appearance
+                        </Link>
+                    </Button>
+                    <AddChannelMenu slug={slug} label="New channel" />
+                </div>
             </div>
             <DashboardStatCards cards={cards} />
             <ChannelGroups slug={slug} />

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-channels.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-channels.tsx
@@ -1,9 +1,6 @@
-import { Palette } from "lucide-react";
-import { Link, useParams } from "react-router";
+import { useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
-import { Button } from "@/components/shadcn/ui/button";
-import { appRoutes } from "@/lib/app-routes";
 import { DashboardStatCards, type DashboardStatCard } from "@/pages/dashboard/dashboard-stat-cards";
 import { AddChannelMenu } from "@/pages/apps/channels/add-channel-menu";
 import { ChannelGroups } from "@/pages/apps/channel-groups";
@@ -23,15 +20,7 @@ export function AppChannels() {
                 <p className="max-w-prose text-sm text-muted-foreground">
                     Channels are the surfaces end users reach your agents through.
                 </p>
-                <div className="flex shrink-0 items-center gap-2">
-                    <Button asChild variant="outline">
-                        <Link to={appRoutes.app(slug, "web-widget/default-customize")}>
-                            <Palette aria-hidden="true" />
-                            Edit default appearance
-                        </Link>
-                    </Button>
-                    <AddChannelMenu slug={slug} label="New channel" />
-                </div>
+                <AddChannelMenu slug={slug} label="New channel" />
             </div>
             <DashboardStatCards cards={cards} />
             <ChannelGroups slug={slug} />

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-usage.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-usage.tsx
@@ -20,7 +20,7 @@ const getDefaultRange = (): DateRange => {
     return { from: subDays(today, 6), to: today };
 };
 
-// The endpoint binds start/end as DateTime, so send the full inclusive span of the picked days.
+// The endpoint accepts ISO start/end query strings and parses them as UTC; send the full inclusive span of the picked days
 function toApiRange(range: DateRange | undefined) {
     if (!range?.from) {
         return undefined;

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.stories.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SAMPLE_WEB_WIDGET_ID } from "@/mocks/channels-mocks";
+import { iframeHandlers, iframeMocks, SAMPLE_DEFAULT_CSS } from "@/mocks/iframe-mocks";
+import { AppWebWidgetCustomize } from "./app-web-widget-customize";
+
+const meta = {
+    title: "Apps/Web widget appearance",
+    component: AppWebWidgetCustomize,
+    parameters: {
+        page: { title: "Web widget appearance" },
+        router: {
+            initialPath: `/apps/demo/web-widget/${SAMPLE_WEB_WIDGET_ID}/customize`,
+            path: "/apps/:slug/web-widget/:widgetId/customize",
+        },
+    },
+} satisfies Meta<typeof AppWebWidgetCustomize>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The widget has its own saved CSS layered over the app default; "Reset to default" restores the default.
+export const Default: Story = {};
+
+// The widget inherits the app default (no CSS of its own): the editor pre-fills with the
+// formatted app default and "Reset to default" is disabled because the content is the default.
+export const InheritsAppDefault: Story = {
+    parameters: {
+        msw: {
+            handlers: {
+                iframe: [
+                    iframeMocks.getCustomization({ css: null, defaultCss: SAMPLE_DEFAULT_CSS }),
+                    ...iframeHandlers(),
+                ],
+            },
+        },
+    },
+};
+
+// The widgetId in the URL isn't a web widget in this app — the page shows a not-found alert.
+export const UnknownWidget: Story = {
+    parameters: {
+        router: {
+            initialPath: "/apps/demo/web-widget/wgt_unknown/customize",
+            path: "/apps/:slug/web-widget/:widgetId/customize",
+        },
+    },
+};

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.stories.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.stories.tsx
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 // The widget inherits the app default (no CSS of its own): the editor pre-fills with the
-// formatted app default and "Reset to default" is disabled because the content is the default.
+// formatted app default, which "Reset to default" restores.
 export const InheritsAppDefault: Story = {
     parameters: {
         msw: {

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.tsx
@@ -1,36 +1,38 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { Link, useParams } from "react-router";
-import { toast } from "sonner";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { appRoutes } from "@/lib/app-routes";
+import { useWebWidgetStyleSave } from "@/pages/apps/channels/use-web-widget-style-save";
 import { WebWidgetStyleEditor } from "@/pages/apps/channels/web-widget-style-editor";
 
 export function AppWebWidgetCustomize() {
     const { slug = "", widgetId = "" } = useParams();
-    const queryClient = useQueryClient();
 
     const channelsQuery = useQuery(api.queries.channels.list(slug));
     const channel = channelsQuery.data?.find((candidate) => candidate.widgetId === widgetId);
+    // Only an existing web widget has customization to load. Gate the widget-scoped queries on the
+    // channel so an unknown/non-iFrame widgetId (which the endpoint 404s) resolves to the not-found
+    // alert below instead of a generic "could not load" error from a request bound to fail.
+    const hasChannel = Boolean(channel);
 
-    const customizationQuery = useQuery(api.queries.webWidget.customization(slug, widgetId));
-    const styleGuideQuery = useQuery(api.queries.webWidget.styleGuide(slug));
+    const customizationQuery = useQuery({
+        ...api.queries.webWidget.customization(slug, widgetId),
+        enabled: hasChannel,
+    });
+    const styleGuideQuery = useQuery({ ...api.queries.webWidget.styleGuide(slug), enabled: hasChannel });
     // Fetch the preview once we know the widget name so its header matches the live widget.
     const previewQuery = useQuery({
         ...api.queries.webWidget.preview(slug, channel?.displayName),
-        enabled: Boolean(channel),
+        enabled: hasChannel,
     });
 
-    const saveMutation = useMutation({
-        mutationFn: (css: string) => api.services.iframe.updateCustomization(slug, widgetId, { css: css || null }),
-        onSuccess: async () => {
-            await queryClient.invalidateQueries({
-                queryKey: api.queries.webWidget.customization(slug, widgetId).queryKey,
-            });
-            toast.success("Customization saved");
-        },
+    const saveMutation = useWebWidgetStyleSave({
+        save: (css) => api.services.iframe.updateCustomization(slug, widgetId, { css }),
+        invalidateKey: api.queries.webWidget.customization(slug, widgetId).queryKey,
+        successMessage: "Customization saved",
     });
 
     const onRetry = async () => {
@@ -50,7 +52,9 @@ export function AppWebWidgetCustomize() {
             </Link>
 
             <ApiState
-                isLoading={channelsQuery.isPending || customizationQuery.isPending || styleGuideQuery.isPending}
+                isLoading={
+                    channelsQuery.isPending || (hasChannel && (customizationQuery.isPending || styleGuideQuery.isPending))
+                }
                 isError={channelsQuery.isError || customizationQuery.isError || styleGuideQuery.isError}
                 errorTitle="Could not load customization"
                 onRetry={onRetry}

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.tsx
@@ -13,20 +13,20 @@ export function AppWebWidgetCustomize() {
 
     const channelsQuery = useQuery(api.queries.channels.list(slug));
     const channel = channelsQuery.data?.find((candidate) => candidate.widgetId === widgetId);
-    // Only an existing web widget has customization to load. Gate the widget-scoped queries on the
-    // channel so an unknown/non-iFrame widgetId (which the endpoint 404s) resolves to the not-found
-    // alert below instead of a generic "could not load" error from a request bound to fail.
-    const hasChannel = Boolean(channel);
+    // Customization is web-widget-only, and the widget-scoped endpoints 404 for anything else. Gate the
+    // widget-scoped queries on the channel being an iFrame so an unknown or non-iFrame widgetId resolves
+    // to the not-found alert below instead of a generic "could not load" error from a request bound to fail.
+    const isWebWidget = channel?.type === "IFrame";
 
     const customizationQuery = useQuery({
         ...api.queries.webWidget.customization(slug, widgetId),
-        enabled: hasChannel,
+        enabled: isWebWidget,
     });
-    const styleGuideQuery = useQuery({ ...api.queries.webWidget.styleGuide(slug), enabled: hasChannel });
+    const styleGuideQuery = useQuery({ ...api.queries.webWidget.styleGuide(slug), enabled: isWebWidget });
     // Fetch the preview once we know the widget name so its header matches the live widget.
     const previewQuery = useQuery({
         ...api.queries.webWidget.preview(slug, channel?.displayName),
-        enabled: hasChannel,
+        enabled: isWebWidget,
     });
 
     const saveMutation = useWebWidgetStyleSave({
@@ -39,6 +39,7 @@ export function AppWebWidgetCustomize() {
         if (channelsQuery.isError) await channelsQuery.refetch();
         if (customizationQuery.isError) await customizationQuery.refetch();
         if (styleGuideQuery.isError) await styleGuideQuery.refetch();
+        if (previewQuery.isError) await previewQuery.refetch();
     };
 
     return (
@@ -53,14 +54,21 @@ export function AppWebWidgetCustomize() {
 
             <ApiState
                 isLoading={
-                    channelsQuery.isPending || (hasChannel && (customizationQuery.isPending || styleGuideQuery.isPending))
+                    channelsQuery.isPending ||
+                    (isWebWidget &&
+                        (customizationQuery.isPending || styleGuideQuery.isPending || previewQuery.isPending))
                 }
-                isError={channelsQuery.isError || customizationQuery.isError || styleGuideQuery.isError}
+                isError={
+                    channelsQuery.isError ||
+                    customizationQuery.isError ||
+                    styleGuideQuery.isError ||
+                    previewQuery.isError
+                }
                 errorTitle="Could not load customization"
                 onRetry={onRetry}
                 loadingLabel="Loading customization..."
             >
-                {!channel ? (
+                {!isWebWidget ? (
                     <Alert variant="destructive">No web widget “{widgetId}” in this app.</Alert>
                 ) : (
                     <>

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.tsx
@@ -1,0 +1,95 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft } from "lucide-react";
+import { Link, useParams } from "react-router";
+import { toast } from "sonner";
+import { api } from "@/api/api";
+import { ApiState } from "@/components/data/api-state";
+import { Alert } from "@/components/shadcn/ui/alert";
+import { appRoutes } from "@/lib/app-routes";
+import { WebWidgetStyleEditor } from "@/pages/apps/channels/web-widget-style-editor";
+
+export function AppWebWidgetCustomize() {
+    const { slug = "", widgetId = "" } = useParams();
+    const queryClient = useQueryClient();
+
+    const channelsQuery = useQuery(api.queries.channels.list(slug));
+    const channel = channelsQuery.data?.find((candidate) => candidate.widgetId === widgetId);
+
+    const customizationQuery = useQuery(api.queries.webWidget.customization(slug, widgetId));
+    const styleGuideQuery = useQuery(api.queries.webWidget.styleGuide(slug));
+    // Fetch the preview once we know the widget name so its header matches the live widget.
+    const previewQuery = useQuery({
+        ...api.queries.webWidget.preview(slug, channel?.displayName),
+        enabled: Boolean(channel),
+    });
+
+    const saveMutation = useMutation({
+        mutationFn: (css: string) => api.services.iframe.updateCustomization(slug, widgetId, { css: css || null }),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: api.queries.webWidget.customization(slug, widgetId).queryKey,
+            });
+            toast.success("Customization saved");
+        },
+    });
+
+    const onRetry = async () => {
+        if (channelsQuery.isError) await channelsQuery.refetch();
+        if (customizationQuery.isError) await customizationQuery.refetch();
+        if (styleGuideQuery.isError) await styleGuideQuery.refetch();
+    };
+
+    return (
+        <div className="grid gap-5">
+            <Link
+                to={appRoutes.app(slug, `channels/${encodeURIComponent(widgetId)}`)}
+                className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+                <ArrowLeft className="size-3.5" aria-hidden="true" />
+                Back to channel
+            </Link>
+
+            <ApiState
+                isLoading={channelsQuery.isPending || customizationQuery.isPending || styleGuideQuery.isPending}
+                isError={channelsQuery.isError || customizationQuery.isError || styleGuideQuery.isError}
+                errorTitle="Could not load customization"
+                onRetry={onRetry}
+                loadingLabel="Loading customization..."
+            >
+                {!channel ? (
+                    <Alert variant="destructive">No web widget “{widgetId}” in this app.</Alert>
+                ) : (
+                    <>
+                        <div className="grid gap-1">
+                            <h2 className="text-lg font-semibold">{channel.displayName}</h2>
+                            <p className="text-sm text-muted-foreground">
+                                Custom styles apply to this web widget&rsquo;s embed page. The editor below starts
+                                pre-filled with the effective styles — edit and save to override them, or clear it to
+                                fall back to the app default.
+                            </p>
+                        </div>
+
+                        {customizationQuery.data && styleGuideQuery.data && (
+                            <WebWidgetStyleEditor
+                                initialCss={customizationQuery.data.css ?? ""}
+                                defaultCss={customizationQuery.data.defaultCss ?? ""}
+                                baseCss={styleGuideQuery.data.baseCss}
+                                previewHtml={previewQuery.data?.html ?? ""}
+                                isSaving={saveMutation.isPending}
+                                onSave={(css) => saveMutation.mutate(css)}
+                            />
+                        )}
+
+                        {saveMutation.isError && (
+                            <Alert variant="destructive">
+                                {saveMutation.error instanceof Error
+                                    ? saveMutation.error.message
+                                    : "Could not save customization."}
+                            </Alert>
+                        )}
+                    </>
+                )}
+            </ApiState>
+        </div>
+    );
+}

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-customize.tsx
@@ -31,7 +31,7 @@ export function AppWebWidgetCustomize() {
 
     const saveMutation = useWebWidgetStyleSave({
         save: (css) => api.services.iframe.updateCustomization(slug, widgetId, { css }),
-        invalidateKey: api.queries.webWidget.customization(slug, widgetId).queryKey,
+        invalidateKeys: [api.queries.webWidget.customization(slug, widgetId).queryKey],
         successMessage: "Customization saved",
     });
 

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.stories.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.stories.tsx
@@ -19,7 +19,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // No default saved yet (the common first visit): the editor pre-fills with the widget's
-// formatted base styles and "Reset to default" is disabled because the content is the default.
+// formatted base styles, which "Reset to default" restores.
 export const Default: Story = {};
 
 // A default has been saved: the editor shows it and "Reset to default" restores the base styles.

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.stories.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { iframeHandlers, iframeMocks, SAMPLE_DEFAULT_CSS } from "@/mocks/iframe-mocks";
+import { AppWebWidgetDefaultCustomize } from "./app-web-widget-default-customize";
+
+const meta = {
+    title: "Apps/Default web widget appearance",
+    component: AppWebWidgetDefaultCustomize,
+    parameters: {
+        page: { title: "Default web widget appearance" },
+        router: {
+            initialPath: "/apps/demo/web-widget/default-customize",
+            path: "/apps/:slug/web-widget/default-customize",
+        },
+    },
+} satisfies Meta<typeof AppWebWidgetDefaultCustomize>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// No default saved yet (the common first visit): the editor pre-fills with the widget's
+// formatted base styles and "Reset to default" is disabled because the content is the default.
+export const Default: Story = {};
+
+// A default has been saved: the editor shows it and "Reset to default" restores the base styles.
+export const WithSavedCss: Story = {
+    parameters: {
+        msw: {
+            handlers: {
+                iframe: [iframeMocks.getDefaultCustomization({ css: SAMPLE_DEFAULT_CSS }), ...iframeHandlers()],
+            },
+        },
+    },
+};

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.tsx
@@ -17,7 +17,12 @@ export function AppWebWidgetDefaultCustomize() {
 
     const saveMutation = useWebWidgetStyleSave({
         save: (css) => api.services.iframe.updateDefaultCustomization(slug, { css }),
-        invalidateKey: api.queries.webWidget.defaultCustomization(slug).queryKey,
+        invalidateKeys: [
+            api.queries.webWidget.defaultCustomization(slug).queryKey,
+            // Each channel's customization embeds this default as its fallback (defaultCss), so the
+            // saved default must also refresh their cached customizations, not just this page's query.
+            api.queries.webWidget.customizationsKey(slug),
+        ],
         successMessage: "Default styles saved",
     });
 

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.tsx
@@ -1,0 +1,76 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft } from "lucide-react";
+import { Link, useParams } from "react-router";
+import { toast } from "sonner";
+import { api } from "@/api/api";
+import { ApiState } from "@/components/data/api-state";
+import { Alert } from "@/components/shadcn/ui/alert";
+import { appRoutes } from "@/lib/app-routes";
+import { WebWidgetStyleEditor } from "@/pages/apps/channels/web-widget-style-editor";
+
+export function AppWebWidgetDefaultCustomize() {
+    const { slug = "" } = useParams();
+    const queryClient = useQueryClient();
+
+    const defaultQuery = useQuery(api.queries.webWidget.defaultCustomization(slug));
+    const styleGuideQuery = useQuery(api.queries.webWidget.styleGuide(slug));
+    const previewQuery = useQuery(api.queries.webWidget.preview(slug));
+
+    const saveMutation = useMutation({
+        mutationFn: (css: string) => api.services.iframe.updateDefaultCustomization(slug, { css: css || null }),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: api.queries.webWidget.defaultCustomization(slug).queryKey,
+            });
+            toast.success("Default styles saved");
+        },
+    });
+
+    const onRetry = async () => {
+        if (defaultQuery.isError) await defaultQuery.refetch();
+        if (styleGuideQuery.isError) await styleGuideQuery.refetch();
+    };
+
+    return (
+        <div className="grid gap-5">
+            <Link
+                to={appRoutes.app(slug, "channels")}
+                className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+                <ArrowLeft className="size-3.5" aria-hidden="true" />
+                Back to channels
+            </Link>
+
+            <ApiState
+                isLoading={defaultQuery.isPending || styleGuideQuery.isPending}
+                isError={defaultQuery.isError || styleGuideQuery.isError}
+                errorTitle="Could not load default styles"
+                onRetry={onRetry}
+                loadingLabel="Loading default styles..."
+            >
+                <p className="text-sm text-muted-foreground">
+                    These styles apply to every web widget that has no styles of its own. The editor below starts
+                    pre-filled with the widget&rsquo;s base styles as a starting point.
+                </p>
+
+                {defaultQuery.data && styleGuideQuery.data && (
+                    <WebWidgetStyleEditor
+                        initialCss={defaultQuery.data.css ?? ""}
+                        baseCss={styleGuideQuery.data.baseCss}
+                        previewHtml={previewQuery.data?.html ?? ""}
+                        isSaving={saveMutation.isPending}
+                        onSave={(css) => saveMutation.mutate(css)}
+                    />
+                )}
+
+                {saveMutation.isError && (
+                    <Alert variant="destructive">
+                        {saveMutation.error instanceof Error
+                            ? saveMutation.error.message
+                            : "Could not save default styles."}
+                    </Alert>
+                )}
+            </ApiState>
+        </div>
+    );
+}

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.tsx
@@ -1,29 +1,24 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { Link, useParams } from "react-router";
-import { toast } from "sonner";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { appRoutes } from "@/lib/app-routes";
+import { useWebWidgetStyleSave } from "@/pages/apps/channels/use-web-widget-style-save";
 import { WebWidgetStyleEditor } from "@/pages/apps/channels/web-widget-style-editor";
 
 export function AppWebWidgetDefaultCustomize() {
     const { slug = "" } = useParams();
-    const queryClient = useQueryClient();
 
     const defaultQuery = useQuery(api.queries.webWidget.defaultCustomization(slug));
     const styleGuideQuery = useQuery(api.queries.webWidget.styleGuide(slug));
     const previewQuery = useQuery(api.queries.webWidget.preview(slug));
 
-    const saveMutation = useMutation({
-        mutationFn: (css: string) => api.services.iframe.updateDefaultCustomization(slug, { css: css || null }),
-        onSuccess: async () => {
-            await queryClient.invalidateQueries({
-                queryKey: api.queries.webWidget.defaultCustomization(slug).queryKey,
-            });
-            toast.success("Default styles saved");
-        },
+    const saveMutation = useWebWidgetStyleSave({
+        save: (css) => api.services.iframe.updateDefaultCustomization(slug, { css }),
+        invalidateKey: api.queries.webWidget.defaultCustomization(slug).queryKey,
+        successMessage: "Default styles saved",
     });
 
     const onRetry = async () => {

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-web-widget-default-customize.tsx
@@ -29,6 +29,7 @@ export function AppWebWidgetDefaultCustomize() {
     const onRetry = async () => {
         if (defaultQuery.isError) await defaultQuery.refetch();
         if (styleGuideQuery.isError) await styleGuideQuery.refetch();
+        if (previewQuery.isError) await previewQuery.refetch();
     };
 
     return (
@@ -42,8 +43,8 @@ export function AppWebWidgetDefaultCustomize() {
             </Link>
 
             <ApiState
-                isLoading={defaultQuery.isPending || styleGuideQuery.isPending}
-                isError={defaultQuery.isError || styleGuideQuery.isError}
+                isLoading={defaultQuery.isPending || styleGuideQuery.isPending || previewQuery.isPending}
+                isError={defaultQuery.isError || styleGuideQuery.isError || previewQuery.isError}
                 errorTitle="Could not load default styles"
                 onRetry={onRetry}
                 loadingLabel="Loading default styles..."

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channel-groups.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channel-groups.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Cable, CodeXml, Link2, MessageCircle, Pencil, Send, Trash2, type LucideIcon } from "lucide-react";
+import { Cable, CodeXml, Link2, MessageCircle, Palette, Pencil, Send, Trash2, type LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { Link } from "react-router";
 import { api } from "@/api/api";
@@ -88,6 +88,14 @@ export function ChannelGroups({ slug }: { slug: string }) {
                                     <Badge variant="secondary" className="tabular-nums">
                                         {group.channels.length}
                                     </Badge>
+                                    {group.label === "Web widgets" && (
+                                        <Button asChild variant="outline">
+                                            <Link to={appRoutes.app(slug, "web-widget/default-customize")}>
+                                                <Palette aria-hidden="true" />
+                                                Customize default appearance
+                                            </Link>
+                                        </Button>
+                                    )}
                                 </div>
                                 <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
                                     {group.channels.map((channel) => (

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/use-web-widget-style-save.ts
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/use-web-widget-style-save.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient, type QueryKey } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+// Shared save wiring for the web-widget style editors (per-channel and app-default): run the PUT,
+// invalidate the source query so the editor re-reads the saved CSS, and toast on success. An empty
+// string clears the stored CSS so the record falls back to its default (see WebWidgetStyleEditor).
+export function useWebWidgetStyleSave(options: {
+    save: (css: string | null) => Promise<unknown>;
+    invalidateKey: QueryKey;
+    successMessage: string;
+}) {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (css: string) => options.save(css || null),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: options.invalidateKey });
+            toast.success(options.successMessage);
+        },
+    });
+}

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/use-web-widget-style-save.ts
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/use-web-widget-style-save.ts
@@ -2,18 +2,20 @@ import { useMutation, useQueryClient, type QueryKey } from "@tanstack/react-quer
 import { toast } from "sonner";
 
 // Shared save wiring for the web-widget style editors (per-channel and app-default): run the PUT,
-// invalidate the source query so the editor re-reads the saved CSS, and toast on success. An empty
+// invalidate the affected queries so the editors re-read the saved CSS, and toast on success. An empty
 // string clears the stored CSS so the record falls back to its default (see WebWidgetStyleEditor).
 export function useWebWidgetStyleSave(options: {
     save: (css: string | null) => Promise<unknown>;
-    invalidateKey: QueryKey;
+    invalidateKeys: QueryKey[];
     successMessage: string;
 }) {
     const queryClient = useQueryClient();
     return useMutation({
         mutationFn: (css: string) => options.save(css || null),
         onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey: options.invalidateKey });
+            await Promise.all(
+                options.invalidateKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+            );
             toast.success(options.successMessage);
         },
     });

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/web-widget-style-editor.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/web-widget-style-editor.tsx
@@ -47,6 +47,7 @@ export function WebWidgetStyleEditor({
     });
 
     const css = useWatch({ control: form.control, name: "css" });
+    const effectiveCssTrimmed = effectiveCss.trim();
     const previewCss = css.trim() ? css : effectiveCss;
 
     return (
@@ -56,7 +57,7 @@ export function WebWidgetStyleEditor({
                 const trimmed = values.css.trim();
                 // Save empty when the editor still matches the effective default so the record clears
                 // to "inherit the default" instead of freezing a copy that stops tracking future changes.
-                onSave(trimmed === effectiveCss.trim() ? "" : trimmed);
+                onSave(trimmed === effectiveCssTrimmed ? "" : trimmed);
             })}
         >
             <div className="flex items-center justify-end gap-2">
@@ -64,7 +65,7 @@ export function WebWidgetStyleEditor({
                     type="button"
                     variant="outline"
                     size="sm"
-                    disabled={css === effectiveCss || isSaving}
+                    disabled={isSaving}
                     onClick={() => form.setValue("css", effectiveCss, { shouldDirty: true, shouldValidate: true })}
                 >
                     Reset to default

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/web-widget-style-editor.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/web-widget-style-editor.tsx
@@ -50,7 +50,15 @@ export function WebWidgetStyleEditor({
     const previewCss = css.trim() ? css : effectiveCss;
 
     return (
-        <form className="grid gap-4" onSubmit={form.handleSubmit((values) => onSave(values.css.trim()))}>
+        <form
+            className="grid gap-4"
+            onSubmit={form.handleSubmit((values) => {
+                const trimmed = values.css.trim();
+                // Save empty when the editor still matches the effective default so the record clears
+                // to "inherit the default" instead of freezing a copy that stops tracking future changes.
+                onSave(trimmed === effectiveCss.trim() ? "" : trimmed);
+            })}
+        >
             <div className="flex items-center justify-end gap-2">
                 <Button
                     type="button"
@@ -75,7 +83,7 @@ export function WebWidgetStyleEditor({
                     label="Custom CSS"
                     height="560px"
                     actions={[{ component: <AceEditor.FormatAction /> }, { component: <AceEditor.FullScreenAction /> }]}
-                    labelClassName="justify-center"
+                    labelClassName="w-full justify-center"
                 />
 
                 <div className="grid content-start gap-1.5">

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/web-widget-style-editor.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/web-widget-style-editor.tsx
@@ -1,0 +1,90 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, useWatch } from "react-hook-form";
+import { z } from "zod";
+import AceEditor from "@/components/ace-editor/ace-editor";
+import { formatCss } from "@/components/ace-editor/ace-editor-action-utils";
+import { FormAceEditor } from "@/components/form/form-ace-editor";
+import { Button } from "@/components/shadcn/ui/button";
+import { Spinner } from "@/components/shadcn/ui/spinner";
+import { WebWidgetStylePreview } from "@/pages/apps/channels/web-widget-style-preview";
+
+// Mirrors the server-side IFrameCss.MaxLength cap so the editor fails fast.
+const MAX_CSS_LENGTH = 100_000;
+
+const styleSchema = z.object({
+    css: z.string().max(MAX_CSS_LENGTH, `CSS must be ${MAX_CSS_LENGTH.toLocaleString()} characters or fewer`),
+});
+
+type StyleFormData = z.infer<typeof styleSchema>;
+
+type WebWidgetStyleEditorProps = {
+    initialCss: string;
+    /** App default styles for a channel, used as the effective CSS shown in the preview and
+     *  restored by "Reset to default". Omit for the default editor, which falls back to the base styles. */
+    defaultCss?: string;
+    /** The widget's full base stylesheet, used to pre-fill the editor when there is
+     *  nothing saved yet, so operators see real selectors instead of a blank page. */
+    baseCss: string;
+    previewHtml: string;
+    isSaving: boolean;
+    onSave: (css: string) => void;
+};
+
+export function WebWidgetStyleEditor({
+    initialCss,
+    defaultCss,
+    baseCss,
+    previewHtml,
+    isSaving,
+    onSave,
+}: WebWidgetStyleEditorProps) {
+    const effectiveCss = formatCss(defaultCss || baseCss);
+    const startingCss = initialCss || effectiveCss;
+
+    const form = useForm<StyleFormData>({
+        resolver: zodResolver(styleSchema),
+        values: { css: startingCss },
+    });
+
+    const css = useWatch({ control: form.control, name: "css" });
+    const previewCss = css.trim() ? css : effectiveCss;
+
+    return (
+        <form className="grid gap-4" onSubmit={form.handleSubmit((values) => onSave(values.css.trim()))}>
+            <div className="flex items-center justify-end gap-2">
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={css === effectiveCss || isSaving}
+                    onClick={() => form.setValue("css", effectiveCss, { shouldDirty: true, shouldValidate: true })}
+                >
+                    Reset to default
+                </Button>
+                <Button type="submit" size="sm" disabled={!form.formState.isDirty || isSaving}>
+                    {isSaving && <Spinner />}
+                    Save
+                </Button>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-2">
+                <FormAceEditor
+                    control={form.control}
+                    name="css"
+                    mode="css"
+                    label="Custom CSS"
+                    height="560px"
+                    actions={[{ component: <AceEditor.FormatAction /> }, { component: <AceEditor.FullScreenAction /> }]}
+                    labelClassName="justify-center"
+                />
+
+                <div className="grid content-start gap-1.5">
+                    <span className="text-center text-sm font-medium">Live preview</span>
+                    <div className="mx-auto h-[560px] w-full max-w-[420px] overflow-hidden rounded-lg border bg-white">
+                        <WebWidgetStylePreview previewHtml={previewHtml} css={previewCss} />
+                    </div>
+                </div>
+            </div>
+        </form>
+    );
+}

--- a/src/Raven.AiAppliance.Web/src/pages/apps/channels/web-widget-style-preview.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/channels/web-widget-style-preview.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+type WebWidgetStylePreviewProps = {
+    previewHtml: string;
+    css: string;
+    className?: string;
+};
+
+const CUSTOM_STYLE_ID = "raven-custom";
+
+function injectCss(doc: Document | null | undefined, css: string) {
+    const styleEl = doc?.getElementById(CUSTOM_STYLE_ID);
+    if (styleEl) {
+        styleEl.textContent = css;
+    }
+}
+
+export function WebWidgetStylePreview({ previewHtml, css, className }: WebWidgetStylePreviewProps) {
+    const iframeRef = useRef<HTMLIFrameElement>(null);
+
+    // Re-inject on every CSS edit (same document, no reload). A previewHtml change reloads
+    // the iframe and is re-applied by onLoad once the new document is ready.
+    useEffect(() => {
+        injectCss(iframeRef.current?.contentDocument, css);
+    }, [css]);
+
+    return (
+        <iframe
+            ref={iframeRef}
+            title="Web widget preview"
+            srcDoc={previewHtml}
+            onLoad={(event) => injectCss(event.currentTarget.contentDocument, css)}
+            className={cn("h-full w-full border-0 bg-white", className)}
+        />
+    );
+}

--- a/src/Raven.AiAppliance.Web/src/pages/dashboard/usage.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/dashboard/usage.tsx
@@ -103,7 +103,7 @@ export function DashboardUsage() {
                 <CardHeader>
                     <CardTitle>Token usage per app</CardTitle>
                     <CardDescription>
-                        Tracked for this period.
+                        All-time totals.
                         {refreshedAt !== undefined && ` Refreshed ${formatRelativeTime(refreshedAt)}.`}
                     </CardDescription>
                     <CardAction>

--- a/src/Raven.AiAppliance.Web/src/routes.tsx
+++ b/src/Raven.AiAppliance.Web/src/routes.tsx
@@ -20,6 +20,8 @@ import { AppAgents } from "@/pages/apps/app-agents";
 import { AppApiUnavailable } from "@/pages/apps/app-api-unavailable";
 import { AppChannelDetail } from "@/pages/apps/app-channel-detail";
 import { AppChannels } from "@/pages/apps/app-channels";
+import { AppWebWidgetCustomize } from "@/pages/apps/app-web-widget-customize";
+import { AppWebWidgetDefaultCustomize } from "@/pages/apps/app-web-widget-default-customize";
 import { AppConversations } from "@/pages/apps/app-conversations";
 import { AppDataSource } from "@/pages/apps/app-data-source";
 import { AppOverview } from "@/pages/apps/app-overview";
@@ -189,6 +191,18 @@ const appPages: AppRouteDefinition[] = [
         path: "channels/:widgetId",
         title: "Channel",
         element: <AppChannelDetail />,
+    },
+    {
+        // Per-widget embed styling editor + live preview. Reached from channel detail.
+        path: "web-widget/:widgetId/customize",
+        title: "Web widget appearance",
+        element: <AppWebWidgetCustomize />,
+    },
+    {
+        // App-level default web-widget styling. Reached from the Channels list.
+        path: "web-widget/default-customize",
+        title: "Default web widget appearance",
+        element: <AppWebWidgetDefaultCustomize />,
     },
     {
         path: "usage",

--- a/src/Raven.AiAppliance/Channels/Channel.cs
+++ b/src/Raven.AiAppliance/Channels/Channel.cs
@@ -56,6 +56,14 @@ internal sealed class Channel
     /// <summary>UTC creation timestamp.</summary>
     public DateTime CreatedAt { get; set; }
 
+    /// <summary>Operator-authored CSS injected into this channel's embed page
+    /// (after the widget's base styles, so it overrides them). Null or empty
+    /// means "fall back to the app-level default" (see
+    /// <see cref="IFrameStyleDefaults"/>). This is the iFrame channel's slice of
+    /// the per-type theme config the class summary notes will later move into a
+    /// polymorphic <c>Config</c> sub-object.</summary>
+    public string? CustomCss { get; set; }
+
     /// <summary>Doc id of the corresponding <see cref="ChannelBinding"/>:
     /// <c>channel-bindings/{slug}/{type}/{agentId}</c>. Stored for
     /// forward-compat: the delete flow reads it instead of recomputing it from

--- a/src/Raven.AiAppliance/Channels/IFrameCss.cs
+++ b/src/Raven.AiAppliance/Channels/IFrameCss.cs
@@ -1,0 +1,50 @@
+namespace Raven.AiAppliance.Channels;
+
+/// <summary>
+/// Validation + render-time hardening for operator-authored web-widget (iFrame) embed CSS,
+/// shared by the iFrame customization PUT endpoints (validate on save) and the embed page
+/// renderer (defensive strip on render). The CSS is injected into a <c>&lt;style&gt;</c>
+/// element server-side, so a literal <c>&lt;/style&gt;</c> would break out of the element into
+/// HTML — the one sequence that turns operator CSS into stored XSS.
+/// </summary>
+internal static class IFrameCss
+{
+    /// <summary>Caps stored CSS so a channel/defaults doc can't grow unbounded. Generous next
+    /// to any hand-written theme (tens of KB at most).</summary>
+    internal const int MaxLength = 100_000;
+
+    // The only sequence that ends a <style> element's raw-text content. HTML requires the "</"
+    // to be contiguous and the tag name to follow immediately, so a case-insensitive substring
+    // check is exact — no regex (and no source-generated partial) needed.
+    private const string StyleClose = "</style";
+
+    /// <summary>Validates CSS accepted on a PUT. Null/empty is valid (clears to the default).
+    /// Rejects over-length input and any <c>&lt;/style&gt;</c> breakout sequence.</summary>
+    internal static bool TryValidate(string? css, out string? error)
+    {
+        error = null;
+        if (string.IsNullOrEmpty(css))
+            return true;
+
+        if (css.Length > MaxLength)
+        {
+            error = $"css exceeds {MaxLength} chars";
+            return false;
+        }
+
+        if (css.Contains(StyleClose, StringComparison.OrdinalIgnoreCase))
+        {
+            error = "css must not contain a '</style>' sequence";
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>Defense-in-depth for render: neutralizes any <c>&lt;/style&gt;</c> breakout so a
+    /// doc written outside the PUT path can't escape the <c>&lt;style&gt;</c> element. Inserting
+    /// the backslash stops the HTML tokenizer from seeing an end tag without altering how the
+    /// (already invalid) CSS renders.</summary>
+    internal static string Sanitize(string? css) =>
+        string.IsNullOrEmpty(css) ? "" : css.Replace(StyleClose, @"<\/style", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Raven.AiAppliance/Channels/IFrameStyleDefaults.cs
+++ b/src/Raven.AiAppliance/Channels/IFrameStyleDefaults.cs
@@ -1,0 +1,23 @@
+namespace Raven.AiAppliance.Channels;
+
+/// <summary>
+/// Per-app default web-widget (iFrame) embed styling. A single document per app database (id
+/// <see cref="DocumentId"/>) holding the CSS applied to every iFrame channel that does not
+/// define its own <see cref="Channel.CustomCss"/>. Lives in the app's own database alongside
+/// the <see cref="Channel"/> docs so channel styling is co-located and resolves without
+/// crossing into the config DB.
+/// </summary>
+internal sealed class IFrameStyleDefaults
+{
+    /// <summary>Fixed singleton id — one defaults doc per app database.</summary>
+    internal const string DocumentId = "iframe-style-defaults/config";
+
+    public string? Id { get; set; }
+
+    /// <summary>Operator-authored default CSS. Null or empty means "no default"; channels with
+    /// no <see cref="Channel.CustomCss"/> then render only the widget's base styles.</summary>
+    public string? Css { get; set; }
+
+    /// <summary>UTC timestamp of the last edit.</summary>
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/src/Raven.AiAppliance/Channels/IFrameStyleVariables.cs
+++ b/src/Raven.AiAppliance/Channels/IFrameStyleVariables.cs
@@ -1,0 +1,33 @@
+namespace Raven.AiAppliance.Channels;
+
+/// <summary>
+/// Catalog of CSS custom properties declared by the embed page's base stylesheet (see
+/// <c>EmbedEndpoints.WidgetBaseCss</c>, whose <c>:root</c> block is generated from
+/// <see cref="BuildRootBlock"/>). Keeping the catalog as the single source means the shipped
+/// <c>:root</c> defaults can't drift from what the widget actually renders.
+/// </summary>
+internal static class IFrameStyleVariables
+{
+    internal static readonly IReadOnlyList<IFrameStyleVariable> All =
+    [
+        new("--ai-bg", "#ffffff"),
+        new("--ai-fg", "#0f172a"),
+        new("--ai-border-color", "#e2e8f0"),
+        new("--ai-bubble-agent-bg", "#f1f5f9"),
+        new("--ai-user-bg", "#2563eb"),
+        new("--ai-user-fg", "#ffffff"),
+        new("--ai-input-border-color", "#cbd5e1"),
+        new("--ai-radius-bubble", "12px"),
+        new("--ai-radius-control", "8px"),
+        new("--ai-font-family", """system-ui, -apple-system, "Segoe UI", Roboto, sans-serif"""),
+    ];
+
+    /// <summary>Renders the catalog as the <c>:root { ... }</c> declaration block prepended to
+    /// <c>EmbedEndpoints.WidgetBaseCssRules</c> to form the widget's base stylesheet.</summary>
+    internal static string BuildRootBlock() =>
+        ":root {\n" + string.Join('\n', All.Select(variable => $"  {variable.Name}: {variable.DefaultValue};")) + "\n}";
+}
+
+/// <param name="Name">CSS custom property name, e.g. <c>--ai-user-bg</c>.</param>
+/// <param name="DefaultValue">The value shipped in the base stylesheet.</param>
+internal sealed record IFrameStyleVariable(string Name, string DefaultValue);

--- a/src/Raven.AiAppliance/Contracts/IFrameCustomizationResponse.cs
+++ b/src/Raven.AiAppliance/Contracts/IFrameCustomizationResponse.cs
@@ -1,0 +1,10 @@
+namespace Raven.AiAppliance.Contracts;
+
+/// <summary>
+/// A web-widget (iFrame) channel's embed-styling state for the dashboard editor.
+/// </summary>
+/// <param name="Css">The channel's own CSS. <c>null</c> means it has no override and renders
+/// with the app default (or just the widget base styles).</param>
+/// <param name="DefaultCss">The app-level default CSS, surfaced so the editor can preview the
+/// effective styling when <paramref name="Css"/> is empty and offer a "reset to default" affordance.</param>
+public sealed record IFrameCustomizationResponse(string? Css, string? DefaultCss);

--- a/src/Raven.AiAppliance/Contracts/IFrameDefaultCustomizationResponse.cs
+++ b/src/Raven.AiAppliance/Contracts/IFrameDefaultCustomizationResponse.cs
@@ -1,0 +1,7 @@
+namespace Raven.AiAppliance.Contracts;
+
+/// <summary>
+/// The app-level default embed CSS applied to web-widget (iFrame) channels that define no CSS
+/// of their own. <c>null</c> means no default is set.
+/// </summary>
+public sealed record IFrameDefaultCustomizationResponse(string? Css);

--- a/src/Raven.AiAppliance/Contracts/IFramePreviewResponse.cs
+++ b/src/Raven.AiAppliance/Contracts/IFramePreviewResponse.cs
@@ -1,0 +1,11 @@
+namespace Raven.AiAppliance.Contracts;
+
+/// <summary>
+/// A self-contained HTML document mirroring the web-widget (iFrame) embed — the same base
+/// styles and markup the live embed page uses, with sample chat bubbles and an empty
+/// <c>&lt;style id="raven-custom"&gt;</c> slot, but no live chat script. The dashboard renders it
+/// in a same-origin <c>srcdoc</c> iframe and injects the editor's CSS into the slot so the
+/// customization preview matches production without the cross-origin restriction of framing
+/// the real <c>public.*</c> page.
+/// </summary>
+public sealed record IFramePreviewResponse(string Html);

--- a/src/Raven.AiAppliance/Contracts/IFrameStyleGuideResponse.cs
+++ b/src/Raven.AiAppliance/Contracts/IFrameStyleGuideResponse.cs
@@ -1,0 +1,9 @@
+namespace Raven.AiAppliance.Contracts;
+
+/// <summary>
+/// The web-widget (iFrame) embed page's base CSS. Surfaced so the dashboard styling editor can
+/// pre-fill a blank customization with a full starting template and restore it on "reset to default".
+/// </summary>
+/// <param name="BaseCss">The widget's full base stylesheet — selectors and the <c>:root</c>
+/// variable declarations — verbatim what the live embed page injects before operator CSS.</param>
+public sealed record IFrameStyleGuideResponse(string BaseCss);

--- a/src/Raven.AiAppliance/Contracts/UpdateIFrameCustomizationRequest.cs
+++ b/src/Raven.AiAppliance/Contracts/UpdateIFrameCustomizationRequest.cs
@@ -1,0 +1,8 @@
+namespace Raven.AiAppliance.Contracts;
+
+/// <summary>
+/// Saves web-widget (iFrame) embed CSS — shared by the per-channel and the app-default PUTs.
+/// A <c>null</c> or empty <paramref name="Css"/> clears the stored CSS: a channel then falls
+/// back to the app default, and the app default falls back to the widget's base styles.
+/// </summary>
+public sealed record UpdateIFrameCustomizationRequest(string? Css);

--- a/src/Raven.AiAppliance/Endpoints/EmbedEndpoints.cs
+++ b/src/Raven.AiAppliance/Endpoints/EmbedEndpoints.cs
@@ -29,6 +29,15 @@ public static class EmbedEndpoints
     /// route (configured in <c>Program.cs</c>). RavenDB-26775 backstop.</summary>
     public const string ChatRateLimitPolicy = "embed-chat";
 
+    // Resource CSP for the embed page: default-deny with only what the self-contained widget needs —
+    // inline <style>/<script>, same-origin (+ data:) images/fonts, and same-origin fetch for the chat
+    // stream. This contains operator-authored CSS so it can't @import or url(...) to a foreign origin
+    // (beaconing/exfiltration). frame-ancestors is appended per-request from the channel's allowed
+    // origins (see ServeEmbedPageAsync); IFrameCss.Sanitize handles the </style> HTML-breakout case.
+    internal const string BaseCsp =
+        "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; " +
+        "img-src 'self' data:; font-src 'self' data:; connect-src 'self'; base-uri 'none'";
+
     public static void Map(WebApplication app)
     {
         app.MapGet("/embed/{token}", ServeEmbedPageAsync)
@@ -49,16 +58,18 @@ public static class EmbedEndpoints
     {
         var ct = ctx.RequestAborted;
 
-        var resolved = await TryResolveLiveLinkAsync(ctx, store, token, ct);
+        var resolved = await TryResolveLiveLinkAsync(ctx, store, token, resolveCss: true, ct);
         if (resolved is null)
             return;
 
-        var (app, _, channel) = resolved.Value;
+        var (_, _, channel, customCss) = resolved.Value;
 
-        // frame-ancestors from the configured origins; empty list = embeddable
-        // anywhere (M1 contract). 'self' (the public.* embed host) plus the operator
-        // dashboard origin are always included so the appliance's own UI can preview
-        // the widget cross-origin (the dashboard frames the public.* page).
+        // Contain the page — and, above all, operator-authored __CUSTOM_CSS__ — with a default-deny
+        // resource policy, then append frame-ancestors from the configured origins (empty list =
+        // embeddable anywhere, the M1 contract). 'self' (the public.* embed host) plus the operator
+        // dashboard origin are always included so the appliance's own UI can preview the widget
+        // cross-origin (the dashboard frames the public.* page).
+        var csp = BaseCsp;
         if (channel.AllowedOrigins.Length > 0)
         {
             // 'self' (the public.* embed host) + the operator dashboard origin so the in-appliance
@@ -66,30 +77,15 @@ public static class EmbedEndpoints
             // dashboard origin when a configured origin already lists it (single-host dev collapses them).
             var dashboardOrigin = $"{ctx.Request.Scheme}://{ApplianceHost.WithSubdomain(ctx.Request.Host, "dashboard").ToUriComponent()}";
             var head = Array.IndexOf(channel.AllowedOrigins, dashboardOrigin) >= 0 ? "'self'" : $"'self' {dashboardOrigin}";
-            ctx.Response.Headers["Content-Security-Policy"] = $"frame-ancestors {head} {string.Join(' ', channel.AllowedOrigins)}";
+            csp += $"; frame-ancestors {head} {string.Join(' ', channel.AllowedOrigins)}";
         }
+        ctx.Response.Headers["Content-Security-Policy"] = csp;
 
         // Keep the bearer token out of cross-origin referer logs.
         ctx.Response.Headers["Referrer-Policy"] = "no-referrer";
 
-        var customCss = await ResolveEffectiveCssAsync(store, app.Database, channel, ct);
-
         ctx.Response.ContentType = "text/html; charset=utf-8";
         await ctx.Response.WriteAsync(BuildEmbedHtml(token, channel.DisplayName, customCss), ct);
-    }
-
-    /// <summary>Resolves the CSS to inject for a channel: its own
-    /// <see cref="Channel.CustomCss"/> when set, otherwise the app-level
-    /// <see cref="IFrameStyleDefaults"/> (null when neither exists).</summary>
-    private static async Task<string?> ResolveEffectiveCssAsync(
-        IDocumentStore store, string database, Channel channel, CancellationToken ct)
-    {
-        if (string.IsNullOrWhiteSpace(channel.CustomCss) == false)
-            return channel.CustomCss;
-
-        using var session = store.OpenAsyncSession(database);
-        var defaults = await session.LoadAsync<IFrameStyleDefaults>(IFrameStyleDefaults.DocumentId, ct);
-        return defaults?.Css;
     }
 
     private static async Task StreamEmbedChatAsync(
@@ -109,11 +105,11 @@ public static class EmbedEndpoints
             return;
         }
 
-        var resolved = await TryResolveLiveLinkAsync(ctx, store, token, ct);
+        var resolved = await TryResolveLiveLinkAsync(ctx, store, token, resolveCss: false, ct);
         if (resolved is null)
             return;
 
-        var (app, link, channel) = resolved.Value;
+        var (app, link, channel, _) = resolved.Value;
 
         // M1b Origin defense-in-depth (see IsOriginAllowed).
         if (IsOriginAllowed(ctx.Request, channel.AllowedOrigins) == false)
@@ -323,8 +319,8 @@ public static class EmbedEndpoints
     /// (unresolved / malformed) or 410 (disabled channel / revoked / expired) and
     /// returning null in those cases; otherwise the live (App, EmbedLink, Channel).
     /// The invocation cap is enforced separately at chat time (429).</summary>
-    private static async Task<(App app, EmbedLink link, Channel channel)?> TryResolveLiveLinkAsync(
-        HttpContext ctx, IDocumentStore store, string token, CancellationToken ct)
+    private static async Task<(App app, EmbedLink link, Channel channel, string? effectiveCss)?> TryResolveLiveLinkAsync(
+        HttpContext ctx, IDocumentStore store, string token, bool resolveCss, CancellationToken ct)
     {
         if (EmbedLink.IsWellFormedToken(token) == false)
         {
@@ -332,14 +328,14 @@ public static class EmbedEndpoints
             return null;
         }
 
-        var resolved = await ResolveAsync(store, token, ct);
+        var resolved = await ResolveAsync(store, token, resolveCss, ct);
         if (resolved is null)
         {
             ctx.Response.StatusCode = StatusCodes.Status404NotFound;
             return null;
         }
 
-        var (_, link, channel) = resolved.Value;
+        var (_, link, channel, _) = resolved.Value;
 
         // 410 Gone: link existed but is no longer usable (channel paused, link
         // revoked, or TTL elapsed). All collapse to the same "this link is dead".
@@ -354,9 +350,13 @@ public static class EmbedEndpoints
 
     /// <summary>Resolves a token by hopping config DB → app DB:
     /// <c>link-index/{token}</c> → <c>apps/{slug}</c> → (<c>embed-links/{token}</c>,
-    /// <c>channels/{widgetId}</c>). Null on any miss (callers surface as 404).</summary>
-    private static async Task<(App app, EmbedLink link, Channel channel)?> ResolveAsync(
-        IDocumentStore store, string token, CancellationToken ct)
+    /// <c>channels/{widgetId}</c>). Null on any miss (callers surface as 404). When
+    /// <paramref name="resolveCss"/> is set (the page render path) the effective embed CSS is
+    /// resolved on the same app-DB session — the channel's own <see cref="Channel.CustomCss"/> if
+    /// present, else the app-level <see cref="IFrameStyleDefaults"/> — so rendering needs no second
+    /// session. The chat path passes <c>false</c> and skips that load.</summary>
+    private static async Task<(App app, EmbedLink link, Channel channel, string? effectiveCss)?> ResolveAsync(
+        IDocumentStore store, string token, bool resolveCss, CancellationToken ct)
     {
         App? app;
         using (var cfg = store.OpenAsyncSession())
@@ -373,6 +373,7 @@ public static class EmbedEndpoints
 
         EmbedLink? link;
         Channel? channel;
+        string? effectiveCss = null;
         using (var session = store.OpenAsyncSession(app.Database))
         {
             link = await session.LoadAsync<EmbedLink>(EmbedLink.IdPrefix + token, ct);
@@ -380,24 +381,37 @@ public static class EmbedEndpoints
                 return null;
 
             channel = await session.LoadAsync<Channel>(Channel.IdPrefix + link.WidgetId, ct);
+
+            // Resolve the embed CSS while the app-DB session is open (render path only): the channel's
+            // own CSS wins, otherwise fall back to the app-level default, loaded only when needed. This
+            // keeps the page render to a single app-DB session instead of opening a second one.
+            if (resolveCss && channel is { Type: ChannelType.IFrame })
+            {
+                effectiveCss = string.IsNullOrWhiteSpace(channel.CustomCss) == false
+                    ? channel.CustomCss
+                    : (await session.LoadAsync<IFrameStyleDefaults>(IFrameStyleDefaults.DocumentId, ct))?.Css;
+            }
         }
 
         // iFrame-only surface — a non-IFrame channel sharing the prefix is a miss.
         if (channel is null || channel.Type != ChannelType.IFrame)
             return null;
 
-        return (app, link, channel);
+        return (app, link, channel, effectiveCss);
     }
 
     private static string BuildEmbedHtml(string token, string displayName, string? customCss)
     {
         var title = WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(displayName) ? "AI Assistant" : displayName);
-        // __CUSTOM_CSS__ is substituted last so operator CSS can't reintroduce another placeholder.
+        // Substitute the trusted placeholders (token, base styles) first, then the operator-controlled
+        // ones (custom CSS, then title) last — so nothing an operator can set (DisplayName via __TITLE__,
+        // or custom CSS) can reintroduce __TOKEN__ or another placeholder for a later Replace to expand.
+        // In particular the bearer token can never leak into the rendered title/header.
         return EmbedHtmlTemplate
-            .Replace("__TITLE__", title)
             .Replace("__TOKEN__", token)
             .Replace("__BASE_CSS__", WidgetBaseCss)
-            .Replace("__CUSTOM_CSS__", IFrameCss.Sanitize(customCss));
+            .Replace("__CUSTOM_CSS__", IFrameCss.Sanitize(customCss))
+            .Replace("__TITLE__", title);
     }
 
     /// <summary>Builds the dashboard's customization preview: the same base styles

--- a/src/Raven.AiAppliance/Endpoints/EmbedEndpoints.cs
+++ b/src/Raven.AiAppliance/Endpoints/EmbedEndpoints.cs
@@ -53,7 +53,7 @@ public static class EmbedEndpoints
         if (resolved is null)
             return;
 
-        var (_, _, channel) = resolved.Value;
+        var (app, _, channel) = resolved.Value;
 
         // frame-ancestors from the configured origins; empty list = embeddable
         // anywhere (M1 contract). 'self' (the public.* embed host) plus the operator
@@ -72,8 +72,24 @@ public static class EmbedEndpoints
         // Keep the bearer token out of cross-origin referer logs.
         ctx.Response.Headers["Referrer-Policy"] = "no-referrer";
 
+        var customCss = await ResolveEffectiveCssAsync(store, app.Database, channel, ct);
+
         ctx.Response.ContentType = "text/html; charset=utf-8";
-        await ctx.Response.WriteAsync(BuildEmbedHtml(token, channel.DisplayName), ct);
+        await ctx.Response.WriteAsync(BuildEmbedHtml(token, channel.DisplayName, customCss), ct);
+    }
+
+    /// <summary>Resolves the CSS to inject for a channel: its own
+    /// <see cref="Channel.CustomCss"/> when set, otherwise the app-level
+    /// <see cref="IFrameStyleDefaults"/> (null when neither exists).</summary>
+    private static async Task<string?> ResolveEffectiveCssAsync(
+        IDocumentStore store, string database, Channel channel, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(channel.CustomCss) == false)
+            return channel.CustomCss;
+
+        using var session = store.OpenAsyncSession(database);
+        var defaults = await session.LoadAsync<IFrameStyleDefaults>(IFrameStyleDefaults.DocumentId, ct);
+        return defaults?.Css;
     }
 
     private static async Task StreamEmbedChatAsync(
@@ -373,16 +389,54 @@ public static class EmbedEndpoints
         return (app, link, channel);
     }
 
-    private static string BuildEmbedHtml(string token, string displayName)
+    private static string BuildEmbedHtml(string token, string displayName, string? customCss)
     {
         var title = WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(displayName) ? "AI Assistant" : displayName);
+        // __CUSTOM_CSS__ is substituted last so operator CSS can't reintroduce another placeholder.
         return EmbedHtmlTemplate
+            .Replace("__TITLE__", title)
             .Replace("__TOKEN__", token)
-            .Replace("__TITLE__", title);
+            .Replace("__BASE_CSS__", WidgetBaseCss)
+            .Replace("__CUSTOM_CSS__", IFrameCss.Sanitize(customCss));
+    }
+
+    /// <summary>Builds the dashboard's customization preview: the same base styles
+    /// and markup as the live embed, with sample chat bubbles and an empty
+    /// <c>&lt;style id="raven-custom"&gt;</c> slot the dashboard fills client-side,
+    /// but no live chat script. Sharing <see cref="WidgetBaseCss"/> keeps the
+    /// preview faithful to the real page.</summary>
+    internal static string BuildPreviewHtml(string? displayName)
+    {
+        var title = WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(displayName) ? "AI Assistant" : displayName);
+        return PreviewHtmlTemplate
+            .Replace("__TITLE__", title)
+            .Replace("__BASE_CSS__", WidgetBaseCss);
     }
 
     /// Logger category marker — keeps the ILogger generic-arg out of the public surface.
     internal sealed class EmbedLogger;
+
+    // Base widget styles, shared verbatim by the live embed page, the dashboard preview
+    // skeleton, and the styling editor's starter template, so none of the three can drift.
+    // Injected into a <style> element via __BASE_CSS__ (kept out of the raw-string templates
+    // so the CSS braces need no escaping). Operator CSS follows in a second <style> block so
+    // it overrides these. The :root block is generated from IFrameStyleVariables, the single
+    // source for the shipped variable defaults.
+    internal static readonly string WidgetBaseCss = IFrameStyleVariables.BuildRootBlock() + "\n" + WidgetBaseCssRules;
+
+    private const string WidgetBaseCssRules = """
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; background: var(--ai-bg); color: var(--ai-fg); font-family: var(--ai-font-family); }
+  #ai-chat { display: flex; flex-direction: column; height: 100%; }
+  #ai-chat-header { padding: 12px 16px; font-weight: 600; border-bottom: 1px solid var(--ai-border-color); }
+  #ai-chat-feed { flex: 1; overflow-y: auto; padding: 12px 16px; }
+  .row { margin: 6px 0; padding: 8px 12px; border-radius: var(--ai-radius-bubble); max-width: 80%; white-space: pre-wrap; }
+  .row.user { background: var(--ai-user-bg); color: var(--ai-user-fg); margin-left: auto; }
+  .row.agent { background: var(--ai-bubble-agent-bg); }
+  #ai-chat-form { display: flex; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--ai-border-color); }
+  #ai-chat-input { flex: 1; padding: 10px 12px; border: 1px solid var(--ai-input-border-color); border-radius: var(--ai-radius-control); font-size: 14px; }
+  #ai-chat-form button { padding: 10px 16px; border: 0; border-radius: var(--ai-radius-control); background: var(--ai-user-bg); color: var(--ai-user-fg); cursor: pointer; }
+""";
 
     // Self-contained vanilla page. Placeholders are string-replaced (title is
     // HTML-encoded; token is hex-only) so JS/CSS braces need no escaping.
@@ -395,19 +449,9 @@ public static class EmbedEndpoints
 <meta name="referrer" content="no-referrer">
 <title>__TITLE__</title>
 <style>
-  :root { --ai-bubble-bg: #f1f5f9; --ai-user-bg: #2563eb; --ai-user-fg: #fff; }
-  * { box-sizing: border-box; }
-  html, body { height: 100%; margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-  #ai-chat { display: flex; flex-direction: column; height: 100%; }
-  #ai-chat-header { padding: 12px 16px; font-weight: 600; border-bottom: 1px solid #e2e8f0; }
-  #ai-chat-feed { flex: 1; overflow-y: auto; padding: 12px 16px; }
-  .row { margin: 6px 0; padding: 8px 12px; border-radius: 12px; max-width: 80%; white-space: pre-wrap; }
-  .row.user { background: var(--ai-user-bg); color: var(--ai-user-fg); margin-left: auto; }
-  .row.agent { background: var(--ai-bubble-bg); }
-  #ai-chat-form { display: flex; gap: 8px; padding: 12px 16px; border-top: 1px solid #e2e8f0; }
-  #ai-chat-input { flex: 1; padding: 10px 12px; border: 1px solid #cbd5e1; border-radius: 8px; font-size: 14px; }
-  #ai-chat-form button { padding: 10px 16px; border: 0; border-radius: 8px; background: var(--ai-user-bg); color: #fff; cursor: pointer; }
+__BASE_CSS__
 </style>
+<style id="raven-custom">__CUSTOM_CSS__</style>
 </head>
 <body>
 <div id="ai-chat">
@@ -480,6 +524,39 @@ form.addEventListener("submit", async (e) => {
   }
 });
 </script>
+</body>
+</html>
+""";
+
+    // Inert mirror of the live page for the dashboard customization preview: same
+    // head + base styles, sample bubbles, an empty <style id="raven-custom"> slot the
+    // dashboard fills as the operator types, and no token/chat script (the preview
+    // never talks to the server). __BASE_CSS__ is the only substitution besides the title.
+    private const string PreviewHtmlTemplate = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>__TITLE__</title>
+<style>
+__BASE_CSS__
+</style>
+<style id="raven-custom"></style>
+</head>
+<body>
+<div id="ai-chat">
+  <div id="ai-chat-header">__TITLE__</div>
+  <div id="ai-chat-feed">
+    <div class="row agent">Hi! I'm your AI assistant. How can I help you today?</div>
+    <div class="row user">What can you do?</div>
+    <div class="row agent">I can answer questions about your data and help you get things done — just ask.</div>
+  </div>
+  <form id="ai-chat-form" onsubmit="return false">
+    <input id="ai-chat-input" autocomplete="off" placeholder="Ask a question..." aria-label="Ask a question">
+    <button type="submit">Send</button>
+  </form>
+</div>
 </body>
 </html>
 """;

--- a/src/Raven.AiAppliance/Endpoints/IFrameCustomizationEndpoints.cs
+++ b/src/Raven.AiAppliance/Endpoints/IFrameCustomizationEndpoints.cs
@@ -1,0 +1,203 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Raven.AiAppliance.Channels;
+using Raven.AiAppliance.Contracts;
+using Raven.AiAppliance.Endpoints.Helpers;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+
+namespace Raven.AiAppliance.Endpoints;
+
+/// <summary>
+/// Operator-facing customization of the web-widget (iFrame) embed surface: a channel's own
+/// CSS, the app-level default applied to channels with none, and the inert preview document
+/// the dashboard live-styles. CSS styling is iFrame-only — Telegram/WhatsApp render in their
+/// own apps — so these live in their own <c>iframe</c> group rather than the type-agnostic
+/// <see cref="ChannelsEndpoints"/>. The public embed page that consumes the stored CSS is
+/// <see cref="EmbedEndpoints"/>.
+/// </summary>
+public static class IFrameCustomizationEndpoints
+{
+    public static void Map(WebApplication app)
+    {
+        var group = app.MapGroup("/api/apps/{slug}/iframe").WithTags("iframe").RequireAuthorization();
+
+        group.MapGet("/{widgetId}/customization", GetCustomizationAsync)
+            .WithName("iframe.getCustomization")
+            .WithDescription("Returns a web-widget channel's own embed CSS plus the app default, for the styling editor.")
+            .Produces<IFrameCustomizationResponse>()
+            .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
+
+        group.MapPut("/{widgetId}/customization", UpdateCustomizationAsync)
+            .WithName("iframe.updateCustomization")
+            .WithDescription("Saves a web-widget channel's embed CSS. An empty body clears it so the channel falls back to the app default.")
+            .Accepts<UpdateIFrameCustomizationRequest>("application/json")
+            .Produces<IFrameCustomizationResponse>()
+            .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest)
+            .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
+
+        group.MapGet("/default-customization", GetDefaultCustomizationAsync)
+            .WithName("iframe.getDefaultCustomization")
+            .WithDescription("Returns the app-level default web-widget embed CSS applied to channels with no CSS of their own.")
+            .Produces<IFrameDefaultCustomizationResponse>()
+            .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
+
+        group.MapPut("/default-customization", UpdateDefaultCustomizationAsync)
+            .WithName("iframe.updateDefaultCustomization")
+            .WithDescription("Saves the app-level default web-widget embed CSS. An empty body clears it.")
+            .Accepts<UpdateIFrameCustomizationRequest>("application/json")
+            .Produces<IFrameDefaultCustomizationResponse>()
+            .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest)
+            .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
+
+        group.MapGet("/preview", GetPreviewAsync)
+            .WithName("iframe.preview")
+            .WithDescription("Returns the inert web-widget preview document (base styles + sample bubbles) the dashboard frames to live-preview CSS edits.")
+            .Produces<IFramePreviewResponse>()
+            .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
+
+        group.MapGet("/style-guide", GetStyleGuideAsync)
+            .WithName("iframe.getStyleGuide")
+            .WithDescription("Returns the web-widget embed page's base CSS, used as the styling editor's starter template and \"reset to default\" content.")
+            .Produces<IFrameStyleGuideResponse>()
+            .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
+    }
+
+    private static async Task<IResult> GetCustomizationAsync(
+        string slug,
+        string widgetId,
+        IDocumentStore store,
+        CancellationToken ct)
+    {
+        var app = await AppLookup.LoadAppAsync(store, slug, ct);
+        if (app is null)
+            return Results.NotFound(new ApiErrorResponse($"no app with slug '{slug}'"));
+
+        using var session = store.OpenAsyncSession(app.Database);
+        var channel = await LoadIFrameChannelAsync(session, widgetId, ct);
+        if (channel is null)
+            return Results.NotFound(new ApiErrorResponse($"no iFrame channel '{widgetId}' in app '{slug}'"));
+
+        var defaults = await session.LoadAsync<IFrameStyleDefaults>(IFrameStyleDefaults.DocumentId, ct);
+        return Results.Ok(new IFrameCustomizationResponse(channel.CustomCss, defaults?.Css));
+    }
+
+    private static async Task<IResult> UpdateCustomizationAsync(
+        string slug,
+        string widgetId,
+        UpdateIFrameCustomizationRequest body,
+        IDocumentStore store,
+        ILogger<IFrameCustomizationLogger> logger,
+        CancellationToken ct)
+    {
+        if (body is null)
+            return Results.BadRequest(new ApiErrorResponse("request body is required"));
+        if (IFrameCss.TryValidate(body.Css, out var cssError) == false)
+            return Results.BadRequest(new ApiErrorResponse(cssError!));
+
+        var app = await AppLookup.LoadAppAsync(store, slug, ct);
+        if (app is null)
+            return Results.NotFound(new ApiErrorResponse($"no app with slug '{slug}'"));
+
+        using var session = store.OpenAsyncSession(app.Database);
+        var channel = await LoadIFrameChannelAsync(session, widgetId, ct);
+        if (channel is null)
+            return Results.NotFound(new ApiErrorResponse($"no iFrame channel '{widgetId}' in app '{slug}'"));
+
+        // Collapse empty to null so "uses the app default" has a single representation.
+        channel.CustomCss = string.IsNullOrWhiteSpace(body.Css) ? null : body.Css;
+        await session.SaveChangesAsync(ct);
+
+        var defaults = await session.LoadAsync<IFrameStyleDefaults>(IFrameStyleDefaults.DocumentId, ct);
+        logger.LogInformation(
+            "Updated iFrame customization slug={Slug} widgetId={WidgetId} hasCss={HasCss}",
+            app.Slug, widgetId, channel.CustomCss is not null);
+        return Results.Ok(new IFrameCustomizationResponse(channel.CustomCss, defaults?.Css));
+    }
+
+    private static async Task<IResult> GetDefaultCustomizationAsync(
+        string slug,
+        IDocumentStore store,
+        CancellationToken ct)
+    {
+        var app = await AppLookup.LoadAppAsync(store, slug, ct);
+        if (app is null)
+            return Results.NotFound(new ApiErrorResponse($"no app with slug '{slug}'"));
+
+        using var session = store.OpenAsyncSession(app.Database);
+        var defaults = await session.LoadAsync<IFrameStyleDefaults>(IFrameStyleDefaults.DocumentId, ct);
+        return Results.Ok(new IFrameDefaultCustomizationResponse(defaults?.Css));
+    }
+
+    private static async Task<IResult> UpdateDefaultCustomizationAsync(
+        string slug,
+        UpdateIFrameCustomizationRequest body,
+        IDocumentStore store,
+        ILogger<IFrameCustomizationLogger> logger,
+        CancellationToken ct)
+    {
+        if (body is null)
+            return Results.BadRequest(new ApiErrorResponse("request body is required"));
+        if (IFrameCss.TryValidate(body.Css, out var cssError) == false)
+            return Results.BadRequest(new ApiErrorResponse(cssError!));
+
+        var app = await AppLookup.LoadAppAsync(store, slug, ct);
+        if (app is null)
+            return Results.NotFound(new ApiErrorResponse($"no app with slug '{slug}'"));
+
+        var css = string.IsNullOrWhiteSpace(body.Css) ? null : body.Css;
+
+        using var session = store.OpenAsyncSession(app.Database);
+        var defaults = await session.LoadAsync<IFrameStyleDefaults>(IFrameStyleDefaults.DocumentId, ct);
+        if (defaults is null)
+        {
+            defaults = new IFrameStyleDefaults { Id = IFrameStyleDefaults.DocumentId };
+            await session.StoreAsync(defaults, ct);
+        }
+
+        defaults.Css = css;
+        defaults.UpdatedAt = DateTime.UtcNow;
+        await session.SaveChangesAsync(ct);
+
+        logger.LogInformation("Updated iFrame default customization slug={Slug} hasCss={HasCss}", app.Slug, css is not null);
+        return Results.Ok(new IFrameDefaultCustomizationResponse(defaults.Css));
+    }
+
+    private static async Task<IResult> GetPreviewAsync(
+        string slug,
+        string? title,
+        IDocumentStore store,
+        CancellationToken ct)
+    {
+        var app = await AppLookup.LoadAppAsync(store, slug, ct);
+        if (app is null)
+            return Results.NotFound(new ApiErrorResponse($"no app with slug '{slug}'"));
+
+        return Results.Ok(new IFramePreviewResponse(EmbedEndpoints.BuildPreviewHtml(title)));
+    }
+
+    private static async Task<IResult> GetStyleGuideAsync(
+        string slug,
+        IDocumentStore store,
+        CancellationToken ct)
+    {
+        var app = await AppLookup.LoadAppAsync(store, slug, ct);
+        if (app is null)
+            return Results.NotFound(new ApiErrorResponse($"no app with slug '{slug}'"));
+
+        return Results.Ok(new IFrameStyleGuideResponse(EmbedEndpoints.WidgetBaseCss));
+    }
+
+    /// <summary>Loads a channel by widgetId, returning null unless it exists and is an iFrame
+    /// channel — customization is iFrame-only, so a non-iFrame id collapses to 404.</summary>
+    private static async Task<Channel?> LoadIFrameChannelAsync(
+        IAsyncDocumentSession session, string widgetId, CancellationToken ct)
+    {
+        var channel = await session.LoadAsync<Channel>(Channel.IdPrefix + widgetId, ct);
+        return channel is { Type: ChannelType.IFrame } ? channel : null;
+    }
+
+    /// Logger category marker — keeps the ILogger generic-arg out of the public surface.
+    internal sealed class IFrameCustomizationLogger;
+}

--- a/src/Raven.AiAppliance/Program.cs
+++ b/src/Raven.AiAppliance/Program.cs
@@ -322,6 +322,7 @@ BootstrapEndpoints.Map(app);
 AuthEndpoints.Map(app);
 AppsEndpoints.Map(app);
 ChannelsEndpoints.Map(app);
+IFrameCustomizationEndpoints.Map(app);
 EmbedLinksEndpoints.Map(app);
 AiConnectionStringsEndpoints.Map(app);
 AgentsEndpoints.Map(app);

--- a/test/AiApplianceTests/ChannelLifecycleEndpointsTests.cs
+++ b/test/AiApplianceTests/ChannelLifecycleEndpointsTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using AiApplianceTests.E2E.Fixtures;
 using FastTests;
 using Raven.AiAppliance.Channels;
+using Raven.AiAppliance.Endpoints;
 using Raven.AiAppliance.Wizard;
 using Raven.Client.Documents;
 using Raven.Client.ServerWide;
@@ -217,10 +218,10 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : RavenTes
         var restricted = await client.GetAsync($"/embed/{restrictedToken}");
         Assert.Equal(HttpStatusCode.OK, restricted.StatusCode);
         var csp = Assert.Single(restricted.Headers.GetValues("Content-Security-Policy"));
-        Assert.Equal("frame-ancestors 'self' http://localhost", csp);
+        Assert.Equal($"{EmbedEndpoints.BaseCsp}; frame-ancestors 'self' http://localhost", csp);
 
-        // Empty origins -> NO CSP header at all: the embed page is intentionally
-        // embeddable from anywhere (M1 decision 2026-06-04).
+        // Empty origins -> the resource CSP is still present, but with NO frame-ancestors: the embed
+        // page stays embeddable from anywhere (M1 decision 2026-06-04) while operator CSS stays contained.
         await ApplianceTestSeed.SeedMockAgentAsync(client, "app-b", "demo-agent");
         var openProvision = await client.PostAsJsonAsync("/api/apps/app-b/setup/channel",
             new { type = "iframe", agentId = "demo-agent", allowedOrigins = Array.Empty<string>() });
@@ -228,7 +229,9 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : RavenTes
         var openToken = await MintLinkAsync(client, "app-b");
         var open = await client.GetAsync($"/embed/{openToken}");
         Assert.Equal(HttpStatusCode.OK, open.StatusCode);
-        Assert.False(open.Headers.Contains("Content-Security-Policy"));
+        var openCsp = Assert.Single(open.Headers.GetValues("Content-Security-Policy"));
+        Assert.Equal(EmbedEndpoints.BaseCsp, openCsp);
+        Assert.DoesNotContain("frame-ancestors", openCsp);
     }
 
     [RavenFact(RavenTestCategory.AiAppliance)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26917

### Additional description

IFrame CSS customization per channel and per app.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
