### PR TITLE
RavenDB-26926 CDC Sink - paginate initial load by PK/unique column, fail otherwise

### DIFF
--- a/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
@@ -467,16 +467,58 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
                 Schema = string.IsNullOrEmpty(table.SourceTableSchema) ? defaultSchema : table.SourceTableSchema,
                 TableName = table.SourceTableName,
                 PrimaryKeyColumns = table.PrimaryKeyColumns,
+                InitialLoadKeyColumns = table.PrimaryKeyColumns,
             });
-            ForEachEmbeddedTable(table.EmbeddedTables, e =>
-                tables.Add(new TableInfo
-                {
-                    Schema = string.IsNullOrEmpty(e.SourceTableSchema) ? defaultSchema : e.SourceTableSchema,
-                    TableName = e.SourceTableName,
-                    PrimaryKeyColumns = e.PrimaryKeyColumns,
-                }));
+
+            if (table.EmbeddedTables != null)
+            {
+                foreach (var embedded in table.EmbeddedTables)
+                    CollectEmbeddedTablesFlat(embedded, embedded.JoinColumns, defaultSchema, tables);
+            }
         }
         return tables;
+    }
+
+    private static void CollectEmbeddedTablesFlat(CdcSinkEmbeddedTableConfig embedded, List<string> rootJoinColumns, string defaultSchema, List<TableInfo> tables)
+    {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+
+        tables.Add(new TableInfo
+        {
+            Schema = string.IsNullOrEmpty(embedded.SourceTableSchema) ? defaultSchema : embedded.SourceTableSchema,
+            TableName = embedded.SourceTableName,
+            PrimaryKeyColumns = embedded.PrimaryKeyColumns,
+            InitialLoadKeyColumns = BuildEmbeddedInitialLoadKeyColumns(rootJoinColumns, embedded.JoinColumns, embedded.PrimaryKeyColumns),
+        });
+
+        if (embedded.EmbeddedTables != null)
+        {
+            foreach (var child in embedded.EmbeddedTables)
+                CollectEmbeddedTablesFlat(child, rootJoinColumns, defaultSchema, tables);
+        }
+    }
+
+    public static List<string> BuildEmbeddedInitialLoadKeyColumns(List<string> rootJoinColumns, List<string> joinColumns, List<string> primaryKeyColumns)
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        AddDistinct(rootJoinColumns);
+        AddDistinct(joinColumns);
+        AddDistinct(primaryKeyColumns);
+
+        return result;
+
+        void AddDistinct(List<string> columns)
+        {
+            if (columns == null)
+                return;
+            foreach (var column in columns)
+            {
+                if (string.IsNullOrEmpty(column) == false && seen.Add(column))
+                    result.Add(column);
+            }
+        }
     }
 
     /// <summary>
@@ -503,6 +545,9 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
         public string Schema { get; set; }
         public string TableName { get; set; }
         public List<string> PrimaryKeyColumns { get; set; }
+
+        public List<string> InitialLoadKeyColumns { get; set; }
+
         public string FullName => $"{Schema}.{TableName}";
 
         public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(FullName);

--- a/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
@@ -467,19 +467,18 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
                 Schema = string.IsNullOrEmpty(table.SourceTableSchema) ? defaultSchema : table.SourceTableSchema,
                 TableName = table.SourceTableName,
                 PrimaryKeyColumns = table.PrimaryKeyColumns,
-                InitialLoadKeyColumns = table.PrimaryKeyColumns,
             });
 
             if (table.EmbeddedTables != null)
             {
                 foreach (var embedded in table.EmbeddedTables)
-                    CollectEmbeddedTablesFlat(embedded, embedded.JoinColumns, defaultSchema, tables);
+                    CollectEmbeddedTablesFlat(embedded, defaultSchema, tables);
             }
         }
         return tables;
     }
 
-    private static void CollectEmbeddedTablesFlat(CdcSinkEmbeddedTableConfig embedded, List<string> rootJoinColumns, string defaultSchema, List<TableInfo> tables)
+    private static void CollectEmbeddedTablesFlat(CdcSinkEmbeddedTableConfig embedded, string defaultSchema, List<TableInfo> tables)
     {
         RuntimeHelpers.EnsureSufficientExecutionStack();
 
@@ -488,36 +487,12 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
             Schema = string.IsNullOrEmpty(embedded.SourceTableSchema) ? defaultSchema : embedded.SourceTableSchema,
             TableName = embedded.SourceTableName,
             PrimaryKeyColumns = embedded.PrimaryKeyColumns,
-            InitialLoadKeyColumns = BuildEmbeddedInitialLoadKeyColumns(rootJoinColumns, embedded.JoinColumns, embedded.PrimaryKeyColumns),
         });
 
         if (embedded.EmbeddedTables != null)
         {
             foreach (var child in embedded.EmbeddedTables)
-                CollectEmbeddedTablesFlat(child, rootJoinColumns, defaultSchema, tables);
-        }
-    }
-
-    public static List<string> BuildEmbeddedInitialLoadKeyColumns(List<string> rootJoinColumns, List<string> joinColumns, List<string> primaryKeyColumns)
-    {
-        var result = new List<string>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        AddDistinct(rootJoinColumns);
-        AddDistinct(joinColumns);
-        AddDistinct(primaryKeyColumns);
-
-        return result;
-
-        void AddDistinct(List<string> columns)
-        {
-            if (columns == null)
-                return;
-            foreach (var column in columns)
-            {
-                if (string.IsNullOrEmpty(column) == false && seen.Add(column))
-                    result.Add(column);
-            }
+                CollectEmbeddedTablesFlat(child, defaultSchema, tables);
         }
     }
 
@@ -545,8 +520,6 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
         public string Schema { get; set; }
         public string TableName { get; set; }
         public List<string> PrimaryKeyColumns { get; set; }
-
-        public List<string> InitialLoadKeyColumns { get; set; }
 
         public string FullName => $"{Schema}.{TableName}";
 

--- a/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkTaskState.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkTaskState.cs
@@ -76,6 +76,8 @@ public class CdcSinkTableLoadState : IDynamicJson
     /// Format: list of string representations of the PK column values (in PK column order).
     /// </summary>
     public List<string> LastKeyValues { get; set; }
+    
+    public List<string> KeyColumns { get; set; }
 
     public DynamicJsonValue ToJson()
     {
@@ -83,6 +85,7 @@ public class CdcSinkTableLoadState : IDynamicJson
         {
             [nameof(InitialLoadCompleted)] = InitialLoadCompleted,
             [nameof(LastKeyValues)] = LastKeyValues != null ? new DynamicJsonArray(LastKeyValues) : null,
+            [nameof(KeyColumns)] = KeyColumns != null ? new DynamicJsonArray(KeyColumns) : null,
         };
     }
 }

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -946,10 +946,13 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
                 if (ops[j]?.RawValues == null)
                     continue;
                 var lastValues = ops[j].RawValues;
-                var pkIndices = ops[j].Processor.PrimaryKeyIndices;
+                var sourceColumns = ops[j].Processor.SourceColumnNames;
                 newLastKeys = new string[pkColumns.Count];
                 for (int i = 0; i < pkColumns.Count; i++)
-                    newLastKeys[i] = lastValues[pkIndices[i]]?.ToString() ?? "";
+                {
+                    var idx = CdcSinkTableProcessor.FindColumnIndex(sourceColumns, pkColumns[i]);
+                    newLastKeys[i] = lastValues[idx]?.ToString() ?? "";
+                }
                 break;
             }
 
@@ -1015,6 +1018,8 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             return;
         }
 
+        WarnAboutDeeplyNestedEmbeddedTables(GetDefaultSchema());
+
         // Single connection for the entire initial load — reused across all tables
         await using var conn = await OpenInitialLoadConnection(ct);
 
