### PR TITLE
RavenDB-26936 RavenTestCategory is mapped directly to test categories

### DIFF
--- a/test/SlowTests/Issues/RavenDB_26789.cs
+++ b/test/SlowTests/Issues/RavenDB_26789.cs
@@ -129,8 +129,8 @@ namespace SlowTests.Issues
                 var storage = newShard.DocumentsStorage;
                 using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (var tx = context.OpenWriteTransaction())
-                using (DocumentIdWorker.GetLowerIdSliceAndStorageKeyForBackwardCompatibility(context, name, out _, out Slice nameSlice))
-                using (DocumentIdWorker.GetLowerIdSliceAndStorageKeyForBackwardCompatibility(context, contentType, out _, out Slice contentTypeSlice))
+                using (DocumentIdWorker.Compatibility.GetLowerIdSliceAndStorageKey(context, name, out _, out Slice nameSlice))
+                using (DocumentIdWorker.Compatibility.GetLowerIdSliceAndStorageKey(context, contentType, out _, out Slice contentTypeSlice))
                 using (Slice.From(context.Allocator, putResult.Hash, out Slice base64Hash))
                 using (Slice.From(context.Allocator, tombstone.Key, out Slice keySlice))
                 using (var stream = new MemoryStream(attachmentBytes))

--- a/test/Tests.Infrastructure/XunitExtensions/RavenTraitDiscoverer.cs
+++ b/test/Tests.Infrastructure/XunitExtensions/RavenTraitDiscoverer.cs
@@ -25,7 +25,7 @@ public class RavenTraitDiscoverer : ITraitDiscoverer
             .ToList();
 
         foreach (var category in GetFlags(list[0]))
-            yield return new KeyValuePair<string, string>("Category", category.GetDescription());
+            yield return new KeyValuePair<string, string>("Category", category.ToString());
     }
 
     private static IEnumerable<RavenTestCategory> GetFlags(RavenTestCategory category)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26936/RavenTestCategory-is-incorrectly-transformed-into-test-categories-when-Description-is-present

### Additional description

`RavenTraitHelper.GetTraitsFor` builds the xUnit Category trait from RavenTestCategory using value.GetDescription(). For members carrying a `[Description]` attribute, the trait value becomes the human-readable label instead of the enum member name. As a result `--filter "Category=<Member>"` no longer matches those categories, so their tests are silently skipped. This PR fixes it matching it back `.ToString`

Overrides, wrongly constructed https://github.com/ravendb/ravendb/pull/23109

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
