### PR TITLE
RavenDB-26529 - Remove audit logging from pull replication test

### DIFF
--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -212,53 +212,34 @@ namespace SlowTests.Server.Replication
             }
         }
 
-        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Logging)]
+        [RavenFact(RavenTestCategory.Replication)]
         public async Task UpdatePullReplicationOnSink()
         {
             var definitionName1 = $"pull-replication {GetDatabaseName()}";
             var definitionName2 = $"pull-replication {GetDatabaseName()}";
             var timeout = 3000;
-            var auditLogPath = NewDataPath(suffix: "AuditLog");
-            var settings = new Dictionary<string, string>
-            {
-                [RavenConfiguration.GetKey(x => x.Security.AuditLogPath)] = auditLogPath
-            };
-            var certificates = Certificates.SetupServerAuthentication(settings);
-            var serverCertificate = certificates.ServerCertificateForCommunication.Value;
-            var pullReplicationCertificate = certificates.ClientCertificate1.Value;
 
-            using (var sink = GetDocumentStore(SecuredOptions()))
-            using (var hub = GetDocumentStore(SecuredOptions()))
-            using (var hub2 = GetDocumentStore(SecuredOptions()))
+            using (var sink = GetDocumentStore())
+            using (var hub = GetDocumentStore())
+            using (var hub2 = GetDocumentStore())
             {
-                await DefineHubAndRegisterAccess(hub, definitionName1);
-                await DefineHubAndRegisterAccess(hub2, definitionName2);
+                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(definitionName1));
+                await hub2.Maintenance.ForDatabase(hub2.Database).SendAsync(new PutPullReplicationAsHubOperation(definitionName2));
 
                 using (var main = hub.OpenSession())
                 {
                     main.Store(new User(), "hub1/1");
                     main.SaveChanges();
                 }
-                var pullTasks = await SetupPullReplicationAsync(definitionName1, sink, pullReplicationCertificate, hub);
+                var pullTasks = await SetupPullReplicationAsync(definitionName1, sink, hub);
                 Assert.True(WaitForDocument(sink, "hub1/1", timeout), sink.Identifier);
 
                 var pull = new PullReplicationAsSink(hub2.Database, $"ConnectionString2-{sink.Database}", definitionName2)
                 {
                     Url = sink.Urls[0],
-                    TaskId = pullTasks[0].TaskId,
-                    CertificateWithPrivateKey = Convert.ToBase64String(pullReplicationCertificate.Export(X509ContentType.Pfx))
+                    TaskId = pullTasks[0].TaskId
                 };
                 await AddWatcherToReplicationTopology(sink, pull, hub2.Urls);
-                await WaitForAssertionAsync(() =>
-                {
-                    var auditLog = ReadAuditLog();
-                    var updateSinkAuditLines = auditLog
-                        .Split(Environment.NewLine)
-                        .Where(x => x.Contains("update-sink-pull-replication"));
-
-                    Assert.Contains(updateSinkAuditLines, x => x.Contains(definitionName2));
-                    return Task.CompletedTask;
-                }, TimeSpan.FromSeconds(5));
 
                 using (var main = hub.OpenSession())
                 {
@@ -273,45 +254,6 @@ namespace SlowTests.Server.Replication
                     main.SaveChanges();
                 }
                 Assert.True(WaitForDocument(sink, "hub2", timeout), sink.Identifier);
-            }
-
-            return;
-
-            Options SecuredOptions()
-            {
-                return new Options
-                {
-                    ClientCertificate = serverCertificate,
-                    AdminCertificate = serverCertificate
-                };
-            }
-
-            async Task DefineHubAndRegisterAccess(DocumentStore hub, string definitionName)
-            {
-                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(definitionName));
-                await hub.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation(definitionName,
-                    new ReplicationHubAccess
-                    {
-                        Name = definitionName,
-                        CertificateBase64 = Convert.ToBase64String(pullReplicationCertificate.Export(X509ContentType.Cert))
-                    }));
-            }
-
-            string ReadAuditLog()
-            {
-                NLog.LogManager.Flush(TimeSpan.FromSeconds(1));
-
-                return Directory.Exists(auditLogPath)
-                    ? string.Join(Environment.NewLine, Directory.GetFiles(auditLogPath, "*.log").Select(ReadAuditLogFile))
-                    : string.Empty;
-            }
-
-            static string ReadAuditLogFile(string path)
-            {
-                using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-                using var reader = new StreamReader(stream);
-
-                return reader.ReadToEnd();
             }
         }
 
@@ -1755,22 +1697,13 @@ namespace SlowTests.Server.Replication
 
         //TODO write test for deletion! - make sure replication is stopped after we delete hub!
 
-        public static Task<List<ModifyOngoingTaskResult>> SetupPullReplicationAsync(string remoteName, DocumentStore sink, params DocumentStore[] hub)
-        {
-            return SetupPullReplicationAsync(remoteName, sink, null, hub);
-        }
-
-        private static async Task<List<ModifyOngoingTaskResult>> SetupPullReplicationAsync(string remoteName, DocumentStore sink, X509Certificate2 certificate, params DocumentStore[] hub)
+        public static async Task<List<ModifyOngoingTaskResult>> SetupPullReplicationAsync(string remoteName, DocumentStore sink, params DocumentStore[] hub)
         {
             var tasks = new List<Task<ModifyOngoingTaskResult>>();
             var resList = new List<ModifyOngoingTaskResult>();
             foreach (var store in hub)
             {
                 var pull = new PullReplicationAsSink(store.Database, $"ConnectionString-{store.Database}", remoteName) { Url = sink.Urls[0] };
-                if (certificate != null)
-                {
-                    pull.CertificateWithPrivateKey = Convert.ToBase64String(certificate.Export(X509ContentType.Pfx));
-                }
                 tasks.Add(AddWatcherToReplicationTopology(sink, pull, store.Urls));
             }
             await Task.WhenAll(tasks);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26529

### Additional description

Reverted the audit logging [changes](https://github.com/ravendb/ravendb/pull/22987) from `PullReplicationTests.UpdatePullReplicationOnSink`.

The test is restored to the regular unsecured pull replication flow and no longer configures audit log storage, secured document stores, replication hub access certificates, or audit log file assertions. This avoids enabling audit logging as part of the test run.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed