### PR TITLE
RavenDB-26788 - Time series deleted after bucket migration can be resurrected by a source-failover bucket re-send (v7.2)

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2279,6 +2279,8 @@ namespace Raven.Server.Documents
 
             internal AsyncManualResetEvent DelayQueryByPatch;
 
+            internal AsyncManualResetEvent DelayDeleteBucket;
+
             internal bool EnableWritesToTheWrongShard = false;
             
             internal TimeSpan? EtlFallbackTime;

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -169,6 +169,7 @@ namespace Raven.Server.Documents.Handlers
 
                 if (_operation.Deletes?.Count > 0)
                 {
+                    var createDeletedRangeIfNoStats = _operation.Appends?.Count > 0 || _operation.Increments?.Count > 0;
                     foreach (var removal in _operation.Deletes)
                     {
                         var deletionRange = new TimeSeriesStorage.DeletionRangeRequest
@@ -180,7 +181,7 @@ namespace Raven.Server.Documents.Handlers
                             To = removal.To ?? DateTime.MaxValue
                         };
 
-                        LastChangeVector = tss.DeleteTimestampRange(context, deletionRange);
+                        LastChangeVector = tss.DeleteTimestampRange(context, deletionRange, createDeletedRangeIfNoStats: createDeletedRangeIfNoStats);
 
                         changes++;
                     }

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -169,7 +169,6 @@ namespace Raven.Server.Documents.Handlers
 
                 if (_operation.Deletes?.Count > 0)
                 {
-                    var createDeletedRangeIfNoStats = _operation.Appends?.Count > 0 || _operation.Increments?.Count > 0;
                     foreach (var removal in _operation.Deletes)
                     {
                         var deletionRange = new TimeSeriesStorage.DeletionRangeRequest
@@ -181,7 +180,7 @@ namespace Raven.Server.Documents.Handlers
                             To = removal.To ?? DateTime.MaxValue
                         };
 
-                        LastChangeVector = tss.DeleteTimestampRange(context, deletionRange, createDeletedRangeIfNoStats: createDeletedRangeIfNoStats);
+                        LastChangeVector = tss.DeleteTimestampRange(context, deletionRange);
 
                         changes++;
                     }

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -215,6 +215,9 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
 
     public async Task DeleteBucketAsync(int bucket, long migrationIndex, long confirmationIndex, string uptoChangeVector)
     {
+        if (ForTestingPurposes?.DelayDeleteBucket != null)
+            await ForTestingPurposes.DelayDeleteBucket.WaitAsync(DatabaseShutdown);
+
         if (string.IsNullOrEmpty(uptoChangeVector))
         {
             await ServerStore.Sharding.SourceMigrationCleanup(ShardedDatabaseName, bucket, migrationIndex);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Binary;
 using Sparrow.Json;
-using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Logging;
 using Sparrow.Server.Utils;
@@ -31,7 +31,8 @@ namespace Raven.Server.Documents.TimeSeries
             Start = 2,
             End = 3,
             Count = 4,
-            Name = 5 // original casing
+            Name = 5, // original casing
+            MergedChangeVector = 6
         }
 
         static TimeSeriesStats()
@@ -73,7 +74,7 @@ namespace Raven.Server.Documents.TimeSeries
             tx.CreateTree(TimeSeriesStatsKey);
         }
 
-        private Table GetOrCreateTable(Transaction tx, CollectionName collection)
+        internal static Table GetOrCreateTable(Transaction tx, CollectionName collection)
         {
             var tableName = collection.GetTableName(CollectionTableType.TimeSeriesStats); // TODO: cache the collection and pass Slice
             
@@ -89,53 +90,36 @@ namespace Raven.Server.Documents.TimeSeries
                 return;
 
             var table = GetOrCreateTable(context.Transaction.InnerTransaction, collection);
-            using (ReadStats(context, table, slicer, out var oldCount, out var start, out var end, out var name))
+            using (ReadStats(context, table, slicer, out var oldCount, out var start, out var end, out var name, out var mergedChangeVector))
             {
                 if (oldCount == 0)
                     return;
 
-                using (table.Allocate(out var tvb))
-                {
-                    tvb.Add(slicer.StatsKey);
-                    tvb.Add(GetPolicy(slicer));
-                    tvb.Add(Bits.SwapBytes(start.Ticks));
-                    tvb.Add(end);
-                    tvb.Add(oldCount + count);
-                    tvb.Add(name);
-
-                    table.Set(tvb);
-                }
+                WriteStatsTableRecord(context, table, slicer, start, end, oldCount + count, name, mergedChangeVector);
             }
         }
 
         public void UpdateDates(DocumentsOperationContext context, TimeSeriesSliceHolder slicer, CollectionName collection, DateTime start, DateTime end)
         {
             var table = GetOrCreateTable(context.Transaction.InnerTransaction, collection);
-            using (ReadStats(context, table, slicer, out var count, out _, out _, out var name))
-            using (table.Allocate(out var tvb))
+            using (ReadStats(context, table, slicer, out var count, out _, out _, out var name, out var mergedChangeVector))
             {
                 if (count == 0)
                     return;
 
-                tvb.Add(slicer.StatsKey);
-                tvb.Add(GetPolicy(slicer));
-                tvb.Add(Bits.SwapBytes(start.Ticks));
-                tvb.Add(end);
-                tvb.Add(count);
-                tvb.Add(name);
-
-                table.Set(tvb);
+                WriteStatsTableRecord(context, table, slicer, start, end, count, name, mergedChangeVector);
             }
         }
 
-        private static IDisposable ReadStats(DocumentsOperationContext context, Table table, TimeSeriesSliceHolder slicer, out long count, out DateTime start, out DateTime end, out Slice name)
+        internal static IDisposable ReadStats(DocumentsOperationContext context, Table table, TimeSeriesSliceHolder slicer, out long count, out DateTime start, out DateTime end, out Slice name, out ChangeVector mergedChangeVector)
         {
             count = 0;
             start = DateTime.MaxValue;
             end = DateTime.MinValue;
             name = slicer.NameSlice;
+            mergedChangeVector = null;
 
-            if (table.ReadByKey(slicer.StatsKey, out var tvr) == false) 
+            if (table == null || table.ReadByKey(slicer.StatsKey, out var tvr) == false)
                 return null;
 
             count = DocumentsStorage.TableValueToLong((int)StatsColumns.Count, ref tvr);
@@ -150,11 +134,11 @@ namespace Raven.Server.Documents.TimeSeries
                 return null;
             }
 
+            mergedChangeVector = ReadMergedChangeVector(context, ref tvr);
             return DocumentsStorage.TableValueToSlice(context, (int)StatsColumns.Name, ref tvr, out name);
-
         }
 
-        public long UpdateStats(DocumentsOperationContext context, TimeSeriesSliceHolder slicer, CollectionName collection, TimeSeriesValuesSegment segment, DateTime baseline, int modifiedEntries)
+        public long UpdateStats(DocumentsOperationContext context, TimeSeriesSliceHolder slicer, CollectionName collection, TimeSeriesValuesSegment segment, DateTime baseline, int modifiedEntries, ChangeVector changeVectorToMerge)
         {
             long previousCount;
             DateTime start, end;
@@ -164,7 +148,7 @@ namespace Raven.Server.Documents.TimeSeries
 
             var table = GetOrCreateTable(context.Transaction.InnerTransaction, collection);
 
-            using (ReadStats(context, table, slicer, out previousCount, out start, out end, out var name))
+            using (ReadStats(context, table, slicer, out previousCount, out start, out end, out var name, out var mergedChangeVector))
             {
                 var liveEntries = segment.NumberOfLiveEntries;
                 if (liveEntries > 0)
@@ -183,17 +167,8 @@ namespace Raven.Server.Documents.TimeSeries
 
                 var count = previousCount + liveEntries;
 
-                using (table.Allocate(out var tvb))
-                {
-                    tvb.Add(slicer.StatsKey);
-                    tvb.Add(GetPolicy(slicer));
-                    tvb.Add(Bits.SwapBytes(start.Ticks));
-                    tvb.Add(end);
-                    tvb.Add(count);
-                    tvb.Add(name);
-
-                    table.Set(tvb);
-                }
+                var mergedChangeVectorToSet = ChangeVector.Merge(mergedChangeVector, changeVectorToMerge, context);
+                WriteStatsTableRecord(context, table, slicer, start, end, count, name, mergedChangeVectorToSet);
 
                 return count;
 
@@ -277,6 +252,41 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
+        // Field 6 (MergedChangeVector) is present only on newer stats rows; legacy rows have <=6 fields.
+        private static ChangeVector ReadMergedChangeVector(DocumentsOperationContext context, ref TableValueReader tvr)
+        {
+            if (tvr.Count <= (int)StatsColumns.MergedChangeVector)
+                return null;
+
+            return DocumentsStorage.TableValueToChangeVector(context, (int)StatsColumns.MergedChangeVector, ref tvr);
+        }
+
+        internal static void WriteStatsTableRecord(DocumentsOperationContext context, Table table, TimeSeriesSliceHolder slicer, DateTime start, DateTime end, long count, Slice name, ChangeVector mergedChangeVector)
+        {
+            using (table.Allocate(out var tvb))
+            using (ChangeVectorToSlice(context, mergedChangeVector, out var mergedChangeVectorSlice))
+            {
+                tvb.Add(slicer.StatsKey);
+                tvb.Add(GetPolicy(slicer));
+                tvb.Add(Bits.SwapBytes(start.Ticks));
+                tvb.Add(end);
+                tvb.Add(count);
+                tvb.Add(name);
+                tvb.Add(mergedChangeVectorSlice);
+
+                table.Set(tvb);
+            }
+        }
+
+        private static ByteStringContext.InternalScope ChangeVectorToSlice(DocumentsOperationContext context, ChangeVector changeVector, out Slice changeVectorSlice)
+        {
+            if (changeVector != null)
+                return Slice.From(context.Allocator, changeVector, out changeVectorSlice);
+
+            changeVectorSlice = Slices.Empty;
+            return default;
+        }
+
         private static DateTime GetLastLiveTimestamp(DocumentsOperationContext context, TimeSeriesValuesSegment segment, DateTime baseline)
         {
             return segment.NumberOfEntries == segment.NumberOfLiveEntries
@@ -355,22 +365,12 @@ namespace Raven.Server.Documents.TimeSeries
             // and local-name > remote-name lexicographically 
 
             var table = context.Transaction.InnerTransaction.OpenTable(TimeSeriesStatsSchema, collection.GetTableName(CollectionTableType.TimeSeriesStats));
-            using (ReadStats(context, table, slicer, out var count, out var start, out var end, out _))
+            using (ReadStats(context, table, slicer, out var count, out var start, out var end, out _, out var mergedChangeVector))
             {
                 if (count == 0)
                     return;
 
-                using (table.Allocate(out var tvb))
-                {
-                    tvb.Add(slicer.StatsKey);
-                    tvb.Add(GetPolicy(slicer));
-                    tvb.Add(Bits.SwapBytes(start.Ticks));
-                    tvb.Add(end);
-                    tvb.Add(count);
-                    tvb.Add(slicer.NameSlice);
-
-                    table.Set(tvb);
-                }
+                WriteStatsTableRecord(context, table, slicer, start, end, count, slicer.NameSlice, mergedChangeVector);
             }
         }
 
@@ -475,7 +475,7 @@ namespace Raven.Server.Documents.TimeSeries
             return table.DeleteByPrimaryKeyPrefix(key);
         }
 
-        private Slice GetPolicy(TimeSeriesSliceHolder slicer)
+        private static Slice GetPolicy(TimeSeriesSliceHolder slicer)
         {
             var name = slicer.LowerTimeSeriesName;
             var index = name.Content.IndexOf((byte)TimeSeriesConfiguration.TimeSeriesRollupSeparator);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -125,15 +125,16 @@ namespace Raven.Server.Documents.TimeSeries
             count = DocumentsStorage.TableValueToLong((int)StatsColumns.Count, ref tvr);
             start = new DateTime(Bits.SwapBytes(DocumentsStorage.TableValueToLong((int)StatsColumns.Start, ref tvr)));
             end = DocumentsStorage.TableValueToDateTime((int)StatsColumns.End, ref tvr);
+            mergedChangeVector = ReadMergedChangeVector(context, ref tvr);
 
             if (count == 0 && start == default && end == default)
             {
                 // this is delete a stats, that we re-create, so we need to treat is as a new one.
                 start = DateTime.MaxValue;
                 end = DateTime.MinValue;
+                return null;
             }
 
-            mergedChangeVector = ReadMergedChangeVector(context, ref tvr);
             return DocumentsStorage.TableValueToSlice(context, (int)StatsColumns.Name, ref tvr, out name);
         }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -119,7 +119,7 @@ namespace Raven.Server.Documents.TimeSeries
             name = slicer.NameSlice;
             mergedChangeVector = null;
 
-            if (table == null || table.ReadByKey(slicer.StatsKey, out var tvr) == false)
+            if (table.ReadByKey(slicer.StatsKey, out var tvr) == false)
                 return null;
 
             count = DocumentsStorage.TableValueToLong((int)StatsColumns.Count, ref tvr);
@@ -131,7 +131,6 @@ namespace Raven.Server.Documents.TimeSeries
                 // this is delete a stats, that we re-create, so we need to treat is as a new one.
                 start = DateTime.MaxValue;
                 end = DateTime.MinValue;
-                return null;
             }
 
             mergedChangeVector = ReadMergedChangeVector(context, ref tvr);
