### PR TITLE
RavenDB-26607 Throw when querying a non-indexed (FieldIndexing.No) field in Corax

### DIFF
--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -569,6 +569,14 @@ public static class QueryBuilderHelper
             metadata = FieldMetadata.Build(allocator, fieldName, Corax.Constants.IndexWriter.DynamicField, mode, analyzer, hasBoost: hasBoost);
         }
 
+        if (metadata.Mode == FieldIndexingMode.No)
+        {
+            throw new InvalidQueryException(
+                $"The field '{metadata.FieldName}' is not indexed (its indexing option is set to 'FieldIndexing.No') " +
+                "and therefore cannot be used in a query filter. A non-indexed field can only be stored and returned via " +
+                "a projection. Remove it from the query or change its indexing option.");
+        }
+        
         return metadata;
         void ThrowNotFoundInIndex() => throw new InvalidQueryException($"Field {fieldName} not found in Index '{index.Name}'.");
     }

--- a/test/SlowTests.Issues/Issues/RavenDB-26607.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26607.cs
@@ -1,0 +1,84 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26607 : RavenTestBase
+{
+    public RavenDB_26607(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void Querying_A_Non_Indexed_Field_Should_Throw_In_Corax(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        
+        store.ExecuteIndex(new TestIndex());
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Mitarbeiter { Id = "1", Name = "MA 1" });
+            session.Store(new Mitarbeiter { Id = "2", Name = "MA 2" });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var query = session.Query<TestIndex.Result, TestIndex>()
+                .Customize(c => c.WaitForNonStaleResults())
+                .Where(r => r.Prop != null);
+
+            if (options.SearchEngineMode == RavenSearchEngineMode.Corax)
+            {
+                // 'Prop' is configured with FieldIndexing.No, so Corax has no terms to evaluate the filter against.
+                // Previously the query silently returned every document (AndNot(AllEntries, <empty>)); now it fails loudly.
+                var error = Assert.Throws<InvalidQueryException>(() => query.ToList());
+                Assert.Contains("not indexed", error.Message);
+            }
+            else
+            {
+                // Lucene always indexes a null marker for stored fields, so the filter is evaluated and correctly matches nothing.
+                Assert.Empty(query.ToList());
+            }
+        }
+    }
+
+    private class TestIndex : AbstractIndexCreationTask<Mitarbeiter, TestIndex.Result>
+    {
+
+        public class Result
+        {
+            public string Name { get; set; }
+            public string Prop { get; set; }
+        }
+
+        public TestIndex()
+        {
+            Map = mitarbeitende => from mitarbeiter in mitarbeitende
+                                   select new Result
+                                   {
+                                       Name = mitarbeiter.Name,
+                                       Prop = null
+                                   };
+
+            StoreAllFields(FieldStorage.Yes);
+            Index(r => r.Prop, FieldIndexing.No);
+
+        }
+    }
+
+    private class Mitarbeiter
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26607

### Additional description

Querying a field configured with `FieldIndexing.No` behaved differently in Corax
than in Lucene. For an index that stores but does not index a field, a filter like:

```csharp
.Where(r => r.Prop != null)   // Prop is FieldIndexing.No
```

returned every document under Corax, while Lucene correctly returned an empty
result set.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
