### PR TITLE
RavenDB-26916 Backend polish before release

### DIFF
--- a/src/Raven.AiAppliance.Web/src/api/generated/server-api.ts
+++ b/src/Raven.AiAppliance.Web/src/api/generated/server-api.ts
@@ -904,7 +904,6 @@ export interface components {
         AppUsageMetrics: {
             conversations: components["schemas"]["MetricCard"];
             tokens: components["schemas"]["MetricCard"];
-            cost: components["schemas"]["MetricCard"];
             cdcWrites: components["schemas"]["MetricCard"];
         };
         AppUsageResponse: {
@@ -1401,7 +1400,7 @@ export interface components {
             status: string;
         };
         SuggestCdcRequest: {
-            intentPrompt: string;
+            intentPrompt: null | string;
         };
         SuggestCdcResponse: {
             configuration: null | components["schemas"]["CdcSinkConfiguration"];
@@ -1441,8 +1440,6 @@ export interface components {
             avgTokens: number;
             /** Format: int64 */
             totalTokens: number;
-            /** Format: double */
-            cost: number;
         };
         TopTable: {
             name: string;

--- a/src/Raven.AiAppliance.Web/src/mocks/stats-mocks.ts
+++ b/src/Raven.AiAppliance.Web/src/mocks/stats-mocks.ts
@@ -36,7 +36,10 @@ export const statsMocks = {
     conversations: (conversations: ConversationDto[] = sampleConversations) =>
         apiHttp.get("/api/apps/{slug}/conversations", ({ response }) =>
             response(200).json(
-                conversations.map((conversation) => ({ ...conversation, lastExchange: [], transcript: null })),
+                conversations.map((conversation) => ({
+                    ...conversation,
+                    transcript: null,
+                })),
             ),
         ),
     conversation: (conversations: ConversationDto[] = sampleConversations) =>
@@ -223,7 +226,7 @@ export const sampleConversations: ConversationDto[] = [
         lastExchange: [
             { role: "user", text: "Not yet. What about audit logs and data residency?", at: minutesAgo(20) },
             {
-                role: "assistant",
+                role: "agent",
                 text: "At 60 seats you'd cross the Gold cap. Enterprise removes it — want me to draft a quote?",
                 at: minutesAgo(19),
             },
@@ -248,7 +251,7 @@ export const sampleConversations: ConversationDto[] = [
         lastExchange: [
             { role: "user", text: "Thanks, that worked!", at: minutesAgo(21) },
             {
-                role: "assistant",
+                role: "agent",
                 text: "Glad to hear it. I'll mark this resolved — reach out anytime.",
                 at: minutesAgo(20),
             },
@@ -272,7 +275,7 @@ export const sampleConversations: ConversationDto[] = [
         lastExchange: [
             { role: "user", text: "Wann läuft mein Trial ab?", at: minutesAgo(23) },
             {
-                role: "assistant",
+                role: "agent",
                 text: "Your trial ends on June 14, 2026 — 16 days from now. I can send a reminder.",
                 at: minutesAgo(22),
             },
@@ -297,7 +300,7 @@ export const sampleConversations: ConversationDto[] = [
         lastExchange: [
             { role: "user", text: "Hi, just checking in — has there been any update?", at: minutesAgo(24) },
             {
-                role: "assistant",
+                role: "agent",
                 text: "Got it. I'll look into your order status and get back shortly.",
                 at: minutesAgo(23),
             },
@@ -322,7 +325,7 @@ export const sampleConversations: ConversationDto[] = [
         lastExchange: [
             { role: "user", text: "Can I get a copy of my last invoice?", at: minutesAgo(42) },
             {
-                role: "assistant",
+                role: "agent",
                 text: "Invoice #INV-2026-0489 for $348 (May 1) is attached. Want me to email it too?",
                 at: minutesAgo(41),
             },
@@ -347,7 +350,7 @@ export const sampleConversations: ConversationDto[] = [
         lastExchange: [
             { role: "user", text: "Oui, merci. Et pour les remboursements ?", at: minutesAgo(55) },
             {
-                role: "assistant",
+                role: "agent",
                 text: "Le remboursement sera traité sous 3–5 jours ouvrés sur votre carte.",
                 at: minutesAgo(54),
             },
@@ -372,7 +375,7 @@ export const sampleConversations: ConversationDto[] = [
         lastExchange: [
             { role: "user", text: "Do you have a student discount?", at: minutesAgo(57) },
             {
-                role: "assistant",
+                role: "agent",
                 text: "We offer 40% off on the Starter plan for verified students. I can send the link.",
                 at: minutesAgo(56),
             },
@@ -401,7 +404,7 @@ export const sampleConversations: ConversationDto[] = [
                 at: minutesAgo(61),
             },
             {
-                role: "assistant",
+                role: "agent",
                 text: "Wir akzeptieren SEPA-Lastschrift, Kreditkarte und Rechnungskauf.",
                 at: minutesAgo(60),
             },
@@ -442,7 +445,7 @@ export const sampleConversations: ConversationDto[] = [
         ],
         lastExchange: [
             {
-                role: "assistant",
+                role: "agent",
                 text: "Your refund of $84.00 has been processed and should appear on…",
                 at: minutesAgo(131),
             },
@@ -468,7 +471,7 @@ export const sampleConversations: ConversationDto[] = [
         lastExchange: [
             { role: "user", text: "Can you compare Pro vs Enterprise?", at: minutesAgo(181) },
             {
-                role: "assistant",
+                role: "agent",
                 text: "Enterprise adds SSO, audit logs, and unlimited seats. Here's a quick breakdown.",
                 at: minutesAgo(180),
             },
@@ -493,7 +496,7 @@ export const sampleConversations: ConversationDto[] = [
         lastExchange: [
             { role: "user", text: "My card was charged twice.", at: minutesAgo(301) },
             {
-                role: "assistant",
+                role: "agent",
                 text: "I see two charges on June 27 — I've refunded the duplicate. Sorry about that!",
                 at: minutesAgo(300),
             },
@@ -509,14 +512,14 @@ export const sampleConversations: ConversationDto[] = [
 // Returned by the conversation-detail mock so the transcript sheet has a full thread.
 const sampleTranscript: ConversationDto["lastExchange"] = [
     { role: "user", text: "Hi, do you have the wireless mouse in stock?", at: "2026-06-25T08:59:30Z" },
-    { role: "assistant", text: "Let me check that for you.", at: "2026-06-25T08:59:34Z" },
+    { role: "agent", text: "Let me check that for you.", at: "2026-06-25T08:59:34Z" },
     {
-        role: "assistant",
+        role: "agent",
         text: "Yes, the Wireless Mouse is in stock for $24.99. Want me to add it to your cart?",
         at: "2026-06-25T09:00:01Z",
     },
     { role: "user", text: "Yes please.", at: "2026-06-25T09:00:03Z" },
-    { role: "assistant", text: "Done — it's in your cart. Anything else?", at: "2026-06-25T09:00:04Z" },
+    { role: "agent", text: "Done — it's in your cart. Anything else?", at: "2026-06-25T09:00:04Z" },
 ];
 
 const usageSparkline = (base: number) =>

--- a/src/Raven.AiAppliance.Web/src/mocks/stats-mocks.ts
+++ b/src/Raven.AiAppliance.Web/src/mocks/stats-mocks.ts
@@ -542,7 +542,6 @@ export const sampleAppUsage: AppUsageResponse = {
     metrics: {
         conversations: { value: 7400, delta: 12.5, sparkline: usageSparkline(520) },
         tokens: { value: 6100000, delta: 15, sparkline: usageSparkline(430000) },
-        cost: { value: 128.4, delta: -3, sparkline: usageSparkline(9) },
         cdcWrites: { value: 18400000, delta: 3, sparkline: usageSparkline(1300000) },
     },
     tokensByCapability: buildSeries(
@@ -577,8 +576,8 @@ export const sampleAppUsage: AppUsageResponse = {
         { name: "Inventory", writes: 1800000, lagSeconds: 9, lastWriteAt: "2026-06-25T08:40:00Z" },
     ],
     topCapabilities: [
-        { name: "Sales assistant", invocations: 8100, avgTokens: 540, totalTokens: 4374000, cost: 92.1 },
-        { name: "FAQ bot", invocations: 2400, avgTokens: 320, totalTokens: 768000, cost: 18.6 },
-        { name: "Order tracker", invocations: 1200, avgTokens: 410, totalTokens: 492000, cost: 17.7 },
+        { name: "Sales assistant", invocations: 8100, avgTokens: 540, totalTokens: 4374000 },
+        { name: "FAQ bot", invocations: 2400, avgTokens: 320, totalTokens: 768000 },
+        { name: "Order tracker", invocations: 1200, avgTokens: 410, totalTokens: 492000 },
     ],
 };

--- a/src/Raven.AiAppliance.Web/src/pages/apps/app-usage.stories.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/app-usage.stories.tsx
@@ -27,7 +27,6 @@ const emptyAppUsage: AppUsageResponse = {
     metrics: {
         conversations: zeroMetric,
         tokens: zeroMetric,
-        cost: zeroMetric,
         cdcWrites: zeroMetric,
     },
     tokensByCapability: emptySeries,

--- a/src/Raven.AiAppliance.Web/src/pages/apps/conversations-section.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/conversations-section.tsx
@@ -153,6 +153,7 @@ function filterConversations(
             conversation.channelName,
             conversation.agentName,
             ...conversation.params.flatMap((param) => [param.key, param.value]),
+            ...conversation.lastExchange.map((turn) => turn.text),
         ]
             .join(" ")
             .toLowerCase();

--- a/src/Raven.AiAppliance.Web/src/pages/apps/conversations/conversations-columns.tsx
+++ b/src/Raven.AiAppliance.Web/src/pages/apps/conversations/conversations-columns.tsx
@@ -33,6 +33,12 @@ export function createConversationColumns(slug: string): ColumnDef<ConversationD
             ),
         },
         {
+            id: "lastExchange",
+            header: "Last exchange",
+            size: 480,
+            cell: ({ row }) => <LastExchangeCell conversation={row.original} />,
+        },
+        {
             accessorKey: "lastActivityAt",
             header: "Last activity",
             size: 140,
@@ -83,6 +89,47 @@ function AgentCell({ conversation }: { conversation: ConversationDto }) {
                 {conversation.agentInitials}
             </span>
             <span className="truncate">{conversation.agentName}</span>
+        </span>
+    );
+}
+
+function LastExchangeCell({ conversation }: { conversation: ConversationDto }) {
+    const turns = [...conversation.lastExchange].sort((left, right) => {
+        if (left.at === right.at) {
+            return 0;
+        }
+        if (left.at === null) {
+            return -1;
+        }
+        if (right.at === null) {
+            return 1;
+        }
+        return left.at.localeCompare(right.at);
+    });
+
+    if (turns.length === 0) {
+        return <span className="text-muted-foreground">—</span>;
+    }
+
+    return (
+        <span className="flex max-w-full min-w-0 flex-col gap-1">
+            {turns.map((turn, index) => {
+                const isAgent = turn.role.toLowerCase() === "agent";
+
+                return (
+                    <span key={`${turn.at ?? "undated"}-${index}`} className="flex min-w-0 items-center gap-2">
+                        <span
+                            className="h-3 w-0.5 shrink-0 rounded-full bg-muted-foreground"
+                            style={isAgent ? { backgroundColor: agentAvatarColor(conversation.agentName) } : undefined}
+                            aria-hidden="true"
+                        />
+                        <span className="min-w-0 truncate font-medium" title={turn.text}>
+                            <span className="sr-only">{turn.role}: </span>
+                            {turn.text}
+                        </span>
+                    </span>
+                );
+            })}
         </span>
     );
 }

--- a/src/Raven.AiAppliance/Contracts/AppUsageResponse.cs
+++ b/src/Raven.AiAppliance/Contracts/AppUsageResponse.cs
@@ -21,12 +21,11 @@ public sealed record AppUsageResponse(
     TopTable[] TopTables,
     TopCapability[] TopCapabilities);
 
-/// <summary>The four KPI cards; each carries a current value, a percent delta vs the
+/// <summary>The three KPI cards; each carries a current value, a percent delta vs the
 /// previous equal-length window, and a per-bucket sparkline.</summary>
 public sealed record AppUsageMetrics(
     MetricCard Conversations,
     MetricCard Tokens,
-    MetricCard Cost,
     MetricCard CdcWrites);
 
 public sealed record MetricCard(double Value, double Delta, double[] Sparkline);
@@ -39,6 +38,7 @@ public sealed record SeriesKey(string Key, string Label);
 
 public sealed record CdcWritePoint(string T, long Writes);
 
+// TODO RavenDB-26992: LagSeconds/LastWriteAt are placeholders (0 / "") pending real per-table CDC metrics.
 public sealed record TopTable(string Name, long Writes, int LagSeconds, string LastWriteAt);
 
-public sealed record TopCapability(string Name, long Invocations, long AvgTokens, long TotalTokens, double Cost);
+public sealed record TopCapability(string Name, long Invocations, long AvgTokens, long TotalTokens);

--- a/src/Raven.AiAppliance/Contracts/ConversationDto.cs
+++ b/src/Raven.AiAppliance/Contracts/ConversationDto.cs
@@ -1,10 +1,10 @@
 namespace Raven.AiAppliance.Contracts;
 
 /// <summary>
-/// A conversation for the Conversations page — the prototype's <c>Conversation</c>,
-/// shaped from a <c>@conversations</c> doc. <c>channelName</c> is empty (no channel
-/// link on the doc yet — iframe attribution is a follow-up); <c>agentInitials</c> is
-/// derived from the agent id; <c>state</c> is derived from
+/// A conversation for the Conversations page, shaped from a <c>@conversations</c> doc.
+/// <c>channelName</c> is resolved for iframe conversations via their embed link, and is
+/// empty for conversations opened outside a minted embed link (e.g. the wizard test chat);
+/// <c>agentInitials</c> is derived from the agent id; <c>state</c> is derived from
 /// <c>lastActivityAt</c> (active &lt;1h / idle &lt;24h / else closed).
 /// </summary>
 public sealed record ConversationDto(

--- a/src/Raven.AiAppliance/Contracts/SuggestCdcRequest.cs
+++ b/src/Raven.AiAppliance/Contracts/SuggestCdcRequest.cs
@@ -1,4 +1,5 @@
 namespace Raven.AiAppliance.Contracts;
 
-/// <summary>Dashboard request for an AI-suggested CDC mapping. The admin's intent in prose.</summary>
-public sealed record SuggestCdcRequest(string IntentPrompt);
+/// <summary>Dashboard request for an AI-suggested CDC mapping. <see cref="IntentPrompt"/> is the
+/// admin's intent in prose; it is optional — a blank value falls back to a premade default prompt.</summary>
+public sealed record SuggestCdcRequest(string? IntentPrompt);

--- a/src/Raven.AiAppliance/Endpoints/EmbedEndpoints.cs
+++ b/src/Raven.AiAppliance/Endpoints/EmbedEndpoints.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using System.Net;
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -6,6 +8,7 @@ using Raven.AiAppliance.Agents;
 using Raven.AiAppliance.Channels;
 using Raven.AiAppliance.Contracts;
 using Raven.AiAppliance.Endpoints.Helpers;
+using Raven.AiAppliance.Metrics;
 using Raven.AiAppliance.Wizard;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
@@ -62,7 +65,7 @@ public static class EmbedEndpoints
         if (resolved is null)
             return;
 
-        var (_, _, channel, customCss) = resolved.Value;
+        var (app, link, channel, customCss) = resolved.Value;
 
         // Contain the page — and, above all, operator-authored __CUSTOM_CSS__ — with a default-deny
         // resource policy, then append frame-ancestors from the configured origins (empty list =
@@ -84,8 +87,13 @@ public static class EmbedEndpoints
         // Keep the bearer token out of cross-origin referer logs.
         ctx.Response.Headers["Referrer-Policy"] = "no-referrer";
 
+        // Prior turns for this link's conversation, rendered into the page so a returning
+        // visitor sees their history (mirrors the operator Conversations view). Best-effort:
+        // a fresh link (no conversation yet) or a read failure yields an empty feed.
+        var historyJson = await BuildHistoryJsonAsync(store, app.Database, link.ConversationId, ct);
+
         ctx.Response.ContentType = "text/html; charset=utf-8";
-        await ctx.Response.WriteAsync(BuildEmbedHtml(token, channel.DisplayName, customCss), ct);
+        await ctx.Response.WriteAsync(BuildEmbedHtml(token, channel.DisplayName, customCss, historyJson), ct);
     }
 
     private static async Task StreamEmbedChatAsync(
@@ -400,18 +408,43 @@ public static class EmbedEndpoints
         return (app, link, channel, effectiveCss);
     }
 
-    private static string BuildEmbedHtml(string token, string displayName, string? customCss)
+    private static string BuildEmbedHtml(string token, string displayName, string? customCss, string historyJson)
     {
         var title = WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(displayName) ? "AI Assistant" : displayName);
-        // Substitute the trusted placeholders (token, base styles) first, then the operator-controlled
-        // ones (custom CSS, then title) last — so nothing an operator can set (DisplayName via __TITLE__,
-        // or custom CSS) can reintroduce __TOKEN__ or another placeholder for a later Replace to expand.
-        // In particular the bearer token can never leak into the rendered title/header.
+        // Substitute the trusted placeholders (token, base styles) first, then the operator/visitor-
+        // controlled ones (custom CSS, title, then the conversation history) last — so nothing an
+        // operator or visitor can set can reintroduce __TOKEN__ or another placeholder for a later
+        // Replace to expand. In particular the bearer token can never leak into the title or history.
         return EmbedHtmlTemplate
             .Replace("__TOKEN__", token)
             .Replace("__BASE_CSS__", WidgetBaseCss)
             .Replace("__CUSTOM_CSS__", IFrameCss.Sanitize(customCss))
-            .Replace("__TITLE__", title);
+            .Replace("__TITLE__", title)
+            .Replace("__HISTORY__", historyJson);
+    }
+
+    /// <summary>Serializes the conversation's prior turns as a script-safe JSON array
+    /// (<c>[{role,text}]</c>) for the embed page. Best-effort: a fresh link (no conversation yet)
+    /// or a read failure yields <c>[]</c> so the widget still renders. The default System.Text.Json
+    /// encoder escapes &lt;, &gt; and &amp;, so the array is safe to inline inside &lt;script&gt;.</summary>
+    private static async Task<string> BuildHistoryJsonAsync(
+        IDocumentStore store, string database, string? conversationId, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(conversationId))
+            return "[]";
+        try
+        {
+            var result = await store.AI.ForDatabase(database).GetConversationMessagesAsync(conversationId, ct);
+            if (result is null)
+                return "[]";
+            var turns = MetricsReadService.MapTranscript(result.Messages)
+                .Select(t => new { role = t.Role, text = t.Text });
+            return JsonSerializer.Serialize(turns);
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            return "[]";
+        }
     }
 
     /// <summary>Builds the dashboard's customization preview: the same base styles
@@ -493,6 +526,9 @@ function addRow(cls, text) {
   feed.scrollTop = feed.scrollHeight;
   return div;
 }
+
+// Prior turns for this conversation, server-rendered on load; empty for a fresh link.
+for (const turn of __HISTORY__) addRow(turn.role, turn.text);
 
 form.addEventListener("submit", async (e) => {
   e.preventDefault();

--- a/src/Raven.AiAppliance/Endpoints/StatsEndpoints.cs
+++ b/src/Raven.AiAppliance/Endpoints/StatsEndpoints.cs
@@ -35,21 +35,21 @@ public static class StatsEndpoints
             .RequireAuthorization()
             .Produces<UsagePoint[]>();
 
-        // Per-app token-usage breakdown (mock-api `getTokensByApp()`).
+        // Per-app token-usage breakdown.
         app.MapGet("/api/usage/by-app", GetTokensByAppAsync)
             .WithTags("stats")
             .WithName("stats.tokensByApp")
             .RequireAuthorization()
             .Produces<TokensByAppResponse>();
 
-        // Enriched apps list for the Dashboard table (mock-api `listApps()`).
+        // Enriched apps list for the Dashboard table.
         app.MapGet("/api/dashboard/apps", GetDashboardAppsAsync)
             .WithTags("stats")
             .WithName("stats.dashboardApps")
             .RequireAuthorization()
             .Produces<ApplianceAppResponse[]>();
 
-        // Single enriched app (mock-api `getApp(id)`).
+        // Single enriched app.
         app.MapGet("/api/dashboard/apps/{slug}", GetDashboardAppAsync)
             .WithTags("stats")
             .WithName("stats.dashboardApp")
@@ -64,19 +64,19 @@ public static class StatsEndpoints
             .Produces<AppOverviewResponse>()
             .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
 
-        // Per-app usage analytics (mock-api `getAppUsage({appId,start,end})`).
+        // Per-app usage analytics.
         group.MapGet("/usage", GetAppUsageAsync)
             .WithName("stats.appUsage")
             .Produces<AppUsageResponse>()
             .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
 
-        // Mirrored data collections with document counts (mock-api `listCollections(appId)`).
+        // Mirrored data collections with document counts.
         group.MapGet("/collections", GetCollectionsAsync)
             .WithName("stats.collections")
             .Produces<DataCollectionDto[]>()
             .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
 
-        // Conversations list + detail (mock-api `listConversations` / `getConversation`).
+        // Conversations list + detail.
         // The {*conversationId} catch-all carries the "chats/..." id (it contains a slash);
         // the literal "/conversations/stats" route still wins by routing precedence.
         group.MapGet("/conversations", GetConversationsListAsync)
@@ -89,7 +89,7 @@ public static class StatsEndpoints
             .Produces<ConversationDto>()
             .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
 
-        // CDC "Events" tab (mock-api `listActivity`). Deferred — no event log yet, so
+        // CDC "Events" tab. Deferred — no event log yet, so
         // this returns an empty feed (a real audit log is a separate ticket).
         group.MapGet("/activity", GetActivityAsync)
             .WithName("stats.activity")

--- a/src/Raven.AiAppliance/Endpoints/WizardEndpoints.cs
+++ b/src/Raven.AiAppliance/Endpoints/WizardEndpoints.cs
@@ -27,6 +27,16 @@ public static class WizardEndpoints
     /// overwritten on each Connect call.
     private const string WizardSourceProbeName = "_wizard-source-probe";
 
+    /// Premade CDC-modeling prompt used when the admin leaves the intent prompt blank
+    /// (RavenDB-26916: the intent prompt is optional). Keeps the AI suggestion sensible
+    /// without forcing the admin to describe their intent.
+    private const string DefaultIntentPrompt =
+        "Propose a sensible RavenDB CDC document model from the discovered relational schema: " +
+        "map each root/aggregate table to its own collection, embed parent-owned child rows " +
+        "(1:N ownership) as nested arrays, and keep many-to-many or shared references as separate " +
+        "collections linked by id. Use idiomatic collection names derived from the table names; " +
+        "prefer a minimal, query-friendly shape over a literal table-per-collection mirror.";
+
     public static void Map(WebApplication app)
     {
         var group = app.MapGroup("/api/setup").WithTags("setup").RequireAuthorization();
@@ -218,8 +228,12 @@ public static class WizardEndpoints
         ILogger<WizardLogger> logger,
         CancellationToken ct)
     {
-        if (body is null || string.IsNullOrWhiteSpace(body.IntentPrompt))
-            return Results.BadRequest(new ApiErrorResponse("intentPrompt is required"));
+        if (body is null)
+            return Results.BadRequest(new ApiErrorResponse("request body is required"));
+
+        // The intent prompt is optional (RavenDB-26916): a blank value falls back to a premade
+        // default so the AI still receives a sensible modeling instruction.
+        var intentPrompt = string.IsNullOrWhiteSpace(body.IntentPrompt) ? DefaultIntentPrompt : body.IntentPrompt!;
 
         WizardState? state;
         using (var session = store.OpenAsyncSession())
@@ -230,7 +244,7 @@ public static class WizardEndpoints
 
         // Pass the discovered schema (CdcSinkSourceSchema, internal to Raven.Client) straight to the
         // client as object; the client serializes it via store conventions to the canonical wire shape.
-        var result = await aiClient.SuggestCdcAsync(state.LastDiscoveredSchema, samples: null, body.IntentPrompt, ct);
+        var result = await aiClient.SuggestCdcAsync(state.LastDiscoveredSchema, samples: null, intentPrompt, ct);
 
         if (result.Status != AiHelperStatus.Success)
             return Results.Ok(new SuggestCdcResponse(Configuration: null, result.Rationale, result.Status.ToString()));

--- a/src/Raven.AiAppliance/Metrics/MetricsReadService.cs
+++ b/src/Raven.AiAppliance/Metrics/MetricsReadService.cs
@@ -40,14 +40,17 @@ internal static class MetricsReadService
     private const string ConversationIdPrefix = "chats/";
     private const int ConversationPageSize = 1024;
 
+    // The conversations-list preview needs only the last exchange, so read a small most-recent tail
+    // per row instead of the whole history. Backward paging returns the newest N (oldest-first), and
+    // DetailLevel.Simple already excludes system/tool turns, so 10 comfortably covers the 2 the preview
+    // keeps even after MapTranscript drops any blank/attachment-only turn.
+    private const int LastExchangePageSize = 10;
+
     // Embed links (iframe channel attribution) are id-prefixed; read by prefix.
     private const int EmbedLinkPageSize = 1024;
 
     // Per-app fan-out (dashboard/usage) runs bounded-parallel and isolates failures.
     private const int MaxFanoutConcurrency = 8;
-
-    // Same per-token cost factor the prototype uses for the cost tile.
-    private const double CostPerToken = 0.000015;
 
     // Series key for tokens whose agent has no resolvable connection-string model.
     private const string UnknownModel = "unknown";
@@ -171,7 +174,7 @@ internal static class MetricsReadService
 
     /// <summary>
     /// Per-app usage analytics behind <c>getAppUsage({appId,start,end})</c>. Phase-1
-    /// subset from <see cref="ConversationMetricsIndex"/>: conversations/tokens/cost
+    /// subset from <see cref="ConversationMetricsIndex"/>: conversations/tokens
     /// KPI cards (value + delta-vs-previous-window + per-bucket sparkline),
     /// <c>tokensByCapability</c>, and <c>topCapabilities</c>. <c>cdcWrites</c> and the CDC
     /// KPI card are bucketed from RavenDB's rolling per-batch perf window (recent activity,
@@ -217,8 +220,6 @@ internal static class MetricsReadService
         var metrics = new AppUsageMetrics(
             Conversations: new MetricCard(convNow, Delta(convNow, convPrev), ToDoubles(convByBucket)),
             Tokens: new MetricCard(tokNow, Delta(tokNow, tokPrev), ToDoubles(tokByBucket)),
-            Cost: new MetricCard(Math.Round(tokNow * CostPerToken, 2), Delta(tokNow, tokPrev),
-                tokByBucket.Select(t => t * CostPerToken).ToArray()),
             // Delta 0: the rolling window can't reach the previous window for a real baseline.
             CdcWrites: new MetricCard(cdcWrites.Sum(p => p.Writes), 0,
                 cdcWrites.Select(p => (double)p.Writes).ToArray()));
@@ -256,7 +257,7 @@ internal static class MetricsReadService
                 var invocations = g.Sum(r => r.Conversations);
                 var total = g.Sum(r => r.Tokens);
                 return new TopCapability(NameOf(g.Key), invocations, invocations == 0 ? 0 : total / invocations,
-                    total, Math.Round(total * CostPerToken, 2));
+                    total);
             })
             .OrderByDescending(c => c.TotalTokens)
             .ThenBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
@@ -363,20 +364,20 @@ internal static class MetricsReadService
     }
 
     /// <summary>"Top tables" = the app's business collections by document count
-    /// (egor: collection stats stand in for CDC source-table stats until
-    /// RavenDB-26780). <c>lagSeconds</c>/<c>lastWriteAt</c> are CDC-perf data, left
-    /// empty for now.</summary>
+    /// (collection stats stand in for CDC source-table stats until RavenDB-26780).
+    /// TODO RavenDB-26992: <c>lagSeconds</c>/<c>lastWriteAt</c> ship as placeholders
+    /// (0 / "") until real replication-lag / last-write per table is implemented.</summary>
     private static async Task<TopTable[]> BuildTopTablesAsync(
         MaintenanceOperationExecutor maintenance, CancellationToken ct)
     {
         var stats = await maintenance.SendAsync(new GetCollectionStatisticsOperation(), ct);
-        // name + doc count is what the prototype's "Top source tables" renders;
-        // lagSeconds/lastWriteAt are CDC-perf data (RavenDB-26780) — left empty.
+        // name + doc count is what the "Top source tables" view renders.
         return stats.Collections
             .Where(c => c.Key.StartsWith('@') == false)
             .OrderByDescending(c => c.Value)
             .ThenBy(c => c.Key, StringComparer.OrdinalIgnoreCase)
             .Take(TopTablesLimit)
+            // TODO RavenDB-26992: LagSeconds/LastWriteAt are placeholders pending real per-table CDC metrics.
             .Select(c => new TopTable(c.Key, c.Value, LagSeconds: 0, LastWriteAt: ""))
             .ToArray();
     }
@@ -650,23 +651,60 @@ internal static class MetricsReadService
         }
     }
 
-    /// <summary>Conversations for the Conversations list — metadata only (agent,
-    /// channel, state, timestamps, params), newest activity first. The transcript /
-    /// last-exchange preview is fetched on detail; the list page doesn't render it,
-    /// and reading messages per row would be an N+1 against the AI messages endpoint.</summary>
+    /// <summary>Conversations for the Conversations list (agent, channel, state, timestamps,
+    /// params, and a last-exchange preview), newest activity first. The last exchange is read
+    /// per row through the AI messages endpoint (bounded fan-out); the full transcript stays
+    /// detail-only.</summary>
     public static async Task<List<ConversationDto>> GetConversationsAsync(
         IDocumentStore store, string slug, string database, DateTime nowUtc, CancellationToken ct)
     {
-        using var session = store.OpenAsyncSession(database);
-        var channelByConversation = await BuildConversationChannelMapAsync(session, ct);
-        // Loads every conversation doc (paged) and sorts by last activity in memory — no
-        // truncation. Index-backed *server-side* pagination is a deferred perf follow-up
-        // for very large apps (review SF5).
-        var docs = await LoadAllByPrefixAsync<ConversationDoc>(session, ConversationIdPrefix, ConversationPageSize, ct);
-        return docs
-            .Select(d => ShapeListItem(d, slug, nowUtc, channelByConversation))
-            .OrderByDescending(c => c.LastActivityAt)
-            .ToList();
+        Dictionary<string, string> channelByConversation;
+        List<ConversationDoc> docs;
+        using (var session = store.OpenAsyncSession(database))
+        {
+            channelByConversation = await BuildConversationChannelMapAsync(session, ct);
+            // Loads every conversation doc (paged) and sorts by last activity in memory — no
+            // truncation. Index-backed *server-side* pagination is a deferred perf follow-up
+            // for very large apps (review SF5).
+            docs = await LoadAllByPrefixAsync<ConversationDoc>(session, ConversationIdPrefix, ConversationPageSize, ct);
+        }
+
+        // Each row carries its last exchange (newest two turns), read through the AI runtime —
+        // one read per conversation, bounded-parallel. Server-side pagination would cap this
+        // fan-out; until then it mirrors the whole (already in-memory) conversation set.
+        using var gate = new SemaphoreSlim(MaxFanoutConcurrency);
+        var items = await Task.WhenAll(docs.Select(async doc =>
+        {
+            var lastExchange = doc.Id is { } id
+                ? await LoadLastExchangeAsync(store, database, id, gate, ct)
+                : [];
+            return ShapeListItem(doc, slug, nowUtc, channelByConversation, lastExchange);
+        }));
+
+        return items.OrderByDescending(c => c.LastActivityAt).ToList();
+    }
+
+    /// <summary>Reads the newest two turns of a conversation through the AI runtime, bounded by
+    /// <paramref name="gate"/>. A single unreadable conversation degrades to an empty exchange
+    /// rather than failing the whole list.</summary>
+    private static async Task<ConversationTurn[]> LoadLastExchangeAsync(
+        IDocumentStore store, string database, string conversationId, SemaphoreSlim gate, CancellationToken ct)
+    {
+        await gate.WaitAsync(ct);
+        try
+        {
+            var options = new GetConversationMessagesOptions { ConversationId = conversationId, PageSize = LastExchangePageSize };
+            var result = await store.AI.ForDatabase(database).GetConversationMessagesAsync(options, ct);
+            return result is null ? [] : MapTranscript(result.Messages).TakeLast(2).Reverse().ToArray();
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            return [];
+        }
+        finally
+        {
+            gate.Release();
+        }
     }
 
     /// <summary>One conversation with its full chronological transcript, or null. The AI
@@ -687,13 +725,9 @@ internal static class MetricsReadService
         if (result is null)
             return null;  // 404 — no such conversation
 
-        // Messages arrive oldest-first; DetailLevel.Simple already excludes system/tool and
-        // assistant-without-content, so we only drop attachment-only/blank turns, normalize the
-        // role, and extract the reply text — no re-ordering.
-        var transcript = result.Messages
-            .Where(m => string.IsNullOrWhiteSpace(m.Content) == false)
-            .Select(m => new ConversationTurn(RoleLabel(m.Role), ReplyText(m.Content), Utc(m.Timestamp)))
-            .ToArray();
+        // Messages arrive oldest-first; MapTranscript drops blank/attachment-only turns and
+        // normalizes role + reply text without re-ordering.
+        var transcript = MapTranscript(result.Messages);
 
         using var session = store.OpenAsyncSession(database);
         var channelName = (await BuildConversationChannelMapAsync(session, ct))
@@ -739,7 +773,8 @@ internal static class MetricsReadService
     }
 
     private static ConversationDto ShapeListItem(
-        ConversationDoc doc, string slug, DateTime nowUtc, Dictionary<string, string> channelByConversation)
+        ConversationDoc doc, string slug, DateTime nowUtc, Dictionary<string, string> channelByConversation,
+        ConversationTurn[] lastExchange)
     {
         var agentName = doc.Agent ?? "";
         var channelName = doc.Id is { } id && channelByConversation.TryGetValue(id, out var cn) ? cn : "";
@@ -747,10 +782,10 @@ internal static class MetricsReadService
             .Select(kv => new ConversationParam(kv.Key, kv.Value?.ToString() ?? ""))
             .ToArray();
 
-        // List rows are metadata only — Transcript/LastExchange are detail-only.
+        // The full transcript stays detail-only; the list carries just the last-exchange preview.
         return new ConversationDto(
             doc.Id ?? "", slug, channelName, agentName, AgentInitials(agentName),
-            prms, LastExchange: [], Transcript: null,
+            prms, lastExchange, Transcript: null,
             State(nowUtc - doc.LastMessageAt), Utc(doc.LastMessageAt), Utc(doc.CreatedAt), MaxDuration: null);
     }
 
@@ -760,6 +795,16 @@ internal static class MetricsReadService
     // The UI labels the assistant "agent"; these are the FE wire-contract values, not the enum
     // names (nameof would yield "Assistant"/"User" and break the contract + the FE).
     private static string RoleLabel(AiMessageRole role) => role == AiMessageRole.Assistant ? "agent" : "user";
+
+    // Shared transcript projection: drop attachment-only/blank turns, normalize the role, and
+    // extract the reply text; DetailLevel.Simple already excludes system/tool + assistant-without-
+    // content, so chronological order is preserved. Shared by the conversation detail, the list's
+    // last-exchange preview, and the embed page's history.
+    internal static ConversationTurn[] MapTranscript(IEnumerable<AiConversationMessage> messages) =>
+        messages
+            .Where(m => string.IsNullOrWhiteSpace(m.Content) == false)
+            .Select(m => new ConversationTurn(RoleLabel(m.Role), ReplyText(m.Content), Utc(m.Timestamp)))
+            .ToArray();
 
     // AiConversationMessage.Content is already a string: plain text for user / plain-assistant
     // turns, or the JSON of a structured reply ({"reply":…}) for schema-output agents. For the

--- a/src/Raven.AiAppliance/Wizard/Slugifier.cs
+++ b/src/Raven.AiAppliance/Wizard/Slugifier.cs
@@ -5,7 +5,7 @@ namespace Raven.AiAppliance.Wizard;
 /// <summary>
 /// Derives an URL-safe, RavenDB-DB-name-safe slug from a user-typed appName.
 ///
-/// Mirrors the prototype's `slug` field (`AddAppWizard.tsx` -> `mock-api.ts`):
+/// Matches the Studio's client-side slug derivation:
 /// lowercase, whitespace + any non-alphanumeric character collapsed to a single
 /// dash, leading/trailing dashes stripped. Examples:
 ///

--- a/test/AiApplianceTests/AiHelperSuggestCdcEndpointTests.cs
+++ b/test/AiApplianceTests/AiHelperSuggestCdcEndpointTests.cs
@@ -69,16 +69,26 @@ public class AiHelperSuggestCdcEndpointTests(ITestOutputHelper output) : RavenTe
     }
 
     [RavenFact(RavenTestCategory.AiAppliance)]
-    public async Task Rejects_empty_prompt()
+    public async Task Blank_prompt_falls_back_to_premade_default()
     {
         var store = GetDocumentStore();
         await using var mockAi = await MockAiApi.StartAsync();
+        mockAi.CdcResponse = (200, AiHelperSamples.CdcEnvelope(AiHelperSamples.BuildCdcConfig()));
 
         using var factory = NewApplianceFactory(store, mockAi.BaseAddress);
         var client = factory.CreateClient();
+        await SeedDiscoveredSchemaAsync(client);
 
+        // A blank intent prompt is now accepted; the endpoint substitutes a premade default.
         var resp = await client.PostAsJsonAsync("/api/setup/suggest/cdc", new { intentPrompt = "  " });
-        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.True(resp.IsSuccessStatusCode, await resp.Content.ReadAsStringAsync());
+
+        var node = JsonNode.Parse(await resp.Content.ReadAsStringAsync())!;
+        Assert.Equal("Success", (string?)node["status"]);
+
+        // The AI received a non-empty prompt (the premade default), not the blank input.
+        var sent = JsonNode.Parse(mockAi.LastCdcRequestBody!)!;
+        Assert.False(string.IsNullOrWhiteSpace((string?)sent["Prompt"]));
     }
 
     [RavenFact(RavenTestCategory.AiAppliance)]

--- a/test/AiApplianceTests/AppUsageEndpointTests.cs
+++ b/test/AiApplianceTests/AppUsageEndpointTests.cs
@@ -11,17 +11,15 @@ namespace AiApplianceTests;
 
 /// <summary>
 /// Coverage for <c>GET /api/apps/{slug}/usage</c> — backs the prototype's
-/// <c>api.getAppUsage({appId,start,end})</c>: granularity, the conversations/tokens/cost KPI
+/// <c>api.getAppUsage({appId,start,end})</c>: granularity, the conversations/tokens KPI
 /// values, tokensByCapability/tokensByModel/conversationsByChannel series, and topCapabilities.
 /// cdcWrites bucketing is verified purely in <see cref="AppUsageCdcWritesTests"/>; the populated
 /// end-to-end CDC path needs a live source (the gated Postgres E2E lane).
 /// </summary>
 public class AppUsageEndpointTests(ITestOutputHelper output) : ApplianceMetricsTestBase(output)
 {
-    private const double CostPerToken = 0.000015;
-
     [RavenFact(RavenTestCategory.AiAppliance)]
-    public async Task AppUsage_aggregates_conversations_tokens_cost_and_top_capabilities()
+    public async Task AppUsage_aggregates_conversations_tokens_and_top_capabilities()
     {
         var store = GetDocumentStore();
         var (perAppDb, cleanup) = await CreatePerAppDatabaseAsync(store);
@@ -51,7 +49,6 @@ public class AppUsageEndpointTests(ITestOutputHelper output) : ApplianceMetricsT
         var metrics = json.GetProperty("metrics");
         Assert.Equal(3, metrics.GetProperty("conversations").GetProperty("value").GetDouble());
         Assert.Equal(350_000, metrics.GetProperty("tokens").GetProperty("value").GetDouble());
-        Assert.Equal(350_000 * CostPerToken, metrics.GetProperty("cost").GetProperty("value").GetDouble(), 3);
 
         // topCapabilities: per-agent, sorted by totalTokens descending.
         var top = json.GetProperty("topCapabilities");

--- a/test/AiApplianceTests/ConversationsEndpointTests.cs
+++ b/test/AiApplianceTests/ConversationsEndpointTests.cs
@@ -49,7 +49,7 @@ public class ConversationsEndpointTests(ITestOutputHelper output) : ApplianceMet
         using var factory = NewApplianceFactory(store);
         var client = factory.CreateClient();
 
-        // List — newest first, metadata only (no transcript/last-exchange; that's detail-only),
+        // List — newest first, with a last-exchange preview (full transcript stays detail-only),
         // derived state/initials, channel attribution.
         var list = await client.GetFromJsonAsync<JsonElement>("/api/apps/my-app/conversations");
         Assert.Equal(2, list.GetArrayLength());
@@ -60,7 +60,12 @@ public class ConversationsEndpointTests(ITestOutputHelper output) : ApplianceMet
         Assert.Equal("order-support", first.GetProperty("agentName").GetString());
         Assert.Equal("OS", first.GetProperty("agentInitials").GetString());
         Assert.Equal("active", first.GetProperty("state").GetString());          // 10 min ago
-        Assert.Empty(first.GetProperty("lastExchange").EnumerateArray());        // list carries no preview
+        var firstExchange = first.GetProperty("lastExchange");                   // last-exchange preview, newest first
+        Assert.Equal(2, firstExchange.GetArrayLength());
+        Assert.Equal("agent", firstExchange[0].GetProperty("role").GetString());
+        Assert.Equal("hi there", firstExchange[0].GetProperty("text").GetString());
+        Assert.Equal("user", firstExchange[1].GetProperty("role").GetString());
+        Assert.Equal("hello", firstExchange[1].GetProperty("text").GetString());
         Assert.Equal(JsonValueKind.Null, first.GetProperty("transcript").ValueKind);
         Assert.Equal("wgt1", first.GetProperty("channelName").GetString());      // attributed via EmbedLink
 
@@ -77,6 +82,37 @@ public class ConversationsEndpointTests(ITestOutputHelper output) : ApplianceMet
         // I1: outbound timestamps are UTC, ISO-8601 with a trailing Z (so the browser parses as UTC).
         Assert.EndsWith("Z\"", detail.GetProperty("lastActivityAt").GetRawText());
         Assert.EndsWith("Z\"", detail.GetProperty("startedAt").GetRawText());
+    }
+
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public async Task Conversations_list_preview_returns_the_newest_two_turns_of_a_long_conversation()
+    {
+        var store = GetDocumentStore();
+        var (perAppDb, cleanup) = await CreatePerAppDatabaseAsync(store);
+        using var _db = cleanup;
+        await SeedAppAsync(store, slug: "my-app", database: perAppDb);
+
+        // More turns than the list preview's page size (LastExchangePageSize = 10), so the read must
+        // fetch the most-recent tail — not the oldest page — otherwise TakeLast(2) surfaces the wrong
+        // turns. m1..m14 alternate user/assistant; the newest exchange is m13 (user) + m14 (assistant).
+        var turns = new (string Role, string Text)[14];
+        for (var i = 0; i < turns.Length; i++)
+            turns[i] = (i % 2 == 0 ? "user" : "assistant", $"m{i + 1}");
+        await SeedConversationAsync(store, perAppDb, "chats/long", "agent-x", DateTime.UtcNow.AddMinutes(-5), turns: turns);
+
+        using var factory = NewApplianceFactory(store);
+        var client = factory.CreateClient();
+
+        var list = await client.GetFromJsonAsync<JsonElement>("/api/apps/my-app/conversations");
+        Assert.Equal(1, list.GetArrayLength());
+
+        // Newest two turns, newest-first — proves the bounded page returned the tail, not the head.
+        var exchange = list[0].GetProperty("lastExchange");
+        Assert.Equal(2, exchange.GetArrayLength());
+        Assert.Equal("agent", exchange[0].GetProperty("role").GetString());
+        Assert.Equal("m14", exchange[0].GetProperty("text").GetString());
+        Assert.Equal("user", exchange[1].GetProperty("role").GetString());
+        Assert.Equal("m13", exchange[1].GetProperty("text").GetString());
     }
 
     [RavenFact(RavenTestCategory.AiAppliance)]

--- a/test/AiApplianceTests/E2E/ApplianceFullFlowTests.cs
+++ b/test/AiApplianceTests/E2E/ApplianceFullFlowTests.cs
@@ -24,9 +24,6 @@ namespace AiApplianceTests.E2E;
 ///     infrastructure can create + drop databases on.
 ///   - *.egor-ai.ravendb.run DNS -> 127.0.0.1 (the wildcard cert from the
 ///     embedded setup-package zip is for that domain).
-///
-/// Optional: set APPLIANCE_E2E_HOLD=1 to park the test after T12 so you can
-/// open the live iFrame in a browser.
 public class ApplianceFullFlowTests(ITestOutputHelper output) : CdcSinkIntegrationTestBase(output)
 {
     private const string HardcodedLicenseKey = "egor-ai-test-license";
@@ -299,14 +296,6 @@ public class ApplianceFullFlowTests(ITestOutputHelper output) : CdcSinkIntegrati
         Assert.True(string.IsNullOrEmpty(error2), $"embed chat turn 2 emitted an error frame: {error2}");
         Assert.True(sawDone2, "embed chat turn 2 did not emit a 'done' frame");
         Assert.False(string.IsNullOrWhiteSpace(reply2), "embed chat turn 2 produced no reply text");
-
-        // ---------- Optional manual park ----------
-        if (Environment.GetEnvironmentVariable("APPLIANCE_E2E_HOLD") == "1")
-        {
-            Console.WriteLine($"Embed URL: {client.BaseAddress}embed/{token}");
-            Console.WriteLine("Test parked. Ctrl+C to exit.");
-            await Task.Delay(Timeout.Infinite);
-        }
     }
 
     /// <summary>

--- a/test/AiApplianceTests/EmbedPageHistoryTests.cs
+++ b/test/AiApplianceTests/EmbedPageHistoryTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Raven.AiAppliance.Channels;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace AiApplianceTests;
+
+/// <summary>
+/// Coverage for chat-history rendering on the public embed page
+/// (<c>GET /embed/{token}</c>, RavenDB-26916): a returning visitor sees the prior
+/// turns of the link's conversation, and a fresh link renders an empty feed.
+/// </summary>
+public class EmbedPageHistoryTests(ITestOutputHelper output) : ApplianceMetricsTestBase(output)
+{
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public async Task Embed_page_renders_prior_conversation_history()
+    {
+        var store = GetDocumentStore();
+        var (perAppDb, cleanup) = await CreatePerAppDatabaseAsync(store);
+        using var _db = cleanup;
+        await SeedAppAsync(store, slug: "my-app", database: perAppDb);
+
+        var now = DateTime.UtcNow;
+        await SeedConversationAsync(store, perAppDb, "chats/embed", "demo", now.AddMinutes(-5),
+            turns: [("user", "hello there"), ("assistant", "hi, how can I help?")]);
+        await SeedChannelAsync(store, perAppDb, channelId: "wgt1", enabled: true);
+
+        var token = Guid.NewGuid().ToString("N");
+        await SeedEmbedLinkAsync(store, perAppDb, token, widgetId: "wgt1", conversationId: "chats/embed", now: now);
+
+        using var factory = NewApplianceFactory(store);
+        var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync($"/embed/{token}");
+
+        // The placeholder is replaced with a script-safe JSON array carrying the prior turns,
+        // rendered into the feed on load.
+        Assert.DoesNotContain("__HISTORY__", html);
+        Assert.Contains("for (const turn of [{", html);
+        Assert.Contains("hello there", html);
+        Assert.Contains("hi, how can I help?", html);
+    }
+
+    [RavenFact(RavenTestCategory.AiAppliance)]
+    public async Task Embed_page_for_a_fresh_link_renders_an_empty_feed()
+    {
+        var store = GetDocumentStore();
+        var (perAppDb, cleanup) = await CreatePerAppDatabaseAsync(store);
+        using var _db = cleanup;
+        await SeedAppAsync(store, slug: "my-app", database: perAppDb);
+        await SeedChannelAsync(store, perAppDb, channelId: "wgt1", enabled: true);
+
+        var token = Guid.NewGuid().ToString("N");
+        // No conversation bound yet (fresh link) → empty history array.
+        await SeedEmbedLinkAsync(store, perAppDb, token, widgetId: "wgt1", conversationId: null, now: DateTime.UtcNow);
+
+        using var factory = NewApplianceFactory(store);
+        var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync($"/embed/{token}");
+
+        Assert.DoesNotContain("__HISTORY__", html);
+        Assert.Contains("for (const turn of [])", html);
+    }
+
+    private static async Task SeedEmbedLinkAsync(
+        IDocumentStore store, string database, string token, string widgetId, string? conversationId, DateTime now)
+    {
+        using (var appSession = store.OpenAsyncSession(database))
+        {
+            await appSession.StoreAsync(new EmbedLink
+            {
+                WidgetId = widgetId,
+                AgentId = "demo",
+                ExpiresAt = now.AddHours(1),
+                MaxInvocations = 5,
+                ConversationId = conversationId,
+                CreatedAt = now,
+            }, $"{EmbedLink.IdPrefix}{token}");
+            await appSession.SaveChangesAsync();
+        }
+
+        using (var cfgSession = store.OpenAsyncSession())
+        {
+            await cfgSession.StoreAsync(new LinkIndex { Slug = "my-app" }, $"{LinkIndex.IdPrefix}{token}");
+            await cfgSession.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
- Drop Costs from AppUsage (DTO fields + computation)
- Keep Top-Tables Lag/LastWrite as placeholders, marked TODO RavenDB-26992
- Make Map-Schema intent prompt optional with a premade default
- Populate lastExchange + channelName in the conversations list
- Render prior chat history on the embed page
- Remove the E2E manual-park debug block; clean stale mock-api comments

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26916

### Additional description


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