@@ -315,7 +314,7 @@ namespace Raven.Server.Documents.TimeSeries
             return GetStats(context, slicer.StatsKey);
         }
 
-        public (long Count, DateTime Start, DateTime End) GetStats(DocumentsOperationContext context, Slice statsKey)
+        public static (long Count, DateTime Start, DateTime End) GetStats(DocumentsOperationContext context, Slice statsKey)
         {
             var table = new Table(TimeSeriesStatsSchema, context.Transaction.InnerTransaction);
             if (table.ReadByKey(statsKey, out var tvr) == false)
@@ -324,7 +323,7 @@ namespace Raven.Server.Documents.TimeSeries
             return GetStats(ref tvr);
         }
 
-        public (long Count, DateTime Start, DateTime End) GetStats(ref TableValueReader tvr)
+        public static (long Count, DateTime Start, DateTime End) GetStats(ref TableValueReader tvr)
         {
             var count = DocumentsStorage.TableValueToLong((int)StatsColumns.Count, ref tvr);
             var start = new DateTime(Bits.SwapBytes(DocumentsStorage.TableValueToLong((int)StatsColumns.Start, ref tvr)), DateTimeKind.Utc);
@@ -463,7 +462,7 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        public bool DeleteStats(DocumentsOperationContext context, CollectionName collection, Slice key)
+        public static bool Delete(DocumentsOperationContext context, CollectionName collection, Slice key)
         {
             var table = GetOrCreateTable(context.Transaction.InnerTransaction, collection);
             return table.DeleteByKey(key);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -76,12 +76,15 @@ namespace Raven.Server.Documents.TimeSeries
             if (collectionName == null)
                 return 0;
 
-            var deletedSegments = PurgeSegments(upto, context, collectionName, numberOfEntriesToDelete);
-            var deletedRanges = PurgeDeletedRanges(upto, context, collectionName, numberOfEntriesToDelete - deletedSegments);
+            var statsCleanupCandidates = new HashSet<Slice>(SliceComparer.Instance);
+            var deletedSegments = PurgeSegments(upto, context, collectionName, numberOfEntriesToDelete, statsCleanupCandidates);
+            var deletedRanges = PurgeDeletedRanges(upto, context, collectionName, numberOfEntriesToDelete - deletedSegments, statsCleanupCandidates);
+            DeleteStatsIfNeeded(context, collectionName, statsCleanupCandidates);
+
             return deletedRanges + deletedSegments;
         }
 
-        private long PurgeDeletedRanges(in long upto, DocumentsOperationContext context, CollectionName collectionName, long numberOfEntriesToDelete)
+        private long PurgeDeletedRanges(in long upto, DocumentsOperationContext context, CollectionName collectionName, long numberOfEntriesToDelete, HashSet<Slice> statsCleanupCandidates)
         {
             var tableName = collectionName.GetTableName(CollectionTableType.TimeSeriesDeletedRanges);
             var table = context.Transaction.InnerTransaction.OpenTable(DeleteRangesSchema, tableName);
@@ -89,38 +92,23 @@ namespace Raven.Server.Documents.TimeSeries
             if (table == null || table.NumberOfEntries == 0 || numberOfEntriesToDelete <= 0)
                 return 0;
 
-            var deleted = PurgeDeletedRangesAndCollectTimeSeriesPrefixes(context, table, upto, numberOfEntriesToDelete, out var timeSeriesPrefixes);
-            if (deleted > 0)
-                DeleteStatsForPurgedDeletedRangesIfNeeded(context, collectionName, timeSeriesPrefixes);
-
-            return deleted;
-        }
-
-        private long PurgeDeletedRangesAndCollectTimeSeriesPrefixes(DocumentsOperationContext context, Table deletedRangesTable, long upto, long numberOfEntriesToDelete, out HashSet<Slice> timeSeriesPrefixes)
-        {
-            timeSeriesPrefixes = new HashSet<Slice>(SliceComparer.Instance);
-            var prefixes = timeSeriesPrefixes;
-            var deletedRangesEtagIndex = DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice];
-
-            return deletedRangesTable.DeleteBackwardFrom(deletedRangesEtagIndex, upto, numberOfEntriesToDelete, beforeDelete: tableValueHolder =>
+            var deleted = table.DeleteBackwardFrom(DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice], upto, numberOfEntriesToDelete, beforeDelete: tableValueHolder =>
             {
                 var reader = tableValueHolder.Reader;
 
                 var keyPtr = reader.Read((int)DeletedRangeTable.RangeKey, out var keySize);
-                using (Slice.From(context.Allocator, keyPtr, keySize - sizeof(long), ByteStringType.Immutable, out var prefix))
-                {
-                    if (prefixes.Contains(prefix) == false)
-                        prefixes.Add(prefix.Clone(context.Allocator));
-                }
+                AddStatsCleanupCandidate(context, statsCleanupCandidates, keyPtr, keySize);
             });
+
+            return deleted;
         }
 
-        private void DeleteStatsForPurgedDeletedRangesIfNeeded(DocumentsOperationContext context, CollectionName collectionName, HashSet<Slice> timeSeriesPrefixes)
+        private void DeleteStatsIfNeeded(DocumentsOperationContext context, CollectionName collectionName, HashSet<Slice> statsCleanupCandidates)
         {
             var timeSeriesTable = context.Transaction.InnerTransaction.OpenTable(TimeSeriesSchema, collectionName.GetTableName(CollectionTableType.TimeSeries));
             var deletedRangesTable = context.Transaction.InnerTransaction.OpenTable(DeleteRangesSchema, collectionName.GetTableName(CollectionTableType.TimeSeriesDeletedRanges));
 
-            foreach (var timeSeriesPrefix in timeSeriesPrefixes)
+            foreach (var timeSeriesPrefix in statsCleanupCandidates)
             {
                 if (HasTimeSeriesPrefix(timeSeriesTable, timeSeriesPrefix))
                     continue;
@@ -129,25 +117,20 @@ namespace Raven.Server.Documents.TimeSeries
                     continue;
 
                 using (Slice.External(context.Allocator, timeSeriesPrefix, timeSeriesPrefix.Size - 1, out var statsKey))
-                {
-                    if (TimeSeriesStats.GetStats(context, statsKey).Count == 0)
-                        TimeSeriesStats.Delete(context, collectionName, statsKey);
-                }
+                    TimeSeriesStats.Delete(context, collectionName, statsKey);
             }
         }
 
