### PR TITLE
RavenDB-26961 LINQ translation: stop compiling a throwaway DynamicMethod per captured local

### DIFF
--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -386,14 +386,14 @@ namespace Raven.Client.Documents.Linq
                     return true;
                 case ExpressionType.MemberInit:
                     var memberInitExpression = ((MemberInitExpression)expression);
-                    value = Expression.Lambda(memberInitExpression).Compile().DynamicInvoke();
+                    value = Expression.Lambda(memberInitExpression).Compile(preferInterpretation: true).DynamicInvoke();
                     return true;
                 case ExpressionType.New:
                     value = GetNewExpressionValue(expression);
                     return true;
                 case ExpressionType.Lambda:
                     var lambda = ((LambdaExpression)expression);
-                    value = lambda.Compile().DynamicInvoke();
+                    value = lambda.Compile(preferInterpretation: true).DynamicInvoke();
                     return true;
                 case ExpressionType.Call:
                     if (expression is MethodCallExpression mce)
@@ -413,13 +413,13 @@ namespace Raven.Client.Documents.Linq
                             return true;
                         }
                     }
-                    value = Expression.Lambda(expression).Compile().DynamicInvoke();
+                    value = Expression.Lambda(expression).Compile(preferInterpretation: true).DynamicInvoke();
                     return true;
                 case ExpressionType.Convert:
                     var unaryExpression = (UnaryExpression)expression;
                     if (unaryExpression.Type.IsNullableType())
                         return GetValueFromExpressionWithoutConversion(unaryExpression.Operand, out value);
-                    value = Expression.Lambda(expression).Compile().DynamicInvoke();
+                    value = Expression.Lambda(expression).Compile(preferInterpretation: true).DynamicInvoke();
                     return true;
                 case ExpressionType.NewArrayInit:
                     var expressions = ((NewArrayExpression)expression).Expressions;
@@ -453,7 +453,7 @@ namespace Raven.Client.Documents.Linq
             {
                 if (mce.Arguments[index].NodeType == ExpressionType.Lambda)
                 {
-                    args[index] = ((LambdaExpression)mce.Arguments[index]).Compile();
+                    args[index] = ((LambdaExpression)mce.Arguments[index]).Compile(preferInterpretation: true);
                     continue;
                 }
                 if (GetValueFromExpressionWithoutConversion(mce.Arguments[index], out var value) == false)
@@ -512,10 +512,9 @@ namespace Raven.Client.Documents.Linq
             {
                 return property.GetValue(obj, null);
             }
-            if (memberInfo is FieldInfo)
+            if (memberInfo is FieldInfo field)
             {
-                var value = Expression.Lambda(memberExpression).Compile().DynamicInvoke();
-                return value;
+                return field.GetValue(obj);
             }
             throw new NotSupportedException("MemberInfo type not supported: " + memberInfo.GetType().FullName);
         }

--- a/src/Raven.Client/Documents/Queries/Facets/RangeFacet.cs
+++ b/src/Raven.Client/Documents/Queries/Facets/RangeFacet.cs
@@ -305,7 +305,7 @@ namespace Raven.Client.Documents.Queries.Facets
         {
             try
             {
-                var invoke = Expression.Lambda(expression).Compile();
+                var invoke = Expression.Lambda(expression).Compile(preferInterpretation: true);
                 return invoke.DynamicInvoke();
             }
             catch (Exception e)

--- a/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesQueryVisitor.cs
+++ b/src/Raven.Client/Documents/Queries/TimeSeries/TimeSeriesQueryVisitor.cs
@@ -139,7 +139,7 @@ namespace Raven.Client.Documents.Queries.TimeSeries
                     }
 
                     var typedLambda = Expression.Lambda<Action<ITimePeriodBuilder>>(methodCall, lambda.TailCall, lambda.Parameters);