@@ -1039,7 +1044,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, string tableKey,
         CdcSinkTableLoadState resumeState, CancellationToken ct)
     {
-        var pkColumns = tableInfo.PrimaryKeyColumns;
+        var pkColumns = tableInfo.InitialLoadKeyColumns ?? tableInfo.PrimaryKeyColumns;
         var maxBatchSize = Database.Configuration.CdcSink.MaxBatchSize;
 
         string[] lastKeys = null;
@@ -1107,6 +1112,47 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             await DrainSafely(lastBatch);
             previousBatchCtx?.Dispose();
             currentBatchCtx?.Dispose();
+        }
+    }
+
+    private void WarnAboutDeeplyNestedEmbeddedTables(string defaultSchema)
+    {
+        if (Logger.IsWarnEnabled == false)
+            return;
+
+        var deeplyNested = new List<string>();
+        foreach (var table in Configuration.Tables)
+        {
+            if (table.Disabled)
+                continue;
+            CollectDeeplyNestedEmbeddedTables(table.EmbeddedTables, depth: 1, defaultSchema, deeplyNested);
+        }
+
+        if (deeplyNested.Count == 0)
+            return;
+
+        Logger.Warn(
+            $"[{Name}] The following embedded table(s) are nested 3 or more levels deep: {string.Join(", ", deeplyNested)}. " +
+            "Their initial load is paginated by the root and immediate-parent foreign keys plus the configured PrimaryKeyColumns. " +
+            "If an intermediate ancestor's key is unique only within its own parent (not across the whole source table) and is not " +
+            "denormalized into the child row, some rows may be silently skipped during initial load. Verify that these columns " +
+            "uniquely identify a source row, or denormalize the missing ancestor key column(s) into the child table.");
+    }
+
+    private static void CollectDeeplyNestedEmbeddedTables(List<CdcSinkEmbeddedTableConfig> embeddedTables, int depth, string defaultSchema, List<string> deeplyNested)
+    {
+        if (embeddedTables == null)
+            return;
+
+        foreach (var embedded in embeddedTables)
+        {
+            if (depth >= 3)
+            {
+                var schema = string.IsNullOrEmpty(embedded.SourceTableSchema) ? defaultSchema : embedded.SourceTableSchema;
+                deeplyNested.Add($"{schema}.{embedded.SourceTableName}");
+            }
+
+            CollectDeeplyNestedEmbeddedTables(embedded.EmbeddedTables, depth + 1, defaultSchema, deeplyNested);
         }
     }
 

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -812,6 +812,84 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     /// the load completes.
     /// </summary>
     protected abstract Task<DbConnection> OpenInitialLoadConnection(CancellationToken ct);
+    
+    /// <summary>
+    /// Resolves the columns to paginate a table's initial load by, from the source catalog.
+    /// The source table's PRIMARY KEY is preferred; when it has none, a unique key whose columns
+    /// are all NOT NULL is used instead. Returns null/empty when neither exists, which makes the
+    /// configuration invalid for that table (see <see cref="ProcessTableInitialLoad"/>). The chosen key is
+    /// globally unique and always physically present in SELECT *, so keyset pagination can never silently
+    /// skip rows. Implementations cache the result across tables.
+    /// </summary>
+    protected abstract Task<List<string>> ResolveInitialLoadKeyColumnsAsync(DbConnection conn, string schema, string table, CancellationToken ct);
+
+    /// <summary>
+    /// Appends a discovered primary-key column to the per-table bucket keyed by "schema.table"
+    /// (case-insensitive). Rows must be fed in key order so each table's columns preserve that order.
+    /// </summary>
+    internal static void AddDiscoveredPrimaryKeyColumn(Dictionary<string, List<string>> map, string schema, string table, string column)
+    {
+        var key = $"{schema}.{table}";
+        if (map.TryGetValue(key, out var columns) == false)
+            map[key] = columns = new List<string>();
+        columns.Add(column);
+    }
+
+    /// <summary>
+    /// Accumulates one column of a candidate unique key (keyed by "schema.table" then key/index name),
+    /// tracking whether every column seen for that key is NOT NULL. Columns must be fed in key order.
+    /// </summary>
+    internal static void AddDiscoveredUniqueKeyColumn(
+        Dictionary<string, Dictionary<string, UniqueKeyAccumulator>> map,
+        string schema, string table, string keyName, string column, bool columnNotNull)
+    {
+        var tableKey = $"{schema}.{table}";
+        if (map.TryGetValue(tableKey, out var byKeyName) == false)
+            map[tableKey] = byKeyName = new Dictionary<string, UniqueKeyAccumulator>(StringComparer.OrdinalIgnoreCase);
+        if (byKeyName.TryGetValue(keyName, out var acc) == false)
+            byKeyName[keyName] = acc = new UniqueKeyAccumulator();
+        acc.Columns.Add(column);
+        if (columnNotNull == false)
+            acc.AllColumnsNotNull = false;
+    }
+
+    internal sealed class UniqueKeyAccumulator
+    {
+        public readonly List<string> Columns = new();
+        public bool AllColumnsNotNull = true;
+    }
+
+    /// <summary>
+    /// Chooses the initial-load pagination key for a table: its primary key when present, otherwise the
+    /// NOT-NULL unique key with the fewest columns (ties broken by column names for a stable choice).
+    /// Returns null when neither a primary key nor a fully-NOT-NULL unique key exists.
+    /// </summary>
+    internal static List<string> ChooseInitialLoadKey(List<string> primaryKey, Dictionary<string, UniqueKeyAccumulator> uniqueKeys)
+    {
+        if (primaryKey is { Count: > 0 })
+            return primaryKey;
+
+        if (uniqueKeys == null)
+            return null;
+
+        return uniqueKeys.Values
+            .Where(k => k.AllColumnsNotNull && k.Columns.Count > 0)
+            .OrderBy(k => k.Columns.Count)
+            .ThenBy(k => string.Join(",", k.Columns), StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault()?.Columns;
+    }
+
+    internal static bool ResumeKeyColumnsMatch(List<string> persisted, List<string> current)
+    {
+        if (persisted == null || current == null || persisted.Count != current.Count)
+            return false;
+        for (int i = 0; i < current.Count; i++)
+        {
+            if (string.Equals(persisted[i], current[i], StringComparison.OrdinalIgnoreCase) == false)
+                return false;
+        }
+        return true;
+    }
 
 
     /// <summary>
@@ -820,16 +898,16 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     /// SQL Server overrides this because it does not support row-value comparison.
     /// </summary>
     protected virtual string BuildBatchQuery(
-        CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns,
+        CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
         string[] lastKeys, int maxBatchSize)
     {
         var table = $"{CommandBuilder.QuoteIdentifier(tableInfo.Schema)}.{CommandBuilder.QuoteIdentifier(tableInfo.TableName)}";
-        var pkCols = string.Join(", ", pkColumns.Select(c => CommandBuilder.QuoteIdentifier(c)));
+        var keyCols = string.Join(", ", keyColumns.Select(c => CommandBuilder.QuoteIdentifier(c)));
         var where = lastKeys != null
-            ? $" WHERE ({pkCols}) > ({string.Join(", ", pkColumns.Select((_, i) => $"@k{i}"))})"
+            ? $" WHERE ({keyCols}) > ({string.Join(", ", keyColumns.Select((_, i) => $"@k{i}"))})"
             : "";
 
-        return $"SELECT * FROM {table} {where} ORDER BY {pkCols} LIMIT {maxBatchSize}";
+        return $"SELECT * FROM {table} {where} ORDER BY {keyCols} LIMIT {maxBatchSize}";
     }
 
     /// <summary>
@@ -837,7 +915,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     /// convert string keys to typed values; MySQL passes raw strings.
     /// Only called when <paramref name="lastKeys"/> is not null.
     /// </summary>
-    protected abstract Task BindKeysetParameters(DbCommand cmd, CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns, string[] lastKeys, CancellationToken ct);
+    protected abstract Task BindKeysetParameters(DbCommand cmd, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns, string[] lastKeys, CancellationToken ct);
 
     /// <summary>
     /// Converts a single column value from the initial load DbDataReader to a
@@ -869,16 +947,16 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     }
 
     private async Task<InitialLoadBatch> ReadOneBatch(
-        DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns,
+        DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
         string[] lastKeys, int maxBatchSize, CancellationToken ct)
     {
-        var query = BuildBatchQuery(tableInfo, pkColumns, lastKeys, maxBatchSize);
+        var query = BuildBatchQuery(tableInfo, keyColumns, lastKeys, maxBatchSize);
 
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = query;
 
         if (lastKeys != null)
-            await BindKeysetParameters(cmd, tableInfo, pkColumns, lastKeys, ct);
+            await BindKeysetParameters(cmd, tableInfo, keyColumns, lastKeys, ct);
 
         await using var reader = await cmd.ExecuteReaderAsync(ct);
 
@@ -947,10 +1025,10 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
                     continue;
                 var lastValues = ops[j].RawValues;
                 var sourceColumns = ops[j].Processor.SourceColumnNames;
-                newLastKeys = new string[pkColumns.Count];
-                for (int i = 0; i < pkColumns.Count; i++)
+                newLastKeys = new string[keyColumns.Count];
+                for (int i = 0; i < keyColumns.Count; i++)
                 {
-                    var idx = CdcSinkTableProcessor.FindColumnIndex(sourceColumns, pkColumns[i]);
+                    var idx = CdcSinkTableProcessor.FindColumnIndex(sourceColumns, keyColumns[i]);
                     newLastKeys[i] = lastValues[idx]?.ToString() ?? "";
                 }
                 break;
@@ -1018,8 +1096,6 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             return;
         }
 