-        private long PurgeSegments(long upto, DocumentsOperationContext context, CollectionName collectionName, long numberOfEntriesToDelete)
+        private long PurgeSegments(long upto, DocumentsOperationContext context, CollectionName collectionName, long numberOfEntriesToDelete, HashSet<Slice> statsCleanupCandidates)
         {
             var tableName = collectionName.GetTableName(CollectionTableType.TimeSeries);
             var table = context.Transaction.InnerTransaction.OpenTable(TimeSeriesSchema, tableName);
 
-            if (table?.NumberOfEntries == 0 || numberOfEntriesToDelete <= 0)
+            if (table == null || table.NumberOfEntries == 0 || numberOfEntriesToDelete <= 0)
                 return 0;
 
-            var deleteRangesTable = context.Transaction.InnerTransaction.OpenTable(DeleteRangesSchema, collectionName.GetTableName(CollectionTableType.TimeSeriesDeletedRanges));
             var pendingDeletion = context.Transaction.InnerTransaction.CreateTree(PendingDeletionSegments);
             var outdated = new List<Slice>();
-            var uniqueTimeSeries = new HashSet<Slice>(SliceComparer.Instance);
 
             var hasMore = true;
             var deletedCount = 0;
@@ -170,15 +153,7 @@ namespace Raven.Server.Documents.TimeSeries
                         if (table.FindByIndex(TimeSeriesSchema.FixedSizeIndexes[CollectionTimeSeriesEtagsSlice], etag, out var reader))
                         {
                             var keyPtr = reader.Read((int)TimeSeriesTable.TimeSeriesKey, out int keySize);
-                            using (Slice.From(context.Allocator, keyPtr, keySize, ByteStringType.Immutable, out var key))
-                            {
-                                var size = key.Size - sizeof(long);
-                                using (Slice.External(context.Allocator, key, size, out var tsKey))
-                                {
-                                    if (uniqueTimeSeries.Contains(tsKey) == false)
-                                        uniqueTimeSeries.Add(tsKey.Clone(context.Allocator));
-                                }
-                            }
+                            AddStatsCleanupCandidate(context, statsCleanupCandidates, keyPtr, keySize);
                         }
 
                         if (table.DeleteByIndex(TimeSeriesSchema.FixedSizeIndexes[CollectionTimeSeriesEtagsSlice], etag))
@@ -195,23 +170,18 @@ namespace Raven.Server.Documents.TimeSeries
                     pendingDeletion.MultiDelete(collectionName.Name, etagSlice);
                 }
                 outdated.Clear();
-
-                foreach (var tsKey in uniqueTimeSeries)
-                {
-                    if (table.SeekOnePrimaryKeyPrefix(tsKey, out _) == false)
-                    {
-                        using (Slice.External(context.Allocator, tsKey, tsKey.Size - 1, out var statsKey))
-                        {
-                            if (TimeSeriesStats.GetStats(context, statsKey).Count == 0 &&
-                                HasTimeSeriesPrefix(deleteRangesTable, tsKey) == false)
-                                TimeSeriesStats.Delete(context, collectionName, statsKey);
-                        }
-                    }
-                }
-                uniqueTimeSeries.Clear();
             }
 
             return deletedCount;
+        }
+
+        private static void AddStatsCleanupCandidate(DocumentsOperationContext context, HashSet<Slice> statsCleanupCandidates, byte* keyPtr, int keySize)
+        {
+            using (Slice.From(context.Allocator, keyPtr, keySize - sizeof(long), ByteStringType.Immutable, out var prefix))
+            {
+                if (statsCleanupCandidates.Contains(prefix) == false)
+                    statsCleanupCandidates.Add(prefix.Clone(context.Allocator));
+            }
         }
 
         private static bool HasTimeSeriesPrefix(Table table, Slice timeSeriesPrefix)
@@ -381,18 +351,10 @@ namespace Raven.Server.Documents.TimeSeries
                 {
                     table.DeleteByPrimaryKeyPrefix(slicer.TimeSeriesPrefixSlice);
 
-                    var deleteRangesTable = context.Transaction.InnerTransaction.OpenTable(DeleteRangesSchema, collectionName.GetTableName(CollectionTableType.TimeSeriesDeletedRanges));
-                    if (HasTimeSeriesPrefix(deleteRangesTable, slicer.TimeSeriesPrefixSlice))
+                    var statsTable = TimeSeriesStats.GetOrCreateTable(context.Transaction.InnerTransaction, collectionName);
+                    using (TimeSeriesStats.ReadStats(context, statsTable, slicer, out _, start: out _, end: out _, out var statsName, out var statsMergedChangeVector))
                     {
-                        var statsTable = TimeSeriesStats.GetOrCreateTable(context.Transaction.InnerTransaction, collectionName);
-                        using (TimeSeriesStats.ReadStats(context, statsTable, slicer, out _, out _, out _, out var statsName, out var statsMergedChangeVector))
-                        {
-                            TimeSeriesStats.WriteStatsTableRecord(context, statsTable, slicer, default, default, 0, statsName, statsMergedChangeVector);
-                        }
-                    }
-                    else
-                    {
-                        TimeSeriesStats.Delete(context, collectionName, slicer.StatsKey);
+                        TimeSeriesStats.WriteStatsTableRecord(context, statsTable, slicer, start: default, end: default, count: 0, statsName, statsMergedChangeVector);
                     }
 
                     if (updateMetadata)

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -228,7 +228,7 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        private ChangeVector InsertDeletedRange(DocumentsOperationContext context, DeletionRangeRequest deletionRangeRequest, ChangeVector remoteChangeVector = null, bool createIfNoStats = false)
+        private ChangeVector InsertDeletedRange(DocumentsOperationContext context, DeletionRangeRequest deletionRangeRequest, ChangeVector remoteChangeVector = null)
         {
             var collection = deletionRangeRequest.Collection;
             var documentId = deletionRangeRequest.DocumentId;
@@ -246,7 +246,7 @@ namespace Raven.Server.Documents.TimeSeries
             using (var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name))
             using (TimeSeriesStats.ReadStats(context, statsTable, sliceHolder, out var statsCount, out var statsStart, out var statsEnd, out var statsName, out var statsMergedChangeVector))
             {
-                if (remoteChangeVector == null && statsCount == 0 && statsMergedChangeVector == null && createIfNoStats == false)
+                if (remoteChangeVector == null && statsCount == 0 && statsMergedChangeVector == null)
                     return null;
 
                 long etag = _documentsStorage.GenerateNextEtag();
@@ -305,12 +305,12 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        public string DeleteTimestampRange(DocumentsOperationContext context, DeletionRangeRequest deletionRangeRequest, ChangeVector remoteChangeVector = null, bool updateMetadata = true, bool createDeletedRangeIfNoStats = false)
+        public string DeleteTimestampRange(DocumentsOperationContext context, DeletionRangeRequest deletionRangeRequest, ChangeVector remoteChangeVector = null, bool updateMetadata = true)
         {
             deletionRangeRequest.From = EnsureMillisecondsPrecision(deletionRangeRequest.From);
             deletionRangeRequest.To = EnsureMillisecondsPrecision(deletionRangeRequest.To);
 
-            var deletedRangeChangeVector = InsertDeletedRange(context, deletionRangeRequest, remoteChangeVector, createDeletedRangeIfNoStats);
+            var deletedRangeChangeVector = InsertDeletedRange(context, deletionRangeRequest, remoteChangeVector);
             if (deletedRangeChangeVector == null)
                 return null;
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -216,53 +216,58 @@ namespace Raven.Server.Documents.TimeSeries
             var name = deletionRangeRequest.Name;
 
             var collectionName = _documentsStorage.ExtractCollectionName(context, collection);
-            var table = GetOrCreateDeleteRangesTable(context.Transaction.InnerTransaction, collectionName);
+            var deleteRangesTable = GetOrCreateDeleteRangesTable(context.Transaction.InnerTransaction, collectionName);
+            var statsTable = TimeSeriesStats.GetOrCreateTable(context.Transaction.InnerTransaction, collectionName);
 
             from = EnsureMillisecondsPrecision(from);
             to = EnsureMillisecondsPrecision(to);
 
-            ChangeVector predecessorChangeVector = null;
-            if (remoteChangeVector == null)
+            using (var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name))
+            using (TimeSeriesStats.ReadStats(context, statsTable, sliceHolder, out var statsCount, out var statsStart, out var statsEnd, out var statsName, out var statsMergedChangeVector))
             {
-                using var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name);
-                foreach ((_, Table.TableValueHolder tableValueHolder) in table.SeekByPrimaryKeyPrefix(sliceHolder.TimeSeriesPrefixSlice, startAfter: Slices.Empty, skip: 0))
+                ChangeVector predecessorChangeVector = null;
+                if (remoteChangeVector == null)
                 {
-                    var existingFrom = DocumentsStorage.TableValueToDateTime((int)DeletedRangeTable.From, ref tableValueHolder.Reader);
-                    var existingTo = DocumentsStorage.TableValueToDateTime((int)DeletedRangeTable.To, ref tableValueHolder.Reader);
+                    predecessorChangeVector = statsMergedChangeVector;
 
-                    // A local delete-range update continues only existing ranges that touch the same time interval.
-                    if (existingFrom > to || existingTo < from)
-                        continue;
+                    foreach ((_, Table.TableValueHolder tableValueHolder) in deleteRangesTable.SeekByPrimaryKeyPrefix(sliceHolder.TimeSeriesPrefixSlice, startAfter: Slices.Empty, skip: 0))
+                    {
+                        var existingFrom = DocumentsStorage.TableValueToDateTime((int)DeletedRangeTable.From, ref tableValueHolder.Reader);
+                        var existingTo = DocumentsStorage.TableValueToDateTime((int)DeletedRangeTable.To, ref tableValueHolder.Reader);
 
-                    var currentPredecessorChangeVector = ExtractDeletedRangeChangeVector(context, ref tableValueHolder.Reader);
-                    predecessorChangeVector = predecessorChangeVector == null
-                        ? currentPredecessorChangeVector
-                        : ChangeVector.Merge(predecessorChangeVector, currentPredecessorChangeVector, context);
+                        // A local delete-range update continues only existing ranges that touch the same time interval.
+                        if (existingFrom > to || existingTo < from)
+                            continue;
+
+                        var currentPredecessorChangeVector = ExtractDeletedRangeChangeVector(context, ref tableValueHolder.Reader);
+                        predecessorChangeVector = predecessorChangeVector == null
+                            ? currentPredecessorChangeVector
+                            : ChangeVector.Merge(predecessorChangeVector, currentPredecessorChangeVector, context);
+                    }
                 }
-            }
 
-            long etag;
-            ChangeVector changeVector;
-            if (remoteChangeVector != null)
-            {
-                changeVector = remoteChangeVector;
-                etag = _documentsStorage.GenerateNextEtag();
-            }
-            else if (predecessorChangeVector != null)
-            {
-                etag = _documentsStorage.GenerateNextEtag();
-                changeVector = ChangeVector.GetLocalCvFromPriorAndUpdateDbCv(context, predecessorChangeVector, _documentDatabase, etag);
-            }
-            else
-            {
-                (changeVector, etag) = _documentsStorage.GetNewChangeVector(context);
-            }
+                long etag;
+                ChangeVector changeVector;
+                if (remoteChangeVector != null)
+                {
+                    changeVector = remoteChangeVector;
+                    etag = _documentsStorage.GenerateNextEtag();
+                }
+                else if (predecessorChangeVector != null)
+                {
+                    etag = _documentsStorage.GenerateNextEtag();
+                    changeVector = ChangeVector.GetLocalCvFromPriorAndUpdateDbCv(context, predecessorChangeVector, _documentDatabase, etag);
+                }
+                else
+                {
+                    (changeVector, etag) = _documentsStorage.GetNewChangeVector(context);
+                }
 
-            var hash = (long)Hashing.XXHash64.Calculate(changeVector.Version, Encoding.UTF8);
+                var hash = (long)Hashing.XXHash64.Calculate(changeVector.Version, Encoding.UTF8);
 
-            using (var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name).WithChangeVectorHash(hash))
-            {
-                if (table.ReadByKey(sliceHolder.TimeSeriesKeySlice, out var tableValueReader))
+                sliceHolder.WithChangeVectorHash(hash);
+
+                if (deleteRangesTable.ReadByKey(sliceHolder.TimeSeriesKeySlice, out var tableValueReader))
                 {
                     var storedDeletedRangeChangeVector = ExtractDeletedRangeChangeVector(context, ref tableValueReader);
 
@@ -274,7 +279,7 @@ namespace Raven.Server.Documents.TimeSeries
                     // in case of a hash collision (Conflict) we overwrite the existing entry
                 }
 
-                using (table.Allocate(out var tvb))
+                using (deleteRangesTable.Allocate(out var tvb))
                 using (Slice.From(context.Allocator, changeVector, out var cv))
                 {
                     tvb.Add(sliceHolder.TimeSeriesKeySlice);
@@ -285,9 +290,14 @@ namespace Raven.Server.Documents.TimeSeries
                     tvb.Add(from.Ticks);
                     tvb.Add(to.Ticks);
 
-                    table.Set(tvb);
+                    deleteRangesTable.Set(tvb);
                 }
 
+                if (statsCount == 0)
+                    return changeVector;
+
+                var statsMergedChangeVectorToSet = ChangeVector.Merge(statsMergedChangeVector, changeVector, context);
+                TimeSeriesStats.WriteStatsTableRecord(context, statsTable, sliceHolder, statsStart, statsEnd, statsCount, statsName, statsMergedChangeVectorToSet);
                 return changeVector;
             }
         }
