### PR TITLE
RavenDB-26960 NewPageAllocator.AllPages and GetNumberOfPreAllocatedFreePages must iterate all allocation sections

### DIFF
--- a/src/Voron/Data/Tables/NewPageAllocator.cs
+++ b/src/Voron/Data/Tables/NewPageAllocator.cs
@@ -307,17 +307,20 @@ namespace Voron.Data.Tables
                 if (it.Seek(long.MinValue) == false)
                     throw new InvalidOperationException($"Could not seek to the first element of {fst.Name} tree");
 
-                using (it.Value(out Slice slice))
+                do
                 {
-                    byte* ptr = slice.Content.Ptr;
-                    for (int i = 0; i < _numberOfPagesToAllocate; i++)
+                    using (it.Value(out Slice slice))
                     {
-                        if (PtrBitVector.GetBitInPointer(ptr, i) == false)
+                        byte* ptr = slice.Content.Ptr;
+                        for (int i = 0; i < _numberOfPagesToAllocate; i++)
                         {
-                            free++;
+                            if (PtrBitVector.GetBitInPointer(ptr, i) == false)
+                            {
+                                free++;
+                            }
                         }
                     }
-                }
+                } while (it.MoveNext());
             }
 
 
@@ -342,17 +345,20 @@ namespace Voron.Data.Tables
                 if (it.Seek(long.MinValue) == false)
                     throw new InvalidOperationException($"Could not seek to the first element of {fst.Name} tree");
 
-                using (it.Value(out Slice slice))
+                do
                 {
-                    byte* ptr = slice.Content.Ptr;
-                    for (int i = 0; i < _numberOfPagesToAllocate; i++)
+                    using (it.Value(out Slice slice))
                     {
-                        if (PtrBitVector.GetBitInPointer(ptr, i) == false)
+                        byte* ptr = slice.Content.Ptr;
+                        for (int i = 0; i < _numberOfPagesToAllocate; i++)
                         {
-                            results.Add(it.CurrentKey + i);
+                            if (PtrBitVector.GetBitInPointer(ptr, i) == false)
+                            {
+                                results.Add(it.CurrentKey + i);
+                            }
                         }
                     }
-                }
+                } while (it.MoveNext());
             }
 
 

--- a/test/FastTests/Voron/Tables/Allocations.cs
+++ b/test/FastTests/Voron/Tables/Allocations.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.Linq;
 using Tests.Infrastructure;
+using Voron.Data.Tables;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -9,6 +11,46 @@ namespace FastTests.Voron.Tables
     {
         public Allocations(ITestOutputHelper output) : base(output)
         {
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void NewPageAllocatorMustAccountForAllSections()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var parent = tx.CreateTree("parent");
+                var allocator = new NewPageAllocator(tx.LowLevelTransaction, parent);
+                allocator.Create();
+
+                // right after Create() there is exactly one section, so even a single-section scan sees all of it
+                int sectionCapacity = allocator.AllPages().Count;
+                Assert.True(sectionCapacity > 0);
+
+                var firstSection = new List<long>();
+                for (int i = 0; i < sectionCapacity; i++)
+                    firstSection.Add(allocator.AllocateSinglePage(0).PageNumber);
+
+                var secondSection = new List<long>();
+                for (int i = 0; i < 20; i++)
+                    secondSection.Add(allocator.AllocateSinglePage(0).PageNumber);
+
+                allocator.FreePage(firstSection[5]);
+                allocator.FreePage(firstSection[10]);
+                allocator.FreePage(firstSection[15]);
+                allocator.FreePage(secondSection[3]);
+                allocator.FreePage(secondSection[7]);
+
+                var expectedFree = 3 + (sectionCapacity - 20) + 2;
+
+                var allPages = allocator.AllPages();
+                Assert.Equal(expectedFree, allPages.Count);
+                Assert.Contains(firstSection[5], allPages);
+                Assert.Contains(secondSection[3], allPages);
+
+                var report = allocator.GetNumberOfPreAllocatedFreePages();
+                Assert.Equal(expectedFree, report.NumberOfFreePages);
+                Assert.Equal(2L * sectionCapacity, report.NumberOfOriginallyAllocatedPages);
+            }
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Voron, RavenArchitecture.AllX64)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26960

### Additional description

`NewPageAllocator.AllPages()` and `GetNumberOfPreAllocatedFreePages()` read only the first `Allocation-Storage` entry, so both methods only ever saw the first 256-page section of the allocator.

This is an additional fix for the space leak addressed in #22167 (RavenDB-25842). `Transaction.DeleteTable` releases a deleted table's unused pre-allocated pages via `FreePreAllocatedFreePages()`, but since `AllPages()` returned only the first section, free pages in the remaining sections still leaked on every table deletion. The `Allocation-Storage` bitmaps are deleted right after, so those pages became permanently unreachable (only compaction reclaims them).

Also fixes the storage report, which counted free pre-allocated pages from the first section only, while `NumberOfOriginallyAllocatedPages` covered all sections.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
