### PR TITLE
RavenDB-22358 ensure proper sharded tombsonte marking

### DIFF
--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Binary;
@@ -386,6 +387,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         long lastProcessedEtag = 0;
         bool hasMore = true, collectionNamesUpdated = false;
         var collectionNames = new Dictionary<string, CollectionName>(_collectionsCache, StringComparer.OrdinalIgnoreCase);
+        var holder = new Table.TableValueHolder(); // reused across iterations to avoid a per-row allocation
 
         while (hasMore)
         {
@@ -441,39 +443,33 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
                 var cv = ChangeVector.MergeWithDatabaseChangeVector(context, tombstoneChangeVector);
                 var flags = tombstone.Flags | DocumentFlags.Artificial | DocumentFlags.FromResharding;
 
+                writeTable.DirectRead(tombstone.StorageId, out holder.Reader);
+
+                using (TableValueReaderUtil.CloneTableValueReader(context, holder))
                 using (Slice.From(context.Allocator, cv, out var cvSlice))
-                using (Slice.External(context.Allocator, tombstone.LowerId, out var keySlice))
                 using (writeTable.Allocate(out TableValueBuilder tvb))
                 {
-                    var clonedKey = keySlice.Clone(context.Allocator);
-
-                    var hasCollection = tombstone.Collection != null;
-                    Slice collectionSlice = default;
-                    ByteStringContext.InternalScope collectionScope = default;
-                    if (hasCollection)
-                        collectionScope = DocumentIdWorker.GetStringPreserveCase(context, tombstone.Collection, out collectionSlice);
-
-                    using (collectionScope)
+                    for (int i = 0; i < holder.Reader.Count; i++)
                     {
-                        tvb.Add(clonedKey.Content.Ptr, clonedKey.Size);
-                        tvb.Add(Bits.SwapBytes(newEtag));
-                        tvb.Add(Bits.SwapBytes(tombstone.DeletedEtag));
-                        tvb.Add(tombstone.TransactionMarker);
-                        tvb.Add((byte)tombstone.Type);
-
-                        // Document/revision tombstones carry a collection; attachment tombstones don't, so we
-                        // write an empty 0-byte column - the same as AttachmentsStorage.CreateTombstone (tvb.Add(null, 0)).
-                        if (hasCollection)
-                            tvb.Add(collectionSlice);
-                        else
-                            tvb.Add(null, 0);
-                        tvb.Add((int)flags);
-                        tvb.Add(cvSlice.Content.Ptr, cvSlice.Size);
-                        tvb.Add(tombstone.LastModified.Ticks);
-
-                        writeTable.Update(tombstone.StorageId, tvb);
-                        context.Allocator.Release(ref clonedKey.Content);
+                        switch ((TombstoneTable)i)
+                        {
+                            case TombstoneTable.Etag:
+                                tvb.Add(Bits.SwapBytes(newEtag));
+                                break;
+                            case TombstoneTable.Flags:
+                                tvb.Add((int)flags);
+                                break;
+                            case TombstoneTable.ChangeVector:
+                                tvb.Add(cvSlice.Content.Ptr, cvSlice.Size);
+                                break;
+                            default:
+                                var ptr = holder.Reader.Read(i, out int size);
+                                tvb.Add(ptr, size);
+                                break;
+                        }
                     }
+
+                    writeTable.Update(tombstone.StorageId, tvb);
                 }
 
                 // need to re open the read iterator after we modified the tree

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -867,21 +867,23 @@ namespace SlowTests.Sharding.Cluster
             using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
             {
-                foreach (var tomb in storage.RetrieveTombstonesByBucketFrom(context, bucket, 0))
+                foreach (var item in storage.GetTombstonesByBucketFrom(context, bucket, 0))
                 {
-                    var artificial = tomb.Flags.Contain(DocumentFlags.Artificial) && tomb.Flags.Contain(DocumentFlags.FromResharding);
-                    switch (tomb.Type)
+                    switch (item)
                     {
-                        case Tombstone.TombstoneType.Revision:
-                            if (artificial) artificialRevision++; else plainRevision++;
+                        case RevisionTombstoneReplicationItem revision:
+                            if (IsArtificial(revision.Flags)) artificialRevision++; else plainRevision++;
                             break;
-                        case Tombstone.TombstoneType.Attachment:
-                            if (artificial) artificialAttachment++; else plainAttachment++;
+                        case AttachmentTombstoneReplicationItem attachment:
+                            if (IsArtificial(attachment.Flags)) artificialAttachment++; else plainAttachment++;
                             break;
                     }
                 }
             }
             return (plainRevision, artificialRevision, plainAttachment, artificialAttachment);
+
+            static bool IsArtificial(DocumentFlags flags) =>
+                flags.Contain(DocumentFlags.Artificial) && flags.Contain(DocumentFlags.FromResharding);
         }
 
         [RavenFact(RavenTestCategory.Sharding)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22358 

### Additional description

During resharding, when a bucket migrates away, `MarkTombstonesAsArtificial` re-stamped the bucket's existing tombstones but hand-wrote only 9 columns, dropping the new field 9 (RevisionVersion)

### Type of change

- [x] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