@@ -668,11 +678,10 @@ namespace Raven.Server.Documents.TimeSeries
                 return false;
             }
 
-            if (Stats.GetStats(context, documentId, name) == default &&
-                SegmentAlreadyDeleted(context, documentId, name, changeVector, collectionName, segment, baseline, parentDocCv))
+            if (SegmentAlreadyDeleted(context, documentId, name, changeVector, collectionName, segment, baseline, parentDocCv))
             {
-                // if we reach this point, it means the entire time series was deleted,
-                // and the deletion has a newer change vector than this segment.
+                // if we reach this point, it means this segment was covered by a delete range
+                // that has a newer change vector than this segment.
                 // since the deletion is more recent, we are up-to-date and can safely return
                 return true;
             }
@@ -872,13 +881,13 @@ namespace Raven.Server.Documents.TimeSeries
                         continue;
 
                     var deletedRangeChangeVector = context.GetChangeVector(item.ChangeVector);
-                    if (ChangeVectorUtils.GetConflictStatus(changeVector, deletedRangeChangeVector) == ConflictStatus.AlreadyMerged)
+                    if (ChangeVectorUtils.GetConflictStatus(changeVector, deletedRangeChangeVector, _documentsStorage.UnusedDatabaseIds) == ConflictStatus.AlreadyMerged)
                         return true;
 
                     // Segment CV may advance while replication is broken, so delete-range CV isn't always newer than the segment CV.
                     // As a fallback, compare the delete-range CV to the segment's parent document CV.
                     // If the delete-range already covers that doc CV, the segment belongs to a document version that was already deleted.
-                    if (parentDocCv != null && ChangeVectorUtils.GetConflictStatus(context.GetChangeVector(parentDocCv), deletedRangeChangeVector) == ConflictStatus.AlreadyMerged)
+                    if (parentDocCv != null && ChangeVectorUtils.GetConflictStatus(context.GetChangeVector(parentDocCv), deletedRangeChangeVector, _documentsStorage.UnusedDatabaseIds) == ConflictStatus.AlreadyMerged)
                         return true;
                 }
 
@@ -1055,7 +1064,7 @@ namespace Raven.Server.Documents.TimeSeries
 
                 var modifiedEntries = Math.Abs(newValueSegment.NumberOfLiveEntries - ReadOnlySegment.NumberOfLiveEntries);
                 ReduceCountBeforeAppend();
-                var count = _tss.Stats.UpdateStats(_context, SliceHolder, _collection, newValueSegment, BaselineDate, modifiedEntries);
+                var count = _tss.Stats.UpdateStats(_context, SliceHolder, _collection, newValueSegment, BaselineDate, modifiedEntries, _currentChangeVector);
 
                 using (Table.Allocate(out var tvb))
                 using (Slice.From(_context.Allocator, _currentChangeVector, out var cv))
@@ -1084,7 +1093,7 @@ namespace Raven.Server.Documents.TimeSeries
                 MarkSegmentAsPendingDeletion(_context, _collection.Name, _currentEtag);
 
                 ReduceCountBeforeAppend();
-                _tss.Stats.UpdateStats(_context, SliceHolder, _collection, newValueSegment, BaselineDate, ReadOnlySegment.NumberOfLiveEntries);
+                _tss.Stats.UpdateStats(_context, SliceHolder, _collection, newValueSegment, BaselineDate, ReadOnlySegment.NumberOfLiveEntries, _currentChangeVector);
                 using (Slice.From(_context.Allocator, _currentChangeVector, out Slice cv))
                 using (Table.Allocate(out var tvb))
                 {
@@ -1111,7 +1120,7 @@ namespace Raven.Server.Documents.TimeSeries
                 _currentEtag = _tss._documentsStorage.GenerateNextEtag();
                 _currentChangeVector = GetSegmentMergedChangeVector();
 
-                _tss.Stats.UpdateStats(_context, SliceHolder, _collection, newSegment, BaselineDate, newSegment.NumberOfLiveEntries);
+                _tss.Stats.UpdateStats(_context, SliceHolder, _collection, newSegment, BaselineDate, newSegment.NumberOfLiveEntries, _currentChangeVector);
                 _tss._documentDatabase.TimeSeriesPolicyRunner?.MarkSegmentForPolicy(_context, SliceHolder, baseline, _currentChangeVector, newSegment.NumberOfLiveEntries);
 
                 if (newSegment.NumberOfLiveEntries == 0)

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -77,11 +77,11 @@ namespace Raven.Server.Documents.TimeSeries
                 return 0;
 
             var deletedSegments = PurgeSegments(upto, context, collectionName, numberOfEntriesToDelete);
-            var deletedRanges = PurgeDeletedRanged(upto, context, collectionName, numberOfEntriesToDelete - deletedSegments);
+            var deletedRanges = PurgeDeletedRanges(upto, context, collectionName, numberOfEntriesToDelete - deletedSegments);
             return deletedRanges + deletedSegments;
         }
 
-        private long PurgeDeletedRanged(in long upto, DocumentsOperationContext context, CollectionName collectionName, long numberOfEntriesToDelete)
+        private long PurgeDeletedRanges(in long upto, DocumentsOperationContext context, CollectionName collectionName, long numberOfEntriesToDelete)
         {
             var tableName = collectionName.GetTableName(CollectionTableType.TimeSeriesDeletedRanges);
             var table = context.Transaction.InnerTransaction.OpenTable(DeleteRangesSchema, tableName);
@@ -89,7 +89,51 @@ namespace Raven.Server.Documents.TimeSeries
             if (table == null || table.NumberOfEntries == 0 || numberOfEntriesToDelete <= 0)
                 return 0;
 
-            return table.DeleteBackwardFrom(DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice], upto, numberOfEntriesToDelete);
+            var deleted = PurgeDeletedRangesAndCollectTimeSeriesPrefixes(context, table, upto, numberOfEntriesToDelete, out var timeSeriesPrefixes);
+            if (deleted > 0)
+                DeleteStatsForPurgedDeletedRangesIfNeeded(context, collectionName, timeSeriesPrefixes);
+
+            return deleted;
+        }
+
+        private long PurgeDeletedRangesAndCollectTimeSeriesPrefixes(DocumentsOperationContext context, Table deletedRangesTable, long upto, long numberOfEntriesToDelete, out HashSet<Slice> timeSeriesPrefixes)
+        {
+            timeSeriesPrefixes = new HashSet<Slice>(SliceComparer.Instance);
+            var prefixes = timeSeriesPrefixes;
+            var deletedRangesEtagIndex = DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice];
+
+            return deletedRangesTable.DeleteBackwardFrom(deletedRangesEtagIndex, upto, numberOfEntriesToDelete, beforeDelete: tableValueHolder =>
+            {
+                var reader = tableValueHolder.Reader;
+
+                var keyPtr = reader.Read((int)DeletedRangeTable.RangeKey, out var keySize);
+                using (Slice.From(context.Allocator, keyPtr, keySize - sizeof(long), ByteStringType.Immutable, out var prefix))
+                {
+                    if (prefixes.Contains(prefix) == false)
+                        prefixes.Add(prefix.Clone(context.Allocator));
+                }
+            });
+        }
+
+        private void DeleteStatsForPurgedDeletedRangesIfNeeded(DocumentsOperationContext context, CollectionName collectionName, HashSet<Slice> timeSeriesPrefixes)
+        {
+            var timeSeriesTable = context.Transaction.InnerTransaction.OpenTable(TimeSeriesSchema, collectionName.GetTableName(CollectionTableType.TimeSeries));
+            var deletedRangesTable = context.Transaction.InnerTransaction.OpenTable(DeleteRangesSchema, collectionName.GetTableName(CollectionTableType.TimeSeriesDeletedRanges));
+
+            foreach (var timeSeriesPrefix in timeSeriesPrefixes)
+            {
+                if (HasTimeSeriesPrefix(timeSeriesTable, timeSeriesPrefix))
+                    continue;
+
+                if (HasTimeSeriesPrefix(deletedRangesTable, timeSeriesPrefix))
+                    continue;
+
+                using (Slice.External(context.Allocator, timeSeriesPrefix, timeSeriesPrefix.Size - 1, out var statsKey))
+                {
+                    if (TimeSeriesStats.GetStats(context, statsKey).Count == 0)
+                        TimeSeriesStats.Delete(context, collectionName, statsKey);
+                }
+            }
         }
 
         private long PurgeSegments(long upto, DocumentsOperationContext context, CollectionName collectionName, long numberOfEntriesToDelete)
@@ -97,9 +141,10 @@ namespace Raven.Server.Documents.TimeSeries
             var tableName = collectionName.GetTableName(CollectionTableType.TimeSeries);
             var table = context.Transaction.InnerTransaction.OpenTable(TimeSeriesSchema, tableName);
 
