### PR TITLE
RavenDB-27019 Server ETL, AI tasks and CDC metrics should be gauges instead of counters

### DIFF
--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -219,25 +219,25 @@ namespace Raven.Server.Web.System
                     WriteGaugeWithHelp(writer, "Server license max CPU cores", "license_max_cores", serverMetrics.License.MaxCores);
                     
                     // ETLs
-                    WriteCounterWithHelp(writer, "Number of ETLs", "server_etls_count", serverMetrics.Etls.Count);
-                    WriteCounterWithHelp(writer, "Number of ETL errors", "server_etls_errors_count", serverMetrics.Etls.ErrorsCount);
-                    WriteCounterWithHelp(writer, "Number of healthy ETLs", "server_etls_healthy_count", serverMetrics.Etls.HealthyEtlsCount);
-                    WriteCounterWithHelp(writer, "Number of impaired ETLs", "server_etls_impaired_count", serverMetrics.Etls.ImpairedEtlsCount);
-                    WriteCounterWithHelp(writer, "Number of failed ETLs", "server_etls_failed_count", serverMetrics.Etls.FailedEtlsCount);
+                    WriteGaugeWithHelp(writer, "Number of ETLs", "server_etls_count", serverMetrics.Etls.Count);
+                    WriteGaugeWithHelp(writer, "Number of ETL errors", "server_etls_errors_count", serverMetrics.Etls.ErrorsCount);
+                    WriteGaugeWithHelp(writer, "Number of healthy ETLs", "server_etls_healthy_count", serverMetrics.Etls.HealthyEtlsCount);
+                    WriteGaugeWithHelp(writer, "Number of impaired ETLs", "server_etls_impaired_count", serverMetrics.Etls.ImpairedEtlsCount);
+                    WriteGaugeWithHelp(writer, "Number of failed ETLs", "server_etls_failed_count", serverMetrics.Etls.FailedEtlsCount);
 
                     // AI Tasks
-                    WriteCounterWithHelp(writer, "Number of AI tasks", "server_ai_tasks_count", serverMetrics.AiTasks.Count);
-                    WriteCounterWithHelp(writer, "Number of AI task errors", "server_ai_tasks_errors_count", serverMetrics.AiTasks.ErrorsCount);
-                    WriteCounterWithHelp(writer, "Number of healthy AI tasks", "server_ai_tasks_healthy_count", serverMetrics.AiTasks.HealthyTasksCount);
-                    WriteCounterWithHelp(writer, "Number of impaired AI tasks", "server_ai_tasks_impaired_count", serverMetrics.AiTasks.ImpairedTasksCount);
-                    WriteCounterWithHelp(writer, "Number of failed AI tasks", "server_ai_tasks_failed_count", serverMetrics.AiTasks.FailedTasksCount);
+                    WriteGaugeWithHelp(writer, "Number of AI tasks", "server_ai_tasks_count", serverMetrics.AiTasks.Count);
+                    WriteGaugeWithHelp(writer, "Number of AI task errors", "server_ai_tasks_errors_count", serverMetrics.AiTasks.ErrorsCount);
+                    WriteGaugeWithHelp(writer, "Number of healthy AI tasks", "server_ai_tasks_healthy_count", serverMetrics.AiTasks.HealthyTasksCount);
+                    WriteGaugeWithHelp(writer, "Number of impaired AI tasks", "server_ai_tasks_impaired_count", serverMetrics.AiTasks.ImpairedTasksCount);
+                    WriteGaugeWithHelp(writer, "Number of failed AI tasks", "server_ai_tasks_failed_count", serverMetrics.AiTasks.FailedTasksCount);
 
                     // CDC CdcSinks
-                    WriteCounterWithHelp(writer, "Number of CDC CdcSinks", "server_cdc_sinks_count", serverMetrics.CdcSinks.Count);
-                    WriteCounterWithHelp(writer, "Number of CDC Sink errors", "server_cdc_sinks_errors_count", serverMetrics.CdcSinks.ErrorsCount);
-                    WriteCounterWithHelp(writer, "Number of healthy CDC CdcSinks", "server_cdc_sinks_healthy_count", serverMetrics.CdcSinks.HealthyCdcSinksCount);
-                    WriteCounterWithHelp(writer, "Number of impaired CDC CdcSinks", "server_cdc_sinks_impaired_count", serverMetrics.CdcSinks.ImpairedCdcSinksCount);
-                    WriteCounterWithHelp(writer, "Number of failed CDC CdcSinks", "server_cdc_sinks_failed_count", serverMetrics.CdcSinks.FailedCdcSinksCount);
+                    WriteGaugeWithHelp(writer, "Number of CDC CdcSinks", "server_cdc_sinks_count", serverMetrics.CdcSinks.Count);
+                    WriteGaugeWithHelp(writer, "Number of CDC Sink errors", "server_cdc_sinks_errors_count", serverMetrics.CdcSinks.ErrorsCount);
+                    WriteGaugeWithHelp(writer, "Number of healthy CDC CdcSinks", "server_cdc_sinks_healthy_count", serverMetrics.CdcSinks.HealthyCdcSinksCount);
+                    WriteGaugeWithHelp(writer, "Number of impaired CDC CdcSinks", "server_cdc_sinks_impaired_count", serverMetrics.CdcSinks.ImpairedCdcSinksCount);
+                    WriteGaugeWithHelp(writer, "Number of failed CDC CdcSinks", "server_cdc_sinks_failed_count", serverMetrics.CdcSinks.FailedCdcSinksCount);
                 }
 
                 ms.Position = 0;


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27019

### Additional description

Metrics such as `server_etls_count` can decrement (e.g. on task deletion), we should use gauges instead of counters. Note we already do for database metrics, it's an issue only for server ones.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
Changing type of metric can break the existing setups. We decided to make this change since these metrics were introduced very recently.
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