-        WarnAboutDeeplyNestedEmbeddedTables(GetDefaultSchema());
-
         // Single connection for the entire initial load — reused across all tables
         await using var conn = await OpenInitialLoadConnection(ct);
 
@@ -1044,11 +1120,32 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, string tableKey,
         CdcSinkTableLoadState resumeState, CancellationToken ct)
     {
-        var pkColumns = tableInfo.InitialLoadKeyColumns ?? tableInfo.PrimaryKeyColumns;
+        // Paginate the initial load by the source table's actual unique key, resolved from the source
+        // catalog - not the configured PrimaryKeyColumns (which for an embedded table is the array-match
+        // key and need only be unique within a parent's array, not across the table). The primary key is
+        // preferred; a NOT-NULL unique key is used when there is no primary key. Either is globally unique
+        // and always present in SELECT *.
+        var keyColumns = await ResolveInitialLoadKeyColumnsAsync(conn, tableInfo.Schema, tableInfo.TableName, ct);
+        if (keyColumns == null || keyColumns.Count == 0)
+        {
+            throw new CdcSinkFaultedException(
+                $"Initial load cannot start for table '{tableInfo.FullName}': the source table has neither a primary key nor a NOT-NULL unique key. " +
+                "CDC Sink paginates the initial load by such a key to guarantee that no rows are skipped. " +
+                "Add a primary key or a NOT-NULL unique key to the source table, or remove the table from the CDC Sink configuration; the task will restart once the configuration is valid.");
+        }
+
+        if (Logger.IsInfoEnabled)
+            Logger.Info($"[{Name}] Initial load for {tableInfo.FullName} paginating by ({string.Join(", ", keyColumns)}).");
+
         var maxBatchSize = Database.Configuration.CdcSink.MaxBatchSize;
 
         string[] lastKeys = null;
-        if (resumeState?.LastKeyValues != null && resumeState.LastKeyValues.Count == pkColumns.Count)
+        // Reuse a persisted resume point only when it was captured against the SAME pagination
+        // columns. Legacy state (no KeyColumns) or a key that has since changed -> clean restart of
+        // this (unfinished) table; re-scanning is safe because upserts are idempotent.
+        if (resumeState?.LastKeyValues != null
+            && resumeState.LastKeyValues.Count == keyColumns.Count
+            && ResumeKeyColumnsMatch(resumeState.KeyColumns, keyColumns))
         {
             lastKeys = new string[resumeState.LastKeyValues.Count];
             for (int i = 0; i < resumeState.LastKeyValues.Count; i++)
@@ -1066,7 +1163,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             {
                 ct.ThrowIfCancellationRequested();
 
-                var (ops, newLastKeys, batchCtx) = await ReadOneBatch(conn, tableInfo, pkColumns, lastKeys, maxBatchSize, ct);
+                var (ops, newLastKeys, batchCtx) = await ReadOneBatch(conn, tableInfo, keyColumns, lastKeys, maxBatchSize, ct);
                 currentBatchCtx = batchCtx;
 
                 if (ops.Count == 0)
@@ -1093,7 +1190,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
 
                 var tableLoadUpdate = new Dictionary<string, CdcSinkTableLoadState>
                 {
-                    [tableKey] = new CdcSinkTableLoadState { LastKeyValues = new List<string>(newLastKeys) }
+                    [tableKey] = new CdcSinkTableLoadState { LastKeyValues = new List<string>(newLastKeys), KeyColumns = new List<string>(keyColumns) }
                 };
 
                 lastBatchOps = ops;
@@ -1112,47 +1209,6 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             await DrainSafely(lastBatch);
             previousBatchCtx?.Dispose();
             currentBatchCtx?.Dispose();
-        }
-    }
-
-    private void WarnAboutDeeplyNestedEmbeddedTables(string defaultSchema)
-    {
-        if (Logger.IsWarnEnabled == false)
-            return;
-
-        var deeplyNested = new List<string>();
-        foreach (var table in Configuration.Tables)
-        {
-            if (table.Disabled)
-                continue;
-            CollectDeeplyNestedEmbeddedTables(table.EmbeddedTables, depth: 1, defaultSchema, deeplyNested);
-        }
-
-        if (deeplyNested.Count == 0)
-            return;
-
-        Logger.Warn(
-            $"[{Name}] The following embedded table(s) are nested 3 or more levels deep: {string.Join(", ", deeplyNested)}. " +
-            "Their initial load is paginated by the root and immediate-parent foreign keys plus the configured PrimaryKeyColumns. " +
-            "If an intermediate ancestor's key is unique only within its own parent (not across the whole source table) and is not " +
-            "denormalized into the child row, some rows may be silently skipped during initial load. Verify that these columns " +
-            "uniquely identify a source row, or denormalize the missing ancestor key column(s) into the child table.");
-    }
-
-    private static void CollectDeeplyNestedEmbeddedTables(List<CdcSinkEmbeddedTableConfig> embeddedTables, int depth, string defaultSchema, List<string> deeplyNested)
-    {
-        if (embeddedTables == null)
-            return;
-
-        foreach (var embedded in embeddedTables)
-        {
-            if (depth >= 3)
-            {
-                var schema = string.IsNullOrEmpty(embedded.SourceTableSchema) ? defaultSchema : embedded.SourceTableSchema;
-                deeplyNested.Add($"{schema}.{embedded.SourceTableName}");
-            }
-
-            CollectDeeplyNestedEmbeddedTables(embedded.EmbeddedTables, depth + 1, defaultSchema, deeplyNested);
         }
     }
 

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -154,6 +154,9 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
     protected override async Task RunInternalAsync(CancellationToken ct)
     {
         _resolvedTables.Clear();
+        _sourcePrimaryKeysCache.Clear();
+        _sourceUniqueKeysCache.Clear();
+        _sourcePrimaryKeysFetchedSchemas.Clear();
         await EnsureBinlogConfiguration(ct);
         await ResolveColumnNames(ct);
         await HandleInitialLoad(ct);
@@ -377,11 +380,62 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
 
     protected override DbCommandBuilder CommandBuilder { get; } = new MySqlCommandBuilder();
 
-    protected override Task BindKeysetParameters(DbCommand cmd, CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns, string[] lastKeys, CancellationToken ct)
+    protected override Task BindKeysetParameters(DbCommand cmd, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns, string[] lastKeys, CancellationToken ct)
     {
         for (int i = 0; i < lastKeys.Length; i++)
             AddParameter(cmd, $"@k{i}", lastKeys[i]);
         return Task.CompletedTask;
+    }
+    
+    // Unique (non-PRIMARY) indexes with each column's nullability, joined to COLUMNS for IS_NULLABLE.
+    // Columns: schema, table, index name, column, IS_NULLABLE ('YES'/'NO').
+    private const string SelectNotNullUniqueKeysQuery = """
+                                                        SELECT s.TABLE_SCHEMA, s.TABLE_NAME, s.INDEX_NAME, s.COLUMN_NAME, c.IS_NULLABLE
+                                                        FROM INFORMATION_SCHEMA.STATISTICS s
+                                                        JOIN INFORMATION_SCHEMA.COLUMNS c
+                                                          ON c.TABLE_SCHEMA = s.TABLE_SCHEMA AND c.TABLE_NAME = s.TABLE_NAME AND c.COLUMN_NAME = s.COLUMN_NAME
+                                                        WHERE s.TABLE_SCHEMA = @schema AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY'
+                                                        ORDER BY s.TABLE_NAME, s.INDEX_NAME, s.SEQ_IN_INDEX
+                                                        """;
+
+    private readonly Dictionary<string, List<string>> _sourcePrimaryKeysCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Dictionary<string, UniqueKeyAccumulator>> _sourceUniqueKeysCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _sourcePrimaryKeysFetchedSchemas = new(StringComparer.OrdinalIgnoreCase);
+
+    protected override async Task<List<string>> ResolveInitialLoadKeyColumnsAsync(DbConnection conn, string schema, string table, CancellationToken ct)
+    {
+        if (_sourcePrimaryKeysFetchedSchemas.Add(schema))
+        {
+            try
+            {
+                await using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = new MySqlSchemaQueries().SelectPrimaryKeysQuery;
+                    AddParameter(cmd, "@schema", schema);
+                    await using var reader = await cmd.ExecuteReaderAsync(ct);
+                    while (await reader.ReadAsync(ct))
+                        AddDiscoveredPrimaryKeyColumn(_sourcePrimaryKeysCache, reader.GetString(2), reader.GetString(0), reader.GetString(1));
+                }
+
+                await using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = SelectNotNullUniqueKeysQuery;
+                    AddParameter(cmd, "@schema", schema);
+                    await using var reader = await cmd.ExecuteReaderAsync(ct);
+                    while (await reader.ReadAsync(ct))
+                        AddDiscoveredUniqueKeyColumn(_sourceUniqueKeysCache, reader.GetString(0), reader.GetString(1), reader.GetString(2), reader.GetString(3),
+                            columnNotNull: string.Equals(reader.GetString(4), "NO", StringComparison.OrdinalIgnoreCase));
+                }
+            }
+            catch (Exception e) when (e is not OperationCanceledException)
+            {
+                if (Logger.IsWarnEnabled)
+                    Logger.Warn($"[{Name}] Failed to read keys from the source catalog; tables without a resolvable primary or NOT-NULL unique key will fault the initial load.", e);
+            }
+        }
+
+        var key = $"{schema}.{table}";
+        return ChooseInitialLoadKey(_sourcePrimaryKeysCache.GetValueOrDefault(key), _sourceUniqueKeysCache.GetValueOrDefault(key));
     }
 
     protected override object ConvertInitialLoadValue(DbDataReader reader, int ordinal, CdcSinkConfiguration.TableInfo tableInfo)

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -120,6 +120,8 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
     {
         // in case of error, we'll re-learn the schema (it may have changed).
         _columnTypesCache.Clear();
+        _sourcePrimaryKeysCache = null;
+        _sourceUniqueKeysCache = null;
         _relationProcessors.Clear();
         _unconfiguredRelations.Clear();
         await EnsureReplicationSetup(ct);
@@ -758,8 +760,60 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
 
 
     private readonly Dictionary<string, Dictionary<string, string>> _columnTypesCache = new();
+    
+    // Unique (non-PK) indexes with each column's NOT NULL flag, from pg_catalog so both unique
+    // constraints and CREATE UNIQUE INDEX are covered. Partial/expression indexes are excluded (their
+    // columns don't define a plain keyset order). Columns: schema, table, index name, column, NOT NULL.
+    private const string SelectNotNullUniqueKeysQuery = """
+                                                        SELECT n.nspname, t.relname, i.relname, a.attname, a.attnotnull
+                                                        FROM pg_index ix
+                                                        JOIN pg_class i ON i.oid = ix.indexrelid
+                                                        JOIN pg_class t ON t.oid = ix.indrelid
+                                                        JOIN pg_namespace n ON n.oid = t.relnamespace
+                                                        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+                                                        WHERE ix.indisunique AND ix.indisprimary = false AND ix.indpred IS NULL AND ix.indexprs IS NULL
+                                                          AND t.relkind IN ('r', 'p')
+                                                        ORDER BY n.nspname, t.relname, i.relname, array_position(ix.indkey, a.attnum)
+                                                        """;
 
-    protected override async Task BindKeysetParameters(DbCommand cmd, CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns, string[] lastKeys, CancellationToken ct)
+    private Dictionary<string, List<string>> _sourcePrimaryKeysCache;
+    private Dictionary<string, Dictionary<string, UniqueKeyAccumulator>> _sourceUniqueKeysCache;
+
+    protected override async Task<List<string>> ResolveInitialLoadKeyColumnsAsync(DbConnection conn, string schema, string table, CancellationToken ct)
+    {
+        if (_sourcePrimaryKeysCache == null)
+        {
+            var pks = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            var uniques = new Dictionary<string, Dictionary<string, UniqueKeyAccumulator>>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                var npgsqlConn = (NpgsqlConnection)conn;
+
+                await using (var cmd = new NpgsqlCommand(new NpgSqlSchemaQueries(new[] { schema }).SelectPrimaryKeysQuery, npgsqlConn))
+                await using (var reader = await cmd.ExecuteReaderAsync(ct))
+                    while (await reader.ReadAsync(ct))
+                        AddDiscoveredPrimaryKeyColumn(pks, reader.GetString(0), reader.GetString(1), reader.GetString(2));
+
+                await using (var cmd = new NpgsqlCommand(SelectNotNullUniqueKeysQuery, npgsqlConn))
+                await using (var reader = await cmd.ExecuteReaderAsync(ct))
+                    while (await reader.ReadAsync(ct))
+                        AddDiscoveredUniqueKeyColumn(uniques, reader.GetString(0), reader.GetString(1), reader.GetString(2), reader.GetString(3), reader.GetBoolean(4));
+            }
+            catch (Exception e) when (e is not OperationCanceledException)
+            {
+                if (Logger.IsWarnEnabled)
+                    Logger.Warn($"[{Name}] Failed to read keys from the source catalog; tables without a resolvable primary or NOT-NULL unique key will fault the initial load.", e);
+            }
+
+            _sourcePrimaryKeysCache = pks;
+            _sourceUniqueKeysCache = uniques;
+        }
+
+        var key = $"{schema}.{table}";
+        return ChooseInitialLoadKey(_sourcePrimaryKeysCache.GetValueOrDefault(key), _sourceUniqueKeysCache.GetValueOrDefault(key));
+    }
+
+    protected override async Task BindKeysetParameters(DbCommand cmd, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns, string[] lastKeys, CancellationToken ct)
     {
         var npgsqlCmd = (NpgsqlCommand)cmd;
 
@@ -773,9 +827,9 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
             _columnTypesCache[tableInfo.FullName] = columnTypes;
         }
 
