### PR TITLE
RavenDB-27003 Include ETL/AI/CDC task-error counts in DatabaseStatsChanged so the Studio Task Errors badge updates live

### DIFF
--- a/src/Raven.Server/NotificationCenter/BackgroundWork/AbstractDatabaseStatsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/AbstractDatabaseStatsSender.cs
@@ -47,6 +47,9 @@ public abstract class AbstractDatabaseStatsSender : BackgroundWorkBase
             current.GlobalChangeVector,
             current.LastEtag,
             current.CountOfIndexingErrors,
+            current.CountOfEtlTasksErrors,
+            current.CountOfAiTasksErrors,
+            current.CountOfCdcSinkTasksErrors,
             current.LastIndexingErrorTime,
             modifiedCollections,
             current.CountOfRevisions));

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.TasksErrors;
 using Raven.Server.NotificationCenter.Notifications;
 
 namespace Raven.Server.NotificationCenter.BackgroundWork;
@@ -63,6 +64,9 @@ public sealed class DatabaseStatsSender : AbstractDatabaseStatsSender
                 CountOfStaleIndexes = staleIndexes.Count,
                 StaleIndexes = staleIndexes.ToArray(),
                 CountOfIndexingErrors = countOfIndexingErrors,
+                CountOfEtlTasksErrors = database.TaskErrorsStorage.ReadTotalErrorsCount(TaskCategory.Etl),
+                CountOfAiTasksErrors = database.TaskErrorsStorage.ReadTotalErrorsCount(TaskCategory.Ai),
+                CountOfCdcSinkTasksErrors = database.TaskErrorsStorage.ReadTotalErrorsCount(TaskCategory.CdcSink),
                 LastEtag = database.DocumentsStorage.ReadLastEtag(context.Documents.Transaction.InnerTransaction),
                 GlobalChangeVector = DocumentsStorage.GetDatabaseChangeVector(context.Documents),
                 LastIndexingErrorTime = lastIndexingErrorTime,

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/NotificationCenterDatabaseStats.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/NotificationCenterDatabaseStats.cs
@@ -23,6 +23,12 @@ public sealed class NotificationCenterDatabaseStats
 
     public long CountOfIndexingErrors;
 
+    public long CountOfEtlTasksErrors;
+
+    public long CountOfAiTasksErrors;
+
+    public long CountOfCdcSinkTasksErrors;
+
     public string GlobalChangeVector;
 
     public DateTime? LastIndexingErrorTime;
@@ -41,6 +47,9 @@ public sealed class NotificationCenterDatabaseStats
                CountOfDocuments == other.CountOfDocuments &&
                CountOfIndexes == other.CountOfIndexes &&
                CountOfIndexingErrors == other.CountOfIndexingErrors &&
+               CountOfEtlTasksErrors == other.CountOfEtlTasksErrors &&
+               CountOfAiTasksErrors == other.CountOfAiTasksErrors &&
+               CountOfCdcSinkTasksErrors == other.CountOfCdcSinkTasksErrors &&
                LastEtag == other.LastEtag &&
                CountOfStaleIndexes == other.CountOfStaleIndexes &&
                GlobalChangeVector == other.GlobalChangeVector &&
@@ -70,6 +79,9 @@ public sealed class NotificationCenterDatabaseStats
             hashCode = (hashCode * 397) ^ CountOfIndexes.GetHashCode();
             hashCode = (hashCode * 397) ^ LastEtag.GetHashCode();
             hashCode = (hashCode * 397) ^ CountOfIndexingErrors.GetHashCode();
+            hashCode = (hashCode * 397) ^ CountOfEtlTasksErrors.GetHashCode();
+            hashCode = (hashCode * 397) ^ CountOfAiTasksErrors.GetHashCode();
+            hashCode = (hashCode * 397) ^ CountOfCdcSinkTasksErrors.GetHashCode();
             hashCode = (hashCode * 397) ^ CountOfStaleIndexes.GetHashCode();
             hashCode = (hashCode * 397) ^ GlobalChangeVector.GetHashCode();
             hashCode = (hashCode * 397) ^ (Collections != null ? Collections.GetHashCode() : 0);
@@ -86,6 +98,9 @@ public sealed class NotificationCenterDatabaseStats
         
         CountOfIndexes = stats.CountOfIndexes; // every node has the same amount of indexes
         CountOfIndexingErrors += stats.CountOfIndexingErrors;
+        CountOfEtlTasksErrors += stats.CountOfEtlTasksErrors;
+        CountOfAiTasksErrors += stats.CountOfAiTasksErrors;
+        CountOfCdcSinkTasksErrors += stats.CountOfCdcSinkTasksErrors;
 
         if (StaleIndexes == null)
             StaleIndexes = stats.StaleIndexes;

--- a/src/Raven.Server/NotificationCenter/Handlers/Processors/DatabaseNotificationCenterHandlerProcessorForStats.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/Processors/DatabaseNotificationCenterHandlerProcessorForStats.cs
@@ -51,6 +51,18 @@ internal sealed class DatabaseNotificationCenterHandlerProcessorForStats : Abstr
             writer.WriteInteger(stats.CountOfIndexingErrors);
             writer.WriteComma();
 
+            writer.WritePropertyName(nameof(stats.CountOfEtlTasksErrors));
+            writer.WriteInteger(stats.CountOfEtlTasksErrors);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(stats.CountOfAiTasksErrors));
+            writer.WriteInteger(stats.CountOfAiTasksErrors);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(stats.CountOfCdcSinkTasksErrors));
+            writer.WriteInteger(stats.CountOfCdcSinkTasksErrors);
+            writer.WriteComma();
+
             writer.WritePropertyName(nameof(stats.GlobalChangeVector));
             writer.WriteString(stats.GlobalChangeVector);
             writer.WriteComma();

