### PR TITLE
RavenDB-24909 Better DX after certificate renew

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Code.tsx
+++ b/src/Raven.Studio/typescript/components/common/Code.tsx
@@ -12,7 +12,7 @@ require("prismjs/components/prism-json");
 require("prismjs/components/prism-python");
 require("prismjs/components/prism-java");
 
-type Language =
+export type CodeLanguage =
     | "plaintext"
     | "markup"
     | "html"
@@ -32,7 +32,7 @@ type Language =
 
 interface CodeProps {
     code: string;
-    language: Language;
+    language: CodeLanguage;
     className?: string;
     elementToCopy?: string;
 }

--- a/src/Raven.Studio/typescript/components/common/Code.tsx
+++ b/src/Raven.Studio/typescript/components/common/Code.tsx
@@ -9,7 +9,8 @@ import Button from "react-bootstrap/Button";
 require("prismjs/components/prism-javascript");
 require("prismjs/components/prism-csharp");
 require("prismjs/components/prism-json");
-require("prismjs/components/prism-json");
+require("prismjs/components/prism-python");
+require("prismjs/components/prism-java");
 
 type Language =
     | "plaintext"
@@ -25,7 +26,9 @@ type Language =
     | "clike"
     | "javascript"
     | "csharp"
-    | "json";
+    | "json"
+    | "python"
+    | "java";
 
 interface CodeProps {
     code: string;

--- a/src/Raven.Studio/typescript/components/common/NumberedList.scss
+++ b/src/Raven.Studio/typescript/components/common/NumberedList.scss
@@ -6,22 +6,25 @@
     margin: 0;
     padding: 0 !important;
     position: relative;
-
-    &::before {
-        content: "";
-        position: absolute;
-        left: sizes.$gutter-xs;
-        top: 0;
-        background-color: colors.$border-color-light-var;
-        height: calc(100% - sizes.$gutter-md / 2);
-        width: 1px;
-    }
 }
 
 .numbered-list-item {
     position: relative;
     margin-bottom: sizes.$gutter-sm;
     padding-left: sizes.$gutter-md;
+
+    // Vertical connector line between dots. Drawn on every item except the
+    // last, spanning from this item's dot down to the next item's dot, so the
+    // line never extends past the final number.
+    &:not(:last-of-type)::before {
+        content: "";
+        position: absolute;
+        left: sizes.$gutter-xs;
+        top: 0;
+        bottom: -#{sizes.$gutter-sm};
+        background-color: colors.$border-color-light-var;
+        width: 1px;
+    }
 
     &:last-of-type {
         margin-bottom: 0;

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/Certificates.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/Certificates.spec.tsx
@@ -9,6 +9,10 @@ const { CertificatesStory } = composeStories(stories);
 const selectors = {
     authIsDisabledHeader: /Authentication is disabled/,
     renewNowButton: /Renew now/,
+    renewConfirmButton: /Renew certificate/,
+    renewedDialogTitle: /Your new certificate is ready/,
+    browserAccessTab: /Browser Access/,
+    apiAccessTab: /Application Access \(API\)/,
     renewalDate: "2025-01-15",
     editButtonTitle: /Edit certificate/,
     deleteButtonTitle: /Delete certificate/,
@@ -102,6 +106,22 @@ describe("Certificates", () => {
 
             expect(screen.queryByText(selectors.renewalDate)).not.toBeInTheDocument();
             expect(screen.queryByRole("button", { name: selectors.renewNowButton })).not.toBeInTheDocument();
+        });
+
+        it("opens the guidance dialog after renewing the server certificate", async () => {
+            const { screen, fireClick } = await rtlRender_WithWaitForLoad(
+                <CertificatesStory serverCertRenewalDate={selectors.renewalDate} serverCertSetupMode="LetsEncrypt" />
+            );
+
+            const renewButton = screen.getByRole("button", { name: selectors.renewNowButton });
+            await fireClick(renewButton);
+
+            const confirmButton = await screen.findByRole("button", { name: selectors.renewConfirmButton });
+            await fireClick(confirmButton);
+
+            expect(await screen.findByText(selectors.renewedDialogTitle)).toBeInTheDocument();
+            expect(screen.getByText(selectors.browserAccessTab)).toBeInTheDocument();
+            expect(screen.getByText(selectors.apiAccessTab)).toBeInTheDocument();
         });
     });
 

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesAuthEnabled.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesAuthEnabled.tsx
@@ -16,6 +16,7 @@ import { LoadingView } from "components/common/LoadingView";
 import { LoadError } from "components/common/LoadError";
 import CertificatesFilters from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesFilters";
 import CertificatesManageDropdown from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesManageDropdown";
+import CertificatesRenewedModal from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal";
 
 export default function CertificatesAuthEnabled() {
     const dispatch = useAppDispatch();
@@ -24,6 +25,7 @@ export default function CertificatesAuthEnabled() {
     const isGenerateModalOpen = useAppSelector(certificatesSelectors.isGenerateModalOpen);
     const isUploadModalOpen = useAppSelector(certificatesSelectors.isUploadModalOpen);
     const isReplaceServerModalOpen = useAppSelector(certificatesSelectors.isReplaceServerModalOpen);
+    const isRenewedModalOpen = useAppSelector(certificatesSelectors.isRenewedModalOpen);
     const certificateToEdit = useAppSelector(certificatesSelectors.certificateToEdit);
     const certificateToClone = useAppSelector(certificatesSelectors.certificateToClone);
 
@@ -82,6 +84,7 @@ export default function CertificatesAuthEnabled() {
             {isGenerateModalOpen && <CertificatesGenerateModal />}
             {isUploadModalOpen && <CertificatesUploadModal />}
             {isReplaceServerModalOpen && <CertificatesReplaceServerModal />}
+            {isRenewedModalOpen && <CertificatesRenewedModal />}
             {certificateToClone && <CertificatesCloneModal />}
             {certificateToEdit && <CertificatesEditModal />}
         </div>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesListItem.tsx
@@ -72,6 +72,7 @@ export default function CertificatesListItem({ certificate }: CertificatesListIt
         reportEvent("certificates", "renew");
         await manageServerService.forceRenewServerCertificate();
         await dispatch(certificatesActions.fetchData());
+        dispatch(certificatesActions.isRenewedModalOpenToggled());
     });
 
     const handleRenewServerCertificate = async () => {

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.scss
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.scss
@@ -1,0 +1,73 @@
+@use "Content/scss/sizes";
+@use "Content/scss/colors";
+
+.certificates-renewed-modal {
+    // Top-level Browser Access / Application Access segmented tabs
+    .access-tab-container {
+        .nav {
+            gap: sizes.$gutter-sm;
+        }
+
+        .nav-link {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            color: colors.$text-emphasis-color;
+            font-size: sizes.$font-size-base;
+            text-align: center;
+            background-image: none !important;
+            border: 1px solid colors.$border-color-light-var;
+            border-radius: sizes.$border-radius;
+            padding: sizes.$gutter-xs sizes.$gutter-sm !important;
+            margin-bottom: 0 !important;
+            &[aria-selected="false"] {
+                color: colors.$text-muted-color;
+                background-color: colors.$body-bg-var;
+            }
+
+            &[aria-selected="true"] {
+                border-color: colors.$primary-var;
+                background-color: var(--faded-primary);
+            }
+        }
+    }
+
+    // Segmented tab set (browser + client code) - mirrors .browser-tab-container
+    .segmented-tab-container {
+        border-radius: var(--bs-border-radius);
+        border: 1px solid var(--border-color-light);
+        background-color: var(--panel-bg-2);
+
+        .nav {
+            flex-wrap: nowrap;
+        }
+
+        .nav-link {
+            color: colors.$text-emphasis-color;
+            font-size: sizes.$font-size-base;
+            text-align: center;
+            background-image: none !important;
+
+            &[aria-selected="false"] {
+                color: colors.$text-muted-color;
+                background-color: var(--bs-body-bg);
+                border-bottom: 1px solid var(--border-color-light);
+            }
+        }
+
+        .nav-item {
+            &:not(:last-child) .nav-link {
+                border-right: 1px solid var(--border-color-light);
+            }
+
+            &:first-child .nav-link {
+                border-top-left-radius: var(--bs-border-radius);
+            }
+
+            &:last-child .nav-link {
+                border-top-right-radius: var(--bs-border-radius);
+            }
+        }
+    }
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.scss
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.scss
@@ -1,74 +1,55 @@
-@use "Content/scss/sizes";
 @use "Content/scss/colors";
 
 .certificates-renewed-modal {
-  // Top-level Browser Access / Application Access segmented tabs
-  .access-tab-container {
-    .nav {
-      gap: sizes.$gutter-sm;
+    // Top-level Browser Access / Application Access segmented tabs.
+    // Layout (flex/gap/border/radius/padding/width) is applied via Bootstrap
+    // utility classes in the markup; only stateful styling lives here.
+    .access-tab-container {
+        .nav-link {
+            color: colors.$text-emphasis-color;
+            background-image: none !important;
+
+            &[aria-selected="false"] {
+                color: colors.$text-muted-color;
+                background-color: colors.$body-bg-var;
+            }
+
+            &[aria-selected="true"] {
+                border-color: colors.$primary-var !important;
+                background-color: var(--faded-primary);
+            }
+        }
     }
 
-    .nav-link {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 100%;
-      color: colors.$text-emphasis-color;
-      font-size: sizes.$font-size-base;
-      text-align: center;
-      background-image: none !important;
-      border: 1px solid colors.$border-color-light-var;
-      border-radius: sizes.$border-radius;
-      padding: sizes.$gutter-xs sizes.$gutter-sm !important;
-      margin-bottom: 0 !important;
+    // Segmented tab set (browser + client code) - mirrors .browser-tab-container
+    .segmented-tab-container {
+        border-radius: var(--bs-border-radius);
+        border: 1px solid var(--border-color-light);
+        background-color: var(--panel-bg-2);
 
-      &[aria-selected="false"] {
-        color: colors.$text-muted-color;
-        background-color: colors.$body-bg-var;
-      }
+        .nav-link {
+            color: colors.$text-emphasis-color;
+            background-image: none !important;
 
-      &[aria-selected="true"] {
-        border-color: colors.$primary-var;
-        background-color: var(--faded-primary);
-      }
+            &[aria-selected="false"] {
+                color: colors.$text-muted-color;
+                background-color: var(--bs-body-bg);
+                border-bottom: 1px solid var(--border-color-light);
+            }
+        }
+
+        .nav-item {
+            &:not(:last-child) .nav-link {
+                border-right: 1px solid var(--border-color-light);
+            }
+
+            &:first-child .nav-link {
+                border-top-left-radius: var(--bs-border-radius);
+            }
+
+            &:last-child .nav-link {
+                border-top-right-radius: var(--bs-border-radius);
+            }
+        }
     }
-  }
-
-  // Segmented tab set (browser + client code) - mirrors .browser-tab-container
-  .segmented-tab-container {
-    border-radius: var(--bs-border-radius);
-    border: 1px solid var(--border-color-light);
-    background-color: var(--panel-bg-2);
-
-    .nav {
-      flex-wrap: nowrap;
-    }
-
-    .nav-link {
-      color: colors.$text-emphasis-color;
-      font-size: sizes.$font-size-base;
-      text-align: center;
-      background-image: none !important;
-
-      &[aria-selected="false"] {
-        color: colors.$text-muted-color;
-        background-color: var(--bs-body-bg);
-        border-bottom: 1px solid var(--border-color-light);
-      }
-    }
-
-    .nav-item {
-      &:not(:last-child) .nav-link {
-        border-right: 1px solid var(--border-color-light);
-      }
-
-      &:first-child .nav-link {
-        border-top-left-radius: var(--bs-border-radius);
-      }
-
-      &:last-child .nav-link {
-        border-top-right-radius: var(--bs-border-radius);
-      }
-    }
-  }
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.scss
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.scss
@@ -2,72 +2,73 @@
 @use "Content/scss/colors";
 
 .certificates-renewed-modal {
-    // Top-level Browser Access / Application Access segmented tabs
-    .access-tab-container {
-        .nav {
-            gap: sizes.$gutter-sm;
-        }
-
-        .nav-link {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 100%;
-            color: colors.$text-emphasis-color;
-            font-size: sizes.$font-size-base;
-            text-align: center;
-            background-image: none !important;
-            border: 1px solid colors.$border-color-light-var;
-            border-radius: sizes.$border-radius;
-            padding: sizes.$gutter-xs sizes.$gutter-sm !important;
-            margin-bottom: 0 !important;
-            &[aria-selected="false"] {
-                color: colors.$text-muted-color;
-                background-color: colors.$body-bg-var;
-            }
-
-            &[aria-selected="true"] {
-                border-color: colors.$primary-var;
-                background-color: var(--faded-primary);
-            }
-        }
+  // Top-level Browser Access / Application Access segmented tabs
+  .access-tab-container {
+    .nav {
+      gap: sizes.$gutter-sm;
     }
 
-    // Segmented tab set (browser + client code) - mirrors .browser-tab-container
-    .segmented-tab-container {
-        border-radius: var(--bs-border-radius);
-        border: 1px solid var(--border-color-light);
-        background-color: var(--panel-bg-2);
+    .nav-link {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      color: colors.$text-emphasis-color;
+      font-size: sizes.$font-size-base;
+      text-align: center;
+      background-image: none !important;
+      border: 1px solid colors.$border-color-light-var;
+      border-radius: sizes.$border-radius;
+      padding: sizes.$gutter-xs sizes.$gutter-sm !important;
+      margin-bottom: 0 !important;
 
-        .nav {
-            flex-wrap: nowrap;
-        }
+      &[aria-selected="false"] {
+        color: colors.$text-muted-color;
+        background-color: colors.$body-bg-var;
+      }
 
-        .nav-link {
-            color: colors.$text-emphasis-color;
-            font-size: sizes.$font-size-base;
-            text-align: center;
-            background-image: none !important;
-
-            &[aria-selected="false"] {
-                color: colors.$text-muted-color;
-                background-color: var(--bs-body-bg);
-                border-bottom: 1px solid var(--border-color-light);
-            }
-        }
-
-        .nav-item {
-            &:not(:last-child) .nav-link {
-                border-right: 1px solid var(--border-color-light);
-            }
-
-            &:first-child .nav-link {
-                border-top-left-radius: var(--bs-border-radius);
-            }
-
-            &:last-child .nav-link {
-                border-top-right-radius: var(--bs-border-radius);
-            }
-        }
+      &[aria-selected="true"] {
+        border-color: colors.$primary-var;
+        background-color: var(--faded-primary);
+      }
     }
+  }
+
+  // Segmented tab set (browser + client code) - mirrors .browser-tab-container
+  .segmented-tab-container {
+    border-radius: var(--bs-border-radius);
+    border: 1px solid var(--border-color-light);
+    background-color: var(--panel-bg-2);
+
+    .nav {
+      flex-wrap: nowrap;
+    }
+
+    .nav-link {
+      color: colors.$text-emphasis-color;
+      font-size: sizes.$font-size-base;
+      text-align: center;
+      background-image: none !important;
+
+      &[aria-selected="false"] {
+        color: colors.$text-muted-color;
+        background-color: var(--bs-body-bg);
+        border-bottom: 1px solid var(--border-color-light);
+      }
+    }
+
+    .nav-item {
+      &:not(:last-child) .nav-link {
+        border-right: 1px solid var(--border-color-light);
+      }
+
+      &:first-child .nav-link {
+        border-top-left-radius: var(--bs-border-radius);
+      }
+
+      &:last-child .nav-link {
+        border-top-right-radius: var(--bs-border-radius);
+      }
+    }
+  }
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.tsx
@@ -42,15 +42,21 @@ export default function CertificatesRenewedModal() {
 
                 <Tab.Container activeKey={accessTab} onSelect={(key: AccessTab) => setAccessTab(key)}>
                     <div className="access-tab-container mb-4">
-                        <Nav>
+                        <Nav className="gap-3">
                             <Nav.Item className="flex-grow mb-0">
-                                <Nav.Link eventKey="browser">
+                                <Nav.Link
+                                    eventKey="browser"
+                                    className="d-flex align-items-center justify-content-center w-100 text-center border rounded py-2 px-3"
+                                >
                                     <Icon icon="global" />
                                     Browser Access
                                 </Nav.Link>
                             </Nav.Item>
                             <Nav.Item className="flex-grow mb-0">
-                                <Nav.Link eventKey="api">
+                                <Nav.Link
+                                    eventKey="api"
+                                    className="d-flex align-items-center justify-content-center w-100 text-center border rounded py-2 px-3"
+                                >
                                     <Icon icon="code" />
                                     Application Access (API)
                                 </Nav.Link>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.tsx
@@ -4,40 +4,34 @@ import Tab from "react-bootstrap/Tab";
 import Nav from "react-bootstrap/Nav";
 import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
-import RichAlert from "components/common/RichAlert";
-import { NumberedList, NumberedListItem } from "components/common/NumberedList";
-import Code from "components/common/Code";
 import { useRavenLink } from "components/hooks/useRavenLink";
-import { useAppDispatch, useAppSelector } from "components/store";
+import { useAppDispatch } from "components/store";
 import { certificatesActions } from "components/pages/resources/manageServer/certificates/store/certificatesSlice";
-import { clusterSelectors } from "components/common/shell/clusterSlice";
-import genUtils from "common/generalUtils";
+import CertificatesRenewedModalBrowserAccess from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModalBrowserAccess";
+import CertificatesRenewedModalApiAccess from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModalApiAccess";
 import "./CertificatesRenewedModal.scss";
 
-const serverUrlPlaceholder = "https://your_RavenDB_server_URL";
-const pfxPathPlaceholder = "C:\\path_to_your_pfx_file\\cert.pfx";
-const dbNamePlaceholder = "your_database_name";
-
-type ClientLanguage = "csharp" | "java" | "nodejs" | "python";
+type AccessTab = "browser" | "api";
 
 export default function CertificatesRenewedModal() {
     const dispatch = useAppDispatch();
     const docsLink = useRavenLink({ hash: "RSFSL5" });
 
-    const localNode = useAppSelector(clusterSelectors.localNode);
-    const serverUrl = localNode?.serverUrl || serverUrlPlaceholder;
-
-    const [accessTab, setAccessTab] = useState<"browser" | "api">("browser");
-    const [browserTab, setBrowserTab] = useState<Browser>(genUtils.getBrowser());
-    const [clientTab, setClientTab] = useState<ClientLanguage>("csharp");
+    const [accessTab, setAccessTab] = useState<AccessTab>("browser");
 
     const close = () => dispatch(certificatesActions.isRenewedModalOpenToggled());
 
     return (
-        <Modal scrollable show size="lg" centered contentClassName="modal-border bulge-primary certificates-renewed-modal">
-            <Modal.Header onCloseClick={close}>
-                <Icon icon="certificate" color="primary" addon="check" className="fs-2" />
-                <span className="lead">Your new certificate is ready</span>
+        <Modal
+            scrollable
+            show
+            size="lg"
+            centered
+            contentClassName="modal-border bulge-primary certificates-renewed-modal"
+        >
+            <Modal.Header onCloseClick={close} className="mb-0">
+                <Icon icon="certificate" size="lg" margin="me-3" color="primary" addon="check" />
+                <h3 className="mb-0">Your new certificate is ready</h3>
             </Modal.Header>
             <Modal.Body>
                 <p className="mb-4">
@@ -46,17 +40,17 @@ export default function CertificatesRenewedModal() {
                     matches how you&apos;ll connect to RavenDB.
                 </p>
 
-                <Tab.Container activeKey={accessTab} onSelect={(key: "browser" | "api") => setAccessTab(key)}>
+                <Tab.Container activeKey={accessTab} onSelect={(key: AccessTab) => setAccessTab(key)}>
                     <div className="access-tab-container mb-4">
                         <Nav>
                             <Nav.Item className="flex-grow mb-0">
-                                <Nav.Link eventKey="browser" className="">
+                                <Nav.Link eventKey="browser">
                                     <Icon icon="global" />
                                     Browser Access
                                 </Nav.Link>
                             </Nav.Item>
                             <Nav.Item className="flex-grow mb-0">
-                                <Nav.Link eventKey="api" className="">
+                                <Nav.Link eventKey="api">
                                     <Icon icon="code" />
                                     Application Access (API)
                                 </Nav.Link>
@@ -65,193 +59,8 @@ export default function CertificatesRenewedModal() {
                     </div>
 
                     <Tab.Content>
-                        <Tab.Pane eventKey="browser">
-                            <NumberedList>
-                                <NumberedListItem stepKey={1}>
-                                    <h4 className="mb-1">Locate the certificate file</h4>
-                                    <p className="mb-0">
-                                        Find the downloaded <code>.pfx</code> file in your computer&apos;s
-                                        &quot;Downloads&quot; folder. This file is a secure, password-protected package
-                                        containing your new digital ID.
-                                    </p>
-                                </NumberedListItem>
-                                <NumberedListItem stepKey={2}>
-                                    <h4 className="mb-2">Install the certificate in your browser</h4>
-                                    <Tab.Container
-                                        activeKey={browserTab}
-                                        onSelect={(key: Browser) => setBrowserTab(key)}
-                                    >
-                                        <div className="segmented-tab-container">
-                                            <Nav>
-                                                <Nav.Item className="flex-grow">
-                                                    <Nav.Link eventKey="Chrome">
-                                                        <Icon icon="chrome" />
-                                                        Chrome
-                                                    </Nav.Link>
-                                                </Nav.Item>
-                                                <Nav.Item className="flex-grow">
-                                                    <Nav.Link eventKey="Firefox">
-                                                        <Icon icon="firefox" />
-                                                        Firefox
-                                                    </Nav.Link>
-                                                </Nav.Item>
-                                                <Nav.Item className="flex-grow">
-                                                    <Nav.Link eventKey="Safari">
-                                                        <Icon icon="safari" />
-                                                        Safari
-                                                    </Nav.Link>
-                                                </Nav.Item>
-                                                <Nav.Item className="flex-grow">
-                                                    <Nav.Link eventKey="Other">
-                                                        <Icon icon="global" />
-                                                        Other
-                                                    </Nav.Link>
-                                                </Nav.Item>
-                                            </Nav>
-                                            <Tab.Content className="p-2 text-break">
-                                                <Tab.Pane eventKey="Chrome">
-                                                    Chrome (or any Chromium-based browser) will let you select this
-                                                    certificate automatically. You may need to restart all instances of
-                                                    Chrome to make sure nothing is cached.
-                                                </Tab.Pane>
-                                                <Tab.Pane eventKey="Firefox">
-                                                    Firefox uses its own internal certificate store. After importing the
-                                                    certificate through Firefox settings, it will be available for use
-                                                    automatically. You may need to restart Firefox to ensure the new
-                                                    certificate is recognized properly.
-                                                </Tab.Pane>
-                                                <Tab.Pane eventKey="Safari">
-                                                    Safari uses the macOS Keychain to manage certificates. Once the
-                                                    certificate is imported and marked as trusted in Keychain Access,
-                                                    Safari will select it automatically when needed. Restarting Safari or
-                                                    the system may help if it doesn&apos;t appear right away.
-                                                </Tab.Pane>
-                                                <Tab.Pane eventKey="Other">
-                                                    Browsers that are not Chromium-based and don&apos;t use the system
-                                                    certificate store typically require manual certificate import through
-                                                    their own settings or preferences. Behavior may vary, and restarting
-                                                    the browser is often recommended to ensure the certificate is
-                                                    applied.
-                                                </Tab.Pane>
-                                            </Tab.Content>
-                                        </div>
-                                    </Tab.Container>
-                                </NumberedListItem>
-                                <NumberedListItem stepKey={3}>
-                                    <h4 className="mb-1">Reconnect to Studio</h4>
-                                    <p className="mb-1">
-                                        To activate the new certificate, you may need to restart your browser.
-                                    </p>
-                                    <ul className="mb-0">
-                                        <li>Close all browser windows completely.</li>
-                                        <li>
-                                            Reopen the Studio URL. Your browser should now prompt you to select the new
-                                            certificate you just installed.
-                                        </li>
-                                    </ul>
-                                </NumberedListItem>
-                            </NumberedList>
-                            <RichAlert variant="info">
-                                If you&apos;re not prompted to choose a certificate, try using an Incognito/Private
-                                window.
-                            </RichAlert>
-                        </Tab.Pane>
-
-                        <Tab.Pane eventKey="api">
-                            <NumberedList>
-                                <NumberedListItem stepKey={1}>
-                                    <h4 className="mb-1">Locate and secure the certificate file</h4>
-                                    <p className="mb-0">
-                                        Find the automatically downloaded <code>.pfx</code> file in your computer&apos;s
-                                        &quot;Downloads&quot; folder and move it to a secure location accessible by your
-                                        application (e.g., a protected folder on your server or a cloud secrets vault).
-                                    </p>
-                                </NumberedListItem>
-                                <NumberedListItem stepKey={2}>
-                                    <h4 className="mb-2">Configure your RavenDB client code</h4>
-                                    <p className="mb-2">
-                                        Update your application&apos;s code to point the <code>DocumentStore</code>{" "}
-                                        initialization to the new certificate&apos;s file path and password.
-                                    </p>
-                                    <Tab.Container
-                                        activeKey={clientTab}
-                                        onSelect={(key: ClientLanguage) => setClientTab(key)}
-                                    >
-                                        <div className="segmented-tab-container">
-                                            <Nav>
-                                                <Nav.Item className="flex-grow">
-                                                    <Nav.Link eventKey="csharp">
-                                                        <Icon icon="csharp" />
-                                                        C#
-                                                    </Nav.Link>
-                                                </Nav.Item>
-                                                <Nav.Item className="flex-grow">
-                                                    <Nav.Link eventKey="java">
-                                                        <Icon icon="code" />
-                                                        Java
-                                                    </Nav.Link>
-                                                </Nav.Item>
-                                                <Nav.Item className="flex-grow">
-                                                    <Nav.Link eventKey="nodejs">
-                                                        <Icon icon="node" />
-                                                        Node.js
-                                                    </Nav.Link>
-                                                </Nav.Item>
-                                                <Nav.Item className="flex-grow">
-                                                    <Nav.Link eventKey="python">
-                                                        <Icon icon="code" />
-                                                        Python
-                                                    </Nav.Link>
-                                                </Nav.Item>
-                                            </Nav>
-                                            <Tab.Content className="p-2">
-                                                <Tab.Pane eventKey="csharp">
-                                                    <Code
-                                                        language="csharp"
-                                                        code={csharpSnippet(serverUrl)}
-                                                        elementToCopy={csharpSnippet(serverUrl)}
-                                                    />
-                                                </Tab.Pane>
-                                                <Tab.Pane eventKey="java">
-                                                    <Code
-                                                        language="java"
-                                                        code={javaSnippet(serverUrl)}
-                                                        elementToCopy={javaSnippet(serverUrl)}
-                                                    />
-                                                </Tab.Pane>
-                                                <Tab.Pane eventKey="nodejs">
-                                                    <Code
-                                                        language="javascript"
-                                                        code={nodejsSnippet(serverUrl)}
-                                                        elementToCopy={nodejsSnippet(serverUrl)}
-                                                    />
-                                                </Tab.Pane>
-                                                <Tab.Pane eventKey="python">
-                                                    <Code
-                                                        language="python"
-                                                        code={pythonSnippet(serverUrl)}
-                                                        elementToCopy={pythonSnippet(serverUrl)}
-                                                    />
-                                                </Tab.Pane>
-                                            </Tab.Content>
-                                        </div>
-                                    </Tab.Container>
-                                    <p className="mt-2 mb-0">
-                                        For detailed code examples and more information, please refer to the official{" "}
-                                        <a href={docsLink} target="_blank">
-                                            Documentation <Icon icon="newtab" margin="m-0" />
-                                        </a>
-                                        .
-                                    </p>
-                                </NumberedListItem>
-                                <NumberedListItem stepKey={3}>
-                                    <h4 className="mb-1">Restart your application</h4>
-                                    <p className="mb-0">
-                                        Your application must be restarted to load the new certificate file into memory.
-                                    </p>
-                                </NumberedListItem>
-                            </NumberedList>
-                        </Tab.Pane>
+                        <CertificatesRenewedModalBrowserAccess />
+                        <CertificatesRenewedModalApiAccess />
                     </Tab.Content>
                 </Tab.Container>
             </Modal.Body>
@@ -265,61 +74,4 @@ export default function CertificatesRenewedModal() {
             </Modal.Footer>
         </Modal>
     );
-}
-
-function csharpSnippet(serverUrl: string): string {
-    return `// Load an X.509 certificate
-X509Certificate2 clientCertificate = new X509Certificate2("${pfxPathPlaceholder}");
-
-using (IDocumentStore store = new DocumentStore()
-{
-    // Set the 'Certificate' property with your client certificate
-    Certificate = clientCertificate,
-    Database = "${dbNamePlaceholder}",
-    Urls = new[] {"${serverUrl}"}
-}.Initialize())
-{
-    // Do your work here
-}`;
-}
-
-function javaSnippet(serverUrl: string): string {
-    return `// Load an X.509 certificate into a KeyStore
-KeyStore clientStore = KeyStore.getInstance("PKCS12");
-clientStore.load(new FileInputStream("${pfxPathPlaceholder}"), "your_password".toCharArray());
-
-try (IDocumentStore store = new DocumentStore(
-        new String[]{"${serverUrl}"},
-        "${dbNamePlaceholder}",
-        new KeyStoreOptions(clientStore, "your_password"))) {
-    store.initialize();
-    // Do your work here
-}`;
-}
-
-function nodejsSnippet(serverUrl: string): string {
-    return `import * as fs from "fs";
-import { DocumentStore } from "ravendb";
-
-const authOptions = {
-    certificate: fs.readFileSync("${pfxPathPlaceholder}"),
-    type: "pfx",
-    password: "your_password"
-};
-
-const store = new DocumentStore(["${serverUrl}"], "${dbNamePlaceholder}", authOptions);
-store.initialize();
-// Do your work here`;
-}
-
-function pythonSnippet(serverUrl: string): string {
-    return `from ravendb import DocumentStore
-
-store = DocumentStore(
-    urls=["${serverUrl}"],
-    database="${dbNamePlaceholder}",
-)
-store.certificate_pem_path = "path_to_your_cert.pem"
-store.initialize()
-# Do your work here`;
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.tsx
@@ -1,0 +1,317 @@
+import { useState } from "react";
+import Modal from "components/common/Modal";
+import Tab from "react-bootstrap/Tab";
+import Nav from "react-bootstrap/Nav";
+import Button from "react-bootstrap/Button";
+import { Icon } from "components/common/Icon";
+import RichAlert from "components/common/RichAlert";
+import { NumberedList, NumberedListItem } from "components/common/NumberedList";
+import Code from "components/common/Code";
+import { useRavenLink } from "components/hooks/useRavenLink";
+import { useAppDispatch, useAppSelector } from "components/store";
+import { certificatesActions } from "components/pages/resources/manageServer/certificates/store/certificatesSlice";
+import { clusterSelectors } from "components/common/shell/clusterSlice";
+import genUtils from "common/generalUtils";
+
+const serverUrlPlaceholder = "https://your_RavenDB_server_URL";
+const pfxPathPlaceholder = "C:\\path_to_your_pfx_file\\cert.pfx";
+const dbNamePlaceholder = "your_database_name";
+
+type ClientLanguage = "csharp" | "java" | "nodejs" | "python";
+
+export default function CertificatesRenewedModal() {
+    const dispatch = useAppDispatch();
+    const docsLink = useRavenLink({ hash: "RSFSL5" });
+
+    const localNode = useAppSelector(clusterSelectors.localNode);
+    const serverUrl = localNode?.serverUrl || serverUrlPlaceholder;
+
+    const [accessTab, setAccessTab] = useState<"browser" | "api">("browser");
+    const [browserTab, setBrowserTab] = useState<Browser>(genUtils.getBrowser());
+    const [clientTab, setClientTab] = useState<ClientLanguage>("csharp");
+
+    const close = () => dispatch(certificatesActions.isRenewedModalOpenToggled());
+
+    return (
+        <Modal show size="lg" centered contentClassName="modal-border bulge-primary">
+            <Modal.Header onCloseClick={close}>
+                <Icon icon="certificate" color="primary" addon="check" className="fs-2" />
+                <span className="lead">Your new certificate is ready</span>
+            </Modal.Header>
+            <Modal.Body>
+                <p className="mb-4">
+                    Your new certificate has been created and downloaded to your computer. To begin using it, you need
+                    to install it or move it to a secure location for your application. Choose the option below that
+                    matches how you&apos;ll connect to RavenDB.
+                </p>
+
+                <Tab.Container activeKey={accessTab} onSelect={(key: "browser" | "api") => setAccessTab(key)}>
+                    <Nav variant="pills" className="mb-4">
+                        <Nav.Item className="flex-grow">
+                            <Nav.Link eventKey="browser">
+                                <Icon icon="global" />
+                                Browser Access
+                            </Nav.Link>
+                        </Nav.Item>
+                        <Nav.Item className="flex-grow">
+                            <Nav.Link eventKey="api">
+                                <Icon icon="code" />
+                                Application Access (API)
+                            </Nav.Link>
+                        </Nav.Item>
+                    </Nav>
+
+                    <Tab.Content>
+                        <Tab.Pane eventKey="browser">
+                            <NumberedList>
+                                <NumberedListItem stepKey={1}>
+                                    <h4 className="mb-1">Locate the certificate file</h4>
+                                    <p className="mb-0">
+                                        Find the downloaded <code>.pfx</code> file in your computer&apos;s
+                                        &quot;Downloads&quot; folder. This file is a secure, password-protected package
+                                        containing your new digital ID.
+                                    </p>
+                                </NumberedListItem>
+                                <NumberedListItem stepKey={2}>
+                                    <h4 className="mb-2">Install the certificate in your browser</h4>
+                                    <Tab.Container
+                                        activeKey={browserTab}
+                                        onSelect={(key: Browser) => setBrowserTab(key)}
+                                    >
+                                        <Nav className="mb-2">
+                                            <Nav.Item className="flex-grow">
+                                                <Nav.Link eventKey="Chrome">
+                                                    <Icon icon="chrome" />
+                                                    Chrome
+                                                </Nav.Link>
+                                            </Nav.Item>
+                                            <Nav.Item className="flex-grow">
+                                                <Nav.Link eventKey="Firefox">
+                                                    <Icon icon="firefox" />
+                                                    Firefox
+                                                </Nav.Link>
+                                            </Nav.Item>
+                                            <Nav.Item className="flex-grow">
+                                                <Nav.Link eventKey="Safari">
+                                                    <Icon icon="safari" />
+                                                    Safari
+                                                </Nav.Link>
+                                            </Nav.Item>
+                                            <Nav.Item className="flex-grow">
+                                                <Nav.Link eventKey="Other">
+                                                    <Icon icon="global" />
+                                                    Other
+                                                </Nav.Link>
+                                            </Nav.Item>
+                                        </Nav>
+                                        <Tab.Content className="p-2 text-break">
+                                            <Tab.Pane eventKey="Chrome">
+                                                Chrome (or any Chromium-based browser) will let you select this
+                                                certificate automatically. You may need to restart all instances of
+                                                Chrome to make sure nothing is cached.
+                                            </Tab.Pane>
+                                            <Tab.Pane eventKey="Firefox">
+                                                Firefox uses its own internal certificate store. After importing the
+                                                certificate through Firefox settings, it will be available for use
+                                                automatically. You may need to restart Firefox to ensure the new
+                                                certificate is recognized properly.
+                                            </Tab.Pane>
+                                            <Tab.Pane eventKey="Safari">
+                                                Safari uses the macOS Keychain to manage certificates. Once the
+                                                certificate is imported and marked as trusted in Keychain Access, Safari
+                                                will select it automatically when needed. Restarting Safari or the system
+                                                may help if it doesn&apos;t appear right away.
+                                            </Tab.Pane>
+                                            <Tab.Pane eventKey="Other">
+                                                Browsers that are not Chromium-based and don&apos;t use the system
+                                                certificate store typically require manual certificate import through
+                                                their own settings or preferences. Behavior may vary, and restarting the
+                                                browser is often recommended to ensure the certificate is applied.
+                                            </Tab.Pane>
+                                        </Tab.Content>
+                                    </Tab.Container>
+                                </NumberedListItem>
+                                <NumberedListItem stepKey={3}>
+                                    <h4 className="mb-1">Reconnect to Studio</h4>
+                                    <p className="mb-1">
+                                        To activate the new certificate, you may need to restart your browser.
+                                    </p>
+                                    <ul className="mb-0">
+                                        <li>Close all browser windows completely.</li>
+                                        <li>
+                                            Reopen the Studio URL. Your browser should now prompt you to select the new
+                                            certificate you just installed.
+                                        </li>
+                                    </ul>
+                                </NumberedListItem>
+                            </NumberedList>
+                            <RichAlert variant="info">
+                                If you&apos;re not prompted to choose a certificate, try using an Incognito/Private
+                                window.
+                            </RichAlert>
+                        </Tab.Pane>
+
+                        <Tab.Pane eventKey="api">
+                            <NumberedList>
+                                <NumberedListItem stepKey={1}>
+                                    <h4 className="mb-1">Locate and secure the certificate file</h4>
+                                    <p className="mb-0">
+                                        Find the automatically downloaded <code>.pfx</code> file in your computer&apos;s
+                                        &quot;Downloads&quot; folder and move it to a secure location accessible by your
+                                        application (e.g., a protected folder on your server or a cloud secrets vault).
+                                    </p>
+                                </NumberedListItem>
+                                <NumberedListItem stepKey={2}>
+                                    <h4 className="mb-2">Configure your RavenDB client code</h4>
+                                    <p className="mb-2">
+                                        Update your application&apos;s code to point the <code>DocumentStore</code>{" "}
+                                        initialization to the new certificate&apos;s file path and password.
+                                    </p>
+                                    <Tab.Container
+                                        activeKey={clientTab}
+                                        onSelect={(key: ClientLanguage) => setClientTab(key)}
+                                    >
+                                        <Nav className="mb-2">
+                                            <Nav.Item className="flex-grow">
+                                                <Nav.Link eventKey="csharp">
+                                                    <Icon icon="csharp" />
+                                                    C#
+                                                </Nav.Link>
+                                            </Nav.Item>
+                                            <Nav.Item className="flex-grow">
+                                                <Nav.Link eventKey="java">
+                                                    <Icon icon="code" />
+                                                    Java
+                                                </Nav.Link>
+                                            </Nav.Item>
+                                            <Nav.Item className="flex-grow">
+                                                <Nav.Link eventKey="nodejs">
+                                                    <Icon icon="node" />
+                                                    Node.js
+                                                </Nav.Link>
+                                            </Nav.Item>
+                                            <Nav.Item className="flex-grow">
+                                                <Nav.Link eventKey="python">
+                                                    <Icon icon="code" />
+                                                    Python
+                                                </Nav.Link>
+                                            </Nav.Item>
+                                        </Nav>
+                                        <Tab.Content className="p-2">
+                                            <Tab.Pane eventKey="csharp">
+                                                <Code
+                                                    language="csharp"
+                                                    code={csharpSnippet(serverUrl)}
+                                                    elementToCopy={csharpSnippet(serverUrl)}
+                                                />
+                                            </Tab.Pane>
+                                            <Tab.Pane eventKey="java">
+                                                <Code
+                                                    language="plaintext"
+                                                    code={javaSnippet(serverUrl)}
+                                                    elementToCopy={javaSnippet(serverUrl)}
+                                                />
+                                            </Tab.Pane>
+                                            <Tab.Pane eventKey="nodejs">
+                                                <Code
+                                                    language="javascript"
+                                                    code={nodejsSnippet(serverUrl)}
+                                                    elementToCopy={nodejsSnippet(serverUrl)}
+                                                />
+                                            </Tab.Pane>
+                                            <Tab.Pane eventKey="python">
+                                                <Code
+                                                    language="plaintext"
+                                                    code={pythonSnippet(serverUrl)}
+                                                    elementToCopy={pythonSnippet(serverUrl)}
+                                                />
+                                            </Tab.Pane>
+                                        </Tab.Content>
+                                    </Tab.Container>
+                                    <p className="mt-2 mb-0">
+                                        For detailed code examples and more information, please refer to the official{" "}
+                                        <a href={docsLink} target="_blank">
+                                            Documentation <Icon icon="newtab" margin="m-0" />
+                                        </a>
+                                        .
+                                    </p>
+                                </NumberedListItem>
+                                <NumberedListItem stepKey={3}>
+                                    <h4 className="mb-1">Restart your application</h4>
+                                    <p className="mb-0">
+                                        Your application must be restarted to load the new certificate file into memory.
+                                    </p>
+                                </NumberedListItem>
+                            </NumberedList>
+                        </Tab.Pane>
+                    </Tab.Content>
+                </Tab.Container>
+            </Modal.Body>
+            <Modal.Footer className="hstack justify-content-between">
+                <a href={docsLink} target="_blank" className="btn btn-info rounded-pill">
+                    See documentation <Icon icon="newtab" margin="m-0" />
+                </a>
+                <Button variant="link" onClick={close} className="link-muted">
+                    Close
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}
+
+function csharpSnippet(serverUrl: string): string {
+    return `// Load an X.509 certificate
+X509Certificate2 clientCertificate = new X509Certificate2("${pfxPathPlaceholder}");
+
+using (IDocumentStore store = new DocumentStore()
+{
+    // Set the 'Certificate' property with your client certificate
+    Certificate = clientCertificate,
+    Database = "${dbNamePlaceholder}",
+    Urls = new[] {"${serverUrl}"}
+}.Initialize())
+{
+    // Do your work here
+}`;
+}
+
+function javaSnippet(serverUrl: string): string {
+    return `// Load an X.509 certificate into a KeyStore
+KeyStore clientStore = KeyStore.getInstance("PKCS12");
+clientStore.load(new FileInputStream("${pfxPathPlaceholder}"), "your_password".toCharArray());
+
+try (IDocumentStore store = new DocumentStore(
+        new String[]{"${serverUrl}"},
+        "${dbNamePlaceholder}",
+        new KeyStoreOptions(clientStore, "your_password"))) {
+    store.initialize();
+    // Do your work here
+}`;
+}
+
+function nodejsSnippet(serverUrl: string): string {
+    return `const fs = require("fs");
+const { DocumentStore } = require("ravendb");
+
+const authOptions = {
+    certificate: fs.readFileSync("${pfxPathPlaceholder}"),
+    type: "pfx",
+    password: "your_password"
+};
+
+const store = new DocumentStore(["${serverUrl}"], "${dbNamePlaceholder}", authOptions);
+store.initialize();
+// Do your work here`;
+}
+
+function pythonSnippet(serverUrl: string): string {
+    return `from ravendb import DocumentStore
+
+store = DocumentStore(
+    urls=["${serverUrl}"],
+    database="${dbNamePlaceholder}",
+)
+store.certificate_pem_path = "path_to_your_cert.pem"
+store.initialize()
+# Do your work here`;
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModal.tsx
@@ -12,6 +12,7 @@ import { useAppDispatch, useAppSelector } from "components/store";
 import { certificatesActions } from "components/pages/resources/manageServer/certificates/store/certificatesSlice";
 import { clusterSelectors } from "components/common/shell/clusterSlice";
 import genUtils from "common/generalUtils";
+import "./CertificatesRenewedModal.scss";
 
 const serverUrlPlaceholder = "https://your_RavenDB_server_URL";
 const pfxPathPlaceholder = "C:\\path_to_your_pfx_file\\cert.pfx";
@@ -33,7 +34,7 @@ export default function CertificatesRenewedModal() {
     const close = () => dispatch(certificatesActions.isRenewedModalOpenToggled());
 
     return (
-        <Modal show size="lg" centered contentClassName="modal-border bulge-primary">
+        <Modal scrollable show size="lg" centered contentClassName="modal-border bulge-primary certificates-renewed-modal">
             <Modal.Header onCloseClick={close}>
                 <Icon icon="certificate" color="primary" addon="check" className="fs-2" />
                 <span className="lead">Your new certificate is ready</span>
@@ -46,20 +47,22 @@ export default function CertificatesRenewedModal() {
                 </p>
 
                 <Tab.Container activeKey={accessTab} onSelect={(key: "browser" | "api") => setAccessTab(key)}>
-                    <Nav variant="pills" className="mb-4">
-                        <Nav.Item className="flex-grow">
-                            <Nav.Link eventKey="browser">
-                                <Icon icon="global" />
-                                Browser Access
-                            </Nav.Link>
-                        </Nav.Item>
-                        <Nav.Item className="flex-grow">
-                            <Nav.Link eventKey="api">
-                                <Icon icon="code" />
-                                Application Access (API)
-                            </Nav.Link>
-                        </Nav.Item>
-                    </Nav>
+                    <div className="access-tab-container mb-4">
+                        <Nav>
+                            <Nav.Item className="flex-grow mb-0">
+                                <Nav.Link eventKey="browser" className="">
+                                    <Icon icon="global" />
+                                    Browser Access
+                                </Nav.Link>
+                            </Nav.Item>
+                            <Nav.Item className="flex-grow mb-0">
+                                <Nav.Link eventKey="api" className="">
+                                    <Icon icon="code" />
+                                    Application Access (API)
+                                </Nav.Link>
+                            </Nav.Item>
+                        </Nav>
+                    </div>
 
                     <Tab.Content>
                         <Tab.Pane eventKey="browser">
@@ -78,57 +81,60 @@ export default function CertificatesRenewedModal() {
                                         activeKey={browserTab}
                                         onSelect={(key: Browser) => setBrowserTab(key)}
                                     >
-                                        <Nav className="mb-2">
-                                            <Nav.Item className="flex-grow">
-                                                <Nav.Link eventKey="Chrome">
-                                                    <Icon icon="chrome" />
-                                                    Chrome
-                                                </Nav.Link>
-                                            </Nav.Item>
-                                            <Nav.Item className="flex-grow">
-                                                <Nav.Link eventKey="Firefox">
-                                                    <Icon icon="firefox" />
-                                                    Firefox
-                                                </Nav.Link>
-                                            </Nav.Item>
-                                            <Nav.Item className="flex-grow">
-                                                <Nav.Link eventKey="Safari">
-                                                    <Icon icon="safari" />
-                                                    Safari
-                                                </Nav.Link>
-                                            </Nav.Item>
-                                            <Nav.Item className="flex-grow">
-                                                <Nav.Link eventKey="Other">
-                                                    <Icon icon="global" />
-                                                    Other
-                                                </Nav.Link>
-                                            </Nav.Item>
-                                        </Nav>
-                                        <Tab.Content className="p-2 text-break">
-                                            <Tab.Pane eventKey="Chrome">
-                                                Chrome (or any Chromium-based browser) will let you select this
-                                                certificate automatically. You may need to restart all instances of
-                                                Chrome to make sure nothing is cached.
-                                            </Tab.Pane>
-                                            <Tab.Pane eventKey="Firefox">
-                                                Firefox uses its own internal certificate store. After importing the
-                                                certificate through Firefox settings, it will be available for use
-                                                automatically. You may need to restart Firefox to ensure the new
-                                                certificate is recognized properly.
-                                            </Tab.Pane>
-                                            <Tab.Pane eventKey="Safari">
-                                                Safari uses the macOS Keychain to manage certificates. Once the
-                                                certificate is imported and marked as trusted in Keychain Access, Safari
-                                                will select it automatically when needed. Restarting Safari or the system
-                                                may help if it doesn&apos;t appear right away.
-                                            </Tab.Pane>
-                                            <Tab.Pane eventKey="Other">
-                                                Browsers that are not Chromium-based and don&apos;t use the system
-                                                certificate store typically require manual certificate import through
-                                                their own settings or preferences. Behavior may vary, and restarting the
-                                                browser is often recommended to ensure the certificate is applied.
-                                            </Tab.Pane>
-                                        </Tab.Content>
+                                        <div className="segmented-tab-container">
+                                            <Nav>
+                                                <Nav.Item className="flex-grow">
+                                                    <Nav.Link eventKey="Chrome">
+                                                        <Icon icon="chrome" />
+                                                        Chrome
+                                                    </Nav.Link>
+                                                </Nav.Item>
+                                                <Nav.Item className="flex-grow">
+                                                    <Nav.Link eventKey="Firefox">
+                                                        <Icon icon="firefox" />
+                                                        Firefox
+                                                    </Nav.Link>
+                                                </Nav.Item>
+                                                <Nav.Item className="flex-grow">
+                                                    <Nav.Link eventKey="Safari">
+                                                        <Icon icon="safari" />
+                                                        Safari
+                                                    </Nav.Link>
+                                                </Nav.Item>
+                                                <Nav.Item className="flex-grow">
+                                                    <Nav.Link eventKey="Other">
+                                                        <Icon icon="global" />
+                                                        Other
+                                                    </Nav.Link>
+                                                </Nav.Item>
+                                            </Nav>
+                                            <Tab.Content className="p-2 text-break">
+                                                <Tab.Pane eventKey="Chrome">
+                                                    Chrome (or any Chromium-based browser) will let you select this
+                                                    certificate automatically. You may need to restart all instances of
+                                                    Chrome to make sure nothing is cached.
+                                                </Tab.Pane>
+                                                <Tab.Pane eventKey="Firefox">
+                                                    Firefox uses its own internal certificate store. After importing the
+                                                    certificate through Firefox settings, it will be available for use
+                                                    automatically. You may need to restart Firefox to ensure the new
+                                                    certificate is recognized properly.
+                                                </Tab.Pane>
+                                                <Tab.Pane eventKey="Safari">
+                                                    Safari uses the macOS Keychain to manage certificates. Once the
+                                                    certificate is imported and marked as trusted in Keychain Access,
+                                                    Safari will select it automatically when needed. Restarting Safari or
+                                                    the system may help if it doesn&apos;t appear right away.
+                                                </Tab.Pane>
+                                                <Tab.Pane eventKey="Other">
+                                                    Browsers that are not Chromium-based and don&apos;t use the system
+                                                    certificate store typically require manual certificate import through
+                                                    their own settings or preferences. Behavior may vary, and restarting
+                                                    the browser is often recommended to ensure the certificate is
+                                                    applied.
+                                                </Tab.Pane>
+                                            </Tab.Content>
+                                        </div>
                                     </Tab.Container>
                                 </NumberedListItem>
                                 <NumberedListItem stepKey={3}>
@@ -171,62 +177,64 @@ export default function CertificatesRenewedModal() {
                                         activeKey={clientTab}
                                         onSelect={(key: ClientLanguage) => setClientTab(key)}
                                     >
-                                        <Nav className="mb-2">
-                                            <Nav.Item className="flex-grow">
-                                                <Nav.Link eventKey="csharp">
-                                                    <Icon icon="csharp" />
-                                                    C#
-                                                </Nav.Link>
-                                            </Nav.Item>
-                                            <Nav.Item className="flex-grow">
-                                                <Nav.Link eventKey="java">
-                                                    <Icon icon="code" />
-                                                    Java
-                                                </Nav.Link>
-                                            </Nav.Item>
-                                            <Nav.Item className="flex-grow">
-                                                <Nav.Link eventKey="nodejs">
-                                                    <Icon icon="node" />
-                                                    Node.js
-                                                </Nav.Link>
-                                            </Nav.Item>
-                                            <Nav.Item className="flex-grow">
-                                                <Nav.Link eventKey="python">
-                                                    <Icon icon="code" />
-                                                    Python
-                                                </Nav.Link>
-                                            </Nav.Item>
-                                        </Nav>
-                                        <Tab.Content className="p-2">
-                                            <Tab.Pane eventKey="csharp">
-                                                <Code
-                                                    language="csharp"
-                                                    code={csharpSnippet(serverUrl)}
-                                                    elementToCopy={csharpSnippet(serverUrl)}
-                                                />
-                                            </Tab.Pane>
-                                            <Tab.Pane eventKey="java">
-                                                <Code
-                                                    language="plaintext"
-                                                    code={javaSnippet(serverUrl)}
-                                                    elementToCopy={javaSnippet(serverUrl)}
-                                                />
-                                            </Tab.Pane>
-                                            <Tab.Pane eventKey="nodejs">
-                                                <Code
-                                                    language="javascript"
-                                                    code={nodejsSnippet(serverUrl)}
-                                                    elementToCopy={nodejsSnippet(serverUrl)}
-                                                />
-                                            </Tab.Pane>
-                                            <Tab.Pane eventKey="python">
-                                                <Code
-                                                    language="plaintext"
-                                                    code={pythonSnippet(serverUrl)}
-                                                    elementToCopy={pythonSnippet(serverUrl)}
-                                                />
-                                            </Tab.Pane>
-                                        </Tab.Content>
+                                        <div className="segmented-tab-container">
+                                            <Nav>
+                                                <Nav.Item className="flex-grow">
+                                                    <Nav.Link eventKey="csharp">
+                                                        <Icon icon="csharp" />
+                                                        C#
+                                                    </Nav.Link>
+                                                </Nav.Item>
+                                                <Nav.Item className="flex-grow">
+                                                    <Nav.Link eventKey="java">
+                                                        <Icon icon="code" />
+                                                        Java
+                                                    </Nav.Link>
+                                                </Nav.Item>
+                                                <Nav.Item className="flex-grow">
+                                                    <Nav.Link eventKey="nodejs">
+                                                        <Icon icon="node" />
+                                                        Node.js
+                                                    </Nav.Link>
+                                                </Nav.Item>
+                                                <Nav.Item className="flex-grow">
+                                                    <Nav.Link eventKey="python">
+                                                        <Icon icon="code" />
+                                                        Python
+                                                    </Nav.Link>
+                                                </Nav.Item>
+                                            </Nav>
+                                            <Tab.Content className="p-2">
+                                                <Tab.Pane eventKey="csharp">
+                                                    <Code
+                                                        language="csharp"
+                                                        code={csharpSnippet(serverUrl)}
+                                                        elementToCopy={csharpSnippet(serverUrl)}
+                                                    />
+                                                </Tab.Pane>
+                                                <Tab.Pane eventKey="java">
+                                                    <Code
+                                                        language="java"
+                                                        code={javaSnippet(serverUrl)}
+                                                        elementToCopy={javaSnippet(serverUrl)}
+                                                    />
+                                                </Tab.Pane>
+                                                <Tab.Pane eventKey="nodejs">
+                                                    <Code
+                                                        language="javascript"
+                                                        code={nodejsSnippet(serverUrl)}
+                                                        elementToCopy={nodejsSnippet(serverUrl)}
+                                                    />
+                                                </Tab.Pane>
+                                                <Tab.Pane eventKey="python">
+                                                    <Code
+                                                        language="python"
+                                                        code={pythonSnippet(serverUrl)}
+                                                        elementToCopy={pythonSnippet(serverUrl)}
+                                                    />
+                                                </Tab.Pane>
+                                            </Tab.Content>
+                                        </div>
                                     </Tab.Container>
                                     <p className="mt-2 mb-0">
                                         For detailed code examples and more information, please refer to the official{" "}
@@ -247,7 +255,7 @@ export default function CertificatesRenewedModal() {
                     </Tab.Content>
                 </Tab.Container>
             </Modal.Body>
-            <Modal.Footer className="hstack justify-content-between">
+            <Modal.Footer className="hstack justify-content-between my-2">
                 <a href={docsLink} target="_blank" className="btn btn-info rounded-pill">
                     See documentation <Icon icon="newtab" margin="m-0" />
                 </a>
@@ -290,8 +298,8 @@ try (IDocumentStore store = new DocumentStore(
 }
 
 function nodejsSnippet(serverUrl: string): string {
-    return `const fs = require("fs");
-const { DocumentStore } = require("ravendb");
+    return `import * as fs from "fs";
+import { DocumentStore } from "ravendb";
 
 const authOptions = {
     certificate: fs.readFileSync("${pfxPathPlaceholder}"),

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModalApiAccess.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModalApiAccess.tsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+import Tab from "react-bootstrap/Tab";
+import Nav from "react-bootstrap/Nav";
+import { Icon } from "components/common/Icon";
+import { NumberedList, NumberedListItem } from "components/common/NumberedList";
+import Code, { CodeLanguage } from "components/common/Code";
+import { useRavenLink } from "components/hooks/useRavenLink";
+import { useAppSelector } from "components/store";
+import { clusterSelectors } from "components/common/shell/clusterSlice";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+
+type ClientLanguage = Extract<CodeLanguage, "csharp" | "nodejs" | "python" | "java">;
+
+const serverUrlPlaceholder = "https://your_RavenDB_server_URL";
+const pfxPathPlaceholder = "C:\\path_to_your_pfx_file\\cert.pfx";
+const dbNamePlaceholder = "your_database_name";
+
+export default function CertificatesRenewedModalApiAccess() {
+    const docsLink = useRavenLink({ hash: "RSFSL5" });
+
+    const dbName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const localNode = useAppSelector(clusterSelectors.localNode);
+
+    const serverUrl = localNode?.serverUrl ?? serverUrlPlaceholder;
+    const databaseName = dbName ?? dbNamePlaceholder;
+
+    const [clientTab, setClientTab] = useState<ClientLanguage>("csharp");
+
+    return (
+        <Tab.Pane eventKey="api">
+            <NumberedList>
+                <NumberedListItem stepKey={1}>
+                    <h4 className="mb-1">Locate and secure the certificate file</h4>
+                    <p className="mb-0">
+                        Find the automatically downloaded <code>.pfx</code> file in your computer&apos;s
+                        &quot;Downloads&quot; folder and move it to a secure location accessible by your application
+                        (e.g., a protected folder on your server or a cloud secrets vault).
+                    </p>
+                </NumberedListItem>
+                <NumberedListItem stepKey={2}>
+                    <h4 className="mb-2">Configure your RavenDB client code</h4>
+                    <p className="mb-2">
+                        Update your application&apos;s code to point the <code>DocumentStore</code> initialization to
+                        the new certificate&apos;s file path and password.
+                    </p>
+                    <Tab.Container activeKey={clientTab} onSelect={(key: ClientLanguage) => setClientTab(key)}>
+                        <div className="segmented-tab-container">
+                            <Nav>
+                                <Nav.Item className="flex-grow">
+                                    <Nav.Link eventKey="csharp">C#</Nav.Link>
+                                </Nav.Item>
+                                <Nav.Item className="flex-grow">
+                                    <Nav.Link eventKey="java">Java</Nav.Link>
+                                </Nav.Item>
+                                <Nav.Item className="flex-grow">
+                                    <Nav.Link eventKey="nodejs">Node.js</Nav.Link>
+                                </Nav.Item>
+                                <Nav.Item className="flex-grow">
+                                    <Nav.Link eventKey="python">Python</Nav.Link>
+                                </Nav.Item>
+                            </Nav>
+                            <Tab.Content className="p-2">
+                                <Tab.Pane eventKey="csharp">
+                                    <Code
+                                        language="csharp"
+                                        code={csharpSnippet(serverUrl, databaseName)}
+                                        elementToCopy={csharpSnippet(serverUrl, databaseName)}
+                                    />
+                                </Tab.Pane>
+                                <Tab.Pane eventKey="java">
+                                    <Code
+                                        language="java"
+                                        code={javaSnippet(serverUrl, databaseName)}
+                                        elementToCopy={javaSnippet(serverUrl, databaseName)}
+                                    />
+                                </Tab.Pane>
+                                <Tab.Pane eventKey="nodejs">
+                                    <Code
+                                        language="javascript"
+                                        code={nodejsSnippet(serverUrl, databaseName)}
+                                        elementToCopy={nodejsSnippet(serverUrl, databaseName)}
+                                    />
+                                </Tab.Pane>
+                                <Tab.Pane eventKey="python">
+                                    <Code
+                                        language="python"
+                                        code={pythonSnippet(serverUrl, databaseName)}
+                                        elementToCopy={pythonSnippet(serverUrl, databaseName)}
+                                    />
+                                </Tab.Pane>
+                            </Tab.Content>
+                        </div>
+                    </Tab.Container>
+                    <p className="mt-2 mb-0">
+                        For detailed code examples and more information, please refer to the official{" "}
+                        <a href={docsLink} target="_blank">
+                            Documentation <Icon icon="newtab" margin="m-0" />
+                        </a>
+                        .
+                    </p>
+                </NumberedListItem>
+                <NumberedListItem stepKey={3}>
+                    <h4 className="mb-1">Restart your application</h4>
+                    <p className="mb-0">
+                        Your application must be restarted to load the new certificate file into memory.
+                    </p>
+                </NumberedListItem>
+            </NumberedList>
+        </Tab.Pane>
+    );
+}
+
+function csharpSnippet(serverUrl: string, databaseName: string): string {
+    return `// Load an X.509 certificate
+X509Certificate2 clientCertificate = new X509Certificate2("${pfxPathPlaceholder}");
+
+using (IDocumentStore store = new DocumentStore()
+{
+    // Set the 'Certificate' property with your client certificate
+    Certificate = clientCertificate,
+    Database = "${databaseName}",
+    Urls = new[] {"${serverUrl}"}
+}.Initialize())
+{
+    // Do your work here
+}`;
+}
+
+function javaSnippet(serverUrl: string, databaseName: string): string {
+    return `// Load an X.509 certificate into a KeyStore
+KeyStore clientStore = KeyStore.getInstance("PKCS12");
+clientStore.load(new FileInputStream("${pfxPathPlaceholder}"), "your_password".toCharArray());
+
+try (IDocumentStore store = new DocumentStore(
+        new String[]{"${serverUrl}"},
+        "${databaseName}",
+        new KeyStoreOptions(clientStore, "your_password"))) {
+    store.initialize();
+    // Do your work here
+}`;
+}
+
+function nodejsSnippet(serverUrl: string, databaseName: string): string {
+    return `import * as fs from "fs";
+import { DocumentStore } from "ravendb";
+
+const authOptions = {
+    certificate: fs.readFileSync("${pfxPathPlaceholder}"),
+    type: "pfx",
+    password: "your_password"
+};
+
+const store = new DocumentStore(["${serverUrl}"], "${databaseName}", authOptions);
+store.initialize();
+// Do your work here`;
+}
+
+function pythonSnippet(serverUrl: string, databaseName: string): string {
+    return `from ravendb import DocumentStore
+
+store = DocumentStore(
+    urls=["${serverUrl}"],
+    database="${databaseName}",
+)
+store.certificate_pem_path = "path_to_your_cert.pem"
+store.initialize()
+# Do your work here`;
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModalApiAccess.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModalApiAccess.tsx
@@ -45,18 +45,26 @@ export default function CertificatesRenewedModalApiAccess() {
                     </p>
                     <Tab.Container activeKey={clientTab} onSelect={(key: ClientLanguage) => setClientTab(key)}>
                         <div className="segmented-tab-container">
-                            <Nav>
+                            <Nav className="flex-nowrap">
                                 <Nav.Item className="flex-grow">
-                                    <Nav.Link eventKey="csharp">C#</Nav.Link>
+                                    <Nav.Link eventKey="csharp" className="text-center">
+                                        C#
+                                    </Nav.Link>
                                 </Nav.Item>
                                 <Nav.Item className="flex-grow">
-                                    <Nav.Link eventKey="java">Java</Nav.Link>
+                                    <Nav.Link eventKey="java" className="text-center">
+                                        Java
+                                    </Nav.Link>
                                 </Nav.Item>
                                 <Nav.Item className="flex-grow">
-                                    <Nav.Link eventKey="nodejs">Node.js</Nav.Link>
+                                    <Nav.Link eventKey="nodejs" className="text-center">
+                                        Node.js
+                                    </Nav.Link>
                                 </Nav.Item>
                                 <Nav.Item className="flex-grow">
-                                    <Nav.Link eventKey="python">Python</Nav.Link>
+                                    <Nav.Link eventKey="python" className="text-center">
+                                        Python
+                                    </Nav.Link>
                                 </Nav.Item>
                             </Nav>
                             <Tab.Content className="p-2">

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModalBrowserAccess.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModalBrowserAccess.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import Tab from "react-bootstrap/Tab";
+import Nav from "react-bootstrap/Nav";
+import { Icon } from "components/common/Icon";
+import RichAlert from "components/common/RichAlert";
+import { NumberedList, NumberedListItem } from "components/common/NumberedList";
+import genUtils from "common/generalUtils";
+
+export default function CertificatesRenewedModalBrowserAccess() {
+    const [browserTab, setBrowserTab] = useState<Browser>(genUtils.getBrowser());
+
+    return (
+        <Tab.Pane eventKey="browser">
+            <NumberedList>
+                <NumberedListItem stepKey={1}>
+                    <h4 className="mb-1">Locate the certificate file</h4>
+                    <p className="mb-0">
+                        Find the downloaded <code>.pfx</code> file in your computer&apos;s &quot;Downloads&quot; folder.
+                        This file is a secure, password-protected package containing your new digital ID.
+                    </p>
+                </NumberedListItem>
+                <NumberedListItem stepKey={2}>
+                    <h4 className="mb-2">Install the certificate in your browser</h4>
+                    <Tab.Container activeKey={browserTab} onSelect={(key: Browser) => setBrowserTab(key)}>
+                        <div className="segmented-tab-container">
+                            <Nav>
+                                <Nav.Item className="flex-grow">
+                                    <Nav.Link eventKey="Chrome">
+                                        <Icon icon="chrome" />
+                                        Chrome
+                                    </Nav.Link>
+                                </Nav.Item>
+                                <Nav.Item className="flex-grow">
+                                    <Nav.Link eventKey="Firefox">
+                                        <Icon icon="firefox" />
+                                        Firefox
+                                    </Nav.Link>
+                                </Nav.Item>
+                                <Nav.Item className="flex-grow">
+                                    <Nav.Link eventKey="Safari">
+                                        <Icon icon="safari" />
+                                        Safari
+                                    </Nav.Link>
+                                </Nav.Item>
+                                <Nav.Item className="flex-grow">
+                                    <Nav.Link eventKey="Other">
+                                        <Icon icon="global" />
+                                        Other
+                                    </Nav.Link>
+                                </Nav.Item>
+                            </Nav>
+                            <Tab.Content className="p-2 text-break">
+                                <Tab.Pane eventKey="Chrome">
+                                    Chrome (or any Chromium-based browser) will let you select this certificate
+                                    automatically. You may need to restart all instances of Chrome to make sure nothing
+                                    is cached.
+                                </Tab.Pane>
+                                <Tab.Pane eventKey="Firefox">
+                                    Firefox uses its own internal certificate store. After importing the certificate
+                                    through Firefox settings, it will be available for use automatically. You may need
+                                    to restart Firefox to ensure the new certificate is recognized properly.
+                                </Tab.Pane>
+                                <Tab.Pane eventKey="Safari">
+                                    Safari uses the macOS Keychain to manage certificates. Once the certificate is
+                                    imported and marked as trusted in Keychain Access, Safari will select it
+                                    automatically when needed. Restarting Safari or the system may help if it
+                                    doesn&apos;t appear right away.
+                                </Tab.Pane>
+                                <Tab.Pane eventKey="Other">
+                                    Browsers that are not Chromium-based and don&apos;t use the system certificate store
+                                    typically require manual certificate import through their own settings or
+                                    preferences. Behavior may vary, and restarting the browser is often recommended to
+                                    ensure the certificate is applied.
+                                </Tab.Pane>
+                            </Tab.Content>
+                        </div>
+                    </Tab.Container>
+                </NumberedListItem>
+                <NumberedListItem stepKey={3}>
+                    <h4 className="mb-1">Reconnect to Studio</h4>
+                    <p className="mb-1">To activate the new certificate, you may need to restart your browser.</p>
+                    <ul className="mb-0">
+                        <li>Close all browser windows completely.</li>
+                        <li>
+                            Reopen the Studio URL. Your browser should now prompt you to select the new certificate you
+                            just installed.
+                        </li>
+                    </ul>
+                </NumberedListItem>
+            </NumberedList>
+            <RichAlert variant="info">
+                If you&apos;re not prompted to choose a certificate, try using an Incognito/Private window.
+            </RichAlert>
+        </Tab.Pane>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModalBrowserAccess.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesRenewedModalBrowserAccess.tsx
@@ -23,27 +23,27 @@ export default function CertificatesRenewedModalBrowserAccess() {
                     <h4 className="mb-2">Install the certificate in your browser</h4>
                     <Tab.Container activeKey={browserTab} onSelect={(key: Browser) => setBrowserTab(key)}>
                         <div className="segmented-tab-container">
-                            <Nav>
+                            <Nav className="flex-nowrap">
                                 <Nav.Item className="flex-grow">
-                                    <Nav.Link eventKey="Chrome">
+                                    <Nav.Link eventKey="Chrome" className="text-center">
                                         <Icon icon="chrome" />
                                         Chrome
                                     </Nav.Link>
                                 </Nav.Item>
                                 <Nav.Item className="flex-grow">
-                                    <Nav.Link eventKey="Firefox">
+                                    <Nav.Link eventKey="Firefox" className="text-center">
                                         <Icon icon="firefox" />
                                         Firefox
                                     </Nav.Link>
                                 </Nav.Item>
                                 <Nav.Item className="flex-grow">
-                                    <Nav.Link eventKey="Safari">
+                                    <Nav.Link eventKey="Safari" className="text-center">
                                         <Icon icon="safari" />
                                         Safari
                                     </Nav.Link>
                                 </Nav.Item>
                                 <Nav.Item className="flex-grow">
-                                    <Nav.Link eventKey="Other">
+                                    <Nav.Link eventKey="Other" className="text-center">
                                         <Icon icon="global" />
                                         Other
                                     </Nav.Link>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSlice.ts
@@ -29,6 +29,7 @@ interface InitialState {
     certificateToEdit: CertificateItem;
     certificateToClone: CertificateItem;
     isReplaceServerModalOpen: boolean;
+    isRenewedModalOpen: boolean;
 }
 
 const initialState: InitialState = {
@@ -51,6 +52,7 @@ const initialState: InitialState = {
     certificateToEdit: null,
     certificateToClone: null,
     isReplaceServerModalOpen: false,
+    isRenewedModalOpen: false,
 };
 
 export const certificatesSlice = createSlice({
@@ -92,6 +94,9 @@ export const certificatesSlice = createSlice({
         },
         isReplaceServerModalOpenToggled: (state) => {
             state.isReplaceServerModalOpen = !state.isReplaceServerModalOpen;
+        },
+        isRenewedModalOpenToggled: (state) => {
+            state.isRenewedModalOpen = !state.isRenewedModalOpen;
         },
     },
     extraReducers: (builder) => {

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
@@ -158,4 +158,5 @@ export const certificatesSelectors = {
     certificateToEdit: (state: RootState) => state.certificates.certificateToEdit,
     certificateToClone: (state: RootState) => state.certificates.certificateToClone,
     isReplaceServerModalOpen: (state: RootState) => state.certificates.isReplaceServerModalOpen,
+    isRenewedModalOpen: (state: RootState) => state.certificates.isRenewedModalOpen,
 };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24909

### Additional description
Flow:
Renew certificate in server certificate -> modal asking us if we're sure we want to renew -> the newly added modal is shown in the screenshots below.

<img width="1377" height="1222" alt="image" src="https://github.com/user-attachments/assets/96182aa6-8e02-4b50-8fc7-397dd96bc9c1" />

<img width="1488" height="1236" alt="image" src="https://github.com/user-attachments/assets/ecaa60bf-cd9f-4904-b735-0c4dbb85617c" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
