### PR TITLE
RavenDB-26939 Studio checks database access from certificate permissions case-insensitively [v7.1]

### DIFF
--- a/src/Raven.Studio/typescript/common/shell/accessManager.spec.ts
+++ b/src/Raven.Studio/typescript/common/shell/accessManager.spec.ts
@@ -1,0 +1,46 @@
+import accessManager from "common/shell/accessManager";
+
+describe("accessManager", () => {
+    beforeEach(() => {
+        accessManager.databasesAccess = {
+            Northwind: "DatabaseAdmin",
+            orders: "DatabaseRead",
+        };
+        accessManager.default.securityClearance("ValidUser");
+    });
+
+    describe("getDatabasesAccess", () => {
+        it("can get access level when name casing matches the certificate", () => {
+            expect(accessManager.getDatabasesAccess("Northwind")).toEqual("DatabaseAdmin");
+        });
+
+        it("can get access level when name casing differs from the certificate", () => {
+            expect(accessManager.getDatabasesAccess("northwind")).toEqual("DatabaseAdmin");
+            expect(accessManager.getDatabasesAccess("Orders")).toEqual("DatabaseRead");
+        });
+
+        it("can get access level for a shard when name casing differs from the certificate", () => {
+            expect(accessManager.getDatabasesAccess("NORTHWIND$1")).toEqual("DatabaseAdmin");
+        });
+
+        it("returns undefined when database is not listed in the certificate", () => {
+            expect(accessManager.getDatabasesAccess("unknown")).toBeUndefined();
+        });
+
+        it("returns null when name is not provided", () => {
+            expect(accessManager.getDatabasesAccess(null)).toBeNull();
+        });
+    });
+
+    describe("getEffectiveDatabaseAccessLevel", () => {
+        it("uses certificate access level regardless of name casing", () => {
+            expect(accessManager.default.getEffectiveDatabaseAccessLevel("northWIND")).toEqual("DatabaseAdmin");
+            expect(accessManager.default.getEffectiveDatabaseAccessLevel("ORDERS")).toEqual("DatabaseRead");
+        });
+
+        it("is admin for any database when user is operator or above", () => {
+            accessManager.default.securityClearance("Operator");
+            expect(accessManager.default.getEffectiveDatabaseAccessLevel("unknown")).toEqual("DatabaseAdmin");
+        });
+    });
+});

--- a/src/Raven.Studio/typescript/common/shell/accessManager.ts
+++ b/src/Raven.Studio/typescript/common/shell/accessManager.ts
@@ -212,9 +212,10 @@ class accessManager {
             return null;
         }
 
-        // The certificate may define permissions with different letter casing than the actual database name
-        const groupKey = DatabaseUtils.default.shardGroupKey(name).toLowerCase();
-        const matchingName = Object.keys(accessManager.databasesAccess).find((x) => x.toLowerCase() === groupKey);
+        const groupKey = DatabaseUtils.default.shardGroupKey(name);
+        const matchingName = Object.keys(accessManager.databasesAccess).find((x) =>
+            DatabaseUtils.default.namesEqualIgnoreCase(x, groupKey)
+        );
 
         return matchingName != null ? accessManager.databasesAccess[matchingName] : undefined;
     }

--- a/src/Raven.Studio/typescript/common/shell/accessManager.ts
+++ b/src/Raven.Studio/typescript/common/shell/accessManager.ts
@@ -212,7 +212,11 @@ class accessManager {
             return null;
         }
 
-        return accessManager.databasesAccess[DatabaseUtils.default.shardGroupKey(name)];
+        // The certificate may define permissions with different letter casing than the actual database name
+        const groupKey = DatabaseUtils.default.shardGroupKey(name).toLowerCase();
+        const matchingName = Object.keys(accessManager.databasesAccess).find((x) => x.toLowerCase() === groupKey);
+
+        return matchingName != null ? accessManager.databasesAccess[matchingName] : undefined;
     }
 
 }

