### PR TITLE
RavenDB-26997 Fix PowerBI native SQL explicit projection dropping columns on Load (field-count mismatch)

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/PowerBI/PowerBIFetchQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PowerBI/PowerBIFetchQuery.cs
@@ -149,7 +149,16 @@ namespace Raven.Server.Integrations.PostgreSQL.PowerBI
                 // only when synthetic id+json are wanted (narrow projections must not pick them up) or
                 // when REPLACE() rewrites need its substitution machinery; const projections work on both
                 // paths, so a `1 as "c0"` marker alone doesn't force the wide path.
-                if (WantsPowerBISyntheticColumns(selectStmt) || allReplaces != null)
+                var wantsSyntheticColumns = WantsPowerBISyntheticColumns(selectStmt);
+
+                if (wantsSyntheticColumns
+                    && IsBareSelectStarProjection(selectStmt)
+                    && TryParseInnerSelectStmt(inner.InnerText, out var innerSelect))
+                {
+                    wantsSyntheticColumns = WantsPowerBISyntheticColumns(innerSelect);
+                }
+
+                if (wantsSyntheticColumns || allReplaces != null)
                 {
                     pgQuery = new PowerBIRqlQuery(newRql, parametersDataTypes, documentDatabase, allReplaces, limit: limit, constProjections: constProjections);
                 }
@@ -501,6 +510,41 @@ namespace Raven.Server.Integrations.PostgreSQL.PowerBI
             }
 
             return false;
