### PR TITLE
RavenDB-26941 Filter out expired certificates by default [v7.2]

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/Certificates.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/Certificates.spec.tsx
@@ -1,5 +1,5 @@
 import * as stories from "./Certificates.stories";
-import { rtlRender, rtlRender_WithWaitForLoad } from "test/rtlTestUtils";
+import { act, rtlRender, rtlRender_WithWaitForLoad } from "test/rtlTestUtils";
 import { composeStories } from "@storybook/react-webpack5";
 import { ManageServerStubs } from "test/stubs/ManageServerStubs";
 import moment from "moment";
@@ -14,10 +14,14 @@ const selectors = {
     deleteButtonTitle: /Delete certificate/,
     wellKnownServerCerts: /Well known admin certificates/,
     wellKnownIssuerCerts: /Well known issuer certificates/,
+    stateFilterLabel: "Filter by state",
+    expiredStateOption: "Expired",
 };
 
-const serverCert = ManageServerStubs.certificates().Certificates[0];
-const clientCert = ManageServerStubs.certificates().Certificates[1];
+const stubCertificates = ManageServerStubs.certificates().Certificates;
+const clientCertName = stubCertificates[1].Name;
+const aboutToExpireCertName = stubCertificates[2].Name;
+const expiredCertName = stubCertificates[3].Name;
 
 describe("Certificates", () => {
     it("can render when server is not secure", () => {
@@ -110,7 +114,7 @@ describe("Certificates", () => {
             const { screen } = await rtlRender_WithWaitForLoad(
                 <CertificatesStory
                     certificates={(x) => {
-                        x.Certificates = [serverCert, clientCert];
+                        x.Certificates = [x.Certificates[0], x.Certificates[1]];
                         x.Certificates[1].NotAfter = moment().add(1, "days").format();
                     }}
                 />
@@ -120,15 +124,18 @@ describe("Certificates", () => {
         });
 
         it("can hide edit button when cert is expired", async () => {
-            const { screen } = await rtlRender_WithWaitForLoad(
+            const { screen, user } = await rtlRender_WithWaitForLoad(
                 <CertificatesStory
                     certificates={(x) => {
-                        x.Certificates = [serverCert, clientCert];
+                        x.Certificates = [x.Certificates[0], x.Certificates[1]];
                         x.Certificates[1].NotAfter = moment().subtract(1, "days").format();
                     }}
                 />
             );
 
+            await selectStateFilterOption(screen, user, selectors.expiredStateOption);
+
+            expect(screen.getByText(clientCertName)).toBeInTheDocument();
             expect(screen.queryByTitle(selectors.editButtonTitle)).not.toBeInTheDocument();
         });
 
@@ -136,7 +143,7 @@ describe("Certificates", () => {
             const { screen } = await rtlRender_WithWaitForLoad(
                 <CertificatesStory
                     certificates={(x) => {
-                        x.Certificates = [serverCert, clientCert];
+                        x.Certificates = [x.Certificates[0], x.Certificates[1]];
                         x.Certificates[1].SecurityClearance = "Operator";
                     }}
                     securityClearance="Operator"
@@ -150,7 +157,7 @@ describe("Certificates", () => {
             const { screen } = await rtlRender_WithWaitForLoad(
                 <CertificatesStory
                     certificates={(x) => {
-                        x.Certificates = [serverCert, clientCert];
+                        x.Certificates = [x.Certificates[0], x.Certificates[1]];
                         x.Certificates[1].SecurityClearance = "ClusterAdmin";
                     }}
                     securityClearance="Operator"
@@ -160,4 +167,41 @@ describe("Certificates", () => {
             expect(screen.queryByTitle(selectors.deleteButtonTitle)).not.toBeInTheDocument();
         });
     });
+
+    describe("state filter", () => {
+        it("shows only valid and about to expire certificates by default", async () => {
+            const { screen } = await rtlRender_WithWaitForLoad(<CertificatesStory />);
+
+            const stateFilter = screen.getByText(selectors.stateFilterLabel).closest("div");
+            expect(stateFilter.querySelectorAll(".react-select__multi-value")).toHaveLength(1);
+            expect(stateFilter.querySelector(".react-select__multi-value")).toHaveTextContent("Valid");
+
+            expect(screen.getByText(clientCertName)).toBeInTheDocument();
+            expect(screen.getByText(aboutToExpireCertName)).toBeInTheDocument();
+            expect(screen.queryByText(expiredCertName)).not.toBeInTheDocument();
+        });
+
+        it("can show expired certificates after selecting the Expired state", async () => {
+            const { screen, user } = await rtlRender_WithWaitForLoad(<CertificatesStory />);
+
+            await selectStateFilterOption(screen, user, selectors.expiredStateOption);
+
+            expect(screen.getByText(expiredCertName)).toBeInTheDocument();
+        });
+    });
 });
+
+async function selectStateFilterOption(
+    screen: ReturnType<typeof rtlRender>["screen"],
+    user: ReturnType<typeof rtlRender>["user"],
+    optionLabel: string
+) {
+    const stateFilterInput = screen.getByText(selectors.stateFilterLabel).closest("div").querySelector("input");
+
+    await act(async () => {
+        await user.click(stateFilterInput);
+    });
+    await act(async () => {
+        await user.click(await screen.findByText(optionLabel));
+    });
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSlice.ts
@@ -50,7 +50,7 @@ const initialState: InitialState = {
     nameOrThumbprintFilter: "",
     databaseFilter: "",
     clearanceFilter: [],
-    stateFilter: [],
+    stateFilter: ["Valid"],
     managementTypeFilter: [],
     sortMode: "By Name - Asc",
     isGenerateModalOpen: false,

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
@@ -146,11 +146,11 @@ const selectFilteredCertificates = createSelector(
             }
 
             const state = certificatesUtils.getState(cert);
-            if (stateFilter.includes("Valid") && (state === "Valid" || state === "About to expire")) {
-                return true;
-            }
+            // About to expire certificates are still valid
+            const matchesStateFilter =
+                stateFilter.includes(state) || (stateFilter.includes("Valid") && state === "About to expire");
 
-            if (stateFilter.length > 0 && !stateFilter.includes(state)) {
+            if (stateFilter.length > 0 && !matchesStateFilter) {
                 return false;
             }
 


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-26941/Filter-out-expired-certificates-by-default

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