--- a/src/Raven.Studio/typescript/components/common/shell/accessManagerSlice.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/accessManagerSlice.ts
@@ -14,8 +14,10 @@ interface AccessManagerState {
     clientCertificateThumbprint: string;
 }
 
+// The certificate may define permissions with different letter casing than the actual database name,
+// so entities are keyed by the lowercased name and must be looked up with a lowercased id
 const databaseAccessAdapter = createEntityAdapter<DatabaseAccessInfo, string>({
-    selectId: (x) => x.databaseName,
+    selectId: (x) => x.databaseName.toLowerCase(),
 });
 
 export const databaseAccessSelectors = databaseAccessAdapter.getSelectors();

--- a/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.spec.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.spec.ts
@@ -1,0 +1,94 @@
+import { createStoreConfiguration } from "components/store";
+import { accessManagerActions } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
+import { databasesSlice } from "components/common/shell/databasesSlice";
+import SecurityClearance = Raven.Client.ServerWide.Operations.Certificates.SecurityClearance;
+
+interface CreateStoreArgs {
+    databaseAccess: dictionary<databaseAccessLevel>;
+    securityClearance?: SecurityClearance;
+    activeDatabaseName?: string;
+}
+
+function createStoreWithAccess({
+    databaseAccess,
+    securityClearance = "ValidUser",
+    activeDatabaseName = null,
+}: CreateStoreArgs) {
+    const store = createStoreConfiguration();
+    store.dispatch(accessManagerActions.onDatabaseAccessLoaded(databaseAccess));
+    store.dispatch(accessManagerActions.onSecurityClearanceSet(securityClearance));
+    if (activeDatabaseName) {
+        store.dispatch(databasesSlice.actions.activeDatabaseChanged(activeDatabaseName));
+    }
+    return store;
+}
+
+describe("accessManagerSliceSelectors", () => {
+    const databaseAccess: dictionary<databaseAccessLevel> = {
+        Northwind: "DatabaseAdmin",
+        orders: "DatabaseRead",
+    };
+
+    describe("getEffectiveDatabaseAccessLevel", () => {
+        it("can get access level when name casing matches the certificate", () => {
+            const store = createStoreWithAccess({ databaseAccess });
+            const getLevel = accessManagerSelectors.getEffectiveDatabaseAccessLevel(store.getState());
+
+            expect(getLevel("Northwind")).toEqual("DatabaseAdmin");
+        });
+
+        it("can get access level when name casing differs from the certificate", () => {
+            const store = createStoreWithAccess({ databaseAccess });
+            const getLevel = accessManagerSelectors.getEffectiveDatabaseAccessLevel(store.getState());
+
+            expect(getLevel("northwind")).toEqual("DatabaseAdmin");
+            expect(getLevel("ORDERS")).toEqual("DatabaseRead");
+        });
+
+        it("can get access level for active database when name casing differs from the certificate", () => {
+            const store = createStoreWithAccess({ databaseAccess, activeDatabaseName: "northWIND" });
+            const getLevel = accessManagerSelectors.getEffectiveDatabaseAccessLevel(store.getState());
+
+            expect(getLevel()).toEqual("DatabaseAdmin");
+        });
+
+        it("returns no access level when database is not listed in the certificate", () => {
+            const store = createStoreWithAccess({ databaseAccess });
+            const getLevel = accessManagerSelectors.getEffectiveDatabaseAccessLevel(store.getState());
+
+            expect(getLevel("unknown")).toBeUndefined();
+        });
+    });
+
+    describe("getHasDatabaseAdminAccess", () => {
+        it("can check admin access when name casing differs from the certificate", () => {
+            const store = createStoreWithAccess({ databaseAccess });
+            const hasAdminAccess = accessManagerSelectors.getHasDatabaseAdminAccess(store.getState());
+
+            expect(hasAdminAccess("northwind")).toBe(true);
+            expect(hasAdminAccess("ORDERS")).toBe(false);
+        });
+    });
+
+    describe("getHasDatabaseWriteAccess", () => {
+        it("can check write access when name casing differs from the certificate", () => {
+            const store = createStoreWithAccess({ databaseAccess });
+            const hasWriteAccess = accessManagerSelectors.getHasDatabaseWriteAccess(store.getState());
+
+            expect(hasWriteAccess("NORTHWIND")).toBe(true);
+            expect(hasWriteAccess("Orders")).toBe(false);
+        });
+    });
+
+    describe("getCanHandleOperation", () => {
+        it("can check operation permission when name casing differs from the certificate", () => {
+            const store = createStoreWithAccess({ databaseAccess });
+            const canHandleOperation = accessManagerSelectors.getCanHandleOperation(store.getState());
+
+            expect(canHandleOperation("DatabaseAdmin", "northwind")).toBe(true);
+            expect(canHandleOperation("DatabaseRead", "ORDERS")).toBe(true);
+            expect(canHandleOperation("DatabaseReadWrite", "Orders")).toBe(false);
+        });
+    });
+});