-        for (int i = 0; i < pkColumns.Count; i++)
+        for (int i = 0; i < keyColumns.Count; i++)
         {
-            var value = ConvertStringToType(lastKeys[i], columnTypes.GetValueOrDefault(pkColumns[i], "text"));
+            var value = ConvertStringToType(lastKeys[i], columnTypes.GetValueOrDefault(keyColumns[i], "text"));
             npgsqlCmd.Parameters.AddWithValue($"k{i}", value);
         }
     }

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -62,6 +62,8 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
     {
         // In case of error, re-learn the schema (it may have changed).
         _columnTypesCache.Clear();
+        _sourcePrimaryKeysCache = null;
+        _sourceUniqueKeysCache = null;
         DocumentProcessor.ResetSourceColumnNames();
         await EnsureCdcEnabled(ct);
         await HandleInitialLoad(ct);
@@ -628,12 +630,12 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
     /// equivalent lexicographic-OR form, which yields the same logical result on every provider.
     /// </summary>
     protected override string BuildBatchQuery(
-        CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns,
+        CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
         string[] lastKeys, int maxBatchSize)
     {
         var table = $"{CommandBuilder.QuoteIdentifier(tableInfo.Schema)}.{CommandBuilder.QuoteIdentifier(tableInfo.TableName)}";
-        var quotedCols = pkColumns.Select(c => CommandBuilder.QuoteIdentifier(c)).ToArray();
-        var pkColsList = string.Join(", ", quotedCols);
+        var quotedCols = keyColumns.Select(c => CommandBuilder.QuoteIdentifier(c)).ToArray();
+        var keyColsList = string.Join(", ", quotedCols);
 
         var where = string.Empty;
         if (lastKeys != null)
@@ -656,12 +658,67 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
             where = " WHERE " + string.Join(" OR ", disjuncts);
         }
 
-        return $"SELECT TOP ({maxBatchSize}) * FROM {table}{where} ORDER BY {pkColsList}";
+        return $"SELECT TOP ({maxBatchSize}) * FROM {table}{where} ORDER BY {keyColsList}";
     }
 
     private readonly Dictionary<string, Dictionary<string, string>> _columnTypesCache = new();
