### PR TITLE
RavenDB-26934 - Don't memoize the outer of an AND for large / seekable term matches

### DIFF
--- a/src/Corax/Querying/Matches/BinaryMatch.Boolean.cs
+++ b/src/Corax/Querying/Matches/BinaryMatch.Boolean.cs
@@ -69,11 +69,12 @@ namespace Corax.Querying.Matches
                     //  - A TermMatch has a cheap, seekable AndWith (Seek into the posting list + prune), so
                     //    memoizing it is pure loss: no time saved, and we'd hold the whole set in memory.
                     //  - A large outer would cost gigabytes to materialize AND make every per-batch merge scan
-                    //    the full memoized span (quadratic). A low-confidence count may hide such a large set.
-                    // In those cases we skip memoization and stream via outer.AndWith instead.
+                    //    the full memoized span (quadratic).
+                    // In those cases we skip memoization and stream via outer.AndWith instead. Note we do NOT key
+                    // off Confidence here: a low-confidence count means "unknown", not "large", and some matches
+                    // only support Fill (they rely on being memoized), so we must not route them to AndWith.
                     var outerAndWithIsCheap = typeof(TOuter) == typeof(TermMatch);
-                    var outerTooBigToMemoize = outer.Confidence == QueryCountConfidence.Low ||
-                                               outer.Count > match._indexSearcher.MaxMemoizationSizeInBytes / sizeof(long) / 2;
+                    var outerTooBigToMemoize = outer.Count > match._indexSearcher.MaxMemoizationSizeInBytes / sizeof(long) / 2;
                     if (resultsSpan.Length == 0 && match._memoizedOuter is null &&
                         outerAndWithIsCheap == false && outerTooBigToMemoize == false)
                     {

--- a/src/Corax/Querying/Matches/BinaryMatch.Boolean.cs
+++ b/src/Corax/Querying/Matches/BinaryMatch.Boolean.cs
@@ -62,9 +62,20 @@ namespace Corax.Querying.Matches
                     
                     match._token.ThrowIfCancellationRequested();
                     
-                    // We got more than the matches buffer, we'll need to call AndWith multiple times
-                    // which can be really expensive, instead, let's memoize the outer and remember that 
-                    if (resultsSpan.Length == 0 && match._memoizedOuter is null)
+                    // We got more than the matches buffer, so we'll AND the outer against each inner batch.
+                    // Memoizing the outer once avoids repeating an expensive outer.AndWith per batch, but it is
+                    // only worth it when (a) AndWith is actually expensive to repeat and (b) the outer is small
+                    // enough to materialize safely:
+                    //  - A TermMatch has a cheap, seekable AndWith (Seek into the posting list + prune), so
+                    //    memoizing it is pure loss: no time saved, and we'd hold the whole set in memory.
+                    //  - A large outer would cost gigabytes to materialize AND make every per-batch merge scan
+                    //    the full memoized span (quadratic). A low-confidence count may hide such a large set.
+                    // In those cases we skip memoization and stream via outer.AndWith instead.
+                    var outerAndWithIsCheap = typeof(TOuter) == typeof(TermMatch);
+                    var outerTooBigToMemoize = outer.Confidence == QueryCountConfidence.Low ||
+                                               outer.Count > match._indexSearcher.MaxMemoizationSizeInBytes / sizeof(long) / 2;
+                    if (resultsSpan.Length == 0 && match._memoizedOuter is null &&
+                        outerAndWithIsCheap == false && outerTooBigToMemoize == false)
                     {
                         match._memoizedOuter = new MemoizationMatchProvider<TOuter>(match._indexSearcher, match._outer);
                         match._memoizedOuter.SortingRequired();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26934/Slow-AND-queries-when-both-sides-are-large

### Additional description

#### Problem
In `BinaryMatch.YieldAnd`, once the inner side fills the result buffer we memoize the **entire** outer match and intersect each inner batch against the full materialized span (`MergeHelper.And`). This is wrong when the outer is large:
- it materializes the whole outer set (gigabytes for big terms), and
- every per-batch merge re-scans that span from index 0 → quadratic.

The memoization is only worth it when a single `outer.AndWith` is expensive to repeat. A plain `TermMatch.AndWith` is a cheap seek-into-the-posting-list + prune, so memoizing it saves nothing and only costs memory.

#### Fix
Gate the memoization on two signals — only memoize when it both *helps* and is *safe*:
- **type**: skip when the outer is a `TermMatch` (cheap, seekable `AndWith`);
- **size**: skip when the outer is too large to materialize safely (or its count is low-confidence), falling back to the streaming `outer.AndWith` path.

Composite / expensive outers (`MultiTermMatch`, etc.) still memoize as before. Highly-selective ANDs are unaffected — they already use the `MultiUnaryMatch` scan path.

#### Numbers

duration: `12ms` - 3.8M results

```
from index 'Orders/Totals-Corax'
where Employee = "employees/2-A"
```

duration: `3ms` - 409K results

```
from index 'Orders/Totals-Corax'
where Company = "companies/63-A"
```

Boolean query - 160K results

```
from index 'Orders/Totals-Corax'
where Employee = "employees/2-A" and Company = "companies/63-A"
```

Before: `87ms` After: `13ms`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
