### PR TITLE
RavenDB-26981 CDC Sink PostgreSQL settings: Fix XML comment

### DIFF
--- a/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkPostgresSettings.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkPostgresSettings.cs
@@ -11,14 +11,14 @@ public class CdcSinkPostgresSettings : IDynamicJson
 {
     /// <summary>
     /// The PostgreSQL publication name used for logical replication.
-    /// If null on creation, auto-filled with an auto-generated name (rvn_cdc_p_{guid}).
+    /// If null on creation, auto-filled with an auto-generated name (rvn_cdc_p_{taskId}).
     /// Must be a valid PostgreSQL identifier (alphanumeric + underscore, max 63 chars).
     /// </summary>
     public string PublicationName { get; set; }
 
     /// <summary>
     /// The PostgreSQL logical replication slot name.
-    /// If null on creation, auto-filled with an auto-generated name (rvn_cdc_s_{guid}).
+    /// If null on creation, auto-filled with an auto-generated name (rvn_cdc_s_{taskId}).
     /// Must be a valid PostgreSQL identifier (alphanumeric + underscore, max 63 chars).
     /// </summary>
     public string SlotName { get; set; }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26981/CDC-Sink-PostgreSQL-settings-Fix-XML-comment

### Additional description
Fix xml comment in file: CdcSinkPostgresSettings.cs
`{guid}` → `{taskId}`

### Type of change
- [x] Bug fix => usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