-            if (table == null || table.NumberOfEntries == 0 || numberOfEntriesToDelete <= 0)
+            if (table?.NumberOfEntries == 0 || numberOfEntriesToDelete <= 0)
                 return 0;
 
+            var deleteRangesTable = context.Transaction.InnerTransaction.OpenTable(DeleteRangesSchema, collectionName.GetTableName(CollectionTableType.TimeSeriesDeletedRanges));
             var pendingDeletion = context.Transaction.InnerTransaction.CreateTree(PendingDeletionSegments);
             var outdated = new List<Slice>();
             var uniqueTimeSeries = new HashSet<Slice>(SliceComparer.Instance);
@@ -157,8 +202,9 @@ namespace Raven.Server.Documents.TimeSeries
                     {
                         using (Slice.External(context.Allocator, tsKey, tsKey.Size - 1, out var statsKey))
                         {
-                            if (Stats.GetStats(context, statsKey).Count == 0)
-                                Stats.DeleteStats(context, collectionName, statsKey);
+                            if (TimeSeriesStats.GetStats(context, statsKey).Count == 0 &&
+                                HasTimeSeriesPrefix(deleteRangesTable, tsKey) == false)
+                                TimeSeriesStats.Delete(context, collectionName, statsKey);
                         }
                     }
                 }
@@ -166,6 +212,11 @@ namespace Raven.Server.Documents.TimeSeries
             }
 
             return deletedCount;
+        }
+
+        private static bool HasTimeSeriesPrefix(Table table, Slice timeSeriesPrefix)
+        {
+            return table?.NumberOfEntries > 0 && table.SeekOnePrimaryKeyPrefix(timeSeriesPrefix, out _);
         }
 
         public long GetNumberOfTimeSeriesDeletedRanges(DocumentsOperationContext context)
@@ -225,53 +276,33 @@ namespace Raven.Server.Documents.TimeSeries
             using (var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name))
             using (TimeSeriesStats.ReadStats(context, statsTable, sliceHolder, out var statsCount, out var statsStart, out var statsEnd, out var statsName, out var statsMergedChangeVector))
             {
-                ChangeVector predecessorChangeVector = null;
-                if (remoteChangeVector == null)
-                {
-                    predecessorChangeVector = statsMergedChangeVector;
+                if (remoteChangeVector == null && statsCount == 0 && statsMergedChangeVector == null)
+                    return null;
 
-                    foreach ((_, Table.TableValueHolder tableValueHolder) in deleteRangesTable.SeekByPrimaryKeyPrefix(sliceHolder.TimeSeriesPrefixSlice, startAfter: Slices.Empty, skip: 0))
-                    {
-                        var existingFrom = DocumentsStorage.TableValueToDateTime((int)DeletedRangeTable.From, ref tableValueHolder.Reader);
-                        var existingTo = DocumentsStorage.TableValueToDateTime((int)DeletedRangeTable.To, ref tableValueHolder.Reader);
+                long etag = _documentsStorage.GenerateNextEtag();
 
-                        // A local delete-range update continues only existing ranges that touch the same time interval.
-                        if (existingFrom > to || existingTo < from)
-                            continue;
-
-                        var currentPredecessorChangeVector = ExtractDeletedRangeChangeVector(context, ref tableValueHolder.Reader);
-                        predecessorChangeVector = predecessorChangeVector == null
-                            ? currentPredecessorChangeVector
-                            : ChangeVector.Merge(predecessorChangeVector, currentPredecessorChangeVector, context);
-                    }
-                }
-
-                long etag;
-                ChangeVector changeVector;
+                ChangeVector deletedRangeChangeVector;
                 if (remoteChangeVector != null)
                 {
-                    changeVector = remoteChangeVector;
-                    etag = _documentsStorage.GenerateNextEtag();
+                    deletedRangeChangeVector = remoteChangeVector;
                 }
-                else if (predecessorChangeVector != null)
+                else if (statsMergedChangeVector != null)
                 {
-                    etag = _documentsStorage.GenerateNextEtag();
-                    changeVector = ChangeVector.GetLocalCvFromPriorAndUpdateDbCv(context, predecessorChangeVector, _documentDatabase, etag);
+                    deletedRangeChangeVector = ChangeVector.GetLocalCvFromPriorAndUpdateDbCv(context, statsMergedChangeVector, _documentDatabase, etag);
                 }
                 else
                 {
-                    (changeVector, etag) = _documentsStorage.GetNewChangeVector(context);
+                    deletedRangeChangeVector = _documentsStorage.GetNewChangeVector(context, etag);
                 }
 
-                var hash = (long)Hashing.XXHash64.Calculate(changeVector.Version, Encoding.UTF8);
-
+                var hash = (long)Hashing.XXHash64.Calculate(deletedRangeChangeVector.Version, Encoding.UTF8);
                 sliceHolder.WithChangeVectorHash(hash);
 
                 if (deleteRangesTable.ReadByKey(sliceHolder.TimeSeriesKeySlice, out var tableValueReader))
                 {
                     var storedDeletedRangeChangeVector = ExtractDeletedRangeChangeVector(context, ref tableValueReader);
 
-                    if (ChangeVectorUtils.GetConflictStatus(changeVector, storedDeletedRangeChangeVector) == ConflictStatus.AlreadyMerged)
+                    if (ChangeVectorUtils.GetConflictStatus(deletedRangeChangeVector, storedDeletedRangeChangeVector) == ConflictStatus.AlreadyMerged)
                     {
                         return null;
                     }
@@ -280,11 +311,11 @@ namespace Raven.Server.Documents.TimeSeries
                 }
 
                 using (deleteRangesTable.Allocate(out var tvb))
-                using (Slice.From(context.Allocator, changeVector, out var cv))
+                using (Slice.From(context.Allocator, deletedRangeChangeVector, out var drcv))
                 {
                     tvb.Add(sliceHolder.TimeSeriesKeySlice);
                     tvb.Add(Bits.SwapBytes(etag));
-                    tvb.Add(cv);
+                    tvb.Add(drcv);
                     tvb.Add(sliceHolder.CollectionSlice);
                     tvb.Add(context.GetTransactionMarker());
                     tvb.Add(from.Ticks);
@@ -293,12 +324,9 @@ namespace Raven.Server.Documents.TimeSeries
                     deleteRangesTable.Set(tvb);
                 }
 
-                if (statsCount == 0)
-                    return changeVector;
-
-                var statsMergedChangeVectorToSet = ChangeVector.Merge(statsMergedChangeVector, changeVector, context);
+                var statsMergedChangeVectorToSet = ChangeVector.Merge(statsMergedChangeVector, deletedRangeChangeVector, context);
                 TimeSeriesStats.WriteStatsTableRecord(context, statsTable, sliceHolder, statsStart, statsEnd, statsCount, statsName, statsMergedChangeVectorToSet);
-                return changeVector;
+                return deletedRangeChangeVector;
             }
         }
 
@@ -352,7 +380,20 @@ namespace Raven.Server.Documents.TimeSeries
                     from <= stats.Start && to >= stats.End)
                 {
                     table.DeleteByPrimaryKeyPrefix(slicer.TimeSeriesPrefixSlice);
-                    Stats.DeleteStats(context, collectionName, slicer.StatsKey);
+
+                    var deleteRangesTable = context.Transaction.InnerTransaction.OpenTable(DeleteRangesSchema, collectionName.GetTableName(CollectionTableType.TimeSeriesDeletedRanges));
+                    if (HasTimeSeriesPrefix(deleteRangesTable, slicer.TimeSeriesPrefixSlice))
+                    {
+                        var statsTable = TimeSeriesStats.GetOrCreateTable(context.Transaction.InnerTransaction, collectionName);
+                        using (TimeSeriesStats.ReadStats(context, statsTable, slicer, out _, out _, out _, out var statsName, out var statsMergedChangeVector))
+                        {
+                            TimeSeriesStats.WriteStatsTableRecord(context, statsTable, slicer, default, default, 0, statsName, statsMergedChangeVector);
+                        }
+                    }
+                    else
+                    {
+                        TimeSeriesStats.Delete(context, collectionName, slicer.StatsKey);
+                    }
 
                     if (updateMetadata)
                         RemoveTimeSeriesNameFromMetadata(context, slicer.DocId, slicer.Name);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -228,7 +228,7 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        private ChangeVector InsertDeletedRange(DocumentsOperationContext context, DeletionRangeRequest deletionRangeRequest, ChangeVector remoteChangeVector = null)
+        private ChangeVector InsertDeletedRange(DocumentsOperationContext context, DeletionRangeRequest deletionRangeRequest, ChangeVector remoteChangeVector = null, bool createIfNoStats = false)
         {
             var collection = deletionRangeRequest.Collection;
             var documentId = deletionRangeRequest.DocumentId;
@@ -246,7 +246,7 @@ namespace Raven.Server.Documents.TimeSeries
             using (var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name))
             using (TimeSeriesStats.ReadStats(context, statsTable, sliceHolder, out var statsCount, out var statsStart, out var statsEnd, out var statsName, out var statsMergedChangeVector))
             {
-                if (remoteChangeVector == null && statsCount == 0 && statsMergedChangeVector == null)
+                if (remoteChangeVector == null && statsCount == 0 && statsMergedChangeVector == null && createIfNoStats == false)
                     return null;
 
                 long etag = _documentsStorage.GenerateNextEtag();
@@ -295,17 +295,22 @@ namespace Raven.Server.Documents.TimeSeries
                 }
 
                 var statsMergedChangeVectorToSet = ChangeVector.Merge(statsMergedChangeVector, deletedRangeChangeVector, context);
-                TimeSeriesStats.WriteStatsTableRecord(context, statsTable, sliceHolder, statsStart, statsEnd, statsCount, statsName, statsMergedChangeVectorToSet);
+                TimeSeriesStats.WriteStatsTableRecord(context, statsTable, sliceHolder,
+                    start: statsCount == 0 ? default : statsStart,
+                    end: statsCount == 0 ? default : statsEnd,
+                    count: statsCount,
+                    name: statsName,
+                    mergedChangeVector: statsMergedChangeVectorToSet);
                 return deletedRangeChangeVector;
             }
         }
 
