### PR TITLE
RavenDB-26935 Adjust LazyStringValueReader to use Size instead of Length (byte buffer length vs char buffer length).

### DIFF
--- a/src/Raven.Server/Json/LazyStringValueReader.cs
+++ b/src/Raven.Server/Json/LazyStringValueReader.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Json
             if (value.Length < MinLengthForLazyStringStreamReader && _reader == null)
                 return new ReusableStringReader(GetStringFor(value));
 
-            return GetTextReader(value.Buffer, value.Length);
+            return GetTextReader(value.Buffer, value.Size);
         }
 
         public TextReader GetTextReader(byte* buffer, int len)

--- a/test/SlowTests/Issues/RavenDB-26935.cs
+++ b/test/SlowTests/Issues/RavenDB-26935.cs
@@ -1,0 +1,69 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26935(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void NonAsciiTermTruncationTest(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            new DocIndex().Execute(store);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc { Id = "doc-1", StrVal = new string('a', 3000) });
+                session.Store(new Doc { Id = "doc-2", StrVal = "Jiří Krasnec" });
+                session.SaveChanges();
+            }
+
+            Indexes.WaitForIndexing(store);
+            WaitForUserToContinueTheTest(store);
+            using (var session = store.OpenSession())
+            {
+                var full = session.Query<Doc, DocIndex>()
+                    .Search(x => x.StrVal, "krasnec")
+                    .ToList();
+
+                var truncated = session.Query<Doc, DocIndex>()
+                    .Search(x => x.StrVal, "krasn")
+                    .ToList();
+
+                Assert.Empty(truncated);
+                Assert.Single(full);
+            }
+        }
+    }
+
+    private class DocIndex : AbstractIndexCreationTask<Doc>
+    {
+        public DocIndex()
+        {
+            Map = docs =>
+                from doc in docs
+                select new Doc
+                {
+                    Id = doc.Id,
+                    StrVal = doc.StrVal,
+                };
+
+            Index(x => x.StrVal, FieldIndexing.Search);
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Lucene;
+        }
+    }
+
+    private class Doc
+    {
+        public string Id { get; set; }
+        public string StrVal { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26935

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
