### PR TITLE
RavenDB-26927 LargeValues should not be reported as gaps in storage report.

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -268,6 +267,8 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
             return ("🚨", "Sparse DUPE (BUG!)");
         if (owner == "Gap")
             return ("🚨", "Gap (BUG!)");
+        if (owner.StartsWith("NoKnownOwner/LargeValue"))
+            return ("🚨", "Large value without a known table (BUG?)");
         if (owner == "Sparse")
             return ("🗑️", "Sparse (returned to OS...)");
         if (owner == "Unassigned")

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1045,6 +1045,7 @@ namespace Voron
         public unsafe Dictionary<long, string> GetPageOwners(Transaction tx, Func<PostingList, List<long>> onPostingList = null)
         {
             var r = new Dictionary<long, string>();
+            var sectionOwnerHashToTableName = new Dictionary<ulong, string>();
             RegisterPages(_freeSpaceHandling.AllPages(tx.LowLevelTransaction), "Freed Page");
             for (long pageNumber = NextPageNumber; pageNumber < tx.LowLevelTransaction.DataPagerState.NumberOfAllocatedPages; pageNumber++)
             {
@@ -1146,6 +1147,7 @@ namespace Voron
                                 var readResult = tableTree.Read(TableSchema.ActiveSectionSlice);
                                 long pageNumber = readResult.Reader.Read<long>();
                                 var activeDataSmallSection = new ActiveRawDataSmallSection(tx, pageNumber);
+                                sectionOwnerHashToTableName[activeDataSmallSection.SectionOwnerHash] = name;
                                 RegisterSectionPages(activeDataSmallSection, name + "/" + TableSchema.ActiveSectionSlice);
                                 RegisterTableSection(tableTree, name, TableSchema.ActiveCandidateSectionSlice);
                                 RegisterTableSection(tableTree, name, TableSchema.InactiveSectionSlice);
@@ -1181,6 +1183,32 @@ namespace Voron
                                 throw new ArgumentOutOfRangeException(nameof(type), type.ToString());
                         }
                     } while (rootIterator.MoveNext());
+                }
+            }
+            
+            var numberOfAllocatedPages = tx.LowLevelTransaction.DataPagerState.NumberOfAllocatedPages;
+            for (long pageNumber = 0; pageNumber < numberOfAllocatedPages; pageNumber++)
+            {
+                if (r.ContainsKey(pageNumber))
+                    continue;
+
+                var page = tx.LowLevelTransaction.GetPage(pageNumber);
+                if (page.PageNumber != pageNumber ||
+                    page.IsOverflow == false ||
+                    (page.Flags & PageFlags.RawData) != PageFlags.RawData ||
+                    page.OverflowSize <= 0)
+                    continue;
+
+                var header = (RawDataOverflowPageHeader*)page.Pointer;
+                var owner = sectionOwnerHashToTableName.TryGetValue(header->SectionOwnerHash, out var tableName)
+                    ? tableName + "/LargeValue"
+                    : $"NoKnownOwner/LargeValue (unknown table, type: {header->TableType})";
+
+                var numberOfPages = Paging.GetNumberOfOverflowPages(page.OverflowSize);
+                for (long i = 0; i < numberOfPages && pageNumber + i < numberOfAllocatedPages; i++)
+                {
+                    if (r.TryAdd(pageNumber + i, owner) == false)
+                        break;
                 }
             }
 

--- a/test/SlowTests/Voron/RavenDB_26927.cs
+++ b/test/SlowTests/Voron/RavenDB_26927.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Http;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Voron;
+
+public class RavenDB_26927(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Voron)]
+    public async Task LargeDocumentsShouldNotBeReportedAsGaps()
+    {
+        using var store = GetDocumentStore();
+        
+        await using (var bulk = store.BulkInsert())
+        {
+            for (var i = 0; i < 50; i++)
+                await bulk.StoreAsync(new Item { Payload = GetRandomString(1024 * 1024, 2026) }, "items/" + i);
+        }
+
+        using (var commands = store.Commands())
+        {
+            var database = Uri.EscapeDataString(store.Database);
+            await commands.ExecuteJsonAsync($"/admin/storage/manual-flush?name={database}&type=Documents", HttpMethod.Post, payload: null);
+
+            string report = null;
+            await AssertWaitForValueAsync(async () =>
+            {
+                var command = new GetPagesReportCommand($"name={database}&type=Documents&output=Text");
+                await commands.ExecuteAsync(command);
+                report = command.Result;
+                return report.Contains("/LargeValue") || report.Contains("Gaps");
+            }, true, timeout: 30_000);
+
+            Assert.Contains("/LargeValue", report);
+            Assert.DoesNotContain("Gaps", report);
+        }
+    }
+
+    private static string GetRandomString(int length, int seed)
+    {
+        const string Chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        var random = new Random(seed);
+        return new string(Enumerable.Repeat(Chars, length).Select(s => s[random.Next(s.Length)]).ToArray());
+    }
+    
+    private sealed class GetPagesReportCommand : RavenCommand<string>
+    {
+        private readonly string _query;
+
+        public GetPagesReportCommand(string query)
+        {
+            _query = query;
+            ResponseType = RavenCommandResponseType.Raw;
+        }
+
+        public override bool IsReadRequest => true;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/debug/storage/environment/debug-only/pages?{_query}";
+
+            return new HttpRequestMessage { Method = HttpMethod.Get };
+        }
+
+        public override void SetResponseRaw(HttpResponseMessage response, Stream stream, JsonOperationContext context)
+        {
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            Result = reader.ReadToEnd();
+        }
+    }
+
+    private class Item
+    {
+        public string Payload { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26927

### Additional description



### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
