### PR TITLE
[Custom] RavenDB-26721 & RavenDB-26903

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
@@ -54,7 +54,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
 
         RavenAwsS3Client.FillMetadata(multipartRequest.Metadata, _metadata);
 
-        var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken);
+        var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken).ConfigureAwait(false);
         _uploadId = initiateResponse.UploadId;
         _partNumber = 1;
         _partEtags = new List<PartETag>();
@@ -67,7 +67,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
 
     public async Task UploadPartAsync(Stream stream)
     {
-        await UploadPartAsync(stream, stream.Length);
+        await UploadPartAsync(stream, stream.Length).ConfigureAwait(false);
     }
 
     public async Task UploadPartAsync(Stream stream, long size)
@@ -90,7 +90,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
                     _progress?.UploadProgress.UpdateUploaded(args.IncrementTransferred);
                     _progress?.OnUploadProgress?.Invoke();
                 }
-            }, _cancellationToken);
+            }, _cancellationToken).ConfigureAwait(false);
 
         _partEtags.Add(new PartETag(uploadResponse.PartNumber.GetValueOrDefault(), uploadResponse.ETag));
     }
@@ -110,6 +110,6 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
                 Key = _key,
                 PartETags = _partEtags
             },
-            _cancellationToken);
+            _cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AzureMultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AzureMultiPartUploader.cs
@@ -60,7 +60,7 @@ public class AzureMultiPartUploader : IMultiPartUploader
                 _progress.UploadProgress.SetUploaded(uploadedSoFar + value);
                 _progress.OnUploadProgress?.Invoke();
             })
-        }, _cancellationToken);
+        }, _cancellationToken).ConfigureAwait(false);
     }
 
     public void CompleteUpload()
