### PR TITLE
RavenDB-26879 CDC - Add button to add missing related tables

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/EditCdcSinkTask.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/EditCdcSinkTask.spec.tsx
@@ -1,6 +1,6 @@
 import { composeStory } from "@storybook/react-webpack5";
 import * as stories from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/EditCdcSinkTask.stories";
-import { act, rtlRender, waitFor } from "test/rtlTestUtils";
+import { act, rtlRender, waitFor, within } from "test/rtlTestUtils";
 import { mockServices } from "test/mocks/services/MockServices";
 import { TasksStubs } from "test/stubs/TasksStubs";
 
@@ -29,6 +29,10 @@ const selectors = {
     discoverButton: /^Discover$/i,
     configureSelectedTablesButton: /^Configure selected tables$/i,
     saveTaskButton: /Save task configuration/i,
+    missingRelatedTablesAlert: /Linked tables reference 1 source table that is not configured as a root table/,
+    addMissingRootTableButton: /^Add root table$/,
+    addSelectedMissingRootTablesButton: /^Add 1 root table$/,
+    addRootTablesModalTitle: "Add root tables",
 };
 
 describe("Edit CDC Sink task", () => {
@@ -119,6 +123,38 @@ describe("Edit CDC Sink task", () => {
             selectors.databaseName,
             TasksStubs.getCdcSink().TaskId
         );
+    });
+
+    it("adds missing referenced tables as root tables from the alert", async () => {
+        const Story = composeStory(stories.EditTask, stories.default);
+
+        const { screen, fireClick } = rtlRender(<Story />);
+
+        await screen.findByText(selectors.editTaskTitle);
+        expect(await screen.findByText("orders")).toBeInTheDocument();
+
+        // No "alert is absent before discovery" assertion: discovery also auto-runs for the
+        // saved connection string, so such a check would race it.
+        await fireClick(getButtonByText(screen, selectors.discoverTablesButton));
+        await fireClick(await screen.findByText(selectors.discoverButton).then((x) => x.closest("button")));
+
+        const missingRelatedTablesAlert = await screen.findByText(selectors.missingRelatedTablesAlert);
+        const missingRelatedTablesAlertElement = missingRelatedTablesAlert.closest(".alert") as HTMLElement;
+        expect(missingRelatedTablesAlert).toBeInTheDocument();
+        expect(missingRelatedTablesAlertElement).not.toHaveTextContent(selectors.companiesTable);
+
+        await fireClick(getButtonByText(screen, selectors.addMissingRootTableButton));
+        const addRootTablesModal = (await screen.findByText(selectors.addRootTablesModalTitle)).closest(
+            ".modal-content"
+        ) as HTMLElement;
+        expect(within(addRootTablesModal).getByText(selectors.companiesTable)).toBeInTheDocument();
+
+        await fireClick(
+            within(addRootTablesModal).getByText(selectors.addSelectedMissingRootTablesButton).closest("button")
+        );
+
+        await waitFor(() => expect(screen.queryByText(selectors.missingRelatedTablesAlert)).not.toBeInTheDocument());
+        expect(await screen.findByText("companies")).toBeInTheDocument();
     });
 
     it("can render license restricted view", async () => {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/hooks/useEditCdcSinkTaskTableActions.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/hooks/useEditCdcSinkTaskTableActions.ts
@@ -64,6 +64,19 @@ export function useEditCdcSinkTaskTableActions() {
         dispatch(editCdcSinkTaskActions.activeTableSet({ type: "embedded", path: newPath }));
     };
 
+    const addRootTables = (newTables: FormRootTable[]) => {
+        if (newTables.length === 0) {
+            return;
+        }
+
+        // The added tables are complete (unlike manually added empty rows) — validate immediately
+        // so any problem surfaces at the click, not at save time.
+        setValue("tables", [...getTableList<FormRootTable>("tables"), ...newTables], {
+            shouldDirty: true,
+            shouldValidate: true,
+        });
+    };
+
     const addLinkedTable = (parentPath: RootTablePath | EmbeddedTablePath) => {
         const listPath = `${parentPath}.linkedTables` as TableListPath;
         const linkedTables = getTableList<FormLinkedTable>(listPath);
@@ -94,6 +107,7 @@ export function useEditCdcSinkTaskTableActions() {
     return {
         addEmbeddedTable,
         addLinkedTable,
+        addRootTables,
         removeTable,
         toggleRootTableDisabled,
     };

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/hooks/useEditCdcSinkTaskTableActions.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/hooks/useEditCdcSinkTaskTableActions.ts
@@ -12,6 +12,7 @@ import {
     castToLinkedTablePath,
 } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes";
 import { EditCdcSinkTaskFormData } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation";
+import { alignLinkedTableCollectionNames } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils";
 import { useAppDispatch } from "components/store";
 import { FieldPath, useFormContext, UseFormSetValue } from "react-hook-form";
 
@@ -69,9 +70,12 @@ export function useEditCdcSinkTaskTableActions() {
             return;
         }
 
+        const currentTables = getTableList<FormRootTable>("tables");
+        const alignedCurrentTables = alignLinkedTableCollectionNames(currentTables, newTables);
+
         // The added tables are complete (unlike manually added empty rows) — validate immediately
         // so any problem surfaces at the click, not at save time.
-        setValue("tables", [...getTableList<FormRootTable>("tables"), ...newTables], {
+        setValue("tables", [...alignedCurrentTables, ...newTables], {
             shouldDirty: true,
             shouldValidate: true,
         });

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/EditCdcSinkTaskTablesSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/EditCdcSinkTaskTablesSection.tsx
@@ -2,13 +2,34 @@ import CollapseButton from "components/common/CollapseButton";
 import useBoolean from "components/hooks/useBoolean";
 import { EditCdcSinkTaskFormData } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation";
 import Collapse from "react-bootstrap/Collapse";
-import { UseFieldArrayReturn, useFormContext } from "react-hook-form";
+import { UseFieldArrayReturn, useFormContext, useWatch } from "react-hook-form";
 import EditCdcSinkTaskTablesExplorer from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/EditCdcSinkTaskTablesExplorer";
 import EditCdcSinkTaskTableEditor from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/EditCdcSinkTaskTableEditor";
 import useResizableWidth from "components/hooks/useResizableWidth";
 import ColumnResize from "components/common/ColumnResize";
 import classNames from "classnames";
 import { FormErrorIcon } from "components/common/Form";
+import RichAlert from "components/common/RichAlert";
+import { Icon } from "components/common/Icon";
+import Button from "react-bootstrap/Button";
+import Modal from "components/common/Modal";
+import pluralizeHelpers from "common/helpers/text/pluralizeHelpers";
+import { useAppSelector } from "components/store";
+import { editCdcSinkTaskSelectors } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/store/editCdcSinkTaskSlice";
+import { useEditCdcSinkTaskTableActions } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/hooks/useEditCdcSinkTaskTableActions";
+import {
+    CdcSinkSourceTable,
+    getRelatedSourceTablesToAdd,
+    getSourceTableOptionLabel,
+    mapRelatedSqlTablesToFormData,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils";
+import { useCallback, useMemo, useRef } from "react";
+import { ColumnDef, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
+import VirtualTable from "components/common/virtualTable/VirtualTable";
+import { virtualTableUtils } from "components/common/virtualTable/utils/virtualTableUtils";
+import { columnCheckbox } from "components/common/virtualTable/utils/commonColumnDefs";
+import { CellValueWrapper } from "components/common/virtualTable/cells/CellValue";
+import { useResizeObserver } from "hooks/useResizeObserver";
 
 interface EditCdcSinkTaskTablesSectionProps {
     tablesFieldArray: UseFieldArrayReturn<EditCdcSinkTaskFormData, "tables", "id">;
@@ -42,19 +63,174 @@ function TablesPanel({ tablesFieldArray }: EditCdcSinkTaskTablesSectionProps) {
     });
 
     return (
-        <div className="mt-3 hstack align-items-stretch panel-bg-2 rounded-2 border border-secondary flex-grow-1 min-height-0">
-            <div
-                className={classNames("rounded-2 h-100 p-2 position-relative", {
-                    "is-dragging": resizable.isDragging,
-                })}
-                style={{ width: resizable.width }}
-            >
-                <EditCdcSinkTaskTablesExplorer tablesFieldArray={tablesFieldArray} />
-                <ColumnResize handleMouseDown={resizable.handleMouseDown} placement="right" />
-            </div>
-            <div className="border-start border-secondary panel-bg-1 rounded-end-2 flex-grow-1 overflow-hidden min-height-0">
-                <EditCdcSinkTaskTableEditor />
+        <div className="mt-3 vstack flex-grow-1 min-height-0">
+            <MissingRelatedTablesAlert />
+            <div className="hstack align-items-stretch panel-bg-2 rounded-2 border border-secondary flex-grow-1 min-height-0">
+                <div
+                    className={classNames("rounded-2 h-100 p-2 position-relative", {
+                        "is-dragging": resizable.isDragging,
+                    })}
+                    style={{ width: resizable.width }}
+                >
+                    <EditCdcSinkTaskTablesExplorer tablesFieldArray={tablesFieldArray} />
+                    <ColumnResize handleMouseDown={resizable.handleMouseDown} placement="right" />
+                </div>
+                <div className="border-start border-secondary panel-bg-1 rounded-end-2 flex-grow-1 overflow-hidden min-height-0">
+                    <EditCdcSinkTaskTableEditor />
+                </div>
             </div>
         </div>
+    );
+}
+
+function MissingRelatedTablesAlert() {
+    const sourceSchema = useAppSelector(editCdcSinkTaskSelectors.sourceSchema);
+    const tableActions = useEditCdcSinkTaskTableActions();
+    const {
+        value: isAddTablesModalOpen,
+        setTrue: openAddTablesModal,
+        setFalse: closeAddTablesModal,
+    } = useBoolean(false);
+    const { control } = useFormContext<EditCdcSinkTaskFormData>();
+    const tables = useWatch({ control, name: "tables" });
+
+    const relatedSourceTables = useMemo(
+        () => getRelatedSourceTablesToAdd(sourceSchema, tables ?? []),
+        [sourceSchema, tables]
+    );
+
+    if (relatedSourceTables.length === 0) {
+        return null;
+    }
+
+    const isSingleTable = relatedSourceTables.length === 1;
+    const tableLabel = isSingleTable ? "table" : "tables";
+
+    const handleAddTables = (tablesToAdd: CdcSinkSourceTable[]) => {
+        if (tablesToAdd.length === 0) {
+            return;
+        }
+
+        tableActions.addRootTables(mapRelatedSqlTablesToFormData(sourceSchema, tables ?? [], tablesToAdd));
+    };
+
+    return (
+        <>
+            <RichAlert variant="warning" className="mb-3">
+                <div className="d-flex align-items-center gap-2">
+                    <div className="flex-grow-1 min-width-0">
+                        Linked tables reference {relatedSourceTables.length} source {tableLabel} that{" "}
+                        {isSingleTable ? "is not configured as a root table" : "are not configured as root tables"}.
+                        Related documents for the referenced {tableLabel} will not be created.
+                    </div>
+                    <Button
+                        variant="warning"
+                        size="sm"
+                        className="text-nowrap align-self-center"
+                        onClick={openAddTablesModal}
+                    >
+                        <Icon icon="plus" />
+                        {isSingleTable
+                            ? `Add root ${tableLabel}`
+                            : `Add ${relatedSourceTables.length} root ${tableLabel}`}
+                    </Button>
+                </div>
+            </RichAlert>
+            {isAddTablesModalOpen && (
+                <AddRelatedTablesModal
+                    sourceTables={relatedSourceTables}
+                    onAdd={handleAddTables}
+                    onClose={closeAddTablesModal}
+                />
+            )}
+        </>
+    );
+}
+
+interface AddRelatedTablesModalProps {
+    sourceTables: CdcSinkSourceTable[];
+    onAdd: (sourceTables: CdcSinkSourceTable[]) => void;
+    onClose: () => void;
+}
+
+function AddRelatedTablesModal({ sourceTables, onAdd, onClose }: AddRelatedTablesModalProps) {
+    const tableWrapperRef = useRef<HTMLDivElement>(null);
+    const { width } = useResizeObserver({ ref: tableWrapperRef });
+    const columns = useAddRelatedTablesColumns(width ?? 0);
+    const table = useReactTable({
+        data: sourceTables,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getRowId: getSourceTableOptionLabel,
+        initialState: {
+            rowSelection: Object.fromEntries(
+                sourceTables.map((sourceTable) => [getSourceTableOptionLabel(sourceTable), true])
+            ),
+            sorting: [
+                {
+                    id: "TableName",
+                    desc: false,
+                },
+            ],
+        },
+    });
+
+    const selectedSourceTables = table.getSelectedRowModel().rows.map((row) => row.original);
+    const selectedTablesLabel = pluralizeHelpers.pluralize(selectedSourceTables.length, "root table", "root tables");
+
+    const handleAdd = () => {
+        onAdd(selectedSourceTables);
+        onClose();
+    };
+
+    return (
+        <Modal show onHide={onClose} contentClassName="modal-border bulge-primary" size="lg">
+            <Modal.Header onCloseClick={onClose} className="pb-0">
+                <h3 className="m-0">Add root tables</h3>
+            </Modal.Header>
+            <Modal.Body className="vstack gap-3">
+                <div ref={tableWrapperRef}>
+                    <VirtualTable
+                        table={table}
+                        heightInPx={virtualTableUtils.getHeightInPx(sourceTables.length, 300)}
+                    />
+                </div>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="link" onClick={onClose}>
+                    Cancel
+                </Button>
+                <Button
+                    variant="primary"
+                    className="rounded-pill"
+                    onClick={handleAdd}
+                    disabled={selectedSourceTables.length === 0}
+                >
+                    <Icon icon="plus" />
+                    Add {selectedTablesLabel}
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}
+
+function useAddRelatedTablesColumns(widthPx: number) {
+    const dynamicWidth = widthPx ? widthPx - columnCheckbox.size : 0;
+    const bodyWidth = virtualTableUtils.getTableBodyWidth(dynamicWidth);
+    const getSize = useCallback(virtualTableUtils.getCellSizeProvider(bodyWidth), [bodyWidth]);
+
+    return useMemo<ColumnDef<CdcSinkSourceTable>[]>(
+        () => [
+            columnCheckbox as ColumnDef<CdcSinkSourceTable>,
+            {
+                id: "TableName",
+                header: "Table name",
+                accessorFn: getSourceTableOptionLabel,
+                cell: CellValueWrapper,
+                size: getSize(100),
+            },
+        ],
+        [getSize]
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableItems.spec.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableItems.spec.ts
@@ -107,7 +107,7 @@ describe("buildExplorerRows", () => {
 
         expect(rows.some((row) => row.type === "linked")).toBe(false);
         expect(getRootRows(rows)[0].warningMessages).toEqual([
-            expect.stringContaining('"public.media" is also configured as a root table'),
+            expect.stringContaining('"public.media" is not configured as a root table'),
         ]);
     });
 
@@ -174,7 +174,7 @@ describe("buildExplorerRows", () => {
 
         expect(rows.some((row) => row.type === "linked")).toBe(false);
         expect(embeddedRow?.warningMessages).toEqual([
-            expect.stringContaining('"public.media" is also configured as a root table'),
+            expect.stringContaining('"public.media" is not configured as a root table'),
         ]);
     });
 });

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableItems.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tablesExplorer/EditCdcSinkTaskTableItems.tsx
@@ -47,6 +47,9 @@ interface IndexedRootTable {
     table: FormRootTable;
 }
 
+// Empty schemas are possible in configurations created through the API.
+const emptySchemaKey = "";
+
 export function EditCdcSinkTaskTableItems({ filter, rootFieldIds }: EditCdcSinkTaskTableItemsProps) {
     const parentRef = useRef<HTMLDivElement>(null);
     const expandedTables = useAppSelector((state) => state.editCdcSinkTask.expandedTables);
@@ -126,8 +129,9 @@ export function buildExplorerRows({ allTables, expandedTables, filter, rootField
         index,
     }));
 
+    // Tables with an empty schema are grouped under a "(default schema)" placeholder.
     const filteredGroupedTables = Object.entries(
-        _.groupBy(indexedTables, ({ table }) => table?.sourceTableSchema || "public")
+        _.groupBy(indexedTables, ({ table }) => table?.sourceTableSchema || emptySchemaKey)
     )
         .map(([schema, rootTables]) => ({
             schema,
@@ -145,7 +149,7 @@ export function buildExplorerRows({ allTables, expandedTables, filter, rootField
                 type: "schema",
                 path: `schema:${schema}`,
                 rowKey: `schema:${schema}`,
-                label: schema,
+                label: schema === emptySchemaKey ? "(default schema)" : schema,
             },
         ];
 

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils.spec.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils.spec.ts
@@ -1,7 +1,14 @@
 import {
+    getRelatedSourceTablesToAdd,
     isTableSupported,
+    mapRelatedSqlTablesToFormData,
     mapSourceColumnsToFormData,
+    mapSqlTableToFormData,
 } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils";
+import {
+    FormEmbeddedTable,
+    FormRootTable,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes";
 
 import CdcSinkSchema = Raven.Client.Documents.Operations.CdcSink.Schema;
 
@@ -66,7 +73,358 @@ describe("CDC Sink schema utils", () => {
 
         expect(mapSourceColumnsToFormData(schema, table)).toEqual([]);
     });
+
+    it("maps foreign keys to linked tables by default", () => {
+        const schema = createSchema({});
+        const table = createTable({ ForeignKeys: [createForeignKey()] });
+
+        expect(mapSqlTableToFormData(schema, table).linkedTables).toEqual([
+            {
+                propertyName: "Customer",
+                joinColumns: [{ value: "customer_id" }],
+                linkedCollectionName: "Customers",
+                sourceTableName: "customers",
+                sourceTableSchema: "dbo",
+            },
+        ]);
+    });
 });
+
+describe("mapRelatedSqlTablesToFormData", () => {
+    const countriesForeignKey = createForeignKey({ Columns: ["country_id"], ReferencedTable: "countries" });
+
+    it("keeps a link with the conventional name when the referenced table is neither configured nor in the batch", () => {
+        const customers = createTable({ SourceTableName: "customers", ForeignKeys: [countriesForeignKey] });
+        const schema = createSchema({ Tables: [customers] });
+
+        const [mapped] = mapRelatedSqlTablesToFormData(schema, [], [customers]);
+
+        expect(mapped.linkedTables).toEqual([
+            {
+                propertyName: "Country",
+                joinColumns: [{ value: "country_id" }],
+                linkedCollectionName: "Countries",
+                sourceTableName: "countries",
+                sourceTableSchema: "dbo",
+            },
+        ]);
+    });
+
+    it("keeps a link to a configured root table and aligns the collection name", () => {
+        const customers = createTable({ SourceTableName: "customers", ForeignKeys: [countriesForeignKey] });
+        const countries = createTable({ SourceTableName: "countries" });
+        const schema = createSchema({ Tables: [customers, countries] });
+        const countriesRoot = { ...mapSqlTableToFormData(schema, countries), collectionName: "Nations" };
+
+        const [mapped] = mapRelatedSqlTablesToFormData(schema, [countriesRoot], [customers]);
+
+        expect(mapped.linkedTables).toEqual([
+            {
+                propertyName: "Country",
+                joinColumns: [{ value: "country_id" }],
+                linkedCollectionName: "Nations",
+                sourceTableName: "countries",
+                sourceTableSchema: "dbo",
+            },
+        ]);
+    });
+
+    it("keeps links between tables added in the same batch", () => {
+        const customers = createTable({ SourceTableName: "customers", ForeignKeys: [countriesForeignKey] });
+        const countries = createTable({ SourceTableName: "countries" });
+        const schema = createSchema({ Tables: [customers, countries] });
+
+        const mapped = mapRelatedSqlTablesToFormData(schema, [], [customers, countries]);
+
+        expect(mapped[0].linkedTables).toEqual([
+            expect.objectContaining({ sourceTableName: "countries", linkedCollectionName: "Countries" }),
+        ]);
+        expect(mapped[1].linkedTables).toEqual([]);
+    });
+
+    it("adopts the collection name the referencing linked table uses", () => {
+        const orders = createTable({ SourceTableName: "orders", ForeignKeys: [createForeignKey()] });
+        const customers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, customers] });
+        const ordersRoot = mapSqlTableToFormData(schema, orders);
+        ordersRoot.linkedTables[0].linkedCollectionName = "Clients";
+
+        const [mapped] = mapRelatedSqlTablesToFormData(schema, [ordersRoot], [customers]);
+
+        expect(mapped.collectionName).toBe("Clients");
+    });
+
+    it("ignores collection names referenced only from disabled root tables", () => {
+        const orders = createTable({ SourceTableName: "orders", ForeignKeys: [createForeignKey()] });
+        const customers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, customers] });
+        const disabledOrdersRoot = { ...mapSqlTableToFormData(schema, orders), disabled: true };
+        disabledOrdersRoot.linkedTables[0].linkedCollectionName = "Clients";
+
+        const [mapped] = mapRelatedSqlTablesToFormData(schema, [disabledOrdersRoot], [customers]);
+
+        expect(mapped.collectionName).toBe("Customers");
+    });
+
+    it("falls back to the default collection name when referencing linked tables disagree", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ Columns: ["ship_to"] }), createForeignKey({ Columns: ["bill_to"] })],
+        });
+        const customers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, customers] });
+        const ordersRoot = mapSqlTableToFormData(schema, orders);
+        ordersRoot.linkedTables[0].linkedCollectionName = "Clients";
+        ordersRoot.linkedTables[1].linkedCollectionName = "Buyers";
+
+        const [mapped] = mapRelatedSqlTablesToFormData(schema, [ordersRoot], [customers]);
+
+        expect(mapped.collectionName).toBe("Customers");
+    });
+
+    it("de-duplicates collection names of same-named tables from different schemas", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [
+                createForeignKey({ Columns: ["ship_to"], ReferencedSchema: "dbo", ReferencedTable: "customers" }),
+                createForeignKey({ Columns: ["bill_to"], ReferencedSchema: "archive", ReferencedTable: "customers" }),
+            ],
+        });
+        const dboCustomers = createTable({ SourceTableName: "customers" });
+        const archiveCustomers = createTable({ SourceTableSchema: "archive", SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, dboCustomers, archiveCustomers] });
+
+        const mapped = mapRelatedSqlTablesToFormData(
+            schema,
+            [mapSqlTableToFormData(schema, orders)],
+            [dboCustomers, archiveCustomers]
+        );
+
+        expect(mapped.map((table) => table.collectionName)).toEqual(["Customers", "ArchiveCustomers"]);
+    });
+
+    it("de-duplicates collection names against already configured root tables", () => {
+        const orders = createTable({ SourceTableName: "orders", ForeignKeys: [createForeignKey()] });
+        const salesCustomers = createTable({ SourceTableSchema: "sales", SourceTableName: "customers" });
+        const dboCustomers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, salesCustomers, dboCustomers] });
+        const rootTables = [mapSqlTableToFormData(schema, orders), mapSqlTableToFormData(schema, salesCustomers)];
+
+        const [mapped] = mapRelatedSqlTablesToFormData(schema, rootTables, [dboCustomers]);
+
+        expect(mapped.collectionName).toBe("DboCustomers");
+    });
+});
+
+describe("getRelatedSourceTablesToAdd", () => {
+    it("adds source tables referenced by linked tables that are not configured", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ ReferencedTable: "customers" })],
+        });
+        const customers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, customers] });
+
+        const result = getRelatedSourceTablesToAdd(schema, [mapSqlTableToFormData(schema, orders)]);
+
+        expect(result.map((table) => table.SourceTableName)).toEqual(["customers"]);
+    });
+
+    it("adds a related table only once when referenced by multiple linked tables", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [
+                createForeignKey({ Columns: ["ship_to"], ReferencedTable: "customers" }),
+                createForeignKey({ Columns: ["bill_to"], ReferencedTable: "customers" }),
+            ],
+        });
+        const customers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, customers] });
+
+        const result = getRelatedSourceTablesToAdd(schema, [mapSqlTableToFormData(schema, orders)]);
+
+        expect(result.map((table) => table.SourceTableName)).toEqual(["customers"]);
+    });
+
+    it("skips related tables that are already configured as root tables", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ ReferencedTable: "customers" })],
+        });
+        const customers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, customers] });
+
+        const result = getRelatedSourceTablesToAdd(schema, [
+            mapSqlTableToFormData(schema, orders),
+            mapSqlTableToFormData(schema, customers),
+        ]);
+
+        expect(result).toEqual([]);
+    });
+
+    it("matches references case-insensitively", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ ReferencedSchema: "DBO", ReferencedTable: "Customers" })],
+        });
+        const customers = createTable({ SourceTableSchema: "dbo", SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, customers] });
+
+        const result = getRelatedSourceTablesToAdd(schema, [mapSqlTableToFormData(schema, orders)]);
+
+        expect(result.map((table) => table.SourceTableName)).toEqual(["customers"]);
+    });
+
+    it("follows foreign keys of the referenced tables transitively", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ ReferencedTable: "customers" })],
+        });
+        const customers = createTable({
+            SourceTableName: "customers",
+            ForeignKeys: [createForeignKey({ Columns: ["country_id"], ReferencedTable: "countries" })],
+        });
+        const countries = createTable({ SourceTableName: "countries" });
+        const schema = createSchema({ Tables: [orders, customers, countries] });
+
+        const result = getRelatedSourceTablesToAdd(schema, [mapSqlTableToFormData(schema, orders)]);
+
+        expect(result.map((table) => table.SourceTableName)).toEqual(["customers", "countries"]);
+    });
+
+    it("terminates when the foreign keys form a cycle", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ ReferencedTable: "customers" })],
+        });
+        const customers = createTable({
+            SourceTableName: "customers",
+            ForeignKeys: [
+                createForeignKey({ Columns: ["last_order_id"], ReferencedTable: "orders" }),
+                createForeignKey({ Columns: ["parent_id"], ReferencedTable: "customers" }),
+            ],
+        });
+        const schema = createSchema({ Tables: [orders, customers] });
+
+        const result = getRelatedSourceTablesToAdd(schema, [mapSqlTableToFormData(schema, orders)]);
+
+        expect(result.map((table) => table.SourceTableName)).toEqual(["customers"]);
+    });
+
+    it("does not traverse foreign keys of unsupported referenced tables", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ ReferencedTable: "customers" })],
+        });
+        const customers = createTable({
+            SourceTableName: "customers",
+            IsCdcEnabled: false,
+            ForeignKeys: [createForeignKey({ Columns: ["country_id"], ReferencedTable: "countries" })],
+        });
+        const countries = createTable({ SourceTableName: "countries" });
+        const schema = createSchema({ HasPermissionToSetup: false, Tables: [orders, customers, countries] });
+
+        expect(getRelatedSourceTablesToAdd(schema, [mapSqlTableToFormData(schema, orders)])).toEqual([]);
+    });
+
+    it("does not add related tables that are unsupported", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ ReferencedTable: "customers" })],
+        });
+        const customers = createTable({ SourceTableName: "customers", IsCdcEnabled: false });
+        const schema = createSchema({ HasPermissionToSetup: false, Tables: [orders, customers] });
+
+        const result = getRelatedSourceTablesToAdd(schema, [mapSqlTableToFormData(schema, orders)]);
+
+        expect(result).toEqual([]);
+    });
+
+    it("returns nothing when the source schema is unavailable", () => {
+        expect(getRelatedSourceTablesToAdd(null, [createLinkedTableOwner()])).toEqual([]);
+    });
+
+    it("skips related tables that are already configured as embedded tables", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ ReferencedTable: "customers" })],
+        });
+        const customers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, customers] });
+        const ordersRoot: FormRootTable = {
+            ...mapSqlTableToFormData(schema, orders),
+            embeddedTables: [createEmbeddedTableConfig({ sourceTableSchema: "dbo", sourceTableName: "customers" })],
+        };
+
+        expect(getRelatedSourceTablesToAdd(schema, [ordersRoot])).toEqual([]);
+    });
+
+    it("skips related tables that are configured as disabled root tables", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ ReferencedTable: "customers" })],
+        });
+        const customers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, customers] });
+        const disabledCustomersRoot = { ...mapSqlTableToFormData(schema, customers), disabled: true };
+
+        expect(
+            getRelatedSourceTablesToAdd(schema, [mapSqlTableToFormData(schema, orders), disabledCustomersRoot])
+        ).toEqual([]);
+    });
+
+    it("ignores linked-table references inside disabled root tables", () => {
+        const orders = createTable({
+            SourceTableName: "orders",
+            ForeignKeys: [createForeignKey({ ReferencedTable: "customers" })],
+        });
+        const customers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, customers] });
+        const disabledOrdersRoot = { ...mapSqlTableToFormData(schema, orders), disabled: true };
+
+        expect(getRelatedSourceTablesToAdd(schema, [disabledOrdersRoot])).toEqual([]);
+    });
+});
+
+function createEmbeddedTableConfig(overrides: Partial<FormEmbeddedTable>): FormEmbeddedTable {
+    return {
+        caseSensitiveKeys: false,
+        columns: [
+            {
+                column: "Id",
+                name: "Id",
+                type: "Default",
+            },
+        ],
+        embeddedTables: [],
+        joinColumns: [{ value: "OrderId" }],
+        linkedTables: [],
+        onDelete: {
+            ignoreDeletes: false,
+            patch: "",
+        },
+        patch: "",
+        primaryKeyColumns: [{ value: "Id" }],
+        propertyName: "Items",
+        sourceTableName: "order_lines",
+        sourceTableSchema: "dbo",
+        type: "Array",
+        ...overrides,
+    };
+}
+
+function createLinkedTableOwner() {
+    const schema = createSchema({
+        Tables: [
+            createTable({
+                SourceTableName: "orders",
+                ForeignKeys: [createForeignKey({ ReferencedTable: "customers" })],
+            }),
+        ],
+    });
+
+    return mapSqlTableToFormData(schema, schema.Tables[0]);
+}
 
 function createSchema(overrides: Partial<CdcSinkSchema.CdcSinkSourceSchema>): CdcSinkSchema.CdcSinkSourceSchema {
     return {
@@ -90,6 +448,18 @@ function createTable(overrides: Partial<CdcSinkSchema.CdcSinkSourceTable>): CdcS
         SourceTableSchema: "dbo",
         UnsupportedReason: null,
         Warnings: [],
+        ...overrides,
+    };
+}
+
+function createForeignKey(
+    overrides: Partial<CdcSinkSchema.CdcSinkSourceForeignKey> = {}
+): CdcSinkSchema.CdcSinkSourceForeignKey {
+    return {
+        Columns: ["customer_id"],
+        ReferencedColumns: ["Id"],
+        ReferencedSchema: "dbo",
+        ReferencedTable: "customers",
         ...overrides,
     };
 }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils.spec.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils.spec.ts