+        }
+
+        private static bool IsBareSelectStarProjection(SelectStmt selectStmt)
+        {
+            var targets = selectStmt?.TargetList;
+            if (targets == null || targets.Count == 0)
+                return true;
+
+            if (targets.Count != 1)
+                return false;
+
+            var fields = targets[0]?.ResTarget?.Val?.ColumnRef?.Fields;
+            return fields is { Count: 1 } && fields[0]?.AStar != null;
+        }
+
+        private static bool TryParseInnerSelectStmt(string innerText, out SelectStmt selectStmt)
+        {
+            selectStmt = null;
+
+            if (string.IsNullOrWhiteSpace(innerText))
+                return false;
+
+            try
+            {
+                var parseResult = SqlAstCache.GetOrParse(innerText);
+                if (parseResult.IsSuccess == false || parseResult.Value?.Stmts is not { Count: 1 })
+                    return false;
+
+                selectStmt = parseResult.Value.Stmts[0]?.Stmt?.SelectStmt;
+                return selectStmt != null;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static bool TryGetSimplePublicRangeVarSelect(string sql, out SelectStmt selectStmt)

--- a/test/FastTests/Server/Integrations/PostgreSQL/PowerBI/PowerBIAstTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/PowerBI/PowerBIAstTests.cs
@@ -118,6 +118,54 @@ namespace FastTests.Server.Integrations.PostgreSQL.PowerBI
         }
 
         [RavenFact(RavenTestCategory.PostgreSql | RavenTestCategory.PowerBi)]
+        public void Wrapped_select_star_over_inner_explicit_projection_routes_to_PgSqlTranslatedRqlQuery()
+        {
+            const string sql = """
+                select * from
+                (
+                    SELECT "Name", "Phone"
+                    FROM "public"."Companies"
+                    LIMIT 10
+                ) "_"
+                """;
+
+            Assert.True(PowerBIFetchQuery.TryParse(sql, Array.Empty<int>(), documentDatabase: null, out var pgQuery));
+            Assert.IsType<PgSqlTranslatedRqlQuery>(pgQuery);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql | RavenTestCategory.PowerBi)]
+        public void Wrapped_select_star_over_inner_grouped_aggregate_routes_to_PgSqlTranslatedRqlQuery()
+        {
+            const string sql = """
+                select * from
+                (
+                    SELECT "ShipVia", COUNT(*)
+                    FROM "public"."Orders"
+                    GROUP BY "ShipVia"
+                ) "_"
+                """;
+
+            Assert.True(PowerBIFetchQuery.TryParse(sql, Array.Empty<int>(), documentDatabase: null, out var pgQuery));
+            Assert.IsType<PgSqlTranslatedRqlQuery>(pgQuery);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql | RavenTestCategory.PowerBi)]
+        public void Wrapped_select_star_over_inner_select_star_routes_to_PowerBIRqlQuery()
+        {
+            const string sql = """
+                select * from
+                (
+                    SELECT *
+                    FROM "public"."Companies"
+                    LIMIT 10
+                ) "_"
+                """;
+
+            Assert.True(PowerBIFetchQuery.TryParse(sql, Array.Empty<int>(), documentDatabase: null, out var pgQuery));
+            Assert.IsType<PowerBIRqlQuery>(pgQuery);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql | RavenTestCategory.PowerBi)]
         public void TryParse_should_match_wrapped_rql_fetch_shape_and_apply_outer_limit()
         {
             const string sql = """select * from (from Employees) "$Table" limit 1000""";

--- a/test/FastTests/Server/Integrations/PostgreSQL/PowerBI/RavenDB_26286.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/PowerBI/RavenDB_26286.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using Raven.Server.Integrations.PostgreSQL;
 using Raven.Server.Integrations.PostgreSQL.PowerBI;
+using Raven.Server.Integrations.PostgreSQL.Translation;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -31,7 +32,7 @@ where ""Title"" = 'Sales Representative'
 limit 0";
 
             Assert.True(PowerBIFetchQuery.TryParse(sql, Array.Empty<int>(), documentDatabase: null, out var pgQuery));
-            Assert.IsType<PowerBIRqlQuery>(pgQuery);
+            Assert.IsType<PgSqlTranslatedRqlQuery>(pgQuery);
 
             var queryString = GetQueryString(pgQuery);
             Assert.NotNull(queryString);

--- a/test/SlowTests/Server/Integrations/PostgreSQL/RavenDB_26997.cs
+++ b/test/SlowTests/Server/Integrations/PostgreSQL/RavenDB_26997.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Integrations.PostgreSQL.PowerBI;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Integrations.PostgreSQL;
+
+public class RavenDB_26997 : RavenTestBase
+{
+    public RavenDB_26997(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Company
+    {
+        public string Name { get; set; }
+        public string Phone { get; set; }
+    }
+
+    [RavenFact(RavenTestCategory.PostgreSql | RavenTestCategory.PowerBi)]
+    public async Task ExplicitProjection_PreviewAndLoad_ReturnSameColumns()
+    {
+        using var store = GetDocumentStore();
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Company { Name = "Acme", Phone = "123" });
+            session.Store(new Company { Name = "Beta", Phone = "456" });
+            session.SaveChanges();
+        }
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+        const string rawLoadSql = """
+            SELECT "Name", "Phone"
+            FROM "public"."Companies"
+            LIMIT 10
+            """;
+
+        const string wrappedPreviewSql = """
+            select * from
+            (
+                SELECT "Name", "Phone"
+                FROM "public"."Companies"
+                LIMIT 10
+            ) "_"
+            """;
+
+        Assert.True(PowerBIFetchQuery.TryParse(rawLoadSql, Array.Empty<int>(), database, out var loadQuery));
+        Assert.True(PowerBIFetchQuery.TryParse(wrappedPreviewSql, Array.Empty<int>(), database, out var previewQuery));
+
+        using (loadQuery)
+        using (previewQuery)
+        {
+            var loadColumns = (await loadQuery.Init()).Select(c => c.Name).ToArray();
+            var previewColumns = (await previewQuery.Init()).Select(c => c.Name).ToArray();
+
+            Assert.Equal(new[] { "Name", "Phone" }, previewColumns);
+            Assert.Equal(previewColumns, loadColumns);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-26997

### Additional description

PowerBI queries wrapped like `select * from (...) "_"` incorrectly added synthetic `id` and `json` columns.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