--- a/src/Raven.Server/NotificationCenter/Notifications/DatabaseStatsChanged.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/DatabaseStatsChanged.cs
@@ -25,6 +25,12 @@ namespace Raven.Server.NotificationCenter.Notifications
 
         public long CountOfIndexingErrors { get; private set; }
 
+        public long CountOfEtlTasksErrors { get; private set; }
+
+        public long CountOfAiTasksErrors { get; private set; }
+
+        public long CountOfCdcSinkTasksErrors { get; private set; }
+
         public DateTime? LastIndexingErrorTime { get; private set; }
 
         public string GlobalChangeVector { get; private set; }
@@ -46,6 +52,9 @@ namespace Raven.Server.NotificationCenter.Notifications
             json[nameof(LastEtag)] = LastEtag;
             json[nameof(GlobalChangeVector)] = GlobalChangeVector;
             json[nameof(CountOfIndexingErrors)] = CountOfIndexingErrors;
+            json[nameof(CountOfEtlTasksErrors)] = CountOfEtlTasksErrors;
+            json[nameof(CountOfAiTasksErrors)] = CountOfAiTasksErrors;
+            json[nameof(CountOfCdcSinkTasksErrors)] = CountOfCdcSinkTasksErrors;
             json[nameof(LastIndexingErrorTime)] = LastIndexingErrorTime;
             json[nameof(ModifiedCollections)] = new DynamicJsonArray(ModifiedCollections.Select(x => x.ToJson()));
             json[nameof(CountOfRevisions)] = CountOfRevisions;
@@ -62,6 +71,9 @@ namespace Raven.Server.NotificationCenter.Notifications
             string globalChangeVector,
             long lastEtag,
             long countOfIndexingErrors,
+            long countOfEtlTasksErrors,
+            long countOfAiTasksErrors,
+            long countOfCdcSinkTasksErrors,
             DateTime? lastIndexingErrorTime,
             List<ModifiedCollection> modifiedCollections,
             long countOfRevisions)
@@ -77,6 +89,9 @@ namespace Raven.Server.NotificationCenter.Notifications
                 LastEtag = lastEtag,
                 GlobalChangeVector = globalChangeVector,
                 CountOfIndexingErrors = countOfIndexingErrors,
+                CountOfEtlTasksErrors = countOfEtlTasksErrors,
+                CountOfAiTasksErrors = countOfAiTasksErrors,
+                CountOfCdcSinkTasksErrors = countOfCdcSinkTasksErrors,
                 CountOfIndexes = countOfIndexes,
                 CountOfStaleIndexes = countOfStaleIndexes,
                 LastIndexingErrorTime = lastIndexingErrorTime,

--- a/src/Raven.Studio/typescript/common/shell/footer.ts
+++ b/src/Raven.Studio/typescript/common/shell/footer.ts
@@ -186,6 +186,9 @@ class footer {
         stats.countOfIndexes(event.CountOfIndexes);
         stats.countOfStaleIndexes(event.CountOfStaleIndexes);
         stats.countOfIndexingErrors(event.CountOfIndexingErrors);
+        stats.countOfEtlTasksErrors(event.CountOfEtlTasksErrors);
+        stats.countOfAiTasksErrors(event.CountOfAiTasksErrors);
+        stats.countOfCdcSinkTasksErrors(event.CountOfCdcSinkTasksErrors);
     }
     
 }

--- a/test/SlowTests.Issues/Issues/RavenDB-27003.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27003.cs
@@ -1,0 +1,52 @@
+using System;
+using FastTests;
+using Raven.Server.NotificationCenter.BackgroundWork;
+using Raven.Server.Documents.TasksErrors;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27003 : RavenTestBase
+{
+    public RavenDB_27003(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Sinks)]
+    public void DatabaseStats_IncludeTaskErrorCountsSoTheFooterBadgeUpdatesLive()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var database = GetDatabase(store.Database).GetAwaiter().GetResult();
+            var now = DateTime.UtcNow;
+
+            database.TaskErrorsStorage.StoreProcessError(TaskCategory.CdcSink, new TaskProcessError
+            {
+                CreatedAt = now,
+                TaskName = "CdcSink1",
+                Step = TaskErrorStep.Extraction,
+                Error = "consume error"
+            });
+
+            database.TaskErrorsStorage.StoreItemErrors(TaskCategory.CdcSink, "CdcSink1",
+            [
+                new TaskItemError { DocumentId = "orders/1", TaskName = "CdcSink1", CreatedAt = now, Step = TaskErrorStep.Load, Error = "e1" }
+            ]);
+
+            database.TaskErrorsStorage.StoreProcessError(TaskCategory.Etl, new TaskProcessError
+            {
+                CreatedAt = now,
+                TaskName = "Etl1/Transformation1",
+                Step = TaskErrorStep.Transformation,
+                Error = "etl error"
+            });
+            
+            var stats = DatabaseStatsSender.GetStats(database);
+
+            Assert.Equal(2, stats.CountOfCdcSinkTasksErrors);
+            Assert.Equal(1, stats.CountOfEtlTasksErrors);
+            Assert.Equal(0, stats.CountOfAiTasksErrors);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27003/CDC-Errors-not-cleared

### Additional description

Added ETL, AI and CDC task errors count to database stats notification

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
