### PR TITLE
RavenDB-27000 - prevent `_QueryTools_` from being persisted in `SubConversationIds`

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -1073,7 +1073,8 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         List<Task<SubConversationResult>> tasks = [];
         foreach (var (conversationId, conversationReqs) in reqs)
         {
-            _document.SubConversationIds.Add(conversationId);
+            if (conversationId != QueryVirtualSubConversationId)
+                _document.SubConversationIds.Add(conversationId);
             tasks.Add(ExecuteSingleSubConversationToolCallsAsync(conversationId, conversationReqs, token));
         }
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-27000.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-27000.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_27000 : RavenTestBase
+    {
+        public RavenDB_27000(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task Test(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agent = CreateShoppingAssistant(config.ConnectionStringName);
+
+            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/1", new AiConversationCreationOptions().AddParameter("company", "companies/90-A"));
+
+            chat.SetUserPrompt("what are my recent orders?");
+
+            await chat.RunAsync<OutputSchema>(CancellationToken.None);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<dynamic>("chats/1");
+                var count = doc["SubConversationIds"] is JArray subConversationIds ? subConversationIds.Count : 0;
+                Assert.Equal(0, count);
+            }
+        }
+
+        private class OutputSchema
+        {
+            public static OutputSchema Instance = new OutputSchema()
+            {
+                Answer = "the answer to the user question",
+                Relevant = true,
+                RelevantOrdersId = ["what are the relevant orders?"]
+            };
+
+            public string Answer { get; set; }
+            public bool Relevant { get; set; }
+            public List<string> RelevantOrdersId { get; set; }
+        }
+
+        private static AiAgentConfiguration CreateShoppingAssistant(string connectionStringName, bool withActions = false)
+        {
+            var agent = new AiAgentConfiguration("shopping assistant", connectionStringName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+            if (withActions == false)
+                agent.Parameters.Add(new AiAgentParameter("company"));
+
+            if (withActions)
+            {
+                agent.Actions =
+                [
+                    new AiAgentToolAction { Name = "ProductSearch", Description = "semantic search the store product catalog", ParametersSampleObject = "{}" },
+                    new AiAgentToolAction { Name = "RecentOrder", Description = "Get the recent orders of the current user", ParametersSampleObject = "{}" }
+                ];
+            }
+            else
+            {
+                agent.Queries =
+                [
+                    new AiAgentToolQuery
+                    {
+                        Name = "ProductSearch",
+                        Description = "semantic search the store product catalog",
+                        Query = "from Products where vector.search(embedding.text(Name), $query)",
+                        ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                    },
+                    new AiAgentToolQuery
+                    {
+                        Name = "RecentOrder",
+                        Description = "Get the recent orders of the current user",
+                        Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                        ParametersSampleObject = "{}"
+                    }
+                ];
+            }
+
+            return agent;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27000/QueryTools-always-persisted-in-SubConversationIds

### Additional description

Prevent `_QueryTools_` from being persisted in `SubConversationIds` (in conversation docs)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