@@ -1,4 +1,5 @@
 import {
+    alignLinkedTableCollectionNames,
     getRelatedSourceTablesToAdd,
     isTableSupported,
     mapRelatedSqlTablesToFormData,
@@ -213,6 +214,21 @@ describe("mapRelatedSqlTablesToFormData", () => {
         const [mapped] = mapRelatedSqlTablesToFormData(schema, rootTables, [dboCustomers]);
 
         expect(mapped.collectionName).toBe("DboCustomers");
+    });
+
+    it("aligns existing linked tables when a new root collection name is de-duplicated", () => {
+        const orders = createTable({ SourceTableName: "orders", ForeignKeys: [createForeignKey()] });
+        const salesCustomers = createTable({ SourceTableSchema: "sales", SourceTableName: "customers" });
+        const dboCustomers = createTable({ SourceTableName: "customers" });
+        const schema = createSchema({ Tables: [orders, salesCustomers, dboCustomers] });
+        const rootTables = [mapSqlTableToFormData(schema, orders), mapSqlTableToFormData(schema, salesCustomers)];
+        const newTables = mapRelatedSqlTablesToFormData(schema, rootTables, [dboCustomers]);
+
+        const alignedRootTables = alignLinkedTableCollectionNames(rootTables, newTables);
+
+        expect(newTables[0].collectionName).toBe("DboCustomers");
+        expect(alignedRootTables[0].linkedTables[0].linkedCollectionName).toBe("DboCustomers");
+        expect(alignedRootTables[1]).toBe(rootTables[1]);
     });
 });
 

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils.ts
@@ -305,6 +305,57 @@ export function mapRelatedSqlTablesToFormData(
     return formTables;
 }
 
