### PR TITLE
RavenDB-26941 Filter out expired certificates by default [v6.2]

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/Certificates.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/Certificates.spec.tsx
@@ -14,10 +14,14 @@ const selectors = {
     deleteButtonTitle: /Delete certificate/,
     wellKnownServerCerts: /Well known admin certificates/,
     wellKnownIssuerCerts: /Well known issuer certificates/,
+    validStateFilter: /Valid/,
+    expiredStateFilter: /Expired/,
 };
 
-const serverCert = ManageServerStubs.certificates().Certificates[0];
-const clientCert = ManageServerStubs.certificates().Certificates[1];
+const stubCertificates = ManageServerStubs.certificates().Certificates;
+const clientCertName = stubCertificates[1].Name;
+const aboutToExpireCertName = stubCertificates[2].Name;
+const expiredCertName = stubCertificates[3].Name;
 
 describe("Certificates", () => {
     it("can render when server is not secure", () => {
@@ -110,7 +114,7 @@ describe("Certificates", () => {
             const { screen } = await rtlRender_WithWaitForLoad(
                 <CertificatesStory
                     certificates={(x) => {
-                        x.Certificates = [serverCert, clientCert];
+                        x.Certificates = [x.Certificates[0], x.Certificates[1]];
                         x.Certificates[1].NotAfter = moment().add(1, "days").format();
                     }}
                 />
@@ -120,15 +124,18 @@ describe("Certificates", () => {
         });
 
         it("can hide edit button when cert is expired", async () => {
-            const { screen } = await rtlRender_WithWaitForLoad(
+            const { screen, fireClick } = await rtlRender_WithWaitForLoad(
                 <CertificatesStory
                     certificates={(x) => {
-                        x.Certificates = [serverCert, clientCert];
+                        x.Certificates = [x.Certificates[0], x.Certificates[1]];
                         x.Certificates[1].NotAfter = moment().subtract(1, "days").format();
                     }}
                 />
             );
 
+            await fireClick(screen.getByLabelText(selectors.expiredStateFilter));
+
+            expect(screen.getByText(clientCertName)).toBeInTheDocument();
             expect(screen.queryByTitle(selectors.editButtonTitle)).not.toBeInTheDocument();
         });
 
@@ -136,7 +143,7 @@ describe("Certificates", () => {
             const { screen } = await rtlRender_WithWaitForLoad(
                 <CertificatesStory
                     certificates={(x) => {
-                        x.Certificates = [serverCert, clientCert];
+                        x.Certificates = [x.Certificates[0], x.Certificates[1]];
                         x.Certificates[1].SecurityClearance = "Operator";
                     }}
                     securityClearance="Operator"
@@ -150,7 +157,7 @@ describe("Certificates", () => {
             const { screen } = await rtlRender_WithWaitForLoad(
                 <CertificatesStory
                     certificates={(x) => {
-                        x.Certificates = [serverCert, clientCert];
+                        x.Certificates = [x.Certificates[0], x.Certificates[1]];
                         x.Certificates[1].SecurityClearance = "ClusterAdmin";
                     }}
                     securityClearance="Operator"
@@ -158,6 +165,27 @@ describe("Certificates", () => {
             );
 
             expect(screen.queryByTitle(selectors.deleteButtonTitle)).not.toBeInTheDocument();
+        });
+    });
+
+    describe("state filter", () => {
+        it("shows only valid and about to expire certificates by default", async () => {
+            const { screen } = await rtlRender_WithWaitForLoad(<CertificatesStory />);
+
+            expect(screen.getByLabelText(selectors.validStateFilter)).toBeChecked();
+            expect(screen.getByLabelText(selectors.expiredStateFilter)).not.toBeChecked();
+
+            expect(screen.getByText(clientCertName)).toBeInTheDocument();
+            expect(screen.getByText(aboutToExpireCertName)).toBeInTheDocument();
+            expect(screen.queryByText(expiredCertName)).not.toBeInTheDocument();
+        });
+
+        it("can show expired certificates after selecting the Expired state", async () => {
+            const { screen, fireClick } = await rtlRender_WithWaitForLoad(<CertificatesStory />);
+
+            await fireClick(screen.getByLabelText(selectors.expiredStateFilter));
+
+            expect(screen.getByText(expiredCertName)).toBeInTheDocument();
         });
     });
 });

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSlice.ts
@@ -44,7 +44,7 @@ const initialState: InitialState = {
     nameOrThumbprintFilter: "",
     databaseFilter: "",
     clearanceFilter: [],
-    stateFilter: [],
+    stateFilter: ["Valid"],
     sortMode: "By Name - Asc",
     isGenerateModalOpen: false,
     isUploadModalOpen: false,


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-26941/Filter-out-expired-certificates-by-default

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
