### PR TITLE
RavenDB-27029: Fix false gap detection in storage mapping

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
@@ -76,64 +76,74 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
 
         var gaps = new List<(long Start, long End)>();
 
-        for (long i = 0; i < totalPages; i++)
+        long i = 0;
+        while (i < totalPages)
         {
-            if (owners.ContainsKey(i) == false)
+            if (owners.ContainsKey(i))
             {
-                using (var tx = env.Environment.ReadTransaction())
+                i++;
+                continue;
+            }
+
+            using (var tx = env.Environment.ReadTransaction())
+            {
+                var claimed = false;
+                try
                 {
+                    var page = tx.LowLevelTransaction.GetPage(i);
+                    var isOverflow = page.Flags.HasFlag(PageFlags.Overflow);
+                    var isRawData = page.Flags.HasFlag(PageFlags.RawData);
+
+                    // If it's RawData or Overflow, it's legitimate table data we just didn't trace.
+                    // Claim it so it isn't reported as a gap.
+                    if (isOverflow || isRawData)
+                    {
+                        string pageType = isOverflow ? "Overflow (Large Data)" : "RawData (Table Data)";
+                        owners[i] = $"Unmapped {pageType}";
+
+                        // If it's an overflow page, it likely spans multiple pages.
+                        // Claim the subsequent pages dictated by the overflow size.
+                        if (isOverflow)
+                        {
+                            var numberOfOverflowPages = Paging.GetNumberOfOverflowPages(page.OverflowSize);
+                            // Never claim past the last allocated page.
+                            for (int overflowPage = 1; overflowPage < numberOfOverflowPages && i + 1 < totalPages; ++overflowPage)
+                            {
+                                i++;
+                                owners[i] = "Overflow (Continuation)";
+                            }
+                        }
+
+                        i++; // advance past the claimed region
+                        claimed = true;
+                    }
+                }
+                catch
+                {
+                    // If we can't read the page for some reason, let it fall through to become a gap
+                }
+
+                if (claimed)
+                    continue; // It's owned now, so it's not a gap!
+
+                // If we get here, it's a TRUE gap (not RawData, not Overflow, and unowned).
+                // Extend until an owned page OR an unmapped RawData/Overflow page.
+                var start = i;
+                while (i < totalPages && owners.ContainsKey(i) == false)
+                {
+                    // Stop at valid unmapped RawData/Overflow so we don't group it into a true gap block.
                     try
                     {
                         var page = tx.LowLevelTransaction.GetPage(i);
-
-                        // If it's RawData or Overflow, it's legitimate table data we just didn't trace.
-                        // Let's claim it!
                         if (page.Flags.HasFlag(PageFlags.Overflow) || page.Flags.HasFlag(PageFlags.RawData))
-                        {
-                            string pageType = page.Flags.HasFlag(PageFlags.Overflow) ? "Overflow (Large Data)" : "RawData (Table Data)";
-                            owners[i] = $"Unmapped {pageType}";
-
-                            // If it's an overflow page, it likely spans multiple pages.
-                            // We should claim the subsequent pages dictated by the overflow size.
-                            if (page.Flags.HasFlag(PageFlags.Overflow))
-                            {
-                                var numberOfOverflowPages = Paging.GetNumberOfOverflowPages(page.OverflowSize);
-                                for (int overflowPage = 1; overflowPage < numberOfOverflowPages; ++overflowPage)
-                                {
-                                    // Advance our main loop index and claim the contiguous pages
-                                    i++;
-                                    owners[i] = "Overflow (Continuation)";
-                                }
-                            }
-                            continue; // It's owned now, so it's not a gap!
-                        }
+                            break; // do NOT advance past it; the outer loop re-examines and claims it
                     }
-                    catch
-                    {
-                        // If we can't read the page for some reason, let it fall through to become a gap
-                    }
+                    catch { }
 
-                    // If we get here, it's a TRUE gap (not RawData, not Overflow, and unowned)
-                    var start = i;
-                    while (i < totalPages)
-                    {
-                        if (owners.ContainsKey(i))
-                            break;
-
-                        // We should also check inside the while loop so we don't group 
-                        // valid unmapped RawData into a true gap block.
-                        try
-                        {
-                            var page = tx.LowLevelTransaction.GetPage(i);
-                            if (page.Flags.HasFlag(PageFlags.Overflow) || page.Flags.HasFlag(PageFlags.RawData))
-                                break;
-                        }
-                        catch { }
-
-                        i++;
-                    }
-                    gaps.Add((start, i));
+                    i++;
                 }
+                gaps.Add((start, i));
+                // No i++ here: the outer while re-examines the terminating page.
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
@@ -44,10 +44,13 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
         Dictionary<long, string> owners;
         long totalPages;
 
+        var gaps = new List<(long Start, long End)>();
+
         using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-        using (var tx = env.Environment.ReadTransaction()) 
+        using (var tx = env.Environment.ReadTransaction())
         {
-            totalPages = tx.LowLevelTransaction.DataPagerState.NumberOfAllocatedPages;
+            var llt = tx.LowLevelTransaction;
+            totalPages = llt.DataPagerState.NumberOfAllocatedPages;
             owners = env.Environment.GetPageOwners(tx, postingList =>
             {
                 if (postingList.Name.ToString() != "LargePostingListsSet")
@@ -62,9 +65,9 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
                     {
                         for (int i = 0; i < read; i++)
                         {
-                            Container.Get(tx.LowLevelTransaction, new ContainerEntryId(buffer[i]), out var item);
+                            Container.Get(llt, new ContainerEntryId(buffer[i]), out var item);
                             var state = (PostingListState*)item.Address;
-                            var pl = new PostingList(tx.LowLevelTransaction, Constants.IndexWriter.LargePostingListsSetSlice, *state);
+                            var pl = new PostingList(llt, Constants.IndexWriter.LargePostingListsSetSlice, *state);
                             list.AddRange(pl.AllPages());
                         }
                     }
@@ -72,25 +75,33 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
 
                 return list;
             });
-        }
 
-        var gaps = new List<(long Start, long End)>();
-
-        long i = 0;
-        while (i < totalPages)
-        {
-            if (owners.ContainsKey(i))
+            // Walk every page under this single read transaction, classifying each unowned page as
+            // either legitimate-but-untraced table data (RawData/Overflow, which we claim) or a true gap.
+            long i = 0;
+            while (i < totalPages)
             {
-                i++;
-                continue;
-            }
+                if (owners.ContainsKey(i))
+                {
+                    i++;
+                    continue;
+                }
 
-            using (var tx = env.Environment.ReadTransaction())
-            {
-                var claimed = false;
+                // Unowned page: read it once to decide whether it's claimable table data or a gap.
+                Page page = default;
+                var readable = true;
                 try
                 {
-                    var page = tx.LowLevelTransaction.GetPage(i);
+                    page = llt.GetPage(i);
+                }
+                catch
+                {
+                    // Can't read it -> treat it as the start of a true gap.
+                    readable = false;
+                }
+
+                if (readable)
+                {
                     var isOverflow = page.Flags.HasFlag(PageFlags.Overflow);
                     var isRawData = page.Flags.HasFlag(PageFlags.RawData);
 
@@ -98,11 +109,9 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
                     // Claim it so it isn't reported as a gap.
                     if (isOverflow || isRawData)
                     {
-                        string pageType = isOverflow ? "Overflow (Large Data)" : "RawData (Table Data)";
-                        owners[i] = $"Unmapped {pageType}";
+                        owners[i] = $"Unmapped {(isOverflow ? "Overflow (Large Data)" : "RawData (Table Data)")}";
 
-                        // If it's an overflow page, it likely spans multiple pages.
-                        // Claim the subsequent pages dictated by the overflow size.
+                        // An overflow page spans multiple pages; claim the continuation pages too.
                         if (isOverflow)
                         {
                             var numberOfOverflowPages = Paging.GetNumberOfOverflowPages(page.OverflowSize);
@@ -115,83 +124,36 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
                         }
 
                         i++; // advance past the claimed region
-                        claimed = true;
+                        continue; // It's owned now, so it's not a gap!
                     }
                 }
-                catch
-                {
-                    // If we can't read the page for some reason, let it fall through to become a gap
-                }
 
-                if (claimed)
-                    continue; // It's owned now, so it's not a gap!
-
-                // If we get here, it's a TRUE gap (not RawData, not Overflow, and unowned).
-                // Extend until an owned page OR an unmapped RawData/Overflow page.
+                // True gap starting at i (either unreadable, or readable and not RawData/Overflow).
+                // page i is already classified, so scan the pages that follow.
                 var start = i;
+                i++;
                 while (i < totalPages && owners.ContainsKey(i) == false)
                 {
-                    // Stop at valid unmapped RawData/Overflow so we don't group it into a true gap block.
+                    // Stop at a valid unmapped RawData/Overflow page so we don't group it into a true gap
+                    // block; leave i on it so the outer loop re-examines and claims it.
+                    var boundary = false;
                     try
                     {
-                        var page = tx.LowLevelTransaction.GetPage(i);
-                        if (page.Flags.HasFlag(PageFlags.Overflow) || page.Flags.HasFlag(PageFlags.RawData))
-                            break; // do NOT advance past it; the outer loop re-examines and claims it
+                        var next = llt.GetPage(i);
+                        boundary = next.Flags.HasFlag(PageFlags.Overflow) || next.Flags.HasFlag(PageFlags.RawData);
                     }
-                    catch { }
+                    catch
+                    {
+                        // Unreadable page is still part of the gap.
+                    }
+
+                    if (boundary)
+                        break;
 
                     i++;
                 }
                 gaps.Add((start, i));
-                // No i++ here: the outer while re-examines the terminating page.
             }
-        }
-
-        using (var tx = env.Environment.ReadTransaction())
-        {
-            // --- GAP ANALYSIS SNIPPET ---
-
-            var gapAnalysis = new Dictionary<string, int>();
-            var gapPageDetails = new Dictionary<long, string>(); // Optional: If you want to pass this to your renderer
-
-            foreach (var gap in gaps)
-            {
-                for (long pageNumber = gap.Start; pageNumber < gap.End; pageNumber++)
-                {
-                    try
-                    {
-                        // Grab the raw page from the low-level pager
-                        var page = tx.LowLevelTransaction.GetPage(pageNumber);
-
-                        // The Flags enum will tell you exactly what Voron thinks this page is
-                        var flags = page.Flags;
-
-                        string gapType = flags.ToString();
-
-                        // Track how many of each type we are missing
-                        if (gapAnalysis.ContainsKey(gapType))
-                            gapAnalysis[gapType]++;
-                        else
-                            gapAnalysis[gapType] = 1;
-
-                        // Keep track of the specific page details for your UI
-                        gapPageDetails[pageNumber] = $"Gap - {gapType}";
-                    }
-                    catch (Exception ex)
-                    {
-                        // Just in case we hit an unmapped or strictly locked region
-                        gapPageDetails[pageNumber] = $"Gap - Unreadable ({ex.Message})";
-                    }
-                }
-            }
-
-            // Quick debug output to your console/logger so you can see it immediately
-            foreach (var kvp in gapAnalysis)
-            {
-                Console.WriteLine($"VORON DEBUG: Found {kvp.Value} gap pages with flags: {kvp.Key}");
-            }
-
-            // --- END GAP ANALYSIS SNIPPET ---
         }
 
         var output = RequestHandler.GetEnumQueryString<OutputType>("output", required: false);
@@ -412,6 +374,8 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
             return ("⏱️", "TimeSeries");
         if (owner.Contains("Metadata") || owner.Contains("(VST)"))
             return ("🔧", owner);
+        if (owner.Contains("Overflow"))
+            return ("🟧", "Overflow (Large Data)");
         return ("🟦", owner);
     }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -42,6 +41,7 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
 
         Dictionary<long, string> owners;
         long totalPages;
+        var unownedOverflowPages = new Dictionary<long, (string ClaimedTableName, byte TableType, long NumberOfPages, long SizeInBytes)>();
 
         using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
         using (var tx = env.Environment.ReadTransaction())
@@ -71,7 +71,7 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
                 }
 
                 return list;
-            });
+            }, unownedOverflowPages);
         }
 
         var gaps = new List<(long Start, long End)>();
@@ -96,10 +96,10 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
         switch (output)
         {
             case OutputType.Emojis:
-                await RenderEmojis(env.Environment, owners, gaps, totalPages);
+                await RenderEmojis(env.Environment, owners, gaps, unownedOverflowPages, totalPages);
                 break;
             default:
-                await RenderRaw(env.Environment, owners, gaps);
+                await RenderRaw(env.Environment, owners, gaps, unownedOverflowPages);
                 break;
         }
     }
@@ -110,7 +110,8 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
         Text,
     }
 
-    private async Task RenderRaw(StorageEnvironment env, Dictionary<long, string> owners, List<(long Start, long End)> gaps)
+    private async Task RenderRaw(StorageEnvironment env, Dictionary<long, string> owners, List<(long Start, long End)> gaps,
+        Dictionary<long, (string ClaimedTableName, byte TableType, long NumberOfPages, long SizeInBytes)> unownedOverflowPages)
     {
         HttpContext.Response.Headers.ContentType = "text/plain; charset=utf-8";
 
@@ -119,7 +120,7 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
         // it is not meant for general consumption, that is partly why it returns text
         // and not JSON, this is meant purely to be human readable.
         await using var sw = new StreamWriter(RequestHandler.ResponseBodyStream(), Encoding.UTF8);
-        
+
         if (gaps.Count > 0)
         {
             await sw.WriteLineAsync("Gaps");
@@ -129,11 +130,28 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
                 await sw.WriteLineAsync($"{start}-{end}");
                 for (long i = start; i < end; i++)
                 {
-                    await sw.WriteLineAsync($"  Page {i:N0}");
+                    if (unownedOverflowPages.TryGetValue(i, out var claim))
+                        await sw.WriteLineAsync($"  Page {i:N0} 🚨 header claims '{GetClaimedTableName(claim)}', {claim.NumberOfPages:N0} pages, ~{new Sparrow.Size(claim.SizeInBytes, Sparrow.SizeUnit.Bytes)} - leaked LargeValue?");
+                    else
+                        await sw.WriteLineAsync($"  Page {i:N0}");
                 }
             }
             await sw.WriteLineAsync("------------------");
             await sw.WriteLineAsync();
+
+            if (unownedOverflowPages.Count > 0)
+            {
+                await sw.WriteLineAsync("Leaked by table (claimed)");
+                await sw.WriteLineAsync("------------------");
+                foreach (var group in unownedOverflowPages.GroupBy(x => GetClaimedTableName(x.Value)).OrderBy(x => x.Key))
+                {
+                    var pages = group.Sum(x => x.Value.NumberOfPages);
+                    var bytes = group.Sum(x => x.Value.SizeInBytes);
+                    await sw.WriteLineAsync($"{group.Key}: {group.Count():N0} large values, {pages:N0} pages, ~{new Sparrow.Size(bytes, Sparrow.SizeUnit.Bytes)}");
+                }
+                await sw.WriteLineAsync("------------------");
+                await sw.WriteLineAsync();
+            }
         }
 
         await sw.WriteLineAsync("Pages");
@@ -146,20 +164,28 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
         await sw.WriteLineAsync("------------------");
     }
 
-    private async Task RenderEmojis(StorageEnvironment env, Dictionary<long, string> owners, List<(long Start, long End)> gaps, long totalPages)
+    private async Task RenderEmojis(StorageEnvironment env, Dictionary<long, string> owners, List<(long Start, long End)> gaps,
+        Dictionary<long, (string ClaimedTableName, byte TableType, long NumberOfPages, long SizeInBytes)> unownedOverflowPages, long totalPages)
     {
         await using var sw = new StreamWriter(RequestHandler.ResponseBodyStream(), Encoding.UTF8);
         HttpContext.Response.Headers.ContentType = "text/html; charset=utf-8";
 
         var filePath = env.DataPager.FileName;
-        
+
         var pages = new string[totalPages];
         Array.Fill(pages, "Unassigned");
-        
+
         foreach (var gap in gaps)
         {
             for (long i = gap.Start; i < gap.End && i < totalPages; i++)
                 pages[i] = "Gap";
+        }
+
+        foreach (var (startPage, claim) in unownedOverflowPages)
+        {
+            var label = $"Gap (header claims '{GetClaimedTableName(claim)}', leaked LargeValue?)";
+            for (long i = startPage; i < startPage + claim.NumberOfPages && i < totalPages; i++)
+                pages[i] = label;
         }
 
         foreach (var (page, owner) in owners)
@@ -269,6 +295,8 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
             return ("🚨", "Sparse DUPE (BUG!)");
         if (owner == "Gap")
             return ("🚨", "Gap (BUG!)");
+        if (owner.StartsWith("Gap (header claims"))
+            return ("🚨", "Gap - header claims a table large value, leaked? (BUG!)");
         if (owner == "Sparse")
             return ("🗑️", "Sparse (returned to OS...)");
         if (owner == "Unassigned")
@@ -279,6 +307,8 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
             return ("⚪", "Unused Page");
         if (owner == "$free-space")
             return ("♻️", "$free-space");
+        if (owner.EndsWith("/LargeValue"))
+            return ("🟧", "Overflow (Large Data)");
         if (owner.StartsWith("Collection.Documents."))
             return ("📄", "Documents");
         if (owner.StartsWith("Collection.Tombstones."))
@@ -314,4 +344,8 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
         return ("🟦", owner);
     }
 
+    private static string GetClaimedTableName((string ClaimedTableName, byte TableType, long NumberOfPages, long SizeInBytes) claim)
+    {
+        return claim.ClaimedTableName ?? $"unknown table (type: {claim.TableType})";
+    }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
@@ -14,6 +14,7 @@ using Raven.Server.Web.Http;
 using Voron;
 using Voron.Data.Containers;
 using Voron.Data.PostingLists;
+using Voron.Impl.Paging;
 
 namespace Raven.Server.Documents.Handlers.Processors.Debugging;
 
@@ -79,15 +80,108 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
         {
             if (owners.ContainsKey(i) == false)
             {
-                var start = i;
-                while (i < totalPages)
+                using (var tx = env.Environment.ReadTransaction())
                 {
-                    if (owners.ContainsKey(i))
-                        break;
-                    i++;
+                    try
+                    {
+                        var page = tx.LowLevelTransaction.GetPage(i);
+
+                        // If it's RawData or Overflow, it's legitimate table data we just didn't trace.
+                        // Let's claim it!
+                        if (page.Flags.HasFlag(PageFlags.Overflow) || page.Flags.HasFlag(PageFlags.RawData))
+                        {
+                            string pageType = page.Flags.HasFlag(PageFlags.Overflow) ? "Overflow (Large Data)" : "RawData (Table Data)";
+                            owners[i] = $"Unmapped {pageType}";
+
+                            // If it's an overflow page, it likely spans multiple pages.
+                            // We should claim the subsequent pages dictated by the overflow size.
+                            if (page.Flags.HasFlag(PageFlags.Overflow))
+                            {
+                                var numberOfOverflowPages = Paging.GetNumberOfOverflowPages(page.OverflowSize);
+                                for (int overflowPage = 1; overflowPage < numberOfOverflowPages; ++overflowPage)
+                                {
+                                    // Advance our main loop index and claim the contiguous pages
+                                    i++;
+                                    owners[i] = "Overflow (Continuation)";
+                                }
+                            }
+                            continue; // It's owned now, so it's not a gap!
+                        }
+                    }
+                    catch
+                    {
+                        // If we can't read the page for some reason, let it fall through to become a gap
+                    }
+
+                    // If we get here, it's a TRUE gap (not RawData, not Overflow, and unowned)
+                    var start = i;
+                    while (i < totalPages)
+                    {
+                        if (owners.ContainsKey(i))
+                            break;
+
+                        // We should also check inside the while loop so we don't group 
+                        // valid unmapped RawData into a true gap block.
+                        try
+                        {
+                            var page = tx.LowLevelTransaction.GetPage(i);
+                            if (page.Flags.HasFlag(PageFlags.Overflow) || page.Flags.HasFlag(PageFlags.RawData))
+                                break;
+                        }
+                        catch { }
+
+                        i++;
+                    }
+                    gaps.Add((start, i));
                 }
-                gaps.Add((start, i));
             }
+        }
+
+        using (var tx = env.Environment.ReadTransaction())
+        {
+            // --- GAP ANALYSIS SNIPPET ---
+
+            var gapAnalysis = new Dictionary<string, int>();
+            var gapPageDetails = new Dictionary<long, string>(); // Optional: If you want to pass this to your renderer
+
+            foreach (var gap in gaps)
+            {
+                for (long pageNumber = gap.Start; pageNumber < gap.End; pageNumber++)
+                {
+                    try
+                    {
+                        // Grab the raw page from the low-level pager
+                        var page = tx.LowLevelTransaction.GetPage(pageNumber);
+
+                        // The Flags enum will tell you exactly what Voron thinks this page is
+                        var flags = page.Flags;
+
+                        string gapType = flags.ToString();
+
+                        // Track how many of each type we are missing
+                        if (gapAnalysis.ContainsKey(gapType))
+                            gapAnalysis[gapType]++;
+                        else
+                            gapAnalysis[gapType] = 1;
+
+                        // Keep track of the specific page details for your UI
+                        gapPageDetails[pageNumber] = $"Gap - {gapType}";
+                    }
+                    catch (Exception ex)
+                    {
+                        // Just in case we hit an unmapped or strictly locked region
+                        gapPageDetails[pageNumber] = $"Gap - Unreadable ({ex.Message})";
+                    }
+                }
+            }
+
+            // Quick debug output to your console/logger so you can see it immediately
+            foreach (var kvp in gapAnalysis)
+            {
+                Console.WriteLine($"VORON DEBUG: Found {kvp.Value} gap pages with flags: {kvp.Key}");
+            }
+
+            // --- END GAP ANALYSIS SNIPPET ---
         }
 
         var output = RequestHandler.GetEnumQueryString<OutputType>("output", required: false);

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
@@ -14,7 +14,6 @@ using Raven.Server.Web.Http;
 using Voron;
 using Voron.Data.Containers;
 using Voron.Data.PostingLists;
-using Voron.Impl.Paging;
 
 namespace Raven.Server.Documents.Handlers.Processors.Debugging;
 
@@ -43,8 +42,6 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
 
         Dictionary<long, string> owners;
         long totalPages;
-
-        var gaps = new List<(long Start, long End)>();
 
         using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
         using (var tx = env.Environment.ReadTransaction())
@@ -75,81 +72,19 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
 
                 return list;
             });
+        }
 
-            // Walk every page under this single read transaction, classifying each unowned page as
-            // either legitimate-but-untraced table data (RawData/Overflow, which we claim) or a true gap.
-            long i = 0;
-            while (i < totalPages)
+        var gaps = new List<(long Start, long End)>();
+
+        for (long i = 0; i < totalPages; i++)
+        {
+            if (owners.ContainsKey(i) == false)
             {
-                if (owners.ContainsKey(i))
-                {
-                    i++;
-                    continue;
-                }
-
-                // Unowned page: read it once to decide whether it's claimable table data or a gap.
-                Page page = default;
-                var readable = true;
-                try
-                {
-                    page = llt.GetPage(i);
-                }
-                catch
-                {
-                    // Can't read it -> treat it as the start of a true gap.
-                    readable = false;
-                }
-
-                if (readable)
-                {
-                    var isOverflow = page.Flags.HasFlag(PageFlags.Overflow);
-                    var isRawData = page.Flags.HasFlag(PageFlags.RawData);
-
-                    // If it's RawData or Overflow, it's legitimate table data we just didn't trace.
-                    // Claim it so it isn't reported as a gap.
-                    if (isOverflow || isRawData)
-                    {
-                        owners[i] = $"Unmapped {(isOverflow ? "Overflow (Large Data)" : "RawData (Table Data)")}";
-
-                        // An overflow page spans multiple pages; claim the continuation pages too.
-                        if (isOverflow)
-                        {
-                            var numberOfOverflowPages = Paging.GetNumberOfOverflowPages(page.OverflowSize);
-                            // Never claim past the last allocated page.
-                            for (int overflowPage = 1; overflowPage < numberOfOverflowPages && i + 1 < totalPages; ++overflowPage)
-                            {
-                                i++;
-                                owners[i] = "Overflow (Continuation)";
-                            }
-                        }
-
-                        i++; // advance past the claimed region
-                        continue; // It's owned now, so it's not a gap!
-                    }
-                }
-
-                // True gap starting at i (either unreadable, or readable and not RawData/Overflow).
-                // page i is already classified, so scan the pages that follow.
                 var start = i;
-                i++;
-                while (i < totalPages && owners.ContainsKey(i) == false)
+                while (i < totalPages)
                 {
-                    // Stop at a valid unmapped RawData/Overflow page so we don't group it into a true gap
-                    // block; leave i on it so the outer loop re-examines and claims it.
-                    var boundary = false;
-                    try
-                    {
-                        var next = llt.GetPage(i);
-                        boundary = next.Flags.HasFlag(PageFlags.Overflow) || next.Flags.HasFlag(PageFlags.RawData);
-                    }
-                    catch
-                    {
-                        // Unreadable page is still part of the gap.
-                    }
-
-                    if (boundary)
+                    if (owners.ContainsKey(i))
                         break;
-
                     i++;
                 }
                 gaps.Add((start, i));

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1077,8 +1077,20 @@ namespace Voron.Data.Tables
             {
                 if (_schema.Key is { IsGlobal: false })
                 {
-                    foreach (var holder in SeekByPrimaryKey(Slices.BeforeAllKeys, 0))
-                        yield return holder.Reader.Id;
+                    var tree = GetTree(_schema.Key);
+                    if (tree == null)
+                        yield break;
+
+                    using (var it = tree.Iterate(_prefetch))
+                    {
+                        if (it.Seek(Slices.BeforeAllKeys) == false)
+                            yield break;
+
+                        do
+                        {
+                            yield return it.CreateReaderForCurrent().Read<long>();
+                        } while (it.MoveNext());
+                    }
 
                     yield break;
                 }
@@ -1086,8 +1098,38 @@ namespace Voron.Data.Tables
                 var variableSizeIndex = _schema.Indexes.Values.FirstOrDefault(x => x.IsGlobal == false);
                 if (variableSizeIndex != null)
                 {
-                    foreach (var seek in SeekForwardFrom(variableSizeIndex, Slices.BeforeAllKeys, 0))
-                        yield return seek.Result.Reader.Id;
+                    var tree = GetTree(variableSizeIndex);
+                    if (tree == null)
+                        yield break;
+
+                    using (var it = tree.Iterate(_prefetch))
+                    {
+                        if (it.Seek(Slices.BeforeAllKeys) == false)
+                            yield break;
+
+                        do
+                        {
+                            var value = it.CurrentKey.Clone(_tx.Allocator);
+                            try
+                            {
+                                var fstIndex = GetFixedSizeTree(tree, value, 0, variableSizeIndex.IsGlobal);
+                                using (var entryIt = fstIndex.Iterate())
+                                {
+                                    if (entryIt.Seek(long.MinValue) == false)
+                                        continue;
+
+                                    do
+                                    {
+                                        yield return entryIt.CurrentKey;
+                                    } while (entryIt.MoveNext());
+                                }
+                            }
+                            finally
+                            {
+                                value.Release(_tx.Allocator);
+                            }
+                        } while (it.MoveNext());
+                    }
 
                     yield break;
                 }
@@ -1095,8 +1137,17 @@ namespace Voron.Data.Tables
                 var fixedSizeIndex = _schema.FixedSizeIndexes.Values.FirstOrDefault(x => x.IsGlobal == false);
                 if (fixedSizeIndex != null)
                 {
-                    foreach (var holder in SeekForwardFrom(fixedSizeIndex, long.MinValue, 0))
-                        yield return holder.Reader.Id;
+                    var fst = GetFixedSizeTree(fixedSizeIndex);
+                    using (var it = fst.Iterate(_prefetch))
+                    {
+                        if (it.Seek(long.MinValue) == false)
+                            yield break;
+
+                        do
+                        {
+                            yield return ReadFixedSizeIndexEntryId(it);
+                        } while (it.MoveNext());
+                    }
                 }
 
                 // A table with only global indexes cannot be enumerated locally (StorageCompaction throws in
@@ -2268,6 +2319,9 @@ namespace Voron.Data.Tables
             var ptr = DirectRead(id, out int size, out _);
             reader = new TableValueReader(id, ptr, size);
         }
+
+        // Extracted because a pointer deref cannot appear inside an iterator block (see EnumerateAllEntryIds).
+        private long ReadFixedSizeIndexEntryId(FixedSizeTree.IFixedSizeIterator it) => *(long*)it.ValuePtr(out int _);
 
         private void GetTableValueReader(IIterator it, out TableValueReader reader)
         {

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1062,6 +1062,48 @@ namespace Voron.Data.Tables
             }
         }
 
+        // Large values live on standalone overflow pages that belong to no section or page-set, so there is no
+        // enumerator; we find them by walking every entry (via one local index) and taking the page-aligned ids.
+        internal IEnumerable<long> GetAllLargeValuePageNumbers()
+        {
+            foreach (var id in EnumerateAllEntryIds())
+            {
+                // A page-aligned id means the value is stored on its own overflow page(s).
+                if (id % Constants.Storage.PageSize == 0)
+                    yield return id / Constants.Storage.PageSize;
+            }
+
+            IEnumerable<long> EnumerateAllEntryIds()
+            {
+                if (_schema.Key is { IsGlobal: false })
+                {
+                    foreach (var holder in SeekByPrimaryKey(Slices.BeforeAllKeys, 0))
+                        yield return holder.Reader.Id;
+
+                    yield break;
+                }
+
+                var variableSizeIndex = _schema.Indexes.Values.FirstOrDefault(x => x.IsGlobal == false);
+                if (variableSizeIndex != null)
+                {
+                    foreach (var seek in SeekForwardFrom(variableSizeIndex, Slices.BeforeAllKeys, 0))
+                        yield return seek.Result.Reader.Id;
+
+                    yield break;
+                }
+
+                var fixedSizeIndex = _schema.FixedSizeIndexes.Values.FirstOrDefault(x => x.IsGlobal == false);
+                if (fixedSizeIndex != null)
+                {
+                    foreach (var holder in SeekForwardFrom(fixedSizeIndex, long.MinValue, 0))
+                        yield return holder.Reader.Id;
+                }
+
+                // A table with only global indexes cannot be enumerated locally (StorageCompaction throws in
+                // that case); we simply skip it here
+            }
+        }
+
         internal long Insert(ref TableValueReader reader)
         {
             AssertWritableTable();

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1042,11 +1042,14 @@ namespace Voron
             return generator.Generate(detailedReportInput);
         }
 
-        public unsafe Dictionary<long, string> GetPageOwners(Transaction tx, Func<PostingList, List<long>> onPostingList = null)
+        public unsafe Dictionary<long, string> GetPageOwners(Transaction tx, Func<PostingList, List<long>> onPostingList = null,
+            Dictionary<long, (string ClaimedTableName, byte TableType, long NumberOfPages, long SizeInBytes)> unownedOverflowPages = null)
         {
             var r = new Dictionary<long, string>();
+            var numberOfAllocatedPages = tx.LowLevelTransaction.DataPagerState.NumberOfAllocatedPages;
+            var sectionOwnerHashToTableName = new Dictionary<ulong, string>();
             RegisterPages(_freeSpaceHandling.AllPages(tx.LowLevelTransaction), "Freed Page");
-            for (long pageNumber = NextPageNumber; pageNumber < tx.LowLevelTransaction.DataPagerState.NumberOfAllocatedPages; pageNumber++)
+            for (long pageNumber = NextPageNumber; pageNumber < numberOfAllocatedPages; pageNumber++)
             {
                 r[pageNumber] = "Unused Page";
             }
@@ -1146,6 +1149,7 @@ namespace Voron
                                 var readResult = tableTree.Read(TableSchema.ActiveSectionSlice);
                                 long pageNumber = readResult.Reader.Read<long>();
                                 var activeDataSmallSection = new ActiveRawDataSmallSection(tx, pageNumber);
+                                sectionOwnerHashToTableName[activeDataSmallSection.SectionOwnerHash] = name;
                                 RegisterSectionPages(activeDataSmallSection, name + "/" + TableSchema.ActiveSectionSlice);
                                 RegisterTableSection(tableTree, name, TableSchema.ActiveCandidateSectionSlice);
                                 RegisterTableSection(tableTree, name, TableSchema.InactiveSectionSlice);
@@ -1192,6 +1196,37 @@ namespace Voron
                                 throw new ArgumentOutOfRangeException(nameof(type), type.ToString());
                         }
                     } while (rootIterator.MoveNext());
+                }
+            }
+
+            if (unownedOverflowPages != null)
+            {
+                for (long pageNumber = 0; pageNumber < numberOfAllocatedPages; pageNumber++)
+                {
+                    if (r.ContainsKey(pageNumber))
+                        continue;
+
+                    var page = tx.LowLevelTransaction.GetPage(pageNumber);
+                    if (page.PageNumber != pageNumber ||
+                        page.IsOverflow == false ||
+                        (page.Flags & PageFlags.RawData) != PageFlags.RawData ||
+                        page.OverflowSize <= 0)
+                        continue;
+
+                    var header = (RawDataOverflowPageHeader*)page.Pointer;
+                    sectionOwnerHashToTableName.TryGetValue(header->SectionOwnerHash, out var claimedTableName);
+
+                    long numberOfPages = Paging.GetNumberOfOverflowPages(page.OverflowSize);
+                    long run = 1;
+                    while (run < numberOfPages &&
+                           pageNumber + run < numberOfAllocatedPages &&
+                           r.ContainsKey(pageNumber + run) is false)
+                    {
+                        run++;
+                    }
+
+                    unownedOverflowPages[pageNumber] = (claimedTableName, header->TableType, run, page.OverflowSize);
+                    pageNumber += run - 1;
                 }
             }
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1149,6 +1149,17 @@ namespace Voron
                                 RegisterSectionPages(activeDataSmallSection, name + "/" + TableSchema.ActiveSectionSlice);
                                 RegisterTableSection(tableTree, name, TableSchema.ActiveCandidateSectionSlice);
                                 RegisterTableSection(tableTree, name, TableSchema.InactiveSectionSlice);
+
+                                // Large values (> RawDataSection.MaxItemSize) live on standalone overflow pages
+                                // that belong to no section and no page-set, so we register them explicitly here,
+                                var largeValueName = name + "/LargeValue";
+                                foreach (var largeValuePageNumber in table.GetAllLargeValuePageNumbers())
+                                {
+                                    var largeValuePage = tx.LowLevelTransaction.GetPage(largeValuePageNumber);
+                                    var numberOfLargeValuePages = Paging.GetNumberOfOverflowPages(largeValuePage.OverflowSize);
+                                    for (int p = 0; p < numberOfLargeValuePages; p++)
+                                        r.Add(largeValuePageNumber + p, largeValueName);
+                                }
                                 break;
                             case RootObjectType.Container:
                                 var container = tx.OpenContainer(currentKey);

--- a/test/FastTests/Voron/Tables/RavenDB_27029.cs
+++ b/test/FastTests/Voron/Tables/RavenDB_27029.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using Tests.Infrastructure;
 using Voron;
+using Voron.Data.RawData;
 using Voron.Global;
 using Voron.Impl.Paging;
 using Xunit;
@@ -8,6 +10,12 @@ namespace FastTests.Voron.Tables
 {
     public unsafe class RavenDB_27029(ITestOutputHelper output) : TableStorageTest(output)
     {
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            base.Configure(options);
+            options.ManualFlushing = true;
+        }
+
         [RavenFact(RavenTestCategory.Voron)]
         public void GetPageOwners_MapsLargeValueOverflowPages()
         {
@@ -29,6 +37,7 @@ namespace FastTests.Voron.Tables
                 tx.Commit();
             }
 
+            Env.FlushLogToDataFile();
             long pageNumber;
             int overflowPageCount;
             using (var tx = Env.ReadTransaction())
@@ -57,6 +66,50 @@ namespace FastTests.Voron.Tables
                     Assert.Contains(p, owners.Keys);
                     Assert.EndsWith("/LargeValue", owners[p]);
                 }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void GetPageOwnersReportsUnreferencedLargeValueAsGapWithClaimedTable()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                DocsSchema.Create(tx, "docs", 16);
+                tx.Commit();
+            }
+
+            const int dataSize = 32 * 1024;
+            long leakedPageNumber;
+            int numberOfLeakedPages;
+            using (var tx = Env.WriteTransaction())
+            {
+                var docs = tx.OpenTable(DocsSchema, "docs");
+                
+                numberOfLeakedPages = Paging.GetNumberOfOverflowPages(dataSize);
+                var page = tx.LowLevelTransaction.AllocatePage(numberOfLeakedPages);
+                page.Flags = PageFlags.Overflow | PageFlags.RawData;
+                page.OverflowSize = dataSize;
+                ((RawDataOverflowPageHeader*)page.Pointer)->SectionOwnerHash = docs.ActiveDataSmallSection.SectionOwnerHash;
+                ((RawDataOverflowPageHeader*)page.Pointer)->TableType = DocsSchema.TableType;
+                leakedPageNumber = page.PageNumber;
+
+                tx.Commit();
+            }
+            
+            Env.FlushLogToDataFile();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var unownedOverflowPages = new Dictionary<long, (string ClaimedTableName, byte TableType, long NumberOfPages, long SizeInBytes)>();
+                var owners = Env.GetPageOwners(tx, unownedOverflowPages: unownedOverflowPages);
+
+                for (long p = leakedPageNumber; p < leakedPageNumber + numberOfLeakedPages; p++)
+                    Assert.False(owners.ContainsKey(p), $"page {p} unexpectedly got owner '{owners.GetValueOrDefault(p)}'");
+
+                Assert.True(unownedOverflowPages.TryGetValue(leakedPageNumber, out var claim));
+                Assert.Equal("docs", claim.ClaimedTableName);
+                Assert.Equal((long)numberOfLeakedPages, claim.NumberOfPages);
+                Assert.Equal((long)dataSize, claim.SizeInBytes);
             }
         }
     }

--- a/test/FastTests/Voron/Tables/RavenDB_27029.cs
+++ b/test/FastTests/Voron/Tables/RavenDB_27029.cs
@@ -1,0 +1,63 @@
+using Tests.Infrastructure;
+using Voron;
+using Voron.Global;
+using Voron.Impl.Paging;
+using Xunit;
+
+namespace FastTests.Voron.Tables
+{
+    public unsafe class RavenDB_27029(ITestOutputHelper output) : TableStorageTest(output)
+    {
+        [RavenFact(RavenTestCategory.Voron)]
+        public void GetPageOwners_MapsLargeValueOverflowPages()
+        {
+            const string key = "users/1";
+
+            using (var tx = Env.WriteTransaction())
+            {
+                DocsSchema.Create(tx, "docs", 16);
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var docs = tx.OpenTable(DocsSchema, "docs");
+                // A value comfortably larger than RawDataSection.MaxItemSize forces the row to be
+                // stored as standalone overflow pages instead of inside a small RawData section.
+                var big = new string('x', 32 * 1024);
+                SetHelper(docs, key, "Users", 1L, big);
+                tx.Commit();
+            }
+
+            long pageNumber;
+            int overflowPageCount;
+            using (var tx = Env.ReadTransaction())
+            {
+                var docs = tx.OpenTable(DocsSchema, "docs");
+                Slice.From(tx.Allocator, key, out var k);
+                Assert.True(docs.ReadByKey(k, out var reader));
+
+                // Large values live on dedicated overflow pages, so their id is page-aligned.
+                Assert.Equal(0, reader.Id % Constants.Storage.PageSize);
+                pageNumber = reader.Id / Constants.Storage.PageSize;
+
+                var page = tx.LowLevelTransaction.GetPage(pageNumber);
+                Assert.True(page.IsOverflow);
+                overflowPageCount = Paging.GetNumberOfOverflowPages(page.OverflowSize);
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var owners = Env.GetPageOwners(tx);
+
+                // Every page of the large value (header + continuations) must be attributed to the
+                // table, otherwise the storage-pages debug endpoint reports them as false gaps.
+                for (long p = pageNumber; p < pageNumber + overflowPageCount; p++)
+                {
+                    Assert.Contains(p, owners.Keys);
+                    Assert.EndsWith("/LargeValue", owners[p]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27029/Fix-bug-in-storage-mapping-view

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed - Could be verified as part of [this ticket](https://issues.hibernatingrhinos.com/issue/RavenDB-24500/Voron-v8-Testing-Phase-I-Hole-Punching-Snapshot-backup-and-restore)

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