+    
+    // Unique (non-PK) indexes with each column's nullability, from sys catalog (covers unique
+    // constraints and unique indexes). Included (non-key) columns are excluded. Columns: schema, table,
+    // index name, column, is_nullable (bit; 1 = nullable).
+    private const string SelectNotNullUniqueKeysQuery = """
+                                                        SELECT s.name, t.name, i.name, c.name, c.is_nullable
+                                                        FROM sys.indexes i
+                                                        JOIN sys.tables t ON t.object_id = i.object_id
+                                                        JOIN sys.schemas s ON s.schema_id = t.schema_id
+                                                        JOIN sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+                                                        JOIN sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+                                                        WHERE i.is_unique = 1 AND i.is_primary_key = 0 AND ic.is_included_column = 0
+                                                        ORDER BY s.name, t.name, i.name, ic.key_ordinal
+                                                        """;
 
-    protected override async Task BindKeysetParameters(DbCommand cmd, CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns, string[] lastKeys, CancellationToken ct)
+    private Dictionary<string, List<string>> _sourcePrimaryKeysCache;
+    private Dictionary<string, Dictionary<string, UniqueKeyAccumulator>> _sourceUniqueKeysCache;
+
+    protected override async Task<List<string>> ResolveInitialLoadKeyColumnsAsync(DbConnection conn, string schema, string table, CancellationToken ct)
+    {
+        if (_sourcePrimaryKeysCache == null)
+        {
+            var pks = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            var uniques = new Dictionary<string, Dictionary<string, UniqueKeyAccumulator>>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                await using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = new MsSqlSchemaQueries().SelectPrimaryKeysQuery;
+                    await using var reader = await cmd.ExecuteReaderAsync(ct);
+                    while (await reader.ReadAsync(ct))
+                        AddDiscoveredPrimaryKeyColumn(pks, reader.GetString(0), reader.GetString(1), reader.GetString(2));
+                }
+
+                await using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = SelectNotNullUniqueKeysQuery;
+                    await using var reader = await cmd.ExecuteReaderAsync(ct);
+                    while (await reader.ReadAsync(ct))
+                        AddDiscoveredUniqueKeyColumn(uniques, reader.GetString(0), reader.GetString(1), reader.GetString(2), reader.GetString(3), columnNotNull: reader.GetBoolean(4) == false);
+                }
+            }
+            catch (Exception e) when (e is not OperationCanceledException)
+            {
+                if (Logger.IsWarnEnabled)
+                    Logger.Warn($"[{Name}] Failed to read keys from the source catalog; tables without a resolvable primary or NOT-NULL unique key will fault the initial load.", e);
+            }
+
+            _sourcePrimaryKeysCache = pks;
+            _sourceUniqueKeysCache = uniques;
+        }
+
+        var key = $"{schema}.{table}";
+        return ChooseInitialLoadKey(_sourcePrimaryKeysCache.GetValueOrDefault(key), _sourceUniqueKeysCache.GetValueOrDefault(key));
+    }
+
+    protected override async Task BindKeysetParameters(DbCommand cmd, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns, string[] lastKeys, CancellationToken ct)
     {
         if (_columnTypesCache.TryGetValue(tableInfo.FullName, out var columnTypes) == false)
         {
@@ -672,9 +729,9 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
             _columnTypesCache[tableInfo.FullName] = columnTypes;
         }
 
-        for (int i = 0; i < pkColumns.Count; i++)
+        for (int i = 0; i < keyColumns.Count; i++)
         {
-            var value = ConvertStringToType(lastKeys[i], columnTypes.GetValueOrDefault(pkColumns[i], "nvarchar"));
+            var value = ConvertStringToType(lastKeys[i], columnTypes.GetValueOrDefault(keyColumns[i], "nvarchar"));
             AddParameter(cmd, $"@k{i}", value);
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB-26838.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26838.cs
@@ -687,6 +687,8 @@ public class RavenDB_26838 : RavenTestBase
 
         protected override Task<DbConnection> OpenInitialLoadConnection(CancellationToken ct) => throw new NotSupportedException();
 
+        protected override Task<List<string>> ResolveInitialLoadKeyColumnsAsync(DbConnection conn, string schema, string table, CancellationToken ct) => throw new NotSupportedException();
+
         protected override Task BindKeysetParameters(DbCommand cmd, CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns, string[] lastKeys, CancellationToken ct) => throw new NotSupportedException();
 
         protected override object ConvertInitialLoadValue(DbDataReader reader, int ordinal, CdcSinkConfiguration.TableInfo tableInfo) => throw new NotSupportedException();

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkInitialLoadKeyTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkInitialLoadKeyTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Operations.CdcSink;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.CdcSink
+{
+    public class CdcSinkInitialLoadKeyTests : RavenTestBase
+    {
+        public CdcSinkInitialLoadKeyTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private static List<string> InitialLoadKey(CdcSinkConfiguration config, string tableName)
+        {
+            return config.CollectAllTablesFlat("public")
+                .Single(t => string.Equals(t.TableName, tableName, StringComparison.OrdinalIgnoreCase))
+                .InitialLoadKeyColumns;
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void RootTable_InitialLoadKey_IsItsPrimaryKey()
+        {
+            var config = new CdcSinkConfiguration
+            {
+                Name = "t",
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = "public",
+                        SourceTableName = "orders",
+                        Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "order_id", Name = "OrderId" } },
+                        PrimaryKeyColumns = new List<string> { "order_id" }
+                    }
+                }
+            };
+
+            Assert.Equal(new[] { "order_id" }, InitialLoadKey(config, "orders"));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void EmbeddedTable_InitialLoadKey_GluesJoinColumnAndPrimaryKey()
+        {
+            var config = new CdcSinkConfiguration
+            {
+                Name = "t",
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = "public",
+                        SourceTableName = "orders",
+                        Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "order_id", Name = "OrderId" } },
+                        PrimaryKeyColumns = new List<string> { "order_id" },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = "public",
+                                SourceTableName = "order_details",
+                                PropertyName = "Lines",
+                                Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "product_id", Name = "ProductId" } },
+                                PrimaryKeyColumns = new List<string> { "product_id" },
+                                JoinColumns = new List<string> { "order_id" },
+                                Type = CdcSinkRelationType.Array
+                            }
+                        }
+                    }
+                }
+            };
+
+            Assert.Equal(new[] { "order_id", "product_id" }, InitialLoadKey(config, "order_details"));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void EmbeddedTable_InitialLoadKey_DoesNotDuplicateSharedColumns()
+        {
+            var config = new CdcSinkConfiguration
+            {
+                Name = "t",
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = "public",
+                        SourceTableName = "orders",
+                        Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "order_id", Name = "OrderId" } },
+                        PrimaryKeyColumns = new List<string> { "order_id" },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = "public",
+                                SourceTableName = "order_details",
+                                PropertyName = "Lines",
+                                Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "product_id", Name = "ProductId" } },
+                                PrimaryKeyColumns = new List<string> { "order_id", "product_id" },
+                                JoinColumns = new List<string> { "order_id" },
+                                Type = CdcSinkRelationType.Array
+                            }
+                        }
+                    }
+                }
+            };
+
+            Assert.Equal(new[] { "order_id", "product_id" }, InitialLoadKey(config, "order_details"));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void TwoLevelNesting_InitialLoadKey_IncludesRootAndImmediateParentFks()
+        {
+            var config = new CdcSinkConfiguration
+            {
+                Name = "t",
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Companies",
+                        SourceTableSchema = "public",
+                        SourceTableName = "companies",
+                        Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "company_id", Name = "CompanyId" } },
+                        PrimaryKeyColumns = new List<string> { "company_id" },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = "public",
+                                SourceTableName = "departments",
+                                PropertyName = "Departments",
+                                Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "dept_id", Name = "DeptId" } },
+                                PrimaryKeyColumns = new List<string> { "dept_id" },
+                                JoinColumns = new List<string> { "company_id" },
+                                Type = CdcSinkRelationType.Array,
+                                EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                                {
+                                    new CdcSinkEmbeddedTableConfig
+                                    {
+                                        SourceTableSchema = "public",
+                                        SourceTableName = "employees",
+                                        PropertyName = "Employees",
+                                        Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "emp_id", Name = "EmpId" } },
+                                        PrimaryKeyColumns = new List<string> { "emp_id" },
+                                        JoinColumns = new List<string> { "dept_id" },
+                                        Type = CdcSinkRelationType.Array
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Assert.Equal(new[] { "company_id", "dept_id", "emp_id" }, InitialLoadKey(config, "employees"));
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkInitialLoadKeyTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkInitialLoadKeyTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Operations.CdcSink;
+using Raven.Server.Documents.CdcSink;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -14,37 +15,8 @@ namespace SlowTests.Server.Documents.CdcSink
         {
         }
 
-        private static List<string> InitialLoadKey(CdcSinkConfiguration config, string tableName)
-        {
-            return config.CollectAllTablesFlat("public")
-                .Single(t => string.Equals(t.TableName, tableName, StringComparison.OrdinalIgnoreCase))
-                .InitialLoadKeyColumns;
-        }
-
         [RavenFact(RavenTestCategory.Sinks)]
-        public void RootTable_InitialLoadKey_IsItsPrimaryKey()
-        {
-            var config = new CdcSinkConfiguration
-            {
-                Name = "t",
-                Tables = new List<CdcSinkTableConfig>
-                {
-                    new CdcSinkTableConfig
-                    {
-                        CollectionName = "Orders",
-                        SourceTableSchema = "public",
-                        SourceTableName = "orders",
-                        Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "order_id", Name = "OrderId" } },
-                        PrimaryKeyColumns = new List<string> { "order_id" }
-                    }
-                }
-            };
-
-            Assert.Equal(new[] { "order_id" }, InitialLoadKey(config, "orders"));
-        }
-
-        [RavenFact(RavenTestCategory.Sinks)]
-        public void EmbeddedTable_InitialLoadKey_GluesJoinColumnAndPrimaryKey()
+        public void CollectAllTablesFlat_EnumeratesRootAndEmbeddedTables()
         {
             var config = new CdcSinkConfiguration
             {
@@ -75,90 +47,113 @@ namespace SlowTests.Server.Documents.CdcSink
                 }
             };
 
-            Assert.Equal(new[] { "order_id", "product_id" }, InitialLoadKey(config, "order_details"));
+            var tables = config.CollectAllTablesFlat("public");
+
+            Assert.Equal(new[] { "public.orders", "public.order_details" }, tables.Select(t => t.FullName).ToArray());
         }
 
         [RavenFact(RavenTestCategory.Sinks)]
-        public void EmbeddedTable_InitialLoadKey_DoesNotDuplicateSharedColumns()
+        public void ResumeKeyColumnsMatch_SameColumns_Matches()
         {
-            var config = new CdcSinkConfiguration
-            {
-                Name = "t",
-                Tables = new List<CdcSinkTableConfig>
-                {
-                    new CdcSinkTableConfig
-                    {
-                        CollectionName = "Orders",
-                        SourceTableSchema = "public",
-                        SourceTableName = "orders",
-                        Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "order_id", Name = "OrderId" } },
-                        PrimaryKeyColumns = new List<string> { "order_id" },
-                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
-                        {
-                            new CdcSinkEmbeddedTableConfig
-                            {
-                                SourceTableSchema = "public",
-                                SourceTableName = "order_details",
-                                PropertyName = "Lines",
-                                Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "product_id", Name = "ProductId" } },
-                                PrimaryKeyColumns = new List<string> { "order_id", "product_id" },
-                                JoinColumns = new List<string> { "order_id" },
-                                Type = CdcSinkRelationType.Array
-                            }
-                        }
-                    }
-                }
-            };
-
-            Assert.Equal(new[] { "order_id", "product_id" }, InitialLoadKey(config, "order_details"));
+            Assert.True(CdcSinkProcess.ResumeKeyColumnsMatch(
+                new List<string> { "order_id", "product_id" },
+                new List<string> { "order_id", "product_id" }));
         }
 
         [RavenFact(RavenTestCategory.Sinks)]
