### PR TITLE
RavenDB-26797: SlowTests.Server.Documents.AI.AiConnectionTests.CanConnectGenAi(integration: AzureOpenAI)

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiConnectionTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiConnectionTests.cs
@@ -24,7 +24,7 @@ namespace SlowTests.Server.Documents.AI
         {
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenRetryTheory(RavenTestCategory.Ai, maxRetries: 3, delayBetweenRetriesMs: 10_000)]
         [ClassData(typeof(IntegrationDataType<GenAi>))]
         public void CanConnectGenAi(RavenAiIntegration integration)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26797/SlowTests.Server.Documents.AI.AiConnectionTests.CanConnectGenAiintegration-AzureOpenAI

### Additional description

Transient external-provider issue, not a product bug.
CanConnectGenAi(AzureOpenAI) makes a live call to the Azure OpenAI chatCompletions endpoint and asserts it succeeds within a 1 minute token. Occasionally that single request doesn't get a timely response, the provider is briefly slow or has a short outage ect' 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
