### PR TITLE
RavenDB-27025 Retry CDC-enable SQL on transient msdb deadlock

### DIFF
--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkResilienceSqlServerTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkResilienceSqlServerTests.cs
@@ -20,13 +20,31 @@ namespace SlowTests.Server.Documents.CdcSink
         {
         }
 
+        private const int SqlDeadlockErrorNumber = 1205;
+
+        private static bool IsDeadlock(SqlException e) =>
+            e.Number == SqlDeadlockErrorNumber ||
+            e.Message.Contains("deadlock", StringComparison.OrdinalIgnoreCase);
+
         private void ExecuteMsSql(string connectionString, string sql)
         {
-            using var connection = new SqlConnection(connectionString);
-            connection.Open();
-            using var cmd = new SqlCommand(sql, connection);
-            cmd.CommandTimeout = 120;
-            cmd.ExecuteNonQuery();
+            const int maxAttempts = 5;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    using var connection = new SqlConnection(connectionString);
+                    connection.Open();
+                    using var cmd = new SqlCommand(sql, connection);
+                    cmd.CommandTimeout = 120;
+                    cmd.ExecuteNonQuery();
+                    return;
+                }
+                catch (SqlException e) when (IsDeadlock(e) && attempt < maxAttempts)
+                {
+                    System.Threading.Thread.Sleep(500 * attempt);
+                }
+            }
         }
 
         private void EnableCdc(string connectionString)


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27025/SlowTests.Server.Documents.CdcSink.CdcSinkResilienceSqlServerTests.LsnGapDetectedWhenChangesArePurged
https://issues.ravendb.net/issue/RavenDB-27026/SlowTests.Server.Documents.CdcSink.CdcSinkResilienceSqlServerTests.SchemaEvolutionRemoveColumnProcessEntersFallbackOnRecreatedCa
https://issues.ravendb.net/issue/RavenDB-27028/SlowTests.Server.Documents.CdcSink.CdcSinkResilienceSqlServerTests.SchemaEvolutionDropOldCaptureInstanceProcessRecovers

### Additional description

Fix flaky `CdcSinkResilienceSqlServerTests`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
