### PR TITLE
RavenDB-26921 Fix Corax search() wildcards on dynamic (CreateField) fields

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -12,7 +12,6 @@ using Corax.Querying.Matches.SortingMatches.Meta;
 using Corax.Utils;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Standard;
-using NetTopologySuite.Utilities;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Corax;
 using Raven.Server.Documents.Indexes.Persistence.Corax.QueryOptimizer;
@@ -27,7 +26,6 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Server;
 using Spatial4n.Shapes;
-using Analyzer = Corax.Analyzers.Analyzer;
 using RavenConstants = Raven.Client.Constants;
 using IndexSearcher = Corax.Querying.IndexSearcher;
 using CoraxConstants = Corax.Constants;
@@ -1240,9 +1238,8 @@ public static class CoraxQueryBuilder
             // We need to retrieve the analyzer for the dynamic field since the field metadata is created dynamically.
             if (original.IsDynamic)
                 result = fieldMetadata.ChangeAnalyzer(original.Mode, builderParameters.IndexFieldsMapping.SearchAnalyzer(original.FieldName.ToString()));
-
             
-            if (original.Analyzer is LuceneAnalyzerAdapter laa)
+            if (result.Analyzer is LuceneAnalyzerAdapter laa)
             {
                 //logic from LuceneQueryBuilder
                 var luceneAnalyzer = laa.Analyzer switch
@@ -1257,9 +1254,9 @@ public static class CoraxQueryBuilder
                     // in wildcard queries
                     _ => null
                 };
-            
-                if (luceneAnalyzer != null) 
-                    result = original.ChangeAnalyzer(FieldIndexingMode.Search, luceneAnalyzer);
+
+                if (luceneAnalyzer != null)
+                    result = result.ChangeAnalyzer(FieldIndexingMode.Search, luceneAnalyzer);
             }
             
             // Currently, we do not have any custom Corax analyzers, so we don't need to address them.

--- a/test/SlowTests/Issues/RavenDB_26921.cs
+++ b/test/SlowTests/Issues/RavenDB_26921.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26921(ITestOutputHelper output) : RavenTestBase(output)
+{
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["qui*"])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["*ick"])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["*ic*"])]
+    public void PrefixSuffixSearchOperatorStaticField(Options options, string query)
+        => TestExecutor<MyDocsStaticField>(options, query);
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["qui*"])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["*ick"])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["*ic*"])]
+    public void PrefixSuffixSearchOperatorDynamicField(Options options, string query)
+        => TestExecutor<MyDocsDynamicField>(options, query);
+
+    private void TestExecutor<TIndex>(Options options, string query)
+        where TIndex : AbstractIndexCreationTask<MyDoc>, new()
+    {
+        using var store = GetDocumentStore(options);
+        Spawn<TIndex>(store);
+
+        using var session = store.OpenSession();
+        List<MyDoc> result = session.Query<MyDoc, TIndex>().Search(x => x.CustomFieldName, query).ToList();
+        Assert.Single(result);
+    }
+    
+    private class MyDoc
+    {
+        public string Name { get; set; }
+        public string CustomFieldName { get; set; }
+    }
+
+    private class MyDocsDynamicField : AbstractIndexCreationTask<MyDoc>
+    {
+        public MyDocsDynamicField()
+        {
+            Map = docs => from doc in docs
+                select new
+                {
+                    _ = CreateField("CustomFieldName", doc.Name, new CreateFieldOptions 
+                        { Indexing = FieldIndexing.Search, Storage = FieldStorage.No })
+                };
+        }
+    }
+    
+    private class MyDocsStaticField : AbstractIndexCreationTask<MyDoc>
+    {
+        public MyDocsStaticField()
+        {
+            Map = docs => from doc in docs
+                select new
+                {
+                    CustomFieldName = doc.Name
+                };
+
+            Index("CustomFieldName", FieldIndexing.Search);
+            Store("CustomFieldName", FieldStorage.No);
+        }
+    }
+
+    private void Spawn<TIndex>(IDocumentStore store) where TIndex : AbstractIndexCreationTask<MyDoc>, new()
+    {
+        using var session = store.OpenSession();
+        session.Store(new MyDoc { Name = "The quick brown fox jumps over the lazy dog" });
+        session.SaveChanges();
+        new TIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+    }
+    
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26921 

### Additional description

Fix Corax search() wildcards on dynamic (CreateField) fields

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
