### PR TITLE
RavenDB-26937 Fix HNSW parallel-placement preloading the wrong node on edge-index gaps

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -118,6 +118,17 @@ public partial class Hnsw
 
         public int MaxConcurrentBatches = 512;
 
+        internal static void CollectVectorsToPreload(ReadOnlySpan<int> edgesIndexes, ReadOnlySpan<Node> nodes, List<long> batch)
+        {
+            foreach (int index in edgesIndexes)
+            {
+                Node edge = nodes[index];
+                if (edge.VectorLoaded)
+                    continue;
+                batch.Add(edge.NodeId);
+            }
+        }
+
         private void InsertVectorsToGraph(ref ContextBoundNativeList<byte> byteBuffer, CancellationToken token)
         {
             if (_searchState.TryGetLocationForNode(EntryPointId, out var entryPointNode) is false)
@@ -993,13 +1004,7 @@ public partial class Hnsw
                     }
                 }
                 
-                for (int i = 0; i < edgesIndexes.Count; i++)
-                {
-                    int index = edgesIndexes[i];
-                    if (searchState.Nodes[index].VectorLoaded)
-                        continue;
-                    batch.Add(edgesList[i]);
-                }
+                CollectVectorsToPreload(edgesIndexes.ToSpan(), searchState.Nodes, batch);
                 return old != batch.Count;
             }
         }

--- a/test/FastTests/Voron/Graphs/HnswPreloadAlignment.cs
+++ b/test/FastTests/Voron/Graphs/HnswPreloadAlignment.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Sparrow;
+using Tests.Infrastructure;
+using Voron.Data.Graphs;
+using Xunit;
+
+namespace FastTests.Voron.Graphs;
+
+public unsafe class HnswPreloadAlignment(ITestOutputHelper output) : StorageTest(output)
+{
+    // When an unfound edge makes edgesIndexes shorter than edgesList, the preload
+    // collector must batch the node behind edgesIndexes[i], not the positionally
+    // misaligned edgesList[i]. Getting this wrong preloads the wrong vector and the
+    // needed one is demand-loaded via a singleton Container.Get that NREs under eviction.
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void CollectVectorsToPreload_batches_the_node_behind_the_index()
+    {
+        byte[] loaded = new byte[1];
+        fixed (byte* p = loaded)
+        {
+            Hnsw.Node a = new() { NodeId = 100 };
+            a.SetVector(default, new UnmanagedSpan(p, 1)); // VectorLoaded == true
+            Hnsw.Node b = new() { NodeId = 200 };          // unfound edge — skipped, never in edgesIndexes
+            Hnsw.Node c = new() { NodeId = 300 };          // resolved, vector NOT loaded
+
+            Hnsw.Node[] nodes = [a, b, c];
+            int[] edgesIndexes = [0, 2]; // compacted: B was skipped
+
+            List<long> batch = [];
+            Hnsw.Registration.CollectVectorsToPreload(edgesIndexes, nodes, batch);
+
+            Assert.Equal(new List<long> { 300 }, batch);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26937

### Additional description

The parallel HNSW node-placement builds a per-node preload batch in `RegisterForPreloading` in two passes: the first resolves each neighbor id in `edgesList` to a resident node index, appending to `edgesIndexes` but skipping any neighbor that isn't loaded yet (so `edgesIndexes` becomes shorter than `edgesList`). The second pass then walked `edgesIndexes` while indexing `edgesList` with the same counter, so after any skip the two lists were misaligned and it batched the wrong neighbor — leaving the node that genuinely needed its vector unloaded. That node later got demand-loaded via a single Container.Get outside the batch page-pinning path, and under memory pressure its page could be evicted, producing the intermittent `NullReferenceException` in `PopulateWorkListsOnWorker`. The fix is to batch the node that `edgesIndexes[i]` actually resolves to (`nodes[index].NodeId`) instead of the positional `edgesList[i]`, so the correct vectors are always preloaded regardless of skips.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