-        public void TwoLevelNesting_InitialLoadKey_IncludesRootAndImmediateParentFks()
+        public void ResumeKeyColumnsMatch_IsCaseInsensitive()
         {
-            var config = new CdcSinkConfiguration
-            {
-                Name = "t",
-                Tables = new List<CdcSinkTableConfig>
-                {
-                    new CdcSinkTableConfig
-                    {
-                        CollectionName = "Companies",
-                        SourceTableSchema = "public",
-                        SourceTableName = "companies",
-                        Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "company_id", Name = "CompanyId" } },
-                        PrimaryKeyColumns = new List<string> { "company_id" },
-                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
-                        {
-                            new CdcSinkEmbeddedTableConfig
-                            {
-                                SourceTableSchema = "public",
-                                SourceTableName = "departments",
-                                PropertyName = "Departments",
-                                Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "dept_id", Name = "DeptId" } },
-                                PrimaryKeyColumns = new List<string> { "dept_id" },
-                                JoinColumns = new List<string> { "company_id" },
-                                Type = CdcSinkRelationType.Array,
-                                EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
-                                {
-                                    new CdcSinkEmbeddedTableConfig
-                                    {
-                                        SourceTableSchema = "public",
-                                        SourceTableName = "employees",
-                                        PropertyName = "Employees",
-                                        Columns = new List<CdcColumnMapping> { new CdcColumnMapping { Column = "emp_id", Name = "EmpId" } },
-                                        PrimaryKeyColumns = new List<string> { "emp_id" },
-                                        JoinColumns = new List<string> { "dept_id" },
-                                        Type = CdcSinkRelationType.Array
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
+            Assert.True(CdcSinkProcess.ResumeKeyColumnsMatch(
+                new List<string> { "Order_Id" },
+                new List<string> { "order_id" }));
+        }
 
-            Assert.Equal(new[] { "company_id", "dept_id", "emp_id" }, InitialLoadKey(config, "employees"));
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void ResumeKeyColumnsMatch_DifferentColumnsSameCount_DoesNotMatch()
+        {
+            Assert.False(CdcSinkProcess.ResumeKeyColumnsMatch(
+                new List<string> { "order_id" },
+                new List<string> { "line_id" }));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void ResumeKeyColumnsMatch_NullPersisted_DoesNotMatch()
+        {
+            Assert.False(CdcSinkProcess.ResumeKeyColumnsMatch(null, new List<string> { "order_id" }));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void ResumeKeyColumnsMatch_DifferentCount_DoesNotMatch()
+        {
+            Assert.False(CdcSinkProcess.ResumeKeyColumnsMatch(
+                new List<string> { "order_id" },
+                new List<string> { "order_id", "product_id" }));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void AddDiscoveredPrimaryKeyColumn_BucketsByTableAndPreservesOrder()
+        {
+            var map = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            
+            CdcSinkProcess.AddDiscoveredPrimaryKeyColumn(map, "public", "order_details", "order_id");
+            CdcSinkProcess.AddDiscoveredPrimaryKeyColumn(map, "public", "orders", "order_id");
+            CdcSinkProcess.AddDiscoveredPrimaryKeyColumn(map, "public", "order_details", "product_id");
+
+            Assert.Equal(new[] { "order_id", "product_id" }, map["public.order_details"]);
+            Assert.Equal(new[] { "order_id" }, map["public.orders"]);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void ChooseInitialLoadKey_PrefersPrimaryKeyOverUniqueKey()
+        {
+            var uniques = new Dictionary<string, Dictionary<string, CdcSinkProcess.UniqueKeyAccumulator>>(StringComparer.OrdinalIgnoreCase);
+            CdcSinkProcess.AddDiscoveredUniqueKeyColumn(uniques, "public", "users", "uq_email", "email", columnNotNull: true);
+
+            var chosen = CdcSinkProcess.ChooseInitialLoadKey(new List<string> { "id" }, uniques["public.users"]);
+
+            Assert.Equal(new[] { "id" }, chosen);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void ChooseInitialLoadKey_NoPrimaryKey_UsesNotNullUniqueKey()
+        {
+            var uniques = new Dictionary<string, Dictionary<string, CdcSinkProcess.UniqueKeyAccumulator>>(StringComparer.OrdinalIgnoreCase);
+            CdcSinkProcess.AddDiscoveredUniqueKeyColumn(uniques, "public", "users", "uq_email", "email", columnNotNull: true);
+
+            var chosen = CdcSinkProcess.ChooseInitialLoadKey(primaryKey: null, uniques["public.users"]);
+
+            Assert.Equal(new[] { "email" }, chosen);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void ChooseInitialLoadKey_PicksFewestColumnUniqueKey()
+        {
+            var uniques = new Dictionary<string, Dictionary<string, CdcSinkProcess.UniqueKeyAccumulator>>(StringComparer.OrdinalIgnoreCase);
+            // A two-column unique key and a single-column unique key, both fully NOT NULL.
+            CdcSinkProcess.AddDiscoveredUniqueKeyColumn(uniques, "public", "t", "uq_a_b", "a", columnNotNull: true);
+            CdcSinkProcess.AddDiscoveredUniqueKeyColumn(uniques, "public", "t", "uq_a_b", "b", columnNotNull: true);
+            CdcSinkProcess.AddDiscoveredUniqueKeyColumn(uniques, "public", "t", "uq_c", "c", columnNotNull: true);
+
+            var chosen = CdcSinkProcess.ChooseInitialLoadKey(primaryKey: null, uniques["public.t"]);
+
+            Assert.Equal(new[] { "c" }, chosen);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void ChooseInitialLoadKey_SkipsUniqueKeyWithNullableColumn()
+        {
+            var uniques = new Dictionary<string, Dictionary<string, CdcSinkProcess.UniqueKeyAccumulator>>(StringComparer.OrdinalIgnoreCase);
+            // The only unique key has a nullable column → unusable → no key.
+            CdcSinkProcess.AddDiscoveredUniqueKeyColumn(uniques, "public", "t", "uq_email", "email", columnNotNull: false);
+
+            Assert.Null(CdcSinkProcess.ChooseInitialLoadKey(primaryKey: null, uniques["public.t"]));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public void ChooseInitialLoadKey_NoKeys_ReturnsNull()
+        {
+            Assert.Null(CdcSinkProcess.ChooseInitialLoadKey(primaryKey: null, uniqueKeys: null));
+            Assert.Null(CdcSinkProcess.ChooseInitialLoadKey(new List<string>(), uniqueKeys: null));
         }
     }
 }

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkIntegrationTestBase.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkIntegrationTestBase.cs
@@ -102,6 +102,27 @@ namespace SlowTests.Server.Documents.CdcSink
             return tcs.Task;
         }
 
+        /// <summary>
+        /// Waits until the named CDC Sink process has faulted (a permanent configuration error that
+        /// stops retrying) and returns the exception that faulted it. Polls IsFaulted so it never races
+        /// the fault, unlike subscribing to ProcessError after the process has already started.
+        /// </summary>
+        protected async Task<Exception> WaitForProcessFaultAsync(IDocumentStore store, string configName, int timeoutMs = 60_000)
+        {
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            var sw = Stopwatch.StartNew();
+            while (sw.ElapsedMilliseconds < timeoutMs)
+            {
+                var process = db.CdcSinkLoader.Processes.FirstOrDefault(p => p.Name == configName);
+                if (process is { IsFaulted: true })
+                    return process.LastProcessException;
+
+                await Task.Delay(250);
+            }
+
+            throw new TimeoutException($"CDC Sink '{configName}' did not fault within {timeoutMs}ms");
+        }
+
         protected async Task<T> WaitForDocumentAsync<T>(IDocumentStore store, string docId, int timeoutMs = 30_000)
             where T : class
         {

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
@@ -107,6 +107,90 @@ namespace SlowTests.Server.Documents.CdcSink
         // --- Tests ---
 
         [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
+        public async Task InitialLoad_NoPrimaryKeyOrUniqueKey_Faults()
+        {
+            // A table with no primary key and no unique key has nothing safe to keyset-paginate by,
+            // so initial load must fault loudly rather than risk silently skipping rows.
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE items (
+                    id INT NOT NULL,
+                    name VARCHAR(200) NOT NULL
+                )");
+            ExecuteMySql(connectionString, "INSERT INTO items (id, name) VALUES (1, 'Alpha'), (2, 'Beta');");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-mysql-no-key-faults",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Items",
+                        SourceTableName = "items",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "name", Name = "Name" }
+                        }
+                    }
+                }
+            };
+            AddCdcSink(store, config);
+
+            var fault = await WaitForProcessFaultAsync(store, config.Name);
+            Assert.IsType<Raven.Server.Documents.CdcSink.CdcSinkFaultedException>(fault);
+            Assert.Contains("neither a primary key nor a NOT-NULL unique key", fault.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
+        public async Task InitialLoad_NoPrimaryKey_UsesNotNullUniqueKey()
+        {
+            // No primary key, but a NOT-NULL unique key. Initial load must paginate by that key and
+            // load every row (the document id still comes from the configured PrimaryKeyColumns).
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE items (
+                    id INT NOT NULL,
+                    name VARCHAR(200) NOT NULL,
+                    UNIQUE KEY uq_items_id (id)
+                )");
+            ExecuteMySql(connectionString, "INSERT INTO items (id, name) VALUES (1, 'Alpha'), (2, 'Beta'), (3, 'Gamma');");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-mysql-unique-key-fallback",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Items",
+                        SourceTableName = "items",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "name", Name = "Name" }
+                        }
+                    }
+                }
+            };
+            AddCdcSink(store, config);
+
+            Assert.Equal("Alpha", (await WaitForSinkDocumentAsync<Item>(store, config.Name, "Items/1")).Name);
+            Assert.Equal("Gamma", (await WaitForSinkDocumentAsync<Item>(store, config.Name, "Items/3")).Name);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
         public async Task InitialLoad_RootTable()
         {
             using var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkPostgresIntegrationTests.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
 using Tests.Infrastructure;
 using Tests.Infrastructure.ConnectionString;
 using Xunit;
@@ -119,6 +120,184 @@ namespace SlowTests.Server.Documents.CdcSink
                 Assert.NotNull(p4);
                 Assert.Equal(123456789.01m, p4.Price);
             }
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, NpgSqlCdcRequired = true)]
+        public async Task InitialLoad_NoPrimaryKeyOrUniqueKey_Faults()
+        {
+            // A heap table (no primary key, no unique key) has nothing safe to keyset-paginate by,
+            // so initial load must fault loudly rather than risk silently skipping rows.
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.NpgSQL, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            ExecuteNpgSql(connectionString, @"
+                CREATE TABLE items (
+                    id INT NOT NULL,
+                    name VARCHAR(200) NOT NULL
+                )");
+            ExecuteNpgSql(connectionString, "INSERT INTO items (id, name) VALUES (1, 'Alpha'), (2, 'Beta');");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-no-key-faults",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Items",
+                        SourceTableSchema = "public",
+                        SourceTableName = "items",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "name", Name = "Name" }
+                        }
+                    }
+                }
+            };
+            AddCdcSink(store, config);
+
+            var fault = await WaitForProcessFaultAsync(store, config.Name);
+            Assert.IsType<Raven.Server.Documents.CdcSink.CdcSinkFaultedException>(fault);
+            Assert.Contains("neither a primary key nor a NOT-NULL unique key", fault.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, NpgSqlCdcRequired = true)]
+        public async Task InitialLoad_NoPrimaryKey_UsesNotNullUniqueKey()
+        {
+            // No primary key, but a NOT-NULL unique key. Initial load must paginate by that key and
+            // load every row (the document id still comes from the configured PrimaryKeyColumns).
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.NpgSQL, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            ExecuteNpgSql(connectionString, @"
+                CREATE TABLE items (
+                    id INT NOT NULL UNIQUE,
+                    name VARCHAR(200) NOT NULL
+                )");
+            ExecuteNpgSql(connectionString, "INSERT INTO items (id, name) VALUES (1, 'Alpha'), (2, 'Beta'), (3, 'Gamma');");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-unique-key-fallback",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Items",
+                        SourceTableSchema = "public",
+                        SourceTableName = "items",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "name", Name = "Name" }
+                        }
+                    }
+                }
+            };
+            AddCdcSink(store, config);
+
+            Assert.Equal("Alpha", (await WaitForSinkDocumentAsync<Item>(store, config.Name, "Items/1")).Name);
+            Assert.Equal("Gamma", (await WaitForSinkDocumentAsync<Item>(store, config.Name, "Items/3")).Name);
+            Assert.Equal(3, await WaitForDocumentCountAsync(store, "Items", expectedCount: 3, timeoutMs: 60_000));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, NpgSqlCdcRequired = true)]
+        public async Task InitialLoad_EmbeddedTableWithNonUniqueConfiguredKey_LoadsAllRows()
+        {
+            // Regression for RavenDB-26926. order_details has a composite real PK (order_id, product_id),
+            // but the embedded config's PrimaryKeyColumns is just product_id — unique within one order,
+            // NOT across the table. Under the old heuristic, keyset pagination by product_id dropped rows
+            // across batch boundaries. A tiny MaxBatchSize forces multi-batch pagination; paginating by
+            // the real composite PK must load all rows.
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record =>
+                    record.Settings[RavenConfiguration.GetKey(x => x.CdcSink.MaxBatchSize)] = "2"
+            });
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.NpgSQL, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            ExecuteNpgSql(connectionString, @"
+                CREATE TABLE orders (id INT PRIMARY KEY, customer VARCHAR(200) NOT NULL);
+                CREATE TABLE order_details (
+                    order_id INT NOT NULL REFERENCES orders(id),
+                    product_id INT NOT NULL,
+                    product VARCHAR(200) NOT NULL,
+                    quantity INT NOT NULL,
+                    PRIMARY KEY (order_id, product_id)
+                );");
+
+            // 4 orders x 3 lines = 12 detail rows; product_id in {1,2,3} repeats across every order.
+            var sb = new System.Text.StringBuilder();
+            for (int o = 1; o <= 4; o++)
+            {
+                sb.AppendLine($"INSERT INTO orders (id, customer) VALUES ({o}, 'Customer {o}');");
+                for (int p = 1; p <= 3; p++)
+                    sb.AppendLine($"INSERT INTO order_details (order_id, product_id, product, quantity) VALUES ({o}, {p}, 'P{p}', {p * 10});");
+            }
+            ExecuteNpgSql(connectionString, sb.ToString());
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-nonunique-embedded-key",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = "public",
+                        SourceTableName = "orders",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "customer", Name = "Customer" }
+                        },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = "public",
+                                SourceTableName = "order_details",
+                                PropertyName = "Lines",
+                                Type = CdcSinkRelationType.Array,
+                                JoinColumns = new List<string> { "order_id" },
+                                PrimaryKeyColumns = new List<string> { "product_id" },
+                                Columns = new List<CdcColumnMapping>
+                                {
+                                    new CdcColumnMapping { Column = "product_id", Name = "ProductNum" },
+                                    new CdcColumnMapping { Column = "product", Name = "Product" },
+                                    new CdcColumnMapping { Column = "quantity", Name = "Quantity" }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            AddCdcSink(store, config);
+
+            await WaitForCdcInitialLoadAsync(store, config.Name, timeoutMs: 60_000);
+
+            // All 12 detail rows must be present (4 orders x 3 lines) — none dropped across batches.
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                int total = 0;
+                for (int o = 1; o <= 4; o++)
+                {
+                    var order = await session.LoadAsync<Order>($"Orders/{o}");
+                    total += order?.Lines?.Count ?? 0;
+                }
+                return total;
+            }, 12, timeout: 60_000);
         }
 
         [RavenFact(RavenTestCategory.Sinks, NpgSqlCdcRequired = true)]

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
@@ -312,6 +312,95 @@ namespace SlowTests.Server.Documents.CdcSink
         // ─────────────────────────────────────────────────────────────────────
 
         [RavenFact(RavenTestCategory.Sinks, MsSqlRequired = true, MsSqlCdcRequired = true)]
