### PR TITLE
RavenDB-26877 Prevent recovery from overwriting flushed data when alid journals are skipped

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -138,11 +138,12 @@ namespace Voron.Impl.Journal
             return journal;
         }
 
-        public bool RecoverDatabase(TransactionHeader* txHeader, Action<LogMode, string> addToInitLog)
+        public bool RecoverDatabase(TransactionHeader* txHeader, Action<LogMode, string> addToInitLog, out bool skippedInvalidJournals)
         {
             // note, we don't need to do any concurrency here, happens as a single threaded
             // fashion on db startup
             var requireHeaderUpdate = false;
+            skippedInvalidJournals = false;
 
             var logInfo = _headerAccessor.Get(ptr => ptr->Journal);
             var currentFileHeader = _headerAccessor.Get(ptr => *ptr);
@@ -245,6 +246,8 @@ namespace Voron.Impl.Journal
                 {
                     if (_env.Options.IgnoreInvalidJournalErrors == true)
                     {
+                        skippedInvalidJournals = true;
+
                         addToInitLog?.Invoke(LogMode.Information,
                             $"Encountered invalid journal {journalNumber} @ {_env.Options}. Skipping this journal and keep going the recovery operation because '{nameof(_env.Options.IgnoreInvalidJournalErrors)}' options is set");
                         continue;

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -291,7 +291,7 @@ namespace Voron
             var header = stackalloc TransactionHeader[1];
 
             Options.AddToInitLog?.Invoke(LogMode.Information, "Starting Recovery");
-            bool hadIntegrityIssues = _journal.RecoverDatabase(header, Options.AddToInitLog);
+            bool hadIntegrityIssues = _journal.RecoverDatabase(header, Options.AddToInitLog, out var skippedInvalidJournals);
             var successString = hadIntegrityIssues ? "(with integrity issues)" : "(successfully)";
             Options.AddToInitLog?.Invoke(LogMode.Information, $"Recovery Ended {successString}");
 
@@ -304,6 +304,14 @@ namespace Voron
 
             var entry = _headerAccessor.CopyHeader();
             var nextPageNumber = (header->TransactionId == 0 ? entry.LastPageNumber : header->LastPageNumber) + 1;
+
+            if (skippedInvalidJournals)
+            {
+                Debug.Assert(Options.IgnoreInvalidJournalErrors == true, "Options.IgnoreInvalidJournalErrors == true");
+
+                nextPageNumber = Math.Max(nextPageNumber, _dataPager.NumberOfAllocatedPages);
+            }
+
             State = new StorageEnvironmentState(nextPageNumber);
 
             Interlocked.Exchange(ref _transactionsCounter, header->TransactionId == 0 ? entry.TransactionId : header->TransactionId);

--- a/test/SlowTests/Voron/RavenDB_26877.cs
+++ b/test/SlowTests/Voron/RavenDB_26877.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.BTrees;
+using Voron.Impl.Journal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron
+{
+    public class RavenDB_26877 : StorageTest
+    {
+        public RavenDB_26877(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.MaxLogFileSize = 128 * 1024;
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void Can_write_after_recovery_which_ignored_missing_journals()
+        {
+            RequireFileBasedPager();
+
+            WriteToTree("A", numberOfTxs: 2, itemsPerTx: 10);
+
+            Env.FlushLogToDataFile();
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+            {
+                Assert.True(operation.SyncDataFile());
+            }
+
+            // the sync point (header) must stay in the first journal while further transactions are added to it
+            Assert.Equal(0, Env.HeaderAccessor.CopyHeader().Journal.LastSyncedJournal);
+
+            WriteToTree("B", numberOfTxs: 30, itemsPerTx: 30);
+
+            // apply everything to the data file but do NOT sync - the data file content gets ahead of the header
+            Env.FlushLogToDataFile();
+
+            StopDatabase(shouldDisposeOptions: true);
+
+            var journals = new DirectoryInfo(Path.Combine(DataDir, "Journals")).GetFiles("*.journal").OrderBy(x => x.Name).ToList();
+            Assert.True(journals.Count > 1);
+
+            // the first journal contains transactions after the sync point, deleting it makes
+            // the recovery skip it and all the following journals (tx id gap)
+            journals.First().Delete();
+
+            Options = StorageEnvironmentOptions.ForPath(DataDir);
+            ForceConstantCompressionAcceleration(Options);
+            Options.IgnoreInvalidJournalErrors = true;
+            Configure(Options);
+            StartDatabase();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                Tree tree = tx.CreateTree("tree");
+                tree.Add("key-after-recovery", new byte[16]);
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                Tree tree = tx.ReadTree("tree");
+
+                Assert.NotNull(tree.Read("key-after-recovery"));
+
+                // everything was flushed to the data file before the restart so no data must be lost
+                for (int i = 0; i < 2; i++)
+                for (int j = 0; j < 10; j++)
+                    Assert.NotNull(tree.Read($"A-{i:D5}-{j:D5}"));
+
+                for (int i = 0; i < 30; i++)
+                for (int j = 0; j < 30; j++)
+                    Assert.NotNull(tree.Read($"B-{i:D5}-{j:D5}"));
+            }
+        }
+
+        private void WriteToTree(string prefix, int numberOfTxs, int itemsPerTx)
+        {
+            var r = new Random(42);
+            var bytes = new byte[1024];
+
+            for (int i = 0; i < numberOfTxs; i++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    Tree tree = tx.CreateTree("tree");
+
+                    for (int j = 0; j < itemsPerTx; j++)
+                    {
+                        r.NextBytes(bytes);
+                        tree.Add($"{prefix}-{i:D5}-{j:D5}", bytes);
+                    }
+
+                    tx.Commit();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26877

### Additional description

_Problem_: with `Storage.Dangerous.IgnoreInvalidJournalErrors` enabled, a missing/invalid journal that still held flushed-but-unsynced transactions makes recovery skip it (and every later journal, on the tx-id gap). `NextPageNumber` is restored from the header (sync point) while the data file content is ahead (flush point), so the first write after load allocates over live pages. Trips the `Debug.Assert` in `AllocatePage`; in Release it silently overwrites flushed data. Not an 8.0 regression: reproduces back to 6.2.


Fix: `WriteAheadJournal.RecoverDatabase` reports when it skipped a faulty or missing journal; LoadExistingDatabase then clamps NextPageNumber to at least the data file size so new allocations can't overwrite that content. The clamp only fires on this salvage path, so normal loads still reuse preallocated tail space.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
