### PR TITLE
RavenDB-26889 AssertThrowsAnyAsync: match the expected type anywhere in the exception tree

### DIFF
--- a/test/SlowTests/SparrowTests/ControlCharacterTests.cs
+++ b/test/SlowTests/SparrowTests/ControlCharacterTests.cs
@@ -683,12 +683,27 @@ public class ControlCharacterTests : ClusterTestBase
 
     public static async Task AssertThrowsAnyAsync<T>(Func<Task> testCode) where T : Exception
     {
-        var e = await Assert.ThrowsAnyAsync<Exception>(testCode);
+        var actual = await Assert.ThrowsAnyAsync<Exception>(testCode);
 
-        while (e.InnerException is { } temp)
-            e = temp;
+        Assert.True(Flatten(actual).OfType<T>().Any(),
+            $"Expected an exception of type '{typeof(T)}' somewhere in the exception tree, but none was found.{Environment.NewLine}" +
+            $"Actual exception tree:{Environment.NewLine}{actual}");
+        return;
 
-        Assert.IsType<T>(e);
+        static IEnumerable<Exception> Flatten(Exception exception)
+        {
+            if (exception == null)
+                yield break;
+
+            yield return exception;
+
+            IEnumerable<Exception> inner = exception is AggregateException aggregate
+                ? aggregate.InnerExceptions.SelectMany(Flatten)
+                : Flatten(exception.InnerException);
+
+            foreach (var child in inner)
+                yield return child;
+        }
     }
     
     private static unsafe LazyStringValue GetLazyStringValue(JsonOperationContext context, Slice idSlice)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26889

### Additional description
  #### Summary                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                             
  `ControlCharacters_InTimeSeriesNameAndTag_ShouldReject` failed intermittently on CI.                                                                                                                                                       
  The cause was an over-strict assertion helper, not a product bug.                                                                                                                                                                          
                                                                                                                                                                                                                                             
  #### Failure                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                             
  ```                                                                                                                                                                                                                                        
  Assert.IsType() Failure: Value is not the exact type                                                                                                                                                                                       
  Expected: BulkInsertAbortedException                                                                                                                                                                                                       
  Actual:   System.InvalidOperationException                                                                                                                                                                                                 
  ```                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                             
  #### Root cause                                                                                                                                                                                                                              
                                                                                                                                                                                                                                             
  `AssertThrowsAnyAsync<T>` walked to the innermost exception and required it to be exactly `T`.                                                                                                                                             
  For an aborted bulk insert the inner exception is InvalidOperationException.
                                                                                                                  
  #### Fix                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                             
  `AssertThrowsAnyAsync<T>` now checks whether `T` appears anywhere in the exception tree, flattening `AggregateException`.                                                                                                                  
  On failure it prints the full actual exception tree, so a real mismatch is easy to read.                                                                                                                                                   
  This is a test-only change.                                                                                                                                                                                                                
  The client already throws `BulkInsertAbortedException` as the outer exception in every case, so only the assertion needed fixing.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test fix

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior
- [x] Not relevant

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