-                    var compiledAction = typedLambda.Compile();
+                    var compiledAction = typedLambda.Compile(preferInterpretation: true);
                     timePeriod = GetGroupByArgsFromAction(compiledAction, out with, out groupByTag);
                     break;
                 }

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -2490,7 +2490,7 @@ namespace Raven.Client.Util
                                 }
                                 else if (mce.Arguments[0] is MethodCallExpression mce2)
                                 {
-                                    var value = Expression.Lambda(mce2).Compile().DynamicInvoke();
+                                    var value = Expression.Lambda(mce2).Compile(preferInterpretation: true).DynamicInvoke();
                                     switch (value)
                                     {
                                         case string s:

--- a/test/FastTests/Issues/RavenDB_26961.cs
+++ b/test/FastTests/Issues/RavenDB_26961.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq.Expressions;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_26961 : NoDisposalNeeded
+    {
+        public RavenDB_26961(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private enum Color
+        {
+            Red,
+            Blue
+        }
+
+        private class Item
+        {
+            public string Name { get; set; }
+            public Color Color { get; set; }
+            public int Kind { get; set; }
+            public DateTime When { get; set; }
+        }
+
+        private class Holder
+        {
+            public string Field;
+        }
+
+        // Captured locals are closure fields; extracting their value must read the field, not compile
+        // an expression per call. The probe is allocation, not JitInfo: JitInfo does not count the
+        // DynamicMethods that Expression.Compile emits.
+        [RavenFact(RavenTestCategory.Querying)]
+        public void Extracting_captured_locals_does_not_compile_an_expression_per_call()
+        {
+            var name = "joe";
+            var prefix = "j";
+            var color = Color.Blue;
+            var holder = new Holder { Field = "joe" };
+
+            var stringLocal = Rhs(x => x.Name == name);                 // FieldInfo on closure
+            var nestedLocal = Rhs(x => x.Name == holder.Field);         // recursive member access
+            var staticField = Rhs(x => x.When > DateTime.MinValue);     // static field, null target
+            var enumLocal = Rhs(x => x.Color == color);                 // Convert(enum field, int), target type is the enum
+            var enumCastToInt = Rhs(x => x.Kind == (int)color);         // Convert(enum field, int), target type is int
+            var methodCall = Rhs(x => x.Name == string.Concat(prefix, "oe")); // Call branch (method invocation)
+
+            var provider = new LinqPathProvider(new DocumentConventions());
+
+            Assert.Equal("joe", provider.GetValueFromExpression(stringLocal, typeof(string)));
+            Assert.Equal("joe", provider.GetValueFromExpression(nestedLocal, typeof(string)));
+            Assert.Equal(DateTime.MinValue, provider.GetValueFromExpression(staticField, typeof(DateTime)));
+            Assert.Equal("Blue", provider.GetValueFromExpression(enumLocal, typeof(Color)));
+            Assert.Equal("joe", provider.GetValueFromExpression(methodCall, typeof(string)));
+            // Convert(enum -> int) with an int target must yield the int, not the enum: a value-preserving
+            // shortcut that returned the operand would pass the enum==enum case but break this one.
+            Assert.Equal(1, provider.GetValueFromExpression(enumCastToInt, typeof(int)));
+
+            const int iterations = 10_000;
+
+            for (int i = 0; i < 50; i++) // warm up so first-call JIT is excluded from the measurement
+                Extract(provider, stringLocal, nestedLocal, staticField);
+
+            long before = GC.GetAllocatedBytesForCurrentThread();
+
+            for (int i = 0; i < iterations; i++)
+                Extract(provider, stringLocal, nestedLocal, staticField);
+
+            long perIteration = (GC.GetAllocatedBytesForCurrentThread() - before) / iterations;
+            Output.WriteLine($"{perIteration} bytes allocated per iteration (3 field extractions)");
+
+            // reflection reads allocate ~nothing; a per-call compile would allocate orders of magnitude more.
+            Assert.True(perIteration < 512, $"{perIteration} bytes/iteration - captured-local field extraction is still compiling expressions");
+        }
+
+        private static void Extract(LinqPathProvider provider, Expression s, Expression n, Expression d)
+        {
+            provider.GetValueFromExpression(s, typeof(string));
+            provider.GetValueFromExpression(n, typeof(string));
+            provider.GetValueFromExpression(d, typeof(DateTime));
+        }
+
+        private static Expression Rhs(Expression<Func<Item, bool>> predicate) => ((BinaryExpression)predicate.Body).Right;
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26961

### Additional description

Since the most normal behavior at the client side is different objects, there is no point in trying to compile. Therefore, the performance choice is to downgrade the compilation to either reflection or interpretation. Compilation serves no purpose. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