+// Keep already configured links in sync when a newly added root table cannot use the collection
+// name they originally requested (for example because that collection name is already taken).
+export function alignLinkedTableCollectionNames(
+    rootTables: FormRootTable[],
+    targetRootTables: FormRootTable[]
+): FormRootTable[] {
+    const collectionNameBySourceKey = new Map<string, string>();
+
+    (targetRootTables ?? []).forEach((rootTable) => {
+        const key = getSourceTableKey(rootTable.sourceTableSchema, rootTable.sourceTableName);
+        const collectionName = rootTable.collectionName?.trim();
+
+        if (key && collectionName) {
+            collectionNameBySourceKey.set(key, collectionName);
+        }
+    });
+
+    if (collectionNameBySourceKey.size === 0) {
+        return rootTables;
+    }
+
+    const alignTable = <TTable extends FormRootTable | FormEmbeddedTable>(table: TTable): TTable => {
+        let isChanged = false;
+
+        const linkedTables = (table.linkedTables ?? []).map((linkedTable) => {
+            const key = getSourceTableKey(linkedTable.sourceTableSchema, linkedTable.sourceTableName);
+            const collectionName = key ? collectionNameBySourceKey.get(key) : null;
+
+            if (
+                !collectionName ||
+                normalizeValue(linkedTable.linkedCollectionName) === normalizeValue(collectionName)
+            ) {
+                return linkedTable;
+            }
+
+            isChanged = true;
+            return { ...linkedTable, linkedCollectionName: collectionName };
+        });
+
+        const embeddedTables = (table.embeddedTables ?? []).map((embeddedTable) => {
+            const alignedTable = alignTable(embeddedTable);
+            isChanged ||= alignedTable !== embeddedTable;
+            return alignedTable;
+        });
+
+        return isChanged ? ({ ...table, linkedTables, embeddedTables } as TTable) : table;
+    };
+
+    return (rootTables ?? []).map(alignTable);
+}
+
 // Normalized collection name -> collection name as the user typed it, per referenced source table
 // key. Disabled roots are skipped, matching getRelatedSourceTablesToAdd.
 function collectReferencedCollectionNames(rootTables: FormRootTable[]): Map<string, Map<string, string>> {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskSchemaUtils.ts
@@ -1,5 +1,11 @@
 import { SelectOption } from "components/common/select/Select";
 import {
+    analyzeRootTables,
+    getSourceTableKey,
+    normalizeValue,
+} from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings";
+import {
+    FormEmbeddedTable,
     FormLinkedTable,
     FormRootTable,
     FormRootTableColumn,
@@ -62,16 +68,16 @@ export function getSourceTableOptions(
     sourceTableSchema: string,
     excludedTable?: { sourceTableSchema: string; sourceTableName: string }
 ): CdcSinkSourceTableOption[] {
-    const schemaFilter = sourceTableSchema?.trim();
+    const schemaFilter = normalizeValue(sourceTableSchema);
+    const excludedKey = excludedTable
+        ? getSourceTableKey(excludedTable.sourceTableSchema, excludedTable.sourceTableName)
+        : null;
 
     return (schema?.Tables ?? [])
         .filter((table) => isTableSupported(schema, table))
-        .filter((table) => !schemaFilter || table.SourceTableSchema === schemaFilter)
+        .filter((table) => !schemaFilter || normalizeValue(table.SourceTableSchema) === schemaFilter)
         .filter(
-            (table) =>
-                !excludedTable ||
-                table.SourceTableSchema !== excludedTable.sourceTableSchema ||
-                table.SourceTableName !== excludedTable.sourceTableName
+            (table) => !excludedKey || getSourceTableKey(table.SourceTableSchema, table.SourceTableName) !== excludedKey
         )
         .map((table) => ({
             value: getSourceTableOptionValue(table),
@@ -96,17 +102,120 @@ export function getSourceSchemaOptions(schema: CdcSinkSourceSchema): SelectOptio
 }
 
 export function findSourceTable(schema: CdcSinkSourceSchema, sourceTableSchema: string, sourceTableName: string) {
+    const key = getSourceTableKey(sourceTableSchema, sourceTableName);
+
+    if (!key) {
+        return undefined;
+    }
+
     return (schema?.Tables ?? []).find(
-        (table) => table.SourceTableSchema === sourceTableSchema && table.SourceTableName === sourceTableName
+        (table) => getSourceTableKey(table.SourceTableSchema, table.SourceTableName) === key
     );
 }
 
 export function getForeignKeysToTable(sourceTable: CdcSinkSourceTable, targetTable: CdcSinkSourceTable) {
+    const targetKey = getSourceTableKey(targetTable.SourceTableSchema, targetTable.SourceTableName);
+
+    if (!targetKey) {
+        return [];
+    }
+
     return (sourceTable?.ForeignKeys ?? []).filter(
-        (foreignKey) =>
-            foreignKey.ReferencedSchema === targetTable.SourceTableSchema &&
-            foreignKey.ReferencedTable === targetTable.SourceTableName
+        (foreignKey) => getSourceTableKey(foreignKey.ReferencedSchema, foreignKey.ReferencedTable) === targetKey
     );
+}
+
+interface SourceTableReference {
+    sourceTableSchema?: string;
+    sourceTableName?: string;
+    linkedCollectionName?: string;
+}
+
+function buildSourceTableLookup(schema: CdcSinkSourceSchema): Map<string, CdcSinkSourceTable> {
+    const lookup = new Map<string, CdcSinkSourceTable>();
+
+    (schema?.Tables ?? []).forEach((table) => {
+        const key = getSourceTableKey(table.SourceTableSchema, table.SourceTableName);
+        if (key) {
+            lookup.set(key, table);
+        }
+    });
+
+    return lookup;
+}
+
+function collectLinkedSourceReferences(table: FormRootTable | FormEmbeddedTable): SourceTableReference[] {
+    const references: SourceTableReference[] = [];
+
+    (table?.linkedTables ?? []).forEach((linkedTable) => {
+        references.push({
+            sourceTableSchema: linkedTable.sourceTableSchema,
+            sourceTableName: linkedTable.sourceTableName,
+            linkedCollectionName: linkedTable.linkedCollectionName,
+        });
+    });
+
+    (table?.embeddedTables ?? []).forEach((embeddedTable) => {
+        references.push(...collectLinkedSourceReferences(embeddedTable));
+    });
+
+    return references;
+}
+
+// Resolves the source tables to add as roots so every linked-table reference points at a
+// configured root table. Follows foreign keys transitively (an added table maps them as linked
+// tables); skips tables already configured as roots or embedded tables and unsupported or
+// undiscovered tables — those stay per-link warnings.
+export function getRelatedSourceTablesToAdd(
+    schema: CdcSinkSourceSchema,
+    rootTables: FormRootTable[]
+): CdcSinkSourceTable[] {
+    if (!schema?.Tables?.length) {
+        return [];
+    }
+
+    const pendingReferences = (rootTables ?? [])
+        .filter((rootTable) => !rootTable?.disabled)
+        .flatMap(collectLinkedSourceReferences);
+
+    if (pendingReferences.length === 0) {
+        return [];
+    }
+
+    const analysis = analyzeRootTables(rootTables ?? []);
+    const lookup = buildSourceTableLookup(schema);
+    const resolvedKeys = new Set(analysis.sourceCountByKey.keys());
+    const tablesToAdd: CdcSinkSourceTable[] = [];
+
+    // The queue grows while it is being consumed: each added table enqueues its own references.
+    for (let index = 0; index < pendingReferences.length; index++) {
+        const reference = pendingReferences[index];
+        const key = getSourceTableKey(reference.sourceTableSchema, reference.sourceTableName);
+
+        if (!key || resolvedKeys.has(key) || analysis.embeddedSourceKeys.has(key)) {
+            continue;
+        }
+
+        // Marked resolved even when unaddable, so a reference is examined only once.
+        resolvedKeys.add(key);
+
+        const sourceTable = lookup.get(key);
+
+        if (!sourceTable || !isTableSupported(schema, sourceTable)) {
+            continue;
+        }
+
+        tablesToAdd.push(sourceTable);
+
+        (sourceTable.ForeignKeys ?? []).forEach((foreignKey) => {
+            pendingReferences.push({
+                sourceTableSchema: foreignKey.ReferencedSchema,
+                sourceTableName: foreignKey.ReferencedTable,
+            });
+        });
+    }
+
+    return tablesToAdd;
 }
 
 export function mapSqlTableToFormData(schema: CdcSinkSourceSchema, table: CdcSinkSourceTable): FormRootTable {
@@ -132,4 +241,114 @@ export function mapSqlTableToFormData(schema: CdcSinkSourceSchema, table: CdcSin
         sourceTableName: table.SourceTableName,
         sourceTableSchema: table.SourceTableSchema,
     } satisfies FormRootTable;
+}
+
+// Unlike a regular add, collection names adopt the name the referencing linked tables already
+// use (de-duplicated against configured collections) and links point at the collections their
+// target roots actually use — so the add cannot introduce a name clash or mismatch.
+export function mapRelatedSqlTablesToFormData(
+    schema: CdcSinkSourceSchema,
+    rootTables: FormRootTable[],
+    tablesToAdd: CdcSinkSourceTable[]
+): FormRootTable[] {
+    const analysis = analyzeRootTables(rootTables ?? []);
+    const referencedNamesBySourceKey = collectReferencedCollectionNames(rootTables ?? []);
+
+    const takenCollectionNames = new Set<string>();
+    (rootTables ?? []).forEach((rootTable) => {
+        const nameKey = normalizeValue(rootTable.collectionName);
+        if (nameKey) {
+            takenCollectionNames.add(nameKey);
+        }
+    });
+
+    const collectionNameBySourceKey = new Map<string, string>();
+    analysis.collectionNamesBySourceKey.forEach((names, key) => {
+        const [firstConfiguredName] = names.values();
+        if (firstConfiguredName) {
+            collectionNameBySourceKey.set(key, firstConfiguredName);
+        }
+    });
+
+    const formTables = (tablesToAdd ?? []).map((table) => {
+        const formTable = mapSqlTableToFormData(schema, table);
+        const key = getSourceTableKey(table.SourceTableSchema, table.SourceTableName);
+
+        const referencedNames = key ? referencedNamesBySourceKey.get(key) : null;
+        const [singleReferencedName] = referencedNames?.size === 1 ? referencedNames.values() : [];
+        const collectionName = toUniqueCollectionName(
+            singleReferencedName || formTable.collectionName,
+            table,
+            takenCollectionNames
+        );
+
+        formTable.collectionName = collectionName;
+        takenCollectionNames.add(normalizeValue(collectionName));
+
+        if (key && !collectionNameBySourceKey.has(key)) {
+            collectionNameBySourceKey.set(key, collectionName);
+        }
+
+        return formTable;
+    });
+
+    // Second pass, so links between batch tables resolve regardless of order.
+    formTables.forEach((formTable) => {
+        formTable.linkedTables = formTable.linkedTables.map((linkedTable) => {
+            const key = getSourceTableKey(linkedTable.sourceTableSchema, linkedTable.sourceTableName);
+            const collectionName = key ? collectionNameBySourceKey.get(key) : null;
+
+            return collectionName ? { ...linkedTable, linkedCollectionName: collectionName } : linkedTable;
+        });
+    });
+
+    return formTables;
+}
+
+// Normalized collection name -> collection name as the user typed it, per referenced source table
+// key. Disabled roots are skipped, matching getRelatedSourceTablesToAdd.
+function collectReferencedCollectionNames(rootTables: FormRootTable[]): Map<string, Map<string, string>> {
+    const namesBySourceKey = new Map<string, Map<string, string>>();
+
+    rootTables
+        .filter((rootTable) => !rootTable?.disabled)
+        .flatMap(collectLinkedSourceReferences)
+        .forEach((reference) => {
+            const key = getSourceTableKey(reference.sourceTableSchema, reference.sourceTableName);
+            const name = reference.linkedCollectionName?.trim();
+            const nameKey = normalizeValue(name);
+
+            if (!key || !nameKey) {
+                return;
+            }
+
+            if (!namesBySourceKey.has(key)) {
+                namesBySourceKey.set(key, new Map<string, string>());
+            }
+
+            const names = namesBySourceKey.get(key);
+            if (!names.has(nameKey)) {
+                names.set(nameKey, name);
+            }
+        });
+
+    return namesBySourceKey;
+}
+
+function toUniqueCollectionName(preferredName: string, table: CdcSinkSourceTable, takenNames: Set<string>) {
+    const candidates = [preferredName, `${pascalCase(table.SourceTableSchema)}${preferredName}`];
+
+    for (const candidate of candidates) {
+        if (candidate && !takenNames.has(normalizeValue(candidate))) {
+            return candidate;
+        }
+    }
+
+    for (let suffix = 2; ; suffix++) {
+        const candidate = `${preferredName}${suffix}`;
+
+        if (!takenNames.has(normalizeValue(candidate))) {
+            return candidate;
+        }
+    }
 }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.spec.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.spec.ts
@@ -6,8 +6,8 @@ import {
     analyzeRootTables,
     getDuplicateRootTableErrors,
     getEmbeddedTableWarningMessagesFromAnalysis,
-    getEmbeddedRootTableConflictWarning,
-    getMissingRelatedCollectionWarning,
+    getEmbeddedRootTableConflictWarningFromAnalysis,
+    getMissingRelatedCollectionWarningFromAnalysis,
     getRootTableWarningMessagesFromAnalysis,
 } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings";
 
@@ -25,15 +25,29 @@ describe("CDC Sink table warnings", () => {
         ]);
     });
 
+    it("reports a duplicate even when one of the root tables is disabled", () => {
+        const duplicateErrors = getDuplicateRootTableErrors([
+            createRootTable({ sourceTableSchema: "dbo", sourceTableName: "orders", collectionName: "Orders" }),
+            createRootTable({
+                sourceTableSchema: "dbo",
+                sourceTableName: "orders",
+                collectionName: "Cars",
+                disabled: true,
+            }),
+        ]);
+
+        expect(duplicateErrors).toEqual([expect.objectContaining({ index: 0 }), expect.objectContaining({ index: 1 })]);
+    });
+
     it("returns an embedded warning when the source table is already configured as a root table", () => {
-        const warning = getEmbeddedRootTableConflictWarning(
-            [
+        const warning = getEmbeddedRootTableConflictWarningFromAnalysis(
+            analyzeRootTables([
                 createRootTable({
                     sourceTableSchema: "dbo",
                     sourceTableName: "companies",
                     collectionName: "Companies",
                 }),
-            ],
+            ]),
             {
                 sourceTableName: "companies",
                 sourceTableSchema: "dbo",
@@ -44,14 +58,14 @@ describe("CDC Sink table warnings", () => {
     });
 
     it("returns null when a matching root table creates the linked collection", () => {
-        const warning = getMissingRelatedCollectionWarning(
-            [
+        const warning = getMissingRelatedCollectionWarningFromAnalysis(
+            analyzeRootTables([
                 createRootTable({
                     sourceTableSchema: "dbo",
                     sourceTableName: "companies",
                     collectionName: "companies",
                 }),
-            ],
+            ]),
             {
                 linkedCollectionName: "Companies",
                 propertyName: "Company",
@@ -63,15 +77,15 @@ describe("CDC Sink table warnings", () => {
         expect(warning).toBeNull();
     });
 
-    it("returns a warning when no root table creates the linked collection", () => {
-        const warning = getMissingRelatedCollectionWarning(
-            [
+    it("returns a warning when the source table is not configured as a root table", () => {
+        const warning = getMissingRelatedCollectionWarningFromAnalysis(
+            analyzeRootTables([
                 createRootTable({
                     sourceTableSchema: "dbo",
-                    sourceTableName: "companies",
-                    collectionName: "Businesses",
+                    sourceTableName: "orders",
+                    collectionName: "Orders",
                 }),
-            ],
+            ]),
             {
                 linkedCollectionName: "Companies",
                 propertyName: "Company",
@@ -80,9 +94,99 @@ describe("CDC Sink table warnings", () => {
             }
         );
 
-        expect(warning).toBe(`No root table is configured for the related "Companies" collection.
-The Company property will contain related document IDs that reference documents in the "Companies" collection.
-However, those documents will not be created unless "dbo.companies" is also configured as a root table.`);
+        expect(warning).toBe(
+            `Related documents in the "Companies" collection will not be created because "dbo.companies" is not configured as a root table.`
+        );
+    });
+
+    it("returns a disabled warning when the only matching root table is disabled", () => {
+        const warning = getMissingRelatedCollectionWarningFromAnalysis(
+            analyzeRootTables([
+                createRootTable({
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "companies",
+                    collectionName: "Companies",
+                    disabled: true,
+                }),
+            ]),
+            {
+                linkedCollectionName: "Companies",
+                propertyName: "Company",
+                sourceTableName: "companies",
+                sourceTableSchema: "dbo",
+            }
+        );
+
+        expect(warning).toBe(
+            `Related documents in the "Companies" collection will not be created because the "dbo.companies" root table is disabled.`
+        );
+    });
+
+    it("ignores the disabled duplicate when an enabled root table also matches", () => {
+        const warning = getMissingRelatedCollectionWarningFromAnalysis(
+            analyzeRootTables([
+                createRootTable({
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "companies",
+                    collectionName: "Companies",
+                }),
+                createRootTable({
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "companies",
+                    collectionName: "Archive",
+                    disabled: true,
+                }),
+            ]),
+            {
+                linkedCollectionName: "Companies",
+                propertyName: "Company",
+                sourceTableName: "companies",
+                sourceTableSchema: "dbo",
+            }
+        );
+
+        expect(warning).toBeNull();
+    });
+
+    it("returns a mismatch warning when the source table is configured with a different collection", () => {
+        const warning = getMissingRelatedCollectionWarningFromAnalysis(
+            analyzeRootTables([
+                createRootTable({
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "companies",
+                    collectionName: "Businesses",
+                }),
+            ]),
+            {
+                linkedCollectionName: "Companies",
+                propertyName: "Company",
+                sourceTableName: "companies",
+                sourceTableSchema: "dbo",
+            }
+        );
+
+        expect(warning).toBe(
+            `Related documents in the "Companies" collection will not be created because the "dbo.companies" root table targets the "Businesses" collection instead.`
+        );
+    });
+
+    it("collects embedded source table keys from the whole configured tree", () => {
+        const analysis = analyzeRootTables([
+            createRootTable({
+                embeddedTables: [
+                    createEmbeddedTable({
+                        sourceTableSchema: "dbo",
+                        sourceTableName: "order_lines",
+                        embeddedTables: [
+                            createEmbeddedTable({ sourceTableSchema: "dbo", sourceTableName: "line_notes" }),
+                        ],
+                    }),
+                ],
+            }),
+        ]);
+
+        expect(analysis.embeddedSourceKeys.has("dbo::order_lines")).toBe(true);
+        expect(analysis.embeddedSourceKeys.has("dbo::line_notes")).toBe(true);
     });
 
     it("returns root-level warnings from the whole table tree", () => {
@@ -134,9 +238,7 @@ However, those documents will not be created unless "dbo.companies" is also conf
 
         expect(warnings).toEqual([
             expect.stringContaining("already configured as a root table"),
-            `No root table is configured for the related "Media" collection.
-The Media property will contain related document IDs that reference documents in the "Media" collection.
-However, those documents will not be created unless "public.media" is also configured as a root table.`,
+            `Related documents in the "Media" collection will not be created because "public.media" is not configured as a root table.`,
         ]);
     });
 
@@ -165,7 +267,7 @@ However, those documents will not be created unless "public.media" is also confi
 
         expect(warnings).toEqual([
             expect.stringContaining("already configured as a root table"),
-            expect.stringContaining('"public.media" is also configured as a root table'),
+            expect.stringContaining('"public.media" is not configured as a root table'),
         ]);
     });
 });

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTableWarnings.ts
@@ -5,9 +5,23 @@ import {
 } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskTypes";
 
 export interface RootTablesAnalysis {
+    // Disabled roots are counted too: replay and the test endpoint resolve them, so a duplicate
+    // would shadow the other table's mapping even when disabled.
     sourceCountByKey: Map<string, number>;
-    collectionNameKeysBySourceKey: Map<string, Set<string>>;
+    // Only enabled roots satisfy linked-table references — a disabled root creates no documents.
+    enabledSourceKeys: Set<string>;
+    // Normalized collection name -> collection name as the user typed it, per source table key.
+    // Enabled roots only.
+    collectionNamesBySourceKey: Map<string, Map<string, string>>;
+    // Includes disabled roots' subtrees: the embedded/root conflict resurfaces on re-enable.
+    embeddedSourceKeys: Set<string>;
+    disabledSourceKeys: Set<string>;
 }
+
+type MissingRelatedCollectionIssue =
+    | { type: "missingRootTable" }
+    | { type: "disabledRootTable" }
+    | { type: "collectionNameMismatch"; configuredCollectionNames: string[] };
 
 interface SourceTableContext {
     sourceTableName?: string;
@@ -26,8 +40,14 @@ interface DuplicateRootTableError {
     message: string;
 }
 
+type EmbeddedTableAnalysisInput = SourceTableContext & {
+    embeddedTables?: ReadonlyArray<EmbeddedTableAnalysisInput>;
+};
+
 type RootTableAnalysisInput = SourceTableContext & {
     collectionName?: string;
+    disabled?: boolean;
+    embeddedTables?: ReadonlyArray<EmbeddedTableAnalysisInput>;
 };
 
 interface TableWarningContext {
@@ -71,17 +91,6 @@ export function getDuplicateRootTableErrors(
             },
         ];
     });
-}
-
-export function getEmbeddedRootTableConflictWarning(rootTables: FormRootTable[], embeddedTable: SourceTableContext) {
-    return getEmbeddedRootTableConflictWarningFromAnalysis(analyzeRootTables(rootTables), embeddedTable);
-}
-
-export function getMissingRelatedCollectionWarning(
-    rootTables: FormRootTable[],
-    linkedTable: LinkedTableWarningContext
-) {
-    return getMissingRelatedCollectionWarningFromAnalysis(analyzeRootTables(rootTables), linkedTable);
 }
 
 export function getRootTableWarningMessagesFromAnalysis(analysis: RootTablesAnalysis, table?: FormRootTable) {
@@ -137,38 +146,91 @@ export function getEmbeddedRootTableConflictWarningFromAnalysis(
 CDC Sink can process a source table only once, so embedded updates may be routed to the root table instead.`;
 }
 
+function getMissingRelatedCollectionIssue(
+    analysis: RootTablesAnalysis,
+    linkedTable: LinkedTableWarningContext
+): MissingRelatedCollectionIssue | null {
+    const linkedCollectionName = linkedTable.linkedCollectionName?.trim();
+    const propertyName = linkedTable.propertyName?.trim();
+    const sourceKey = getSourceTableKey(linkedTable.sourceTableSchema, linkedTable.sourceTableName);
+
+    if (!linkedCollectionName || !sourceKey || !propertyName) {
+        return null;
+    }
+
+    if (!analysis.enabledSourceKeys.has(sourceKey)) {
+        return analysis.disabledSourceKeys.has(sourceKey)
+            ? { type: "disabledRootTable" }
+            : { type: "missingRootTable" };
+    }
+
+    const configuredCollectionNames = analysis.collectionNamesBySourceKey.get(sourceKey);
+
+    if (configuredCollectionNames?.has(normalizeValue(linkedCollectionName))) {
+        return null;
+    }
+
+    return {
+        type: "collectionNameMismatch",
+        configuredCollectionNames: Array.from(configuredCollectionNames?.values() ?? []),
+    };
+}
+
 export function getMissingRelatedCollectionWarningFromAnalysis(
     analysis: RootTablesAnalysis,
     linkedTable: LinkedTableWarningContext
 ) {
-    const linkedCollectionName = linkedTable.linkedCollectionName?.trim();
-    const propertyName = linkedTable.propertyName?.trim();
-    const sourceTableName = linkedTable.sourceTableName?.trim();
-    const sourceTableSchema = linkedTable.sourceTableSchema?.trim();
+    const issue = getMissingRelatedCollectionIssue(analysis, linkedTable);
 
-    if (!linkedCollectionName || !sourceTableName || !sourceTableSchema || !propertyName) {
+    if (!issue) {
         return null;
     }
 
-    const sourceKey = getSourceTableKey(sourceTableSchema, sourceTableName);
-    const collectionNameKey = normalizeValue(linkedCollectionName);
-    const collectionNameKeys = analysis.collectionNameKeysBySourceKey.get(sourceKey);
-    const hasMatchingRootTable = collectionNameKeys?.has(collectionNameKey);
+    const linkedCollectionName = linkedTable.linkedCollectionName.trim();
+    const sourceTableLabel = getSourceTableLabel(linkedTable);
 
-    if (hasMatchingRootTable) {
-        return null;
+    if (issue.type === "missingRootTable") {
+        return `Related documents in the "${linkedCollectionName}" collection will not be created because ${sourceTableLabel} is not configured as a root table.`;
     }
 
-    return `No root table is configured for the related "${linkedCollectionName}" collection.
-The ${propertyName} property will contain related document IDs that reference documents in the "${linkedCollectionName}" collection.
-However, those documents will not be created unless "${sourceTableSchema}.${sourceTableName}" is also configured as a root table.`;
+    if (issue.type === "disabledRootTable") {
+        return `Related documents in the "${linkedCollectionName}" collection will not be created because the ${sourceTableLabel} root table is disabled.`;
+    }
+
+    const configuredCollectionsLabel =
+        issue.configuredCollectionNames.length > 0
+            ? `targets ${formatCollectionNames(issue.configuredCollectionNames)} instead`
+            : "targets a different collection";
+
+    return `Related documents in the "${linkedCollectionName}" collection will not be created because the ${sourceTableLabel} root table ${configuredCollectionsLabel}.`;
+}
+
+function formatCollectionNames(collectionNames: string[]) {
+    const quotedNames = collectionNames.map((name) => `"${name}"`).join(", ");
+    return collectionNames.length === 1 ? `the ${quotedNames} collection` : `the ${quotedNames} collections`;
 }
 
 export function analyzeRootTables(rootTables: ReadonlyArray<RootTableAnalysisInput>): RootTablesAnalysis {
     const sourceCountByKey = new Map<string, number>();
-    const collectionNameKeysBySourceKey = new Map<string, Set<string>>();
+    const enabledSourceKeys = new Set<string>();
+    const collectionNamesBySourceKey = new Map<string, Map<string, string>>();
+    const embeddedSourceKeys = new Set<string>();
+    const disabledSourceKeys = new Set<string>();
+
+    const collectEmbeddedSourceKeys = (embeddedTables?: ReadonlyArray<EmbeddedTableAnalysisInput>) => {
+        (embeddedTables ?? []).forEach((embeddedTable) => {
+            const key = getSourceTableKey(embeddedTable.sourceTableSchema, embeddedTable.sourceTableName);
+            if (key) {
+                embeddedSourceKeys.add(key);
+            }
+
+            collectEmbeddedSourceKeys(embeddedTable.embeddedTables);
+        });
+    };
 
     (rootTables ?? []).forEach((rootTable) => {
+        collectEmbeddedSourceKeys(rootTable.embeddedTables);
+
         const sourceKey = getSourceTableKey(rootTable.sourceTableSchema, rootTable.sourceTableName);
 
         if (!sourceKey) {
@@ -177,25 +239,41 @@ export function analyzeRootTables(rootTables: ReadonlyArray<RootTableAnalysisInp
 
         sourceCountByKey.set(sourceKey, (sourceCountByKey.get(sourceKey) ?? 0) + 1);
 
-        const collectionNameKey = normalizeValue(rootTable.collectionName);
+        if (rootTable.disabled) {
+            disabledSourceKeys.add(sourceKey);
+            return;
+        }
+
+        enabledSourceKeys.add(sourceKey);
+
+        const collectionName = rootTable.collectionName?.trim();
+        const collectionNameKey = normalizeValue(collectionName);
         if (!collectionNameKey) {
             return;
         }
 
-        if (!collectionNameKeysBySourceKey.has(sourceKey)) {
-            collectionNameKeysBySourceKey.set(sourceKey, new Set<string>());
+        if (!collectionNamesBySourceKey.has(sourceKey)) {
+            collectionNamesBySourceKey.set(sourceKey, new Map<string, string>());
         }
 
-        collectionNameKeysBySourceKey.get(sourceKey).add(collectionNameKey);
+        const collectionNames = collectionNamesBySourceKey.get(sourceKey);
+        if (!collectionNames.has(collectionNameKey)) {
+            collectionNames.set(collectionNameKey, collectionName);
+        }
     });
 
     return {
         sourceCountByKey,
-        collectionNameKeysBySourceKey,
+        enabledSourceKeys,
+        collectionNamesBySourceKey,
+        embeddedSourceKeys,
+        disabledSourceKeys,
     };
 }
 
-function getSourceTableKey(sourceTableSchema: string, sourceTableName: string) {
+// Case-insensitive identity of a source table; null when schema or table name is missing —
+// unresolved entries must stay out of any matching.
+export function getSourceTableKey(sourceTableSchema: string, sourceTableName: string) {
     const normalizedSchema = normalizeValue(sourceTableSchema);
     const normalizedTableName = normalizeValue(sourceTableName);
 
@@ -206,7 +284,7 @@ function getSourceTableKey(sourceTableSchema: string, sourceTableName: string) {
     return `${normalizedSchema}::${normalizedTableName}`;
 }
 
-function getSourceTableLabel(table: SourceTableContext) {
+export function getSourceTableLabel(table: SourceTableContext) {
     const sourceTableSchema = table.sourceTableSchema?.trim();
     const sourceTableName = table.sourceTableName?.trim();
 
@@ -217,7 +295,7 @@ function getSourceTableLabel(table: SourceTableContext) {
     return `"${sourceTableSchema}.${sourceTableName}"`;
 }
 
-function normalizeValue(value?: string) {
+export function normalizeValue(value?: string) {
     return value?.trim().toLowerCase() ?? "";
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation.spec.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation.spec.ts
@@ -33,6 +33,66 @@ describe("editCdcSinkTaskSchema", () => {
             ]),
         });
     });
+
+    it("rejects a duplicate root source table even when one of them is disabled", async () => {
+        const formData = createFormData({
+            tables: [
+                createRootTable({
+                    collectionName: "Orders",
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "orders",
+                }),
+                createRootTable({
+                    collectionName: "Cars",
+                    sourceTableSchema: "dbo",
+                    sourceTableName: "orders",
+                    disabled: true,
+                }),
+            ],
+        });
+
+        await expect(editCdcSinkTaskSchema.validate(formData, { abortEarly: false })).rejects.toMatchObject({
+            inner: expect.arrayContaining([
+                expect.objectContaining({
+                    path: "tables.0.sourceTableName",
+                    message: expect.stringContaining('"dbo.orders"'),
+                }),
+                expect.objectContaining({
+                    path: "tables.1.sourceTableName",
+                    message: expect.stringContaining('"dbo.orders"'),
+                }),
+            ]),
+        });
+    });
+
+    it("rejects empty source schema for root, embedded, and linked table configs", async () => {
+        const formData = createFormData({
+            tables: [
+                createRootTable({
+                    sourceTableSchema: "",
+                    embeddedTables: [createEmbeddedTable({ sourceTableSchema: "" })],
+                    linkedTables: [createLinkedTable({ sourceTableSchema: "" })],
+                }),
+            ],
+        });
+
+        await expect(editCdcSinkTaskSchema.validate(formData, { abortEarly: false })).rejects.toMatchObject({
+            inner: expect.arrayContaining([
+                expect.objectContaining({
+                    path: "tables[0].sourceTableSchema",
+                    message: expect.stringContaining("Source schema is required"),
+                }),
+                expect.objectContaining({
+                    path: "tables[0].embeddedTables[0].sourceTableSchema",
+                    message: expect.stringContaining("Source schema is required"),
+                }),
+                expect.objectContaining({
+                    path: "tables[0].linkedTables[0].sourceTableSchema",
+                    message: expect.stringContaining("Source schema is required"),
+                }),
+            ]),
+        });
+    });
 });
 
 function createFormData(overrides: Partial<EditCdcSinkTaskFormData>): EditCdcSinkTaskFormData {
@@ -73,6 +133,48 @@ function createRootTable(
         patch: "",
         primaryKeyColumns: [{ value: "Id" }],
         sourceTableName: "orders",
+        sourceTableSchema: "dbo",
+        ...overrides,
+    };
+}
+
+function createEmbeddedTable(
+    overrides: Partial<EditCdcSinkTaskFormData["tables"][number]["embeddedTables"][number]> = {}
+): EditCdcSinkTaskFormData["tables"][number]["embeddedTables"][number] {
+    return {
+        caseSensitiveKeys: false,
+        columns: [
+            {
+                column: "Id",
+                name: "Id",
+                type: "Default",
+            },
+        ],
+        embeddedTables: [],
+        joinColumns: [{ value: "OrderId" }],
+        linkedTables: [],
+        onDelete: {
+            ignoreDeletes: false,
+            patch: "",
+        },
+        patch: "",
+        primaryKeyColumns: [{ value: "Id" }],
+        propertyName: "Lines",
+        sourceTableName: "order_lines",
+        sourceTableSchema: "dbo",
+        type: "Array",
+        ...overrides,
+    };
+}
+
+function createLinkedTable(
+    overrides: Partial<EditCdcSinkTaskFormData["tables"][number]["linkedTables"][number]> = {}
+): EditCdcSinkTaskFormData["tables"][number]["linkedTables"][number] {
+    return {
+        joinColumns: [{ value: "CompanyId" }],
+        linkedCollectionName: "Companies",
+        propertyName: "Company",
+        sourceTableName: "companies",
         sourceTableSchema: "dbo",
         ...overrides,
     };

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation.ts
@@ -12,6 +12,13 @@ const stringValueItemSchema = yup.object({
     value: yup.string().required(),
 });
 
+// Studio always saves explicit schemas; a configuration created through the API may leave the
+// schema empty (the CDC runtime substitutes the provider default).
+const sourceTableSchemaSchema = yup
+    .string()
+    .nullable()
+    .required('Source schema is required. Enter the schema the source table belongs to (e.g. "public" or "dbo").');
+
 const cdcColumnMappingSchema = yup.object({
     column: yup.string().required(),
     name: yup.string().required(),
@@ -58,7 +65,7 @@ const cdcSinkLinkedTableSchema = yup.object({
     linkedCollectionName: yup.string().required(),
     propertyName: yup.string().required(),
     sourceTableName: yup.string().required(),
-    sourceTableSchema: yup.string().nullable().required(),
+    sourceTableSchema: sourceTableSchemaSchema,
 });
 
 const cdcSinkEmbeddedTableBaseSchema = yup.object({
@@ -77,7 +84,7 @@ const cdcSinkEmbeddedTableBaseSchema = yup.object({
     }),
     propertyName: yup.string().required(),
     sourceTableName: yup.string().required(),
-    sourceTableSchema: yup.string().nullable().required(),
+    sourceTableSchema: sourceTableSchemaSchema,
     type: yup.string<CdcSinkRelationType>().required(),
 });
 
@@ -103,7 +110,7 @@ const cdcSinkTableSchema = yup.object({
         uniqueMessage: "Primary key columns must be unique",
     }),
     sourceTableName: yup.string().required(),
-    sourceTableSchema: yup.string().nullable().required(),
+    sourceTableSchema: sourceTableSchemaSchema,
 });
 
 export const editCdcSinkTaskSchema = yup.object({


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26879/CDC-Add-add-all-related-tables-button

### Additional description

<img width="1158" height="463" alt="image" src="https://github.com/user-attachments/assets/d44ecaf2-460f-4dbd-ac58-3b437e6a0671" />

<img width="814" height="349" alt="image" src="https://github.com/user-attachments/assets/1c8932d5-9dc6-41ba-9eb4-b86901a024e3" />


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
