### PR TITLE
RavenDB-14311 Throw a readable RQL syntax error instead of NRE

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -1299,6 +1299,9 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
 
         private bool Method(FieldExpression field, out MethodExpression op)
         {
+            if (field == null)
+                ThrowParseException("Expected a method name before '(' - this usually means an extra or misplaced '(' in the query");
+            
             if (field.FieldValue.Equals("when", StringComparison.OrdinalIgnoreCase))
             {
                 if (_insideWhenMethod)

--- a/test/SlowTests.Issues/Issues/RavenDB-14311.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-14311.cs
@@ -1,0 +1,48 @@
+using FastTests;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_14311 : RavenTestBase
+{
+    public RavenDB_14311(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private sealed class Doc
+    {
+        public string Id { get; set; }
+        public string StrVal { get; set; }
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Rql)]
+    public void InvalidQueryWithExtraParenthesesShouldThrowSyntaxErrorNotNre()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenSession();
+
+        // Note the extra '()' after search(...) - this is invalid RQL syntax.
+        // Previously this crashed the parser with a bare NullReferenceException (RavenDB-14311);
+        // it should now report a readable syntax error instead.
+        var query = session.Advanced.RawQuery<Doc>("from docs where search(StrVal, \"a\")()");
+
+        var ex = Assert.ThrowsAny<RavenException>(() => query.Count());
+
+        Assert.Contains("Expected a method name before '('", ex.Message);
+        Assert.DoesNotContain(nameof(System.NullReferenceException), ex.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Rql)]
+    public void ValidSearchQueryShouldStillWork()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenSession();
+
+        // The fix must not reject a legitimate search() call.
+        var count = session.Advanced.RawQuery<Doc>("from docs where search(StrVal, \"a\")").Count();
+
+        Assert.Equal(0, count);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-14311/NRE-in-QueryParser-when-sending-invalid-raw-query

### Additional description

Throwing better exception 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
