### PR TITLE
RavenDB-26662 - Use the correct property order in the ctor

### DIFF
--- a/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
+++ b/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Commercial.WriteUsageMetering
 
     public sealed class WriteUsageApplicationSnapshot
     {
-        public WriteUsageApplicationSnapshot(string topologyId, string applicationName, string changeVector)
+        public WriteUsageApplicationSnapshot(string applicationName, string topologyId, string changeVector)
         {
             ApplicationName = applicationName;
             TopologyId = topologyId;

--- a/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
+++ b/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
@@ -38,12 +38,12 @@ namespace Raven.Server.Commercial.WriteUsageMetering
 
     public sealed class WriteUsageSnapshot
     {
-        public WriteUsageSnapshot(IReadOnlyList<WriteUsageApplicationSnapshot> databases)
+        public WriteUsageSnapshot(IReadOnlyList<WriteUsageApplicationSnapshot> applications)
         {
-            Databases = databases;
+            Applications = applications;
         }
 
-        public IReadOnlyList<WriteUsageApplicationSnapshot> Databases { get; }
+        public IReadOnlyList<WriteUsageApplicationSnapshot> Applications { get; }
     }
 
 

--- a/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReporter.cs
+++ b/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReporter.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Commercial.WriteUsageMetering
                     return; // no license to authenticate with; nothing to report
 
                 // Zero-etag entries are legitimate (e.g. brand-new databases) and are reported as-is.
-                var report = new WriteUsageReport(license.ToJson(), snapshot.Databases);
+                var report = new WriteUsageReport(license.ToJson(), snapshot.Applications);
                 var body = report.ToJson();
 
                 _serverStore.ForTestingPurposes?.OnWriteUsageReportReady?.Invoke(body);

--- a/test/SlowTests.Issues/Issues/RavenDB-26662.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26662.cs
@@ -62,7 +62,7 @@ namespace SlowTests.Issues
         }
 
         private static WriteUsageApplicationSnapshot SnapshotEntry(RavenServer leader, string topologyId)
-            => leader.ServerStore.Observer.LatestWriteUsageSnapshot?.Databases.SingleOrDefault(d => d.TopologyId == topologyId);
+            => leader.ServerStore.Observer.LatestWriteUsageSnapshot?.Applications.SingleOrDefault(d => d.TopologyId == topologyId);
 
         private static string Normalize(string changeVector)
             => string.IsNullOrEmpty(changeVector) ? string.Empty : ChangeVectorUtils.MergeVectors(changeVector);
@@ -215,7 +215,7 @@ namespace SlowTests.Issues
 
                 foreach (var topologyId in topologyIds)
                 {
-                    var entries = leader.ServerStore.Observer.LatestWriteUsageSnapshot.Databases
+                    var entries = leader.ServerStore.Observer.LatestWriteUsageSnapshot.Applications
                         .Where(d => d.TopologyId == topologyId)
                         .ToList();
 
@@ -265,7 +265,7 @@ namespace SlowTests.Issues
                 // Exactly one entry per shard topology, each with its own merged change vector.
                 foreach (var (shardTopologyId, expected) in expectedCvByShardTopologyId)
                 {
-                    var entries = leader.ServerStore.Observer.LatestWriteUsageSnapshot.Databases
+                    var entries = leader.ServerStore.Observer.LatestWriteUsageSnapshot.Applications
                         .Where(d => d.TopologyId == shardTopologyId)
                         .ToList();
 
@@ -276,7 +276,7 @@ namespace SlowTests.Issues
                 // The orchestrator topology is NOT a data-bearing topology => it must not produce an entry.
                 if (string.IsNullOrEmpty(orchestratorTopologyId) == false)
                 {
-                    Assert.DoesNotContain(leader.ServerStore.Observer.LatestWriteUsageSnapshot.Databases,
+                    Assert.DoesNotContain(leader.ServerStore.Observer.LatestWriteUsageSnapshot.Applications,
                         d => d.TopologyId == orchestratorTopologyId);
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26662

### Additional description

Use the correct property order in the ctor.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