-        public string DeleteTimestampRange(DocumentsOperationContext context, DeletionRangeRequest deletionRangeRequest, ChangeVector remoteChangeVector = null, bool updateMetadata = true)
+        public string DeleteTimestampRange(DocumentsOperationContext context, DeletionRangeRequest deletionRangeRequest, ChangeVector remoteChangeVector = null, bool updateMetadata = true, bool createDeletedRangeIfNoStats = false)
         {
             deletionRangeRequest.From = EnsureMillisecondsPrecision(deletionRangeRequest.From);
             deletionRangeRequest.To = EnsureMillisecondsPrecision(deletionRangeRequest.To);
 
-            var deletedRangeChangeVector = InsertDeletedRange(context, deletionRangeRequest, remoteChangeVector);
+            var deletedRangeChangeVector = InsertDeletedRange(context, deletionRangeRequest, remoteChangeVector, createDeletedRangeIfNoStats);
             if (deletedRangeChangeVector == null)
                 return null;
 

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -2174,7 +2174,7 @@ namespace Voron.Data.Tables
             return true;
         }
 
-        public long DeleteBackwardFrom(TableSchema.FixedSizeKeyIndexDef index, long value, long numberOfEntriesToDelete)
+        public long DeleteBackwardFrom(FixedSizeKeyIndexDef index, long value, long numberOfEntriesToDelete, Action<TableValueHolder> beforeDelete = null)
         {
             AssertWritableTable();
 
@@ -2183,6 +2183,7 @@ namespace Voron.Data.Tables
 
             long deleted = 0;
             var fst = GetFixedSizeTree(index);
+            TableValueHolder tableValueHolder = null;
             // deleting from a table can shift things around, so we delete 
             // them one at a time
             while (deleted < numberOfEntriesToDelete)
@@ -2195,7 +2196,21 @@ namespace Voron.Data.Tables
                     if (it.CurrentKey > value)
                         return deleted;
 
-                    Delete(it.CreateReaderForCurrent().ReadLittleEndianInt64());
+                    var id = it.CreateReaderForCurrent().ReadLittleEndianInt64();
+
+                    if (beforeDelete != null)
+                    {
+                        var ptr = DirectRead(id, out int size, out bool compressed);
+                        tableValueHolder ??= new TableValueHolder();
+                        tableValueHolder.Reader = new TableValueReader(id, ptr, size);
+                        beforeDelete(tableValueHolder);
+                        Delete(id, ptr, size, compressed);
+                    }
+                    else
+                    {
+                        Delete(id);
+                    }
+
                     deleted++;
                 }
             }

--- a/test/SlowTests.Issues/Issues/RavenDB-26295/FilteredPullDualClusterFirstAndSecondHopTests.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26295/FilteredPullDualClusterFirstAndSecondHopTests.cs
@@ -1686,6 +1686,98 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "deleted time series range after local delete replicated from node A", nodeCDbCvAfterLocalChange, nodeCDeletedRangeAfterLocalChange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
     }
 
+    [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Cluster | RavenTestCategory.Certificates | RavenTestCategory.TimeSeries)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [ClusterSide.Hub])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [ClusterSide.Sink])]
+    public async Task TimeSeriesDeletedRange_WithSeparateLocalSegmentShouldNotRestoreDelayedInternalSegmentAfterLocalDeletedRangeExtension(Options options, ClusterSide filteredPassReceiveSide)
+    {
+        const string itemName = "time-series-deleted-range-delayed-internal-segment";
+        const string timeSeriesName = "HeartRate";
+        var delayedSegmentReplicationMarker = "delayed-time-series-segment-after-delete-range-" + itemName;
+        var firstTimestamp = new DateTime(2024, 01, 01, 00, 00, 00, DateTimeKind.Utc);
+        var deleteFrom = firstTimestamp;
+        var deleteTo = firstTimestamp.AddMinutes(1);
+        var delayedSegmentTimestamp = deleteTo.AddSeconds(30);
+        var localDeleteTo = deleteTo.AddMinutes(1);
+        var separateLocalSegmentTimestamp = firstTimestamp.AddDays(26);
+
+        await using var lab = await CreateDualClusterLabAsync(options, filteredPassReceiveSide, itemName);
+        await lab.StoreFilteredRoundTripTicketAsync(LabNode.B);
+        await lab.AppendFilteredRoundTripTimeSeriesAsync(LabNode.B, timeSeriesName, firstTimestamp, 72);
+        await lab.WaitForFilteredRoundTripDocumentNameAsync(LabNode.A);
+        await lab.WaitForFilteredRoundTripTimeSeriesSegmentAsync(LabNode.A, timeSeriesName, expectedValueCount: 1);
+
+        var bToALegacyBlocker = await lab.BlockInternalReplicationAsync(from: LabNode.B, to: LabNode.A);
+        var bToCLegacyBlocker = await lab.BlockInternalReplicationAsync(from: LabNode.B, to: LabNode.C);
+        await lab.StoreAllowedTicketThenFilteredOutUserAsync(LabNode.B);
+        await bToALegacyBlocker.WaitForBlockedAsync();
+        await bToCLegacyBlocker.WaitForBlockedAsync();
+
+        await lab.PassThroughFilteredReplicationAsync();
+
+        var bToABeforeScanGate = lab.BlockInternalReplicationBeforeScan(from: LabNode.B, to: LabNode.A);
+        var bToCBeforeScanGate = lab.BlockInternalReplicationBeforeScan(from: LabNode.B, to: LabNode.C);
+        await bToALegacyBlocker.DisposeAsync();
+        await bToCLegacyBlocker.DisposeAsync();
+        await bToABeforeScanGate.WaitForBlockedAsync();
+        await bToCBeforeScanGate.WaitForBlockedAsync();
+
+        await lab.AppendFilteredRoundTripTimeSeriesAsync(LabNode.B, timeSeriesName, delayedSegmentTimestamp, 73);
+        await lab.DeleteFilteredRoundTripTimeSeriesRangeAsync(LabNode.B, timeSeriesName, deleteFrom, deleteTo);
+        await lab.StoreFilteredRoundTripTicketWithNameAsync(LabNode.B, itemName + "-source-parent-after-delete");
+        await lab.StoreFilteredOutInternalReplicationMarkerAsync(LabNode.B, delayedSegmentReplicationMarker);
+
+        await lab.WaitForFilteredRoundTripTimeSeriesDeletedRangeAsync(LabNode.A, timeSeriesName, deleteFrom, deleteTo);
+        var aToBLocalDeleteBlocker = await lab.BlockInternalReplicationAsync(from: LabNode.A, to: LabNode.B);
+        await lab.DeleteFilteredRoundTripTimeSeriesRangeAsync(LabNode.A, timeSeriesName, deleteFrom, localDeleteTo);
+        await lab.WaitForFilteredRoundTripTimeSeriesDeletedRangeAsync(LabNode.A, timeSeriesName, deleteFrom, localDeleteTo);
+
+        // Covers the path where the time series still has another live segment, so stale delayed segments must still be checked against deleted ranges.
+        await lab.AppendFilteredRoundTripTimeSeriesAsync(LabNode.A, timeSeriesName, separateLocalSegmentTimestamp, 74);
+        await lab.WaitForFilteredRoundTripTimeSeriesSegmentAsync(LabNode.A, timeSeriesName, expectedValueCount: 1);
+
+        await aToBLocalDeleteBlocker.WaitForBlockedAsync();
+
+        const int expectedVisibleValueCount = 1;
+        var nodeBDelayedSegment = lab.GetFilteredRoundTripTimeSeriesSegment(LabNode.B, timeSeriesName);
+        var nodeADeletedRangeAfterLocalChange = lab.GetFilteredRoundTripTimeSeriesDeletedRange(LabNode.A, timeSeriesName);
+        var nodeASegmentBeforeDelayedInternalReplication = lab.GetFilteredRoundTripTimeSeriesSegment(LabNode.A, timeSeriesName);
+        var nodeADelayedTimestampCountBeforeRelease = lab.GetFilteredRoundTripTimeSeriesValueCount(LabNode.A, timeSeriesName, delayedSegmentTimestamp, delayedSegmentTimestamp);
+
+        Assert.True(
+            nodeBDelayedSegment.Exists && nodeBDelayedSegment.ValueCount == 1,
+            $"Expected delayed source time series segment '{timeSeriesName}' to exist on {NodeTag(filteredPassReceiveSide, LabNode.B)} before releasing internal replication. " +
+            $"nodeBDelayedSegmentExists={nodeBDelayedSegment.Exists}, nodeBDelayedSegmentValueCount={nodeBDelayedSegment.ValueCount}, nodeBDelayedSegmentCV='{nodeBDelayedSegment.ChangeVector ?? "<null>"}'.");
+        Assert.True(
+            nodeASegmentBeforeDelayedInternalReplication.ValueCount == expectedVisibleValueCount && nodeADelayedTimestampCountBeforeRelease == 0,
+            $"Expected {NodeTag(filteredPassReceiveSide, LabNode.A)} not to have the delayed source time series value before releasing internal replication from {NodeTag(filteredPassReceiveSide, LabNode.B)}. " +
+            $"expectedVisibleValueCount={expectedVisibleValueCount}, " +
+            $"nodeASegmentBeforeDelayedInternalReplicationExists={nodeASegmentBeforeDelayedInternalReplication.Exists}, " +
+            $"nodeASegmentBeforeDelayedInternalReplicationValueCount={nodeASegmentBeforeDelayedInternalReplication.ValueCount}, " +
+            $"nodeADelayedTimestampCountBeforeRelease={nodeADelayedTimestampCountBeforeRelease}, " +
+            $"nodeASegmentBeforeDelayedInternalReplicationCV='{nodeASegmentBeforeDelayedInternalReplication.ChangeVector ?? "<null>"}'.");
+
+        bToABeforeScanGate.Release();
+        await lab.WaitForFilteredOutInternalReplicationMarkerAsync(LabNode.A, delayedSegmentReplicationMarker);
+
+        var nodeASegmentAfterDelayedInternalReplication = lab.GetFilteredRoundTripTimeSeriesSegment(LabNode.A, timeSeriesName);
+        var nodeADelayedTimestampCountAfterRelease = lab.GetFilteredRoundTripTimeSeriesValueCount(LabNode.A, timeSeriesName, delayedSegmentTimestamp, delayedSegmentTimestamp);
+
+        Assert.True(
+            nodeASegmentAfterDelayedInternalReplication.ValueCount == expectedVisibleValueCount && nodeADelayedTimestampCountAfterRelease == 0,
+            $"Expected delayed time series segment '{timeSeriesName}' on '{lab.FilteredRoundTripTicketId}' not to be restored on {NodeTag(filteredPassReceiveSide, LabNode.A)} after real internal replication from {NodeTag(filteredPassReceiveSide, LabNode.B)}. " +
+            $"The delayed timestamp is covered by {NodeTag(filteredPassReceiveSide, LabNode.A)}'s local deleted range extension, so the delayed source segment must remain invisible even after replication catches up. " +
+            $"delayedSegmentTimestamp='{delayedSegmentTimestamp:O}', localDeleteTo='{localDeleteTo:O}', separateLocalSegmentTimestamp='{separateLocalSegmentTimestamp:O}', " +
+            $"delayedSourceSegmentCV='{nodeBDelayedSegment.ChangeVector ?? "<null>"}', " +
+            $"deletedRangeAfterLocalChangeCV='{nodeADeletedRangeAfterLocalChange.ChangeVector ?? "<null>"}', " +
+            $"expectedVisibleValueCount={expectedVisibleValueCount}, nodeADelayedTimestampCountAfterRelease={nodeADelayedTimestampCountAfterRelease}, " +
+            $"nodeASegmentAfterDelayedInternalReplicationExists={nodeASegmentAfterDelayedInternalReplication.Exists}, " +
+            $"nodeASegmentAfterDelayedInternalReplicationValueCount={nodeASegmentAfterDelayedInternalReplication.ValueCount}, " +
+            $"nodeASegmentAfterDelayedInternalReplicationCV='{nodeASegmentAfterDelayedInternalReplication.ChangeVector ?? "<null>"}'.");
+
+        await aToBLocalDeleteBlocker.DisposeAsync();
+    }
+
     private static void AssertNoConflictsAfterLocalChange(
         ClusterSide filteredPassReceiveSide,
         string itemDescription,

--- a/test/SlowTests.Issues/Issues/RavenDB-26295/Tools/DualClusterLab.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26295/Tools/DualClusterLab.cs
@@ -290,6 +290,9 @@ public sealed class DualClusterLab : IAsyncDisposable
     public TimeSeriesSegmentSnapshot GetFilteredRoundTripTimeSeriesSegment(LabNode node, string timeSeriesName) =>
         GetTimeSeriesSegment(RequiredFilteredPassReceiveSide, node, RequiredFilteredRoundTripTicketId, timeSeriesName);
 
+    public int GetFilteredRoundTripTimeSeriesValueCount(LabNode node, string timeSeriesName, DateTime from, DateTime to) =>
+        GetTimeSeriesValueCount(RequiredFilteredPassReceiveSide, node, RequiredFilteredRoundTripTicketId, timeSeriesName, from, to);
+
     public TimeSeriesDeletedRangeSnapshot GetFilteredRoundTripTimeSeriesDeletedRange(LabNode node, string timeSeriesName) =>
         GetTimeSeriesDeletedRange(RequiredFilteredPassReceiveSide, node, RequiredFilteredRoundTripTicketId, timeSeriesName);
 
@@ -675,7 +678,7 @@ public sealed class DualClusterLab : IAsyncDisposable
                 .Count();
 
             TimeSeriesSegmentSnapshot latest = null;
-            foreach (var segment in database.DocumentsStorage.TimeSeriesStorage.GetSegmentsFrom(context, etag: 0))
+            foreach (var segment in database.DocumentsStorage.TimeSeriesStorage.GetSegmentsFrom(context, etag: 0, includeDocumentChangeVector: false))
             {
                 using (segment)
                 {
@@ -705,6 +708,19 @@ public sealed class DualClusterLab : IAsyncDisposable
                 Exists = false,
                 ValueCount = valueCount
             };
+        }
+    }
+
+    private int GetTimeSeriesValueCount(ClusterSide side, LabNode node, string documentId, string timeSeriesName, DateTime from, DateTime to)
+    {
+        var database = Database(side, node);
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        using (context.OpenReadTransaction())
+        {
+            return database.DocumentsStorage.TimeSeriesStorage
+                .GetReader(context, documentId, timeSeriesName, from, to)
+                .AllValues()
+                .Count();
         }
     }
 
