### PR TITLE
RavenDB-27004, RavenDB-27005, RavenDB-22734 - Fix replication tests for Debug and composite CV behavior

### DIFF
--- a/test/SlowTests/Server/Replication/FilteredReplicationTestsPullReplicationCompositeChangeVectors.cs
+++ b/test/SlowTests/Server/Replication/FilteredReplicationTestsPullReplicationCompositeChangeVectors.cs
@@ -20,6 +20,7 @@ using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
@@ -1264,8 +1265,10 @@ public sealed class FilteredReplicationTestsPullReplicationCompositeChangeVector
         public string Name { get; set; }
     }
 
-    private sealed class ModifyDatabaseSupportedFeaturesTestCommand(DocumentConventions conventions, string[] add, string[] remove) : RavenCommand
+    private sealed class ModifyDatabaseSupportedFeaturesTestCommand(DocumentConventions conventions, string[] add, string[] remove) : RavenCommand, IRaftCommand
     {
+        public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/admin/features";

--- a/test/StressTests/Issues/FilteredReplicationTestsStress.cs
+++ b/test/StressTests/Issues/FilteredReplicationTestsStress.cs
@@ -34,7 +34,7 @@ namespace StressTests.Issues
             public string Source;
         }
 
-        [RavenFact(RavenTestCategory.Core)]
+        [RavenFact(RavenTestCategory.Core | RavenTestCategory.Replication)]
         public async Task Sinks_should_not_update_hubs_change_vector_with_conflicts()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -141,14 +141,14 @@ namespace StressTests.Issues
             using (ctx.OpenReadTransaction())
             {
                 var sink1GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx).AsString();
-                Assert.Equal(2, sink1GlobalCv.ToChangeVector().Length);
+                Assert.Equal(1, sink1GlobalCv.ToChangeVector().Length);
             }
 
             using (sink2Db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
                 var sink2GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx).AsString();
-                Assert.Equal(2, sink2GlobalCv.ToChangeVector().Length);
+                Assert.Equal(1, sink2GlobalCv.ToChangeVector().Length);
             }
 
             await EnsureNoReplicationLoop(Server, hubStore.Database);
@@ -175,7 +175,7 @@ namespace StressTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.Core)]
+        [RavenFact(RavenTestCategory.Core | RavenTestCategory.Replication)]
         public async Task Sinks_should_not_update_hubs_change_vector_with_conflicts2()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -300,14 +300,14 @@ namespace StressTests.Issues
             using (ctx.OpenReadTransaction())
             {
                 var sink1GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx).AsString();
-                Assert.Equal(2, sink1GlobalCv.ToChangeVector().Length);
+                Assert.Equal(1, sink1GlobalCv.ToChangeVector().Length);
             }
 
             using (sink2Db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
                 var sink2GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx).AsString();
-                Assert.Equal(2, sink2GlobalCv.ToChangeVector().Length);
+                Assert.Equal(1, sink2GlobalCv.ToChangeVector().Length);
             }
 
             await EnsureNoReplicationLoop(Server, hubStore.Database);


### PR DESCRIPTION
### Issue link

- https://issues.hibernatingrhinos.com/issue/RavenDB-27004
- https://issues.hibernatingrhinos.com/issue/RavenDB-27005
- https://issues.hibernatingrhinos.com/issue/RavenDB-22734

### Additional description

Aligns pull replication tests with the current Debug Raft request validation and composite change-vector behavior.

- Makes the private test command implement `IRaftCommand` and generate a Raft request ID, ensuring that Debug requests include `raft-request-id`.
- Updates sink global database change-vector expectations from two entries to one. Cross-database lineage is now preserved in the document composite change vector instead of inflating the global database change vector.
- Adds the `Replication` category while retaining the existing `Core` category.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
