### PR TITLE
RavenDB-26878 Word certificate audit line as create vs update; drop e…

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2477,8 +2477,17 @@ namespace Raven.Server.ServerWide
                 using (var cert = context.ReadObject(command.ValueToJson(), "inner-val"))
                 {
                     if (_clusterAuditLog.IsInfoEnabled)
-                        _clusterAuditLog.Info($"Registering new certificate '{command.Value.Thumbprint}' in the cluster. Security Clearance: {command.Value.SecurityClearance}. " +
-                                              $"Permissions:{Environment.NewLine}{string.Join(Environment.NewLine, command.Value.Permissions.Select(kvp => kvp.Key + ": " + kvp.Value.ToString()))}");
+                    {
+                        // the same code path handles both the initial registration and later edits of a certificate,
+                        // so check whether the thumbprint already exists to word the audit line accordingly
+                        var alreadyExists = certs.ReadByKey(thumbprintSlice, out _);
+                        var action = alreadyExists ? "Updating" : "Registering new";
+                        var permissions = command.Value.Permissions is { Count: > 0 }
+                            ? $" Permissions:{Environment.NewLine}{string.Join(Environment.NewLine, command.Value.Permissions.Select(kvp => kvp.Key + ": " + kvp.Value))}"
+                            : string.Empty;
+
+                        _clusterAuditLog.Info($"{action} certificate '{command.Value.Thumbprint}' in the cluster. Security Clearance: {command.Value.SecurityClearance}.{permissions}");
+                    }
 
                     UpdateCertificate(certs, thumbprintSlice, hashSlice, cert);
                     return;


### PR DESCRIPTION
…mpty Permissions clause

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26878

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