@@ -771,6 +787,15 @@ public sealed class DualClusterLab : IAsyncDisposable
         await StoreUserAsync(RequiredFilteredPassReceiveSide, node, RequiredFilteredOutUserDocumentId, "filtered-out-gap-" + RequiredFilteredRoundTripItemName);
         _allowedTicketThenFilteredOutUserStored = true;
     }
+
+    public Task StoreFilteredOutInternalReplicationMarkerAsync(LabNode node, string markerName) =>
+        StoreUserAsync(RequiredFilteredPassReceiveSide, node, FilteredOutInternalReplicationMarkerId(markerName), markerName);
+
+    public Task WaitForFilteredOutInternalReplicationMarkerAsync(LabNode node, string markerName, TimeSpan? timeout = null) =>
+        WaitForDocumentNameByIdAsync(RequiredFilteredPassReceiveSide, node, FilteredOutInternalReplicationMarkerId(markerName), markerName, timeout);
+
+    private string FilteredOutInternalReplicationMarkerId(string markerName) =>
+        $"{RequiredFilteredOutUserDocumentId}/internal-replication-marker/{markerName}";
 
     public async Task StoreTicketAsync(ClusterSide side, LabNode node, string documentId, string name)
     {
@@ -1364,6 +1389,21 @@ public sealed class DualClusterLab : IAsyncDisposable
 
     public Task<LogicalInternalReplicationBlocker> BlockInternalReplicationAsync(LabNode from, LabNode to) =>
         BlockInternalReplicationAsync(RequiredFilteredPassReceiveSide, from, to);
+
+    public FilteredRoundTripReplicationGate BlockInternalReplicationBeforeScan(LabNode from, LabNode to)
+    {
+        var fromNodeTag = NodeTag(RequiredFilteredPassReceiveSide, from);
+        var toNodeTag = NodeTag(RequiredFilteredPassReceiveSide, to);
+        var gate = new FilteredRoundTripReplicationGate(
+            Database(RequiredFilteredPassReceiveSide, from),
+            matches: handler => handler.Destination is InternalReplication internalReplication &&
+                                string.Equals(internalReplication.NodeTag, toNodeTag, StringComparison.OrdinalIgnoreCase),
+            description: $"{fromNodeTag}->{toNodeTag} internal replication before scan");
+
+        gate.Attach();
+        _testingHookScopes.Add(gate);
+        return gate;
+    }
 
     private async Task BlockInternalReplicationUntilBlockedAsync(ClusterSide side, LabNode from, params LabNode[] to)
     {

--- a/test/SlowTests.Issues/Issues/RavenDB_23754.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_23754.cs
@@ -125,9 +125,9 @@ namespace SlowTests.Issues
                     var tsTime = DateTime.UtcNow;
                     var ts = session.TimeSeriesFor("users/1", "heartrate");
                     ts.Append(tsTime, 72, "wrist");
+                    session.SaveChanges();
 
                     ts.Delete(tsTime.AddMinutes(-5), tsTime.AddMinutes(-1));
-
                     session.SaveChanges();
                 }
 
@@ -156,5 +156,3 @@ namespace SlowTests.Issues
         }
     }
 }
-
-

--- a/test/SlowTests/Client/TimeSeries/TimeSeriesStatsUpdate.cs
+++ b/test/SlowTests/Client/TimeSeries/TimeSeriesStatsUpdate.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
 using System.Linq;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Session;
+using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
 using Tests.Infrastructure;
@@ -161,6 +163,35 @@ namespace SlowTests.Client.TimeSeries
                     var after2delete = ts.Get(DateTime.MinValue, DateTime.MaxValue)?.ToList();
                     Assert.Null(after2delete);
                 }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.TimeSeries)]
+        public async Task DeleteRangeForNonExistingTimeSeriesShouldBeNoOp()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), "users/1-A");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.TimeSeriesFor("users/1-A", "HR").Delete(DateTime.MinValue, DateTime.MaxValue);
+                    session.SaveChanges();
+                }
+
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    Assert.Equal(0, database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRanges(context));
+                }
+
+                var ts = store.Operations.Send(new GetTimeSeriesOperation("users/1-A", "HR", DateTime.MinValue, DateTime.MaxValue));
+                Assert.Null(ts);
             }
         }
 

--- a/test/SlowTests/Sharding/Client/Operations/GetCollectionStatisticsOperationTests.cs
+++ b/test/SlowTests/Sharding/Client/Operations/GetCollectionStatisticsOperationTests.cs
@@ -55,9 +55,9 @@ namespace SlowTests.Sharding.Client.Operations
                     var tsTime = DateTime.UtcNow;
                     var ts = session.TimeSeriesFor("users/1", "heartrate");
                     ts.Append(tsTime, 72, "wrist");
+                    session.SaveChanges();
 
                     ts.Delete(tsTime.AddMinutes(-5), tsTime.AddMinutes(-1));
-
 
                     session.SaveChanges();
                 }