--- a/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.spec.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.spec.ts
@@ -53,6 +53,20 @@ describe("accessManagerSliceSelectors", () => {
             expect(getLevel()).toEqual("DatabaseAdmin");
         });
 
+        it("can get access level for a shard when name casing differs from the certificate", () => {
+            const store = createStoreWithAccess({ databaseAccess });
+            const getLevel = accessManagerSelectors.getEffectiveDatabaseAccessLevel(store.getState());
+
+            expect(getLevel("NORTHWIND$1")).toEqual("DatabaseAdmin");
+        });
+
+        it("can get access level when active database is a shard", () => {
+            const store = createStoreWithAccess({ databaseAccess, activeDatabaseName: "northwind$2" });
+            const getLevel = accessManagerSelectors.getEffectiveDatabaseAccessLevel(store.getState());
+
+            expect(getLevel()).toEqual("DatabaseAdmin");
+        });
+
         it("returns no access level when database is not listed in the certificate", () => {
             const store = createStoreWithAccess({ databaseAccess });
             const getLevel = accessManagerSelectors.getEffectiveDatabaseAccessLevel(store.getState());

--- a/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.ts
@@ -2,6 +2,7 @@ import { RootState } from "components/store";
 import SecurityClearance = Raven.Client.ServerWide.Operations.Certificates.SecurityClearance;
 import { createSelector, EntityState } from "@reduxjs/toolkit";
 import { DatabaseAccessInfo, databaseAccessSelectors } from "components/common/shell/accessManagerSlice";
+import DatabaseUtils from "components/utils/DatabaseUtils";
 
 // If database name is not provided, it will use the active one
 interface GetAccessLevelArgs {
@@ -18,7 +19,8 @@ interface GetEffectiveAccessLevelArgs extends GetAccessLevelArgs {
 
 function getDatabaseAccessLevel(args: GetAccessLevelArgs) {
     const databaseName = args.databaseName ?? args.activeDatabaseName;
-    return databaseAccessSelectors.selectById(args.databaseAccess, databaseName?.toLowerCase())?.level;
+    const groupKey = DatabaseUtils.shardGroupKey(databaseName);
+    return databaseAccessSelectors.selectById(args.databaseAccess, groupKey?.toLowerCase())?.level;
 }
 
 function getIsOperatorOrAbove(securityClearance: SecurityClearance) {

--- a/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.ts
@@ -17,7 +17,8 @@ interface GetEffectiveAccessLevelArgs extends GetAccessLevelArgs {
 // Getters
 
 function getDatabaseAccessLevel(args: GetAccessLevelArgs) {
-    return databaseAccessSelectors.selectById(args.databaseAccess, args.databaseName ?? args.activeDatabaseName)?.level;
+    const databaseName = args.databaseName ?? args.activeDatabaseName;
+    return databaseAccessSelectors.selectById(args.databaseAccess, databaseName?.toLowerCase())?.level;
 }
 
 function getIsOperatorOrAbove(securityClearance: SecurityClearance) {

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
@@ -7,6 +7,7 @@ import {
 } from "components/pages/resources/manageServer/certificates/utils/certificatesTypes";
 import { certificatesUtils } from "components/pages/resources/manageServer/certificates/utils/certificatesUtils";
 import { RootState } from "components/store";
+import DatabaseUtils from "components/utils/DatabaseUtils";
 
 const selectClearanceFilterOptions = createSelector(
     (state: RootState) => state.certificates.certificates,
@@ -85,7 +86,7 @@ const selectFilteredCertificates = createSelector(
             if (
                 databaseFilter &&
                 permissionKeys.length > 0 &&
-                !permissionKeys.some((x) => x.toLowerCase() === databaseFilter.toLowerCase())
+                !permissionKeys.some((x) => DatabaseUtils.namesEqualIgnoreCase(x, databaseFilter))
             ) {
                 return false;
             }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
@@ -82,7 +82,11 @@ const selectFilteredCertificates = createSelector(
             }
 
             const permissionKeys = Object.keys(cert.Permissions);
-            if (databaseFilter && permissionKeys.length > 0 && !permissionKeys.includes(databaseFilter)) {
+            if (
+                databaseFilter &&
+                permissionKeys.length > 0 &&
+                !permissionKeys.some((x) => x.toLowerCase() === databaseFilter.toLowerCase())
+            ) {
                 return false;
             }
 

--- a/src/Raven.Studio/typescript/components/utils/DatabaseUtils.spec.ts
+++ b/src/Raven.Studio/typescript/components/utils/DatabaseUtils.spec.ts
@@ -41,4 +41,19 @@ describe("DatabaseUtils", function () {
             expect(result).toEqual("dbName_shard_3");
         });
     });
+
+    describe("namesEqualIgnoreCase", function () {
+        it("true when names differ only in casing", () => {
+            expect(DatabaseUtils.namesEqualIgnoreCase("Northwind", "northWIND")).toBe(true);
+        });
+
+        it("false when names differ", () => {
+            expect(DatabaseUtils.namesEqualIgnoreCase("Northwind", "orders")).toBe(false);
+        });
+
+        it("false when any name is not provided", () => {
+            expect(DatabaseUtils.namesEqualIgnoreCase("Northwind", null)).toBe(false);
+            expect(DatabaseUtils.namesEqualIgnoreCase(null, null)).toBe(false);
+        });
+    });
 });

--- a/src/Raven.Studio/typescript/components/utils/DatabaseUtils.ts
+++ b/src/Raven.Studio/typescript/components/utils/DatabaseUtils.ts
@@ -38,6 +38,12 @@ export default class DatabaseUtils {
         return DatabaseUtils.isSharded(name) ? name.split("$")[0] : name;
     }
 
+    // Database names are case-insensitive, e.g. a certificate may define permissions
+    // with different letter casing than the actual database name
+    static namesEqualIgnoreCase(name1: string, name2: string) {
+        return name1 != null && name2 != null && name1.toLowerCase() === name2.toLowerCase();
+    }
+
     static shardNumber(name: string): number {
         if (name.includes("$")) {
             return parseInt(name.split("$")[1], 10);


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-26939

### Additional description

The server matches certificate database permissions to databases case-insensitively, but Studio looked up access by exact database name. When a certificate defined a permission with different letter casing than the actual database name (e.g. northwind vs Northwind), Studio treated the user as having no access.

Fixed by making the lookups case-insensitive in:

- accessManager.getDatabasesAccess (knockout side)
- accessManagerSlice / accessManagerSliceSelectors — the database access entity state is now keyed by the lowercased database name (redux side)
- the certificates page database filter, which compared the selected database name exactly against permission keys

Added tests covering both the knockout and redux access resolution.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
