### PR TITLE
RavenDB-26920 Fetching connection strings for tasks refactor

### DIFF
--- a/src/Raven.Studio/typescript/components/common/formFields/FormTaskConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/common/formFields/FormTaskConnectionString.tsx
@@ -1,0 +1,109 @@
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import { FormGroup, FormLabel, FormSelect } from "components/common/Form";
+import { SelectOption } from "components/common/select/Select";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import useBoolean from "components/hooks/useBoolean";
+import { getTypeLabel } from "components/pages/database/settings/connectionStrings/ConnectionStringsPanels";
+import { StudioConnectionType } from "components/pages/database/settings/connectionStrings/connectionStringsTypes";
+import EditConnectionStrings from "components/pages/database/settings/connectionStrings/EditConnectionStrings";
+import {
+    connectionStringsActions,
+    connectionStringSelectors,
+} from "components/pages/database/settings/connectionStrings/store/connectionStringsSlice";
+import { useAppDispatch, useAppSelector } from "components/store";
+import { sortBy } from "lodash";
+import { useEffect } from "react";
+import InputGroup from "react-bootstrap/InputGroup";
+import { FieldValues, FieldPath, UseControllerProps, useController } from "react-hook-form";
+
+type ConnectionTypeProps =
+    | {
+          type: Exclude<StudioConnectionType, "Ai">;
+      }
+    | {
+          type: Extract<StudioConnectionType, "Ai">;
+          modelType: Raven.Client.Documents.Operations.AI.AiModelType;
+      };
+
+type FormTaskConnectionStringProps<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>> = {
+    control: UseControllerProps<TFieldValues>["control"];
+    name: TName;
+} & ConnectionTypeProps;
+
+export function FormTaskConnectionString<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>(
+    props: FormTaskConnectionStringProps<TFieldValues, TName>
+) {
+    const { control, name, type } = props;
+    const modelType = "modelType" in props ? props.modelType : undefined;
+
+    const dispatch = useAppDispatch();
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const loadStatus = useAppSelector(connectionStringSelectors.loadStatus);
+    const { value: isNewOpen, toggle: toggleIsNewOpen } = useBoolean(false);
+
+    const connectionStrings = useAppSelector(connectionStringSelectors.connectionsByType(type)).filter((x) => {
+        if (type === "Ai" && "modelType" in x) {
+            return x.modelType === modelType;
+        }
+        return true;
+    });
+
+    const { field } = useController({
+        name,
+        control,
+    });
+
+    useEffect(() => {
+        dispatch(connectionStringsActions.viewContextSet("task"));
+        dispatch(connectionStringsActions.fetchData(databaseName));
+
+        return () => {
+            dispatch(connectionStringsActions.reset());
+        };
+        // Changing the database causes re-mount
+    }, []);
+
+    const connectionStringOptions: SelectOption[] = sortBy(Object.values(connectionStrings), (x) =>
+        x.name.toUpperCase()
+    ).map((x) => ({
+        value: x.name,
+        label: x.name,
+    }));
+
+    const handleConnectionStringSave = async (connectionName: string) => {
+        field.onChange(connectionName);
+        toggleIsNewOpen();
+    };
+
+    return (
+        <FormGroup>
+            <FormLabel>Connection String</FormLabel>
+            <InputGroup>
+                <FormSelect
+                    control={control}
+                    name={name}
+                    options={connectionStringOptions}
+                    isLoading={loadStatus === "loading"}
+                />
+                <InputGroup.Text>
+                    <ButtonWithSpinner
+                        variant="link"
+                        className="text-reset px-0"
+                        icon="plus"
+                        isSpinning={loadStatus === "loading"}
+                        onClick={toggleIsNewOpen}
+                    >
+                        Create a new {getTypeLabel(type)} connection string
+                    </ButtonWithSpinner>
+                </InputGroup.Text>
+            </InputGroup>
+            {isNewOpen && (
+                <EditConnectionStrings
+                    initialConnection={{ type, modelType }}
+                    afterSave={handleConnectionStringSave}
+                    afterClose={toggleIsNewOpen}
+                />
+            )}
+        </FormGroup>
+    );
+}

--- a/src/Raven.Studio/typescript/components/common/virtualTable/partials/VirtualTableBodyWrapper.tsx
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/partials/VirtualTableBodyWrapper.tsx
@@ -29,7 +29,7 @@ export default function VirtualTableBodyWrapper<T>({
     children,
 }: PropsWithChildren<VirtualTableBodyWrapperProps<T>> & ClassNameProps) {
     const paddingInPx = isPaddingDisabled ? 0 : virtualTableConstants.paddingInPx;
-    const tableHeightInPx = heightInPx - paddingInPx;
+    const tableHeightInPx = Math.max(heightInPx - paddingInPx, virtualTableConstants.minTableHeightInPx);
 
     return (
         <div

--- a/src/Raven.Studio/typescript/components/common/virtualTable/partials/VirtualTableState.tsx
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/partials/VirtualTableState.tsx
@@ -14,7 +14,7 @@ export function VirtualTableState(props: VirtualTableStateProps) {
             {isLoading && <Spinner className="spinner-gradient table-state" data-testid="loader" />}
             {isEmpty && !isLoading && (
                 <div className="table-state">
-                    <EmptySet>No results</EmptySet>
+                    <EmptySet compact>No results</EmptySet>
                 </div>
             )}
         </>

--- a/src/Raven.Studio/typescript/components/common/virtualTable/utils/virtualTableConstants.ts
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/utils/virtualTableConstants.ts
@@ -8,4 +8,5 @@ export const virtualTableConstants = {
     scrollbarWidthInPx: 12,
     scrollbarHeightInPx: 12,
     defaultTableHeightInPx: 300,
+    minTableHeightInPx: 100,
 };

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/hooks/useEditAiAgent.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/hooks/useEditAiAgent.ts
@@ -2,7 +2,6 @@ import { databaseSelectors } from "components/common/shell/databaseSliceSelector
 import { useAppUrls } from "components/hooks/useAppUrls";
 import { useDirtyFlag } from "components/hooks/useDirtyFlag";
 import { useServices } from "components/hooks/useServices";
-import { connectionStringsActions } from "components/pages/database/settings/connectionStrings/store/connectionStringsSlice";
 import { useAppDispatch, useAppSelector } from "components/store";
 import { tryHandleSubmit } from "components/utils/common";
 import { useEffect } from "react";
@@ -36,7 +35,6 @@ export default function useEditAiAgent(queryParams: QueryParams) {
 
     // Set connection strings view context on mount and reset store on unmount
     useEffect(() => {
-        dispatch(connectionStringsActions.viewContextSet("aiTask"));
         dispatch(editAiAgentActions.getAllIdentifiers(databaseName));
 
         return () => {

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentBasicSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentBasicSection.tsx
@@ -1,26 +1,19 @@
-import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { FormGroup, FormInput, FormLabel, FormSelect, FormErrorIcon } from "components/common/Form";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import SampleObjectAndSchemaFields from "components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields";
-import EditConnectionStrings from "components/pages/database/settings/connectionStrings/EditConnectionStrings";
 import { Icon } from "components/common/Icon";
 import { useFormContext, useWatch } from "react-hook-form";
 import { EditAiAgentFormData } from "../utils/editAiAgentValidation";
 import { SelectOption } from "components/common/select/Select";
-import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import useBoolean from "components/hooks/useBoolean";
-import { useServices } from "components/hooks/useServices";
-import { useAppSelector } from "components/store";
 import TaskUtils from "components/utils/TaskUtils";
-import { sortBy } from "lodash";
-import { useAsync } from "react-async-hook";
 import Button from "react-bootstrap/Button";
-import InputGroup from "react-bootstrap/InputGroup";
 import Code from "components/common/Code";
 import Collapse from "react-bootstrap/Collapse";
 import AiAssistantWindow from "components/common/aiAssistant/AiAssistantWindow";
 import AiAssistantButton from "components/common/aiAssistant/AiAssistantButton";
 import CollapseButton from "components/common/CollapseButton";
+import { FormTaskConnectionString } from "components/common/formFields/FormTaskConnectionString";
 
 interface EditAiAgentBasicSectionProps {
     isEditAiAgent: boolean;
@@ -28,40 +21,12 @@ interface EditAiAgentBasicSectionProps {
 
 export default function EditAiAgentBasicSection({ isEditAiAgent }: EditAiAgentBasicSectionProps) {
     const { control, setValue } = useFormContext<EditAiAgentFormData>();
+    const { value: isPanelOpen, setValue: setIsPanelOpen, toggle: toggleIsPanelOpen } = useBoolean(true);
+    const { value: isAiAssistOpen, toggle: toggleIsAiAssistOpen } = useBoolean(false);
 
     const formValues = useWatch({
         control,
     });
-
-    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-
-    const { tasksService } = useServices();
-
-    const { value: isNewConnectionStringOpen, toggle: toggleIsNewConnectionStringOpen } = useBoolean(false);
-    const { value: isPanelOpen, setValue: setIsPanelOpen, toggle: toggleIsPanelOpen } = useBoolean(true);
-    const { value: isAiAssistOpen, toggle: toggleIsAiAssistOpen } = useBoolean(false);
-
-    const asyncGetConnectionStringsOptions = useAsync(async () => {
-        const result = await tasksService.getConnectionStrings(databaseName);
-
-        const connectionStrings = Object.values(result.AiConnectionStrings)
-            .filter((x) => x.ModelType === "Chat")
-            .map((x) => x.Name);
-
-        return sortBy(connectionStrings, (x) => x.toUpperCase()).map(
-            (x) => ({ value: x, label: x }) satisfies SelectOption
-        );
-    }, []);
-
-    const handleConnectionStringSave = async (connectionName: string) => {
-        await asyncGetConnectionStringsOptions.execute();
-        setValue("connectionStringName", connectionName, {
-            shouldValidate: true,
-            shouldTouch: true,
-            shouldDirty: true,
-        });
-        toggleIsNewConnectionStringOpen();
-    };
 
     const handleGenerateIdentifier = () => {
         setValue("identifier", TaskUtils.getGeneratedIdentifier(formValues.name));
@@ -145,40 +110,12 @@ export default function EditAiAgentBasicSection({ isEditAiAgent }: EditAiAgentBa
                             <FormLabel>Agent State</FormLabel>
                             <FormSelect control={control} name="state" options={stateOptions} />
                         </FormGroup>
-                        <FormGroup>
-                            <FormLabel>
-                                Connection String
-                                <PopoverWithHoverWrapper message="The selected connection string determines which LLM the agent will interact with.">
-                                    <Icon icon="info-new" />
-                                </PopoverWithHoverWrapper>
-                            </FormLabel>
-                            <InputGroup>
-                                <FormSelect
-                                    control={control}
-                                    name="connectionStringName"
-                                    options={asyncGetConnectionStringsOptions.result ?? []}
-                                    isLoading={asyncGetConnectionStringsOptions.loading}
-                                />
-                                <InputGroup.Text>
-                                    <ButtonWithSpinner
-                                        variant="link"
-                                        className="text-reset px-0"
-                                        icon="plus"
-                                        isSpinning={asyncGetConnectionStringsOptions.loading}
-                                        onClick={toggleIsNewConnectionStringOpen}
-                                    >
-                                        Create a new AI connection string
-                                    </ButtonWithSpinner>
-                                </InputGroup.Text>
-                                {isNewConnectionStringOpen && (
-                                    <EditConnectionStrings
-                                        initialConnection={{ type: "Ai", modelType: "Chat" }}
-                                        afterSave={handleConnectionStringSave}
-                                        afterClose={toggleIsNewConnectionStringOpen}
-                                    />
-                                )}
-                            </InputGroup>
-                        </FormGroup>
+                        <FormTaskConnectionString
+                            control={control}
+                            name="connectionStringName"
+                            type="Ai"
+                            modelType="Chat"
+                        />
                         <FormGroup>
                             <FormLabel>
                                 System prompt

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/ModelTypeField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/ModelTypeField.tsx
@@ -23,8 +23,8 @@ export default function ModelTypeField({ initialModelType }: ModelTypeFieldProps
 
     const viewContext = useAppSelector(connectionStringSelectors.viewContext);
 
-    const isChatVisible = viewContext !== "aiTask" || initialModelType !== "TextEmbeddings";
-    const isTextEmbeddingsVisible = viewContext !== "aiTask" || initialModelType !== "Chat";
+    const isChatVisible = viewContext !== "task" || initialModelType !== "TextEmbeddings";
+    const isTextEmbeddingsVisible = viewContext !== "task" || initialModelType !== "Chat";
     const isAllVisible = isChatVisible && isTextEmbeddingsVisible;
 
     return (

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
@@ -15,7 +15,7 @@ import { databaseSelectors } from "components/common/shell/databaseSliceSelector
 export type ConnectionStringsViewContext =
     | "connectionStrings"
     | "aiConnectionStrings"
-    | "aiTask"
+    | "task"
     | "serverWideConnectionStrings";
 
 interface ConnectionStringsState {
@@ -189,6 +189,7 @@ export const connectionStringsActions = {
 export const connectionStringSelectors = {
     loadStatus: (store: RootState) => store.connectionStrings.loadStatus,
     connections: (store: RootState) => store.connectionStrings.connections,
+    connectionsByType: (type: StudioConnectionType) => (store: RootState) => store.connectionStrings.connections[type],
     initialEditConnection: (store: RootState) => store.connectionStrings.initialEditConnection,
     isEmpty: (store: RootState) => _.isEqual(store.connectionStrings.connections, initialState.connections),
     viewContext: (store: RootState) => store.connectionStrings.viewContext,

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/basic/EditCdcSinkTaskBasicSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/basic/EditCdcSinkTaskBasicSection.tsx
@@ -1,84 +1,34 @@
-import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import CollapseButton from "components/common/CollapseButton";
 import { SelectOption } from "components/common/select/Select";
-import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import useBoolean from "components/hooks/useBoolean";
-import { useServices } from "components/hooks/useServices";
-import EditConnectionStrings from "components/pages/database/settings/connectionStrings/EditConnectionStrings";
 import { EditCdcSinkTaskFormData } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/utils/editCdcSinkTaskValidation";
-import { useAppDispatch, useAppSelector } from "components/store";
-import { sortBy } from "lodash";
-import { useAsync } from "react-async-hook";
+import { useAppSelector } from "components/store";
 import { useFormContext, useWatch } from "react-hook-form";
-import InputGroup from "react-bootstrap/InputGroup";
 import Collapse from "react-bootstrap/Collapse";
 import { FormErrorIcon, FormGroup, FormInput, FormLabel, FormSelect, FormSwitch } from "components/common/Form";
 import RichAlert from "components/common/RichAlert";
-import { useEffect, useMemo } from "react";
-import { editCdcSinkTaskActions } from "components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/store/editCdcSinkTaskSlice";
 import { FormTaskResponsibleNode } from "components/common/formFields/FormTaskResponsibleNode";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import { Icon } from "components/common/Icon";
+import { FormTaskConnectionString } from "components/common/formFields/FormTaskConnectionString";
+import { connectionStringSelectors } from "components/pages/database/settings/connectionStrings/store/connectionStringsSlice";
 
 type OngoingTaskState = Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskState;
 
 export default function EditCdcSinkTaskBasicSection() {
-    const dispatch = useAppDispatch();
-    const { tasksService } = useServices();
-    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-
-    const { value: isNewConnectionStringOpen, toggle: toggleIsNewConnectionStringOpen } = useBoolean(false);
     const { value: isPanelOpen, setValue: setIsPanelOpen, toggle: toggleIsPanelOpen } = useBoolean(true);
+    const { control } = useFormContext<EditCdcSinkTaskFormData>();
 
-    const { control, setValue } = useFormContext<EditCdcSinkTaskFormData>();
-    const formValues = useWatch({ control });
-
-    const asyncGetConnectionStrings = useAsync(async () => {
-        if (!databaseName) {
-            return {};
-        }
-
-        const result = await tasksService.getConnectionStrings(databaseName);
-        return result.SqlConnectionStrings ?? {};
-    }, [databaseName]);
-
-    const sqlConnectionStrings = useMemo(
-        () => asyncGetConnectionStrings.result ?? {},
-        [asyncGetConnectionStrings.result]
-    );
-
-    const connectionStringOptions: SelectOption[] = sortBy(Object.values(sqlConnectionStrings), (x) =>
-        x.Name.toUpperCase()
-    ).map((x) => ({
-        value: x.Name,
-        label: x.Name,
-    }));
-
-    const selectedConnectionString = useMemo(
-        () => (formValues.connectionStringName ? sqlConnectionStrings[formValues.connectionStringName] : null),
-        [formValues.connectionStringName, sqlConnectionStrings]
-    );
-
-    // Sync selected connection string to the store
-    useEffect(() => {
-        dispatch(editCdcSinkTaskActions.connectionStringSelected(selectedConnectionString));
-    }, [selectedConnectionString]);
+    const [connectionStringName, postgresPublicationName, postgresSlotName] = useWatch({
+        control,
+        name: ["connectionStringName", "postgresPublicationName", "postgresSlotName"],
+    });
+    const sqlConnections = useAppSelector(connectionStringSelectors.connectionsByType("Sql"));
+    const selectedConnection = sqlConnections.find((x) => x.name === connectionStringName);
 
     const hasPostgresSettings =
-        selectedConnectionString?.FactoryName === "Npgsql" ||
-        Boolean(formValues.postgresPublicationName || formValues.postgresSlotName);
-
-    const handleConnectionStringSave = async (connectionName: string) => {
-        await asyncGetConnectionStrings.execute();
-
-        setValue("connectionStringName", connectionName, {
-            shouldValidate: true,
-            shouldTouch: true,
-            shouldDirty: true,
-        });
-
-        toggleIsNewConnectionStringOpen();
-    };
+        (selectedConnection && "factoryName" in selectedConnection && selectedConnection.factoryName === "Npgsql") ||
+        Boolean(postgresPublicationName || postgresSlotName);
 
     return (
         <div>
@@ -103,35 +53,7 @@ export default function EditCdcSinkTaskBasicSection() {
                             <FormLabel>Task State</FormLabel>
                             <FormSelect control={control} name="state" options={taskStateOptions} />
                         </FormGroup>
-                        <FormGroup>
-                            <FormLabel>Connection String</FormLabel>
-                            <InputGroup>
-                                <FormSelect
-                                    control={control}
-                                    name="connectionStringName"
-                                    options={connectionStringOptions}
-                                    isLoading={asyncGetConnectionStrings.loading}
-                                />
-                                <InputGroup.Text>
-                                    <ButtonWithSpinner
-                                        variant="link"
-                                        className="text-reset px-0"
-                                        icon="plus"
-                                        isSpinning={asyncGetConnectionStrings.loading}
-                                        onClick={toggleIsNewConnectionStringOpen}
-                                    >
-                                        Create a new SQL connection string
-                                    </ButtonWithSpinner>
-                                </InputGroup.Text>
-                            </InputGroup>
-                            {isNewConnectionStringOpen && (
-                                <EditConnectionStrings
-                                    initialConnection={{ type: "Sql" }}
-                                    afterSave={handleConnectionStringSave}
-                                    afterClose={toggleIsNewConnectionStringOpen}
-                                />
-                            )}
-                        </FormGroup>
+                        <FormTaskConnectionString control={control} name="connectionStringName" type="Sql" />
                         {hasPostgresSettings && (
                             <>
                                 <RichAlert variant="info">

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskTestPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskTestPanel.tsx
@@ -24,8 +24,11 @@ import { useForm, UseFormReturn, useWatch } from "react-hook-form";
 import * as yup from "yup";
 import ExpandableListContainer from "components/common/ExpandableListContainer";
 import FormStringValueList from "components/common/formFields/FormStringValueList";
+import { connectionStringSelectors } from "components/pages/database/settings/connectionStrings/store/connectionStringsSlice";
+import { mapConnectionStringToDto } from "components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto";
 
 type TestCdcSinkRowSelector = Raven.Client.Documents.Operations.CdcSink.Test.TestCdcSinkRowSelector;
+type SqlConnectionString = Raven.Client.Documents.Operations.ETL.SQL.SqlConnectionString;
 
 interface EditCdcSinkTaskTestPanelProps {
     editForm: UseFormReturn<EditCdcSinkTaskFormData>;
@@ -34,7 +37,7 @@ interface EditCdcSinkTaskTestPanelProps {
 
 export default function EditCdcSinkTaskTestPanel({ editForm, path }: EditCdcSinkTaskTestPanelProps) {
     const taskId = useAppSelector(editCdcSinkTaskSelectors.taskId);
-    const selectedConnectionString = useAppSelector(editCdcSinkTaskSelectors.selectedConnectionString);
+    const sqlConnections = useAppSelector(connectionStringSelectors.connectionsByType("Sql"));
     const table = editForm.watch(path);
 
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
@@ -46,8 +49,11 @@ export default function EditCdcSinkTaskTestPanel({ editForm, path }: EditCdcSink
 
         config.Name ||= "Test-CDC";
 
+        const connection = sqlConnections.find((x) => x.name === formValues.connectionStringName);
+        const connectionDto = mapConnectionStringToDto(connection) as SqlConnectionString;
+
         return await tasksService.testCdcSink(databaseName, {
-            Connection: selectedConnectionString,
+            Connection: connectionDto,
             Configuration: config,
             Operation: formData.isSimulateOnDelete ? "Delete" : "Upsert",
             MaxRows: formData.rowSelector === "First" ? formData.maxRows : 1,

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/store/editCdcSinkTaskSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/store/editCdcSinkTaskSlice.ts
@@ -25,7 +25,6 @@ export type CdcActiveTable =
       };
 
 interface EditCdcSinkTaskState {
-    selectedConnectionString: SqlConnectionString;
     sourceSchema: CdcSinkSourceSchema;
     activeTable?: CdcActiveTable;
     expandedTables: Partial<Record<FieldPath<EditCdcSinkTaskFormData>, boolean>>;
@@ -47,7 +46,6 @@ function getStoredBoolean(key: string, defaultValue: boolean): boolean {
 }
 
 const initialState: EditCdcSinkTaskState = {
-    selectedConnectionString: null,
     sourceSchema: null,
     activeTable: null,
     expandedTables: {},
@@ -66,10 +64,6 @@ export const editCdcSinkTaskSlice = createSlice({
     reducers: {
         taskIdSet: (state, action: PayloadAction<number>) => {
             state.taskId = action.payload;
-        },
-        connectionStringSelected: (state, action: PayloadAction<SqlConnectionString>) => {
-            state.selectedConnectionString = action.payload;
-            state.sourceSchema = null;
         },
         sourceSchemaSet: (state, action: PayloadAction<CdcSinkSourceSchema>) => {
             state.sourceSchema = action.payload;
@@ -121,7 +115,6 @@ export const editCdcSinkTaskActions = editCdcSinkTaskSlice.actions;
 
 export const editCdcSinkTaskSelectors = {
     taskId: (state: RootState) => state.editCdcSinkTask.taskId,
-    selectedConnectionString: (state: RootState) => state.editCdcSinkTask.selectedConnectionString,
     sourceSchema: (state: RootState) => state.editCdcSinkTask.sourceSchema,
     activeTable: (state: RootState) => state.editCdcSinkTask.activeTable,
     isActiveTable: (path: CdcActiveTable["path"]) => (state: RootState) =>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask.stories.tsx
@@ -23,9 +23,10 @@ export default {
 
 export const Basic: StoryObj = {
     render: () => {
-        const { cluster, collectionsTracker, license } = mockStore;
+        const { cluster, collectionsTracker, license, databases } = mockStore;
         const { tasksService, aiAssistantService } = mockServices;
 
+        databases.withActiveDatabase();
         cluster.with_Single();
         collectionsTracker.with_Collections();
 

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask.tsx
@@ -18,7 +18,6 @@ import EditGenAiTaskSteps from "./partials/EditGenAiTaskSteps";
 import EditGenAiTaskPlayground from "./partials/EditGenAiTaskPlayground";
 import useEditGenAiCancel from "./hooks/useEditGenAiCancel";
 import { useDirtyFlag } from "components/hooks/useDirtyFlag";
-import { connectionStringsActions } from "components/pages/database/settings/connectionStrings/store/connectionStringsSlice";
 import { defaultItemsToProcess } from "components/pages/database/settings/documentExpiration/DocumentExpiration";
 import { TimeInSeconds } from "common/constants/timeInSeconds";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
@@ -52,8 +51,6 @@ export default function EditGenAiTask({ queryParams }: ReactQueryParamsProps<Que
         }
 
         dispatch(editGenAiTaskActions.getIsDocumentExpirationEnabled(databaseName));
-
-        dispatch(connectionStringsActions.viewContextSet("aiTask"));
 
         return () => {
             dispatch(editGenAiTaskActions.reset());

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/fields/EditGenAiTaskBasicFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/fields/EditGenAiTaskBasicFields.tsx
@@ -1,16 +1,9 @@
-import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { FormInput, FormSwitch, FormGroup, FormLabel, FormSelect } from "components/common/Form";
 import RichAlert from "components/common/RichAlert";
 import { SelectOption } from "components/common/select/Select";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
-import useBoolean from "components/hooks/useBoolean";
-import EditConnectionStrings from "components/pages/database/settings/connectionStrings/EditConnectionStrings";
-import { useAppDispatch, useAppSelector } from "components/store";
-import { sortBy } from "lodash";
-import { useAsync } from "react-async-hook";
-import { editGenAiTaskActions, editGenAiTaskSelectors } from "../../store/editGenAiTaskSlice";
-import InputGroup from "react-bootstrap/InputGroup";
-import { useServices } from "components/hooks/useServices";
+import { useAppSelector } from "components/store";
+import { editGenAiTaskSelectors } from "../../store/editGenAiTaskSlice";
 import { useFormContext, useWatch } from "react-hook-form";
 import { EditGenAiTaskFormData, GenAiStartingPoint } from "../../utils/editGenAiTaskValidation";
 import TaskUtils from "components/utils/TaskUtils";
@@ -22,46 +15,16 @@ import { editGenAiTaskUtils } from "../../utils/editGenAiTaskUtils";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
 import tasksCommonContent from "models/database/tasks/tasksCommonContent";
 import { FormTaskResponsibleNode } from "components/common/formFields/FormTaskResponsibleNode";
+import { FormTaskConnectionString } from "components/common/formFields/FormTaskConnectionString";
 
 type OngoingTaskState = Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskState;
 
 export default function EditGenAiTaskBasicFields() {
-    const dispatch = useAppDispatch();
-
     const isEncrypted = useAppSelector(databaseSelectors.activeDatabase)?.isEncrypted;
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const isEditTask = useAppSelector(editGenAiTaskSelectors.isEditTask);
-
-    const { value: isNewConnectionStringOpen, toggle: toggleIsNewConnectionStringOpen } = useBoolean(false);
-
-    const { tasksService } = useServices();
-
     const { control, setValue } = useFormContext<EditGenAiTaskFormData>();
     const formValues = useWatch({ control });
-
-    const asyncGetConnectionStringsOptions = useAsync(async () => {
-        const result = await tasksService.getConnectionStrings(databaseName);
-
-        dispatch(editGenAiTaskActions.aiConnectionStringsSet(result.AiConnectionStrings));
-
-        const connectionStrings = Object.values(result.AiConnectionStrings)
-            .filter((x) => x.ModelType === "Chat")
-            .map((x) => x.Name);
-
-        return sortBy(connectionStrings, (x) => x.toUpperCase()).map(
-            (x) => ({ value: x, label: x }) satisfies SelectOption
-        );
-    }, []);
-
-    const handleConnectionStringSave = async (connectionName: string) => {
-        await asyncGetConnectionStringsOptions.execute();
-        setValue("connectionStringName", connectionName, {
-            shouldValidate: true,
-            shouldTouch: true,
-            shouldDirty: true,
-        });
-        toggleIsNewConnectionStringOpen();
-    };
 
     const handleGenerateIdentifier = () => {
         setValue("identifier", TaskUtils.getGeneratedIdentifier(formValues.name));
@@ -151,35 +114,7 @@ export default function EditGenAiTaskBasicFields() {
                 nodeName="responsibleNode"
                 isPinName="isPinResponsibleNode"
             />
-            <FormGroup>
-                <FormLabel>Connection String</FormLabel>
-                <InputGroup>
-                    <FormSelect
-                        control={control}
-                        name="connectionStringName"
-                        options={asyncGetConnectionStringsOptions.result ?? []}
-                        isLoading={asyncGetConnectionStringsOptions.loading}
-                    />
-                    <InputGroup.Text>
-                        <ButtonWithSpinner
-                            variant="link"
-                            className="text-reset px-0"
-                            icon="plus"
-                            isSpinning={asyncGetConnectionStringsOptions.loading}
-                            onClick={toggleIsNewConnectionStringOpen}
-                        >
-                            Create a new AI connection string
-                        </ButtonWithSpinner>
-                    </InputGroup.Text>
-                    {isNewConnectionStringOpen && (
-                        <EditConnectionStrings
-                            initialConnection={{ type: "Ai", modelType: "Chat" }}
-                            afterSave={handleConnectionStringSave}
-                            afterClose={toggleIsNewConnectionStringOpen}
-                        />
-                    )}
-                </InputGroup>
-            </FormGroup>
+            <FormTaskConnectionString control={control} name="connectionStringName" type="Ai" modelType="Chat" />
             <FormGroup>
                 <FormLabel>
                     Max concurrency <OptionalLabel />

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editAzureServiceBusSinkTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editAzureServiceBusSinkTask.ts
@@ -3,7 +3,6 @@ import appUrl = require("common/appUrl");
 import viewModelBase = require("viewmodels/viewModelBase");
 import router = require("plugins/router");
 import eventsCollector = require("common/eventsCollector");
-import getConnectionStringsCommand = require("commands/database/settings/getConnectionStringsCommand");
 import generalUtils = require("common/generalUtils");
 import connectionStringAzureServiceBusModel = require("models/database/settings/connectionStringAzureServiceBusModel");
 import collectionsTracker = require("common/helpers/database/collectionsTracker");
@@ -176,9 +175,6 @@ class editAzureServiceBusSinkTask extends viewModelBase {
     activate(args: any) {
         super.activate(args);
         const deferred = $.Deferred<void>();
-
-        storeCompat.globalDispatch(connectionStringsSlice.connectionStringsActions.viewContextSet("aiTask"));
-
         this.loadPossibleMentors();
 
         if (args.taskId) {
@@ -225,14 +221,17 @@ class editAzureServiceBusSinkTask extends viewModelBase {
         $('.edit-azure-service-bus-sink-task [data-toggle="tooltip"]').tooltip();
     }
 
-    private getAllConnectionStrings() {
-        return new getConnectionStringsCommand(this.activeDatabase())
-            .execute()
-            .done((result: Raven.Client.Documents.Operations.ConnectionStrings.GetConnectionStringsResult) => {
+    private async getAllConnectionStrings() {
+        storeCompat.globalDispatch(connectionStringsSlice.connectionStringsActions.viewContextSet("task"));
+    
+        return storeCompat
+            .globalDispatch(connectionStringsSlice.connectionStringsActions.fetchData(this.activeDatabase()?.name))
+            .unwrap()
+            .then(({connectionStringsDto: result}) => {
                 const queueConnectionStrings = Object.values(result.QueueConnectionStrings);
                 const azureServiceBusStrings = queueConnectionStrings.filter(x => x.BrokerType === "AzureServiceBus");
                 this.azureServiceBusConnectionStringsDetails(typeUtils.sortBy(azureServiceBusStrings, x => x.Name.toUpperCase()));
-            });
+        });
     }
 
     private initObservables() {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
@@ -3,7 +3,6 @@ import appUrl = require("common/appUrl");
 import router = require("plugins/router");
 import database = require("models/resources/database");
 import getOngoingTaskInfoCommand = require("commands/database/tasks/getOngoingTaskInfoCommand");
-import getConnectionStringsCommand = require("commands/database/settings/getConnectionStringsCommand");
 import saveEtlTaskCommand = require("commands/database/tasks/saveEtlTaskCommand");
 import collectionsTracker = require("common/helpers/database/collectionsTracker");
 import transformationScriptSyntax = require("viewmodels/database/tasks/transformationScriptSyntax");
@@ -116,10 +115,7 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
     activate(args: { taskId?: number, sourceView: EditAiTaskSourceView }) {
         super.activate(args);
         const deferred = $.Deferred<void>();
-
-        storeCompat.globalDispatch(connectionStringsSlice.connectionStringsActions.viewContextSet("aiTask"));
         this.sourceView(args.sourceView);
-        
         this.loadPossibleMentors();
 
         if (args.taskId) {
@@ -247,17 +243,20 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
         this.isNewConnectionStringOpen(!this.isNewConnectionStringOpen())
     }
 
-    private getAllConnectionStrings() {
-        return new getConnectionStringsCommand(this.db)
-            .execute()
-            .done((result: Raven.Client.Documents.Operations.ConnectionStrings.GetConnectionStringsResult) => {
+    private async getAllConnectionStrings() {
+        storeCompat.globalDispatch(connectionStringsSlice.connectionStringsActions.viewContextSet("task"));
+    
+        return storeCompat
+            .globalDispatch(connectionStringsSlice.connectionStringsActions.fetchData(this.db.name))
+            .unwrap()
+            .then(({connectionStringsDto: result}) => {
                 this.aiConnectionStrings(Object.values(result.AiConnectionStrings).filter(x => x.ModelType === "TextEmbeddings"));
 
                 const connectionStringsNames = Object.keys(result.AiConnectionStrings).filter(key =>
                     result.AiConnectionStrings[key].ModelType === "TextEmbeddings",
                 );
                 this.connectionStringsNames(typeUtils.sortBy(connectionStringsNames, x => x.toUpperCase()));
-            });
+        });
     }
 
     private initObservables() {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26920

### Additional description

The new connection string modal uses `connectionStringsSlice` for validation.
In this PR, I refactor each task that relies on a React modal to fetch connections through `connectionStringsSlice`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