--- a/test/SlowTests/Sharding/Cluster/TimeSeriesBucketMigrationTests.cs
+++ b/test/SlowTests/Sharding/Cluster/TimeSeriesBucketMigrationTests.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.Documents.Replication.Incoming;
+using Raven.Server.Documents.Replication.Outgoing;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.Documents.TimeSeries;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Sharding.Cluster
+{
+    public class TimeSeriesBucketMigrationTests : ClusterTestBase
+    {
+        public TimeSeriesBucketMigrationTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // Simulate a source-replica failover after bucket ownership moved to shard 1 but before shard 0
+        // cleaned up its bucket data. The surviving replica re-sends the bucket from scratch, so stale
+        // time-series segments reach the destination with a fresh receiver-local order in their change vector.
+        //
+        // The series must remain deleted after that resend. This verifies that the destination deleted-range
+        // preserves predecessor version lineage, and that stale incoming segments are checked against deleted
+        // ranges by version instead of by the flattened change-vector order.
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Replication | RavenTestCategory.TimeSeries)]
+        public async Task DeletedTimeSeriesWithLiveSegmentShouldStayDeletedAfterBucketResendAfterMigrationSourceFailover()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "1",
+                [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
+            };
+
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, customSettings: settings);
+            Assert.Equal("A", leader.ServerStore.NodeTag);
+
+            var options = new Options
+            {
+                Server = leader,
+                DatabaseMode = RavenDatabaseMode.Sharded,
+                ModifyDatabaseRecord = record => record.Sharding = new ShardingConfiguration
+                {
+                    Orchestrator = new OrchestratorConfiguration
+                    {
+                        Topology = new OrchestratorTopology { Members = new List<string> { "A" } }
+                    },
+                    Shards = new Dictionary<int, DatabaseTopology>
+                    {
+                        { 0, new DatabaseTopology { Members = new List<string> { "B", "C" }, DynamicNodesDistribution = false } },
+                        { 1, new DatabaseTopology { Members = new List<string> { "A" }, DynamicNodesDistribution = false } }
+                    }
+                }
+            };
+
+            using (var store = GetDocumentStore(options))
+            {
+                // a document whose bucket lives on shard 0 (the future migration source)
+                string id = null;
+                for (var i = 0; i < 5000; i++)
+                {
+                    var candidate = $"users/1$s{i}";
+                    if (await Sharding.GetShardNumberForAsync(store, candidate) == 0)
+                    {
+                        id = candidate;
+                        break;
+                    }
+                }
+                Assert.NotNull(id);
+
+                var baseline = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "owner" }, id);
+                    var ts = session.TimeSeriesFor(id, "HeartRates");
+                    for (var i = 1; i <= 10; i++)
+                        ts.Append(baseline.AddMinutes(i), i);
+                    await session.SaveChangesAsync();
+                }
+
+                // a deleted range authored on the source BEFORE the migration; after the migration it is
+                // the only carrier of the source's version lineage among the destination's deleted ranges
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.TimeSeriesFor(id, "HeartRates").Delete(baseline.AddMinutes(1), baseline.AddMinutes(5));
+                    await session.SaveChangesAsync();
+                }
+
+                var bucket = await Sharding.GetBucketAsync(store, id);
+                var shard0Name = ShardHelper.ToShardName(store.Database, 0);
+                var shard1Name = ShardHelper.ToShardName(store.Database, 1);
+
+                var serverB = nodes.Single(s => s.ServerStore.NodeTag == "B");
+                var serverC = nodes.Single(s => s.ServerStore.NodeTag == "C");
+
+                var shard0OnB = ShardedDocumentDatabase.CastToShardedDocumentDatabase(
+                    await serverB.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(shard0Name));
+                var shard0OnC = ShardedDocumentDatabase.CastToShardedDocumentDatabase(
+                    await serverC.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(shard0Name));
+
+                foreach (var sourceShard in new[] { shard0OnB, shard0OnC })
+                {
+                    var hasSeries = await WaitForValueAsync(
+                        () => Task.FromResult(CountTimeSeriesSegments(sourceShard, id) > 0 && CountDeletedRanges(sourceShard, id) > 0),
+                        true, timeout: 30_000, interval: 333);
+                    Assert.True(hasSeries,
+                        $"the time series data did not reach shard 0 replica on node {sourceShard.ServerStore.NodeTag}");
+                }
+
+                // hold the source bucket cleanup on both source replicas, so the surviving replica still
+                // has the stale bucket data when it takes over the migration (in production this is the
+                // natural window between ownership transfer and cleanup)
+                shard0OnB.ForTestingPurposesOnly().DelayDeleteBucket = new AsyncManualResetEvent();
+                shard0OnC.ForTestingPurposesOnly().DelayDeleteBucket = new AsyncManualResetEvent();
+
+                await Sharding.Resharding.StartMovingShardForId(store, id, toShard: 1, servers: nodes);
+
+                var status = await WaitForValueAsync(async () =>
+                {
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.BucketMigrations.TryGetValue(bucket, out var migration)
+                        ? migration.Status
+                        : (MigrationStatus?)null;
+                }, MigrationStatus.OwnershipTransferred, timeout: 60_000, interval: 333);
+                Assert.Equal(MigrationStatus.OwnershipTransferred, status);
+
+                var shard1OnA = ShardedDocumentDatabase.CastToShardedDocumentDatabase(
+                    await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(shard1Name));
+
+                // the migrated time series arrived at the destination with composite (order|version) change vectors
+                Assert.True(CountTimeSeriesSegments(shard1OnA, id) > 0);
+                var migratedRangeChangeVector = GetDeletedRangeChangeVectors(shard1OnA, id).SingleOrDefault();
+                Assert.NotNull(migratedRangeChangeVector);
+                Assert.Contains("|", migratedRangeChangeVector);
+
+                // Delete the migrated segment range, then append a value far enough away to create
+                // a separate storage segment. The re-sent stale source segment is still covered by
+                // the deleted range, but the time series itself is no longer empty.
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.TimeSeriesFor(id, "HeartRates").Delete(baseline.AddMinutes(1), baseline.AddMinutes(10));
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.TimeSeriesFor(id, "HeartRates").Append(baseline.AddDays(30), 30);
+                    await session.SaveChangesAsync();
+                }
+
+                await AssertExpectedTimeSeriesValuesAsync(store, id);
+
+                // find which source replica owns the migration (it keeps the connection open for leftovers)
+                RavenServer migrationOwner = null;
+                var hasOwner = await WaitForValueAsync(() =>
+                {
+                    foreach (var (server, shardDb) in new[] { (serverB, shard0OnB), (serverC, shard0OnC) })
+                    {
+                        if (shardDb.ReplicationLoader.OutgoingHandlers.OfType<OutgoingMigrationReplicationHandler>().Any())
+                        {
+                            migrationOwner = server;
+                            return Task.FromResult(true);
+                        }
+                    }
+                    return Task.FromResult(false);
+                }, true, timeout: 30_000, interval: 333);
+                Assert.True(hasOwner, "no outgoing migration handler found on either source replica");
+
+                var survivorShard0 = migrationOwner == serverB ? shard0OnC : shard0OnB;
+
+                // the cleanup hold kept the stale bucket data (incl. the segment) on the survivor
+                Assert.True(CountTimeSeriesSegments(survivorShard0, id) > 0);
+
+                long survivorLastEtag;
+                using (survivorShard0.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    survivorLastEtag = survivorShard0.DocumentsStorage.ReadLastEtag(context.Transaction.InnerTransaction);
+                }
+
+                var preKillIncomingHandlers = shard1OnA.ReplicationLoader.IncomingHandlers
+                    .OfType<IncomingMigrationReplicationHandler>().ToHashSet();
+
+                // kill the migration owner; the surviving source replica takes over the migration task
+                // and re-sends the whole bucket from scratch
+                await DisposeServerAndWaitForFinishOfDisposalAsync(migrationOwner);
+
+                var resendCompleted = await WaitForValueAsync(() =>
+                {
+                    foreach (var handler in shard1OnA.ReplicationLoader.IncomingHandlers.OfType<IncomingMigrationReplicationHandler>())
+                    {
+                        // a NEW incoming migration connection (from the surviving replica) that has
+                        // processed everything the survivor holds
+                        if (preKillIncomingHandlers.Contains(handler) == false &&
+                            handler.LastDocumentEtag >= survivorLastEtag)
+                            return Task.FromResult(true);
+                    }
+                    return Task.FromResult(false);
+                }, true, timeout: 120_000, interval: 333);
+
+                if (resendCompleted == false)
+                {
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    var shard0Topology = record.Sharding.Shards[0];
+                    var diagnostics = new System.Text.StringBuilder()
+                        .AppendLine($"survivor: {survivorShard0.ServerStore.NodeTag}, survivorLastEtag: {survivorLastEtag}")
+                        .AppendLine($"shard0 members: [{string.Join(",", shard0Topology.Members)}], rehabs: [{string.Join(",", shard0Topology.Rehabs)}]")
+                        .AppendLine($"migration record present: {record.Sharding.BucketMigrations.ContainsKey(bucket)}" +
+                                    (record.Sharding.BucketMigrations.TryGetValue(bucket, out var m) ? $", status: {m.Status}" : string.Empty))
+                        .AppendLine($"survivor outgoing handlers: [{string.Join(",", survivorShard0.ReplicationLoader.OutgoingHandlers.Select(h => $"{h.GetType().Name}->{h.Destination?.Database}@{h.Destination?.Url}"))}]")
+                        .AppendLine($"dest incoming handlers: [{string.Join(",", shard1OnA.ReplicationLoader.IncomingHandlers.Select(h => $"{h.GetType().Name} src={h.ConnectionInfo?.SourceDatabaseId} lastDocEtag={h.LastDocumentEtag}"))}]");
+                    Assert.Fail("the surviving source replica did not re-send the bucket to the destination." + Environment.NewLine + diagnostics);
+                }
+
+                // the local delete is causally NEWER than the re-sent stale segment - deleted values must stay deleted
+                await AssertExpectedTimeSeriesValuesAsync(store, id);
+            }
+        }
+
+        private static async Task AssertExpectedTimeSeriesValuesAsync(IDocumentStore store, string id)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var values = await session.TimeSeriesFor(id, "HeartRates").GetAsync();
+
+                Assert.NotNull(values);
+                Assert.Single(values);
+                Assert.Equal(30d, values[0].Value);
+            }
+        }
+
+        private static int CountTimeSeriesSegments(ShardedDocumentDatabase shardDatabase, string docId)
+        {
+            using (shardDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                return shardDatabase.DocumentsStorage.TimeSeriesStorage.GetTimeSeriesFrom(context, 0, long.MaxValue)
+                    .Count(s => s.DocId.ToString().Equals(docId, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        private static int CountDeletedRanges(ShardedDocumentDatabase shardDatabase, string docId)
+        {
+            return GetDeletedRangeChangeVectors(shardDatabase, docId).Count;
+        }
+
+        private static List<string> GetDeletedRangeChangeVectors(ShardedDocumentDatabase shardDatabase, string docId)
+        {
+            var result = new List<string>();
+            using (shardDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                foreach (var deletedRange in shardDatabase.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(context, 0))
+                {
+                    TimeSeriesValuesSegment.ParseTimeSeriesKey(deletedRange.Key, context, out LazyStringValue rangeDocId, out _);
+                    if (string.Equals(rangeDocId, docId, StringComparison.OrdinalIgnoreCase))
+                        result.Add(deletedRange.ChangeVector);
+                }
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26788

### Additional description

This PR completes the remaining coverage and hardening for the time-series deleted-range lineage issue in bucket migration / source-failover scenarios.

A migrated deleted time-series range can carry a composite `order|version` change vector. If a later local delete extends that range but loses the predecessor version lineage, a stale source segment re-sent after migration source failover can be treated as not covered by the delete and become visible again.

Changes in this PR:

- Preserve predecessor deleted-range lineage when a local deleted range supersedes a migrated composite range.
- Check deleted-range coverage even when the same time series still has another live segment.
- Compare deleted-range coverage with unused database ids accounted for.
- Add a test-only bucket cleanup delay hook to make the source-failover bucket re-send scenario deterministic.
- Keep the existing pull-replication regression coverage.
- Add `TimeSeriesBucketMigrationTests` as the thematic sharding/time-series regression suite.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation

Time-series deleted-range conflict handling now checks whether an incoming segment is covered by a deleted range even when the same time series still has other live segments. This is the intended bug fix: covered stale segments should remain invisible instead of being restored.

- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