+        public async Task InitialLoad_NoPrimaryKeyOrUniqueKey_Faults()
+        {
+            // A heap table (no primary key, no unique key) has nothing safe to keyset-paginate by,
+            // so initial load must fault loudly rather than risk silently skipping rows.
+            using var store = GetDocumentStore();
+            var schema = CreateTestSchema();
+
+            ExecuteMsSql($@"
+                CREATE TABLE [{schema}].items (
+                    id INT NOT NULL,
+                    name NVARCHAR(200) NOT NULL
+                )");
+            ExecuteMsSql($"INSERT INTO [{schema}].items (id, name) VALUES (1, 'Alpha'), (2, 'Beta');");
+
+            EnableCdcOnTables((schema, "items"));
+            var sqlCs = SetupSqlConnectionString(store);
+
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-mssql-no-key-faults",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Items",
+                        SourceTableSchema = schema,
+                        SourceTableName = "items",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "name", Name = "Name" }
+                        }
+                    }
+                }
+            };
+            AddCdcSink(store, config);
+
+            var fault = await WaitForProcessFaultAsync(store, config.Name);
+            Assert.IsType<Raven.Server.Documents.CdcSink.CdcSinkFaultedException>(fault);
+            Assert.Contains("neither a primary key nor a NOT-NULL unique key", fault.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, MsSqlRequired = true, MsSqlCdcRequired = true)]
+        public async Task InitialLoad_NoPrimaryKey_UsesNotNullUniqueKey()
+        {
+            // No primary key, but a NOT-NULL unique key. Initial load must paginate by that key and
+            // load every row (the document id still comes from the configured PrimaryKeyColumns).
+            using var store = GetDocumentStore();
+            var schema = CreateTestSchema();
+
+            ExecuteMsSql($@"
+                CREATE TABLE [{schema}].items (
+                    id INT NOT NULL UNIQUE,
+                    name NVARCHAR(200) NOT NULL
+                )");
+            ExecuteMsSql($"INSERT INTO [{schema}].items (id, name) VALUES (1, 'Alpha'), (2, 'Beta'), (3, 'Gamma');");
+
+            EnableCdcOnTables((schema, "items"));
+            var sqlCs = SetupSqlConnectionString(store);
+
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-mssql-unique-key-fallback",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Items",
+                        SourceTableSchema = schema,
+                        SourceTableName = "items",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "name", Name = "Name" }
+                        }
+                    }
+                }
+            };
+            AddCdcSink(store, config);
+
+            Assert.Equal("Alpha", (await WaitForSinkDocumentAsync<Item>(store, config.Name, "Items/1")).Name);
+            Assert.Equal("Gamma", (await WaitForSinkDocumentAsync<Item>(store, config.Name, "Items/3")).Name);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, MsSqlRequired = true, MsSqlCdcRequired = true)]
         public async Task InitialLoad_RootTable()
         {
             using var store = GetDocumentStore();


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-26926/CDC-Sink-non-unique-embedded-table-PrimaryKeyColumns-silently-drops-rows-during-initial-load

### Additional description

When performing initial load of a table, we require (in the preference order)
1. Primary key
2. Unique key (constraint or index) with non-null columns

If the table contains multiple keys that satisfy 2., we pick the one with the fewest columns. Ties are resolved alphabetically by column names

Attempt to load a table without either faults the task because of invalid configuration

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