@@ -73,6 +73,6 @@ public class AzureMultiPartUploader : IMultiPartUploader
         await _blockBlobClient.CommitBlockListAsync(_base64BlockIds, new CommitBlockListOptions
         {
             Metadata = _metadata
-        }, _cancellationToken);
+        }, _cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -11,28 +11,35 @@ namespace Raven.Server.Indexing;
 
 public sealed class LuceneVoronStream : VoronStream
 {
-    // A single, reusable handler shared across every transaction this stream is bound to.
-    // It captures only 'this' (so it can write the Llt field) and crucially does NOT capture any
-    // LowLevelTransaction - otherwise it would pin the disposed transaction and reintroduce the
-    // retention that RavenDB-26186 set out to remove. The transaction to compare against comes from
-    // the OnDispose argument instead.
+    // A single, reusable handler shared across every transaction this stream is bound to (used for both
+    // += and -=, so detaching removes the exact same delegate instance). It is bound to the
+    // CleanupTransaction method rather than a lambda on purpose: a method cannot capture enclosing locals,
+    // so it is impossible to accidentally capture - and thereby pin - a LowLevelTransaction here and
+    // reintroduce the retention that RavenDB-26186 set out to remove.
     private readonly Action<IPagerLevelTransactionState> _cleanupHandler;
 
     public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt) : base(name, chunksDetails, llt)
     {
-        // LowLevelTransaction.Dispose() invokes OnDispose with itself as the argument, so the handler
-        // receives the exact transaction being disposed. The compare-exchange nulls Llt only when it still
-        // points to that transaction, which makes a stale handler (one whose transaction was already replaced
-        // by UpdateCurrentTransaction) a safe no-op, and is race-safe against a concurrent in-flight read.
-        //
-        // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive the
-        // transaction that created them. Nulling Llt on dispose lets the GC collect the disposed
-        // LowLevelTransaction and its associated structures (page positions, journal references, etc.),
-        // which can be substantial depending on the indexing batch size.
-        // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
-        _cleanupHandler = txBeingDisposed => Interlocked.CompareExchange(ref Llt, null, (LowLevelTransaction)txBeingDisposed);
+        _cleanupHandler = CleanupTransaction;
 
         Llt.Transaction.LowLevelTransaction.OnDispose += _cleanupHandler;
+    }
+
+    // Nulls Llt when the transaction it currently points at is disposed. LowLevelTransaction.Dispose() invokes
+    // OnDispose with itself as the argument, so we receive the exact transaction being disposed; the compare-exchange
+    // nulls Llt only when it still points to that transaction. That makes a stale handler (one whose transaction was
+    // already replaced by UpdateCurrentTransaction) a safe no-op, and is race-safe against a concurrent in-flight read.
+    //
+    // Why null Llt at all: Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive the
+    // transaction that created them. Nulling Llt on dispose lets the GC collect the disposed LowLevelTransaction and its
+    // associated structures (page positions, journal references, etc.), which can be substantial depending on the
+    // indexing batch size. When the stream is reused, UpdateCurrentTransaction sets a fresh transaction.
+    //
+    // This is a method, not a lambda, so it cannot capture (and thereby pin) a LowLevelTransaction. The transaction to
+    // compare against always comes from the argument, never a captured variable.
+    private void CleanupTransaction(IPagerLevelTransactionState txBeingDisposed)
+    {
+        Interlocked.CompareExchange(ref Llt, null, (LowLevelTransaction)txBeingDisposed);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Voron;
 using Voron.Data;
 using Voron.Data.BTrees;
@@ -10,22 +11,28 @@ namespace Raven.Server.Indexing;
 
 public sealed class LuceneVoronStream : VoronStream
 {
+    // A single, reusable handler shared across every transaction this stream is bound to.
+    // It captures only 'this' (so it can write the Llt field) and crucially does NOT capture any
+    // LowLevelTransaction - otherwise it would pin the disposed transaction and reintroduce the
+    // retention that RavenDB-26186 set out to remove. The transaction to compare against comes from
+    // the OnDispose argument instead.
+    private readonly Action<IPagerLevelTransactionState> _cleanupHandler;
+
     public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt) : base(name, chunksDetails, llt)
     {
-        RegisterTransactionCleanup();
-    }
+        // LowLevelTransaction.Dispose() invokes OnDispose with itself as the argument, so the handler
+        // receives the exact transaction being disposed. The compare-exchange nulls Llt only when it still
+        // points to that transaction, which makes a stale handler (one whose transaction was already replaced
+        // by UpdateCurrentTransaction) a safe no-op, and is race-safe against a concurrent in-flight read.
+        //
+        // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive the
+        // transaction that created them. Nulling Llt on dispose lets the GC collect the disposed
+        // LowLevelTransaction and its associated structures (page positions, journal references, etc.),
+        // which can be substantial depending on the indexing batch size.
+        // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
+        _cleanupHandler = txBeingDisposed => Interlocked.CompareExchange(ref Llt, null, (LowLevelTransaction)txBeingDisposed);
 
-    private void RegisterTransactionCleanup()
-    {
-        Llt.Transaction.LowLevelTransaction.OnDispose += _ =>
-        {
-            // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive
-            // the transaction that created them. Nulling _llt here allows the GC to collect the
-            // disposed LowLevelTransaction and its associated structures (page positions, journal
-            // references, etc.), which can be substantial depending on the indexing batch size.
-            // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
-            Llt = null;
-        };
+        Llt.Transaction.LowLevelTransaction.OnDispose += _cleanupHandler;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -33,11 +40,24 @@ public sealed class LuceneVoronStream : VoronStream
     {
         if (tx != null)
         {
-            if (Llt == tx.LowLevelTransaction)
+            var newLlt = tx.LowLevelTransaction;
+            if (Llt == newLlt)
                 return;
 
-            Llt = tx.LowLevelTransaction;
-            RegisterTransactionCleanup();
+            // Detach the handler from the old transaction. This is NOT required for correctness - the
+            // compare-exchange in _cleanupHandler already makes a leftover handler a safe no-op (it only nulls
+            // Llt when Llt still points to the transaction being disposed), and since the handler captures only 'this'
+            // (never a LowLevelTransaction) a leftover handler does not pin the old transaction either.
+            // We detach anyway to keep things tidy: handlers don't pile up on a still-live transaction's
+            // OnDispose list, and a disposed transaction's list doesn't carry a dead no-op handler.
+            // (If the old transaction was already disposed, Llt is null here and there is nothing to detach -
+            // the handler already ran and nulled Llt.)
+            var oldLlt = Llt;
+            if (oldLlt != null)
+                oldLlt.Transaction.LowLevelTransaction.OnDispose -= _cleanupHandler;
+
+            Llt = newLlt;
+            newLlt.Transaction.LowLevelTransaction.OnDispose += _cleanupHandler;
             LastPage = default(Page);
             return;
         }

--- a/test/FastTests/Issues/RavenDB-26903.cs
+++ b/test/FastTests/Issues/RavenDB-26903.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Raven.Server.Documents.PeriodicBackup.DirectUpload;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_26903 : NoDisposalNeeded
+    {
+        public RavenDB_26903(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // Backups run the smuggler under AsyncHelpers.RunSyncWithSynchronization, which installs a
+        // single-threaded ExclusiveSynchronizationContext on the dedicated backup thread and pumps it
+        // only while the smuggler is executing. A multipart upload part is started (fire-and-forget)
+        // during that run, and the final in-flight part is awaited later in DirectUploadStream.Dispose.
+        //
+        // If the cloud upload awaits capture that synchronization context (the default ConfigureAwait(true)),
+        // the part's completion continuation is posted back to the context after its message loop has already
+        // ended, so it can never run. DirectUploadStream.Dispose then blocks forever on that task, hanging the
+        // dedicated backup thread.
+        //
+        // This test reproduces the exact lifecycle with the real AwsS3MultiPartUploader and a fake S3 client
+        // (no network): a context that captures continuations but never runs them, an upload started under it,
+        // and a blocking wait afterwards. It times out (fails) unless the uploader uses ConfigureAwait(false).
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public void DirectUpload_multipart_upload_must_not_capture_the_backup_synchronization_context()
+        {
+            var client = new AsyncCompletingS3Client();
+            var uploader = new AwsS3MultiPartUploader(client, bucketName: "bucket", storageClass: S3StorageClass.Standard,
+                progress: null, key: "key", metadata: new Dictionary<string, string>(), cancellationToken: default);
+
+            // Initialize() runs without a synchronization context (fast path), exactly like during backup setup.
+            uploader.Initialize();
+
+            using var stream = new MemoryStream(new byte[1024]);
+
+            var context = new NonPumpingSynchronizationContext();
+            var previous = SynchronizationContext.Current;
+
+            Task uploadTask;
+            SynchronizationContext.SetSynchronizationContext(context);
+            try
+            {
+                // Mirrors StartUploadTask() running on the backup thread while the ExclusiveSynchronizationContext
+                // is current: the upload is kicked off here but not awaited.
+                uploadTask = uploader.UploadPartAsync(stream);
+            }
+            finally
+            {
+                // The smuggler finishes and the message loop ends -> the context is no longer pumped,
+                // just like when RunSyncWithSynchronization returns.
+                SynchronizationContext.SetSynchronizationContext(previous);
+            }
+
+            // Mirrors DirectUploadStream.Dispose blocking on the last in-flight part. If the part's continuation
+            // was captured by 'context' (which is no longer pumped), the task never completes and this times out.
+            var completed = uploadTask.Wait(TimeSpan.FromSeconds(10));
+
+            Assert.True(completed,
+                "The multipart upload task never completed: its continuation was captured by the backup " +
+                "synchronization context and orphaned once the message loop ended. The cloud upload awaits " +
+                "must use ConfigureAwait(false).");
+        }
+
+        // A synchronization context that captures posted continuations but never executes them - modeling the
+        // backup's ExclusiveSynchronizationContext after its message loop has stopped pumping.
+        private sealed class NonPumpingSynchronizationContext : SynchronizationContext
+        {
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                // Intentionally drop the continuation: nothing pumps this context anymore.
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override SynchronizationContext CreateCopy() => this;
+        }
+
+        // Fake S3 client whose async operations complete asynchronously on the thread pool (no network).
+        // It uses ConfigureAwait(false) internally so that its OWN completion does not depend on the test's
+        // non-pumping context - only the production uploader's ConfigureAwait behavior is under test.
+        private sealed class AsyncCompletingS3Client : AmazonS3Client
+        {
+            public AsyncCompletingS3Client()
+                : base(new BasicAWSCredentials("test", "test"), new AmazonS3Config { ServiceURL = "https://localhost:1" })
+            {
+            }
+
+            public override async Task<InitiateMultipartUploadResponse> InitiateMultipartUploadAsync(InitiateMultipartUploadRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                return new InitiateMultipartUploadResponse { UploadId = "test-upload-id" };
+            }
+
+            public override async Task<UploadPartResponse> UploadPartAsync(UploadPartRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+                return new UploadPartResponse { PartNumber = 1, ETag = "\"test-etag\"" };
+            }
+
+            public override async Task<CompleteMultipartUploadResponse> CompleteMultipartUploadAsync(CompleteMultipartUploadRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                return new CompleteMultipartUploadResponse();
+            }
+        }
+    }
+}

--- a/test/StressTests/Issues/RavenDB-26721.cs
+++ b/test/StressTests/Issues/RavenDB-26721.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Issues;
+
+public class RavenDB_26721 : RavenTestBase
+{
+    public RavenDB_26721(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Doc
+    {
+        public string Id { get; set; }
+        public string Body { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<Doc>
+    {
+        public Index()
+        {
+            Map = docs => from d in docs select new { d.Body };
+            Index(x => x.Body, FieldIndexing.Search);
+            Store(x => x.Body, FieldStorage.Yes);
+        }
+    }
+
+    private class Projection
+    {
+        public string Body { get; set; }
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Encryption | RavenTestCategory.Indexes)]
+    public async Task Streaming_Projection_Query_On_Encrypted_Db_Aborted_MidStream_Does_Not_Throw()
+    {
+        // Repro for RavenDB-26721: during a streaming projection query over an encrypted database, the index read
+        // transaction could be disposed on one thread while a VoronStream read was still in flight on another thread
+        // (Lucene caches VoronStream instances per-thread via SegmentReader, and the streaming loop can resume its
+        // async continuation on a different thread). The transaction's OnDispose handler nulled LuceneVoronStream.Llt,
+        // and the in-flight read then dereferenced the now-null Llt in VoronStream.UpdateLastPageIfNeeded -> NRE,
+        // which surfaced to the client as a confusing "Invalid JSON" error.
+        //
+        // It only manifests on encrypted databases because the encrypted read path calls Llt.GetPageWithoutCache at
+        // every page boundary (decrypting each page) - that is ~100-1000x slower than the memory-mapped non-encrypted
+        // path, widening the race window enough for the concurrent dispose to land inside an in-flight read.
+
+        var enc = await Encryption.EncryptedServerAsync();
+        var cert = enc.Certificates.ServerCertificateForCommunication.Value;
+
+        using var store = GetDocumentStore(new Options
+        {
+            AdminCertificate = cert,
+            ClientCertificate = cert,
+            ModifyDatabaseName = _ => enc.DatabaseName,
+            ModifyDatabaseRecord = r => r.Encrypted = true,
+            Path = NewDataPath()
+        });
+
+        await new Index().ExecuteAsync(store);
+
+        const int docCount = 50_000;
+        var filler = new string('x', 300);
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < docCount; i++)
+                await bulk.StoreAsync(new Doc { Body = "common " + filler + " " + i });
+        }
+
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(20));
+
+        Exception failure = null;
+        var deadline = DateTime.UtcNow.AddMinutes(3);
+
+        var workers = Enumerable.Range(0, 32).Select(_ => Task.Run(async () =>
+        {
+            while (DateTime.UtcNow < deadline && Volatile.Read(ref failure) == null)
+            {
+                try
+                {
+                    using var session = store.OpenAsyncSession();
+                    var q = session.Advanced.AsyncDocumentQuery<Doc, Index>()
+                        .Search(x => x.Body, "common")
+                        .SelectFields<Projection>();
+
+                    await using var stream = await session.Advanced.StreamAsync(q);
+
+                    int c = 0;
+                    while (await stream.MoveNextAsync())
+                    {
+                        if (++c >= 2000)
+                            break; // read many, then abort (dispose) -> abort the request mid-stream
+                    }
+                }
+                catch (Exception e)
+                {
+                    var msg = e.GetType().Name + ": " + e.Message;
+                    if (msg.Contains("Invalid JSON") || msg.Contains("NullReference"))
+                        Interlocked.CompareExchange(ref failure, e, null);
+
+                    // any other exception (e.g. an expected cancellation/abort of the stream) is ignored on purpose
+                }
+            }
+        })).ToArray();
+
+        await Task.WhenAll(workers);
+
+        Assert.True(failure == null,
+            "Streaming an encrypted projection query and aborting mid-stream must not surface a NullReferenceException " +
+            "(seen by the client as 'Invalid JSON'). Got: " + failure);
+    }
+}


### PR DESCRIPTION
This fix is on top of 6.2.15 version

- **RavenDB-26721:** Fix `NullReferenceException` in encrypted streaming queries when the read transaction is disposed during an in-flight `VoronStream` read. https://github.com/ravendb/ravendb/pull/23038.
- **RavenDB-26903:** Fix backup hang on cloud direct upload (S3/Azure) after `RunSyncWithSynchronization` change. https://github.com/ravendb/ravendb/pull/23071.