### PR TITLE
RavenDB-26913 - Fix ObjectDisposedException in offline database migration audit logging

### DIFF
--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1527,17 +1527,6 @@ namespace Raven.Server.Web.System
 
                                     await smuggler.ExecuteAsync();
                                 }
-
-                                if (LoggingSource.AuditLog.IsInfoEnabled)
-                                {
-                                    using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                                    {
-                                        var configurationString = context.ReadObject(configuration.ToAuditJson(), nameof(configuration)).ToString();
-                                        LogAuditFor(databaseName, "IMPORT",
-                                            $"{EnumHelper.GetDescription(OperationType.MigrationFromLegacyData)} " +
-                                            $"using configuration: '{configurationString}'");
-                                    }
-                                }
                             }
                         }
                         catch (Exception e)
@@ -1587,6 +1576,17 @@ namespace Raven.Server.Web.System
                     });
                 },
                 token: token);
+
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+            {
+                using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                {
+                    var configurationString = context.ReadObject(configuration.ToAuditJson(), nameof(configuration)).ToString();
+                    LogAuditFor(databaseName, "IMPORT",
+                        $"{EnumHelper.GetDescription(OperationType.MigrationFromLegacyData)} " +
+                        $"using configuration: '{configurationString}'");
+                }
+            }
 
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26913/ObjectDisposedException-Request-has-finished-and-HttpContext-disposed

### Additional description

#### Problem

Triggering an offline database migration with audit logging enabled could fail with:

```
System.ObjectDisposedException: Request has finished and HttpContext disposed.
Object name: 'HttpContext'.
```

The `LogAuditFor` call was placed inside the background operation task (`Task.Run`) that performs the migration. That task is scheduled via `Operations.AddLocalOperation` and keeps running **after** `MigrateDatabaseOffline` returns and the HTTP request completes. By the time the audit line was written, the request's `HttpContext` had already been disposed, and `LogAuditFor` — which reads the request IP and client certificate off `HttpContext` — threw `ObjectDisposedException`.

#### Fix

Move the audit-log call out of the background task and into the synchronous portion of the handler, right after the operation is registered and before the response is written. This keeps the exact same audit content but emits it while the request's `HttpContext` is still alive.

#### Files

- `src/Raven.Server/Web/System/AdminDatabasesHandler.cs`

#### Notes

The audit line is now written when the migration operation is *started* rather than when the import phase completes. Since the audit content only describes the migration configuration (not the result), this is the appropriate place to log it and avoids touching a disposed context.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
