### PR TITLE
RavenDB-26951 GenAI: authenticate model queries with the server certificate

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -188,6 +188,9 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
             Array.Fill(executingTasks, Task.CompletedTask);
             List<GenAiResultItem> itemsSentToModel = [];
 
+            var certificate = RavenServer.GetCertificateForAuthorization(Database.ServerStore.Server.Certificate.ClientCertificate);
+            var authentication = Database.ServerStore.Server.AuthenticateConnectionCertificate(certificate, $"GenAI access for '{Name}'");
+
             foreach (var item in items)
             {
                 statsScope.NumberOfContextObjects++;
@@ -208,8 +211,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 var agentConfiguration = CreateAgentConfiguration(context, item);
                 var handler = new GenAiConversationHandler(Database.ServerStore, Database, Configuration)
                 {
-                    // GenAI task uses full access
-                    Authentication = Database.ServerStore.Server.AuthenticateConnectionCertificate(Database.ServerStore.Server.Certificate.ClientCertificate, $"GenAI access for '{Name}'")
+                    Authentication = authentication
                 };
 
                 handler.Initialize(agentConfiguration, $"{Configuration.Identifier}/{item.DocumentId}/", new RequestBody

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_26951.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_26951.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues;
+
+public class RavenDB_26951 : RavenTestBase
+{
+    public RavenDB_26951(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Ai | RavenTestCategory.Certificates)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GenAiTask_InitialContextQuery_ShouldAuthenticateWithFullAccess(bool with2Eku)
+    {
+        var certificates = Certificates.SetupServerAuthentication(with2Eku: with2Eku);
+        var adminCert = Certificates.RegisterClientCertificate(certificates, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+        using var store = GetDocumentStore(new Options { AdminCertificate = adminCert, ClientCertificate = adminCert });
+
+        Assert.NotNull(Server.Certificate.ClientCertificate);
+        if (with2Eku)
+            Assert.Equal(Server.Certificate.ServerCertificate.Thumbprint, Server.Certificate.ClientCertificate.Thumbprint);
+        else
+            Assert.NotEqual(Server.Certificate.ServerCertificate.Thumbprint, Server.Certificate.ClientCertificate.Thumbprint);
+
+        var deadModelEndpoint = "http://127.0.0.1:1/";
+
+        var config = new GenAiConfiguration
+        {
+            Name = "genai-initial-query",
+            Identifier = "genai-initial-query",
+            ConnectionStringName = "genai-cs",
+            Collection = "Orders",
+            Prompt = "Summarize the orders.",
+            SampleObject = "{\"Answer\":\"the answer\"}",
+            UpdateScript = "this.Processed = true;",
+            Connection = new AiConnectionString
+            {
+                Name = "genai-cs",
+                ModelType = AiModelType.Chat,
+                OpenAiSettings = new OpenAiSettings("fake-key", deadModelEndpoint, "gpt-4o")
+            },
+            GenAiTransformation = new GenAiTransformation
+            {
+                Script = "ai.genContext({ company: this.Company });"
+            },
+            Queries =
+            [
+                new AiAgentToolQuery("RecentOrder", "Get the recent orders", "from Orders limit 5")
+                {
+                    ParametersSampleObject = "{}",
+                    Options = new AiAgentToolQueryOptions { AddToInitialContext = true, AllowModelQueries = false }
+                }
+            ]
+        };
+
+        store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        store.Maintenance.Send(new AddGenAiOperation(config));
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Order { Company = "companies/1-A", Lines = [new OrderLine { ProductName = "widget", Quantity = 2 }] }, "orders/1-A");
+            session.SaveChanges();
+        }
+
+        EtlErrorInfo error = null;
+        var hadError = await WaitForValueAsync(async () =>
+        {
+            error = await Etl.TryGetLoadErrorAsync(store.Database, config);
+            return error != null;
+        }, expectedVal: true, timeout: 60_000);
+
+        Assert.True(hadError, "Expected the GenAI task to record an error (the model endpoint is a dead port).");
+        Assert.DoesNotContain("unknown to the server", error.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("InvalidAuth", error.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class Order
+    {
+        public string Id { get; set; }
+        public string Company { get; set; }
+        public List<OrderLine> Lines { get; set; }
+        public bool Processed { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26951

### Additional description

The GenAI task authenticated its in-process queries with `Server.Certificate.ClientCertificate`. When the server certificate lacks the TLS **Client Authentication** EKU, that `ClientCertificate` is a freshly-derived certificate the cluster has never seen. `AuthenticateConnectionCertificate` recognizes the server identity only via `IsServerCertificate()` (equality against `ServerCertificate`), so the derived cert is treated as `UnfamiliarCertificate` and the query is rejected - the intended "full access" never applies, and GenAI throws on auth.

The HTTPS and TCP entry points already normalize the presented certificate through `GetCertificateForAuthorization` (which extracts the embedded server cert and verifies the pinning hash) before authenticating; the GenAI in-process path was the only caller that skipped this step.

Fix: normalize the certificate via `GetCertificateForAuthorization` before authenticating, so it resolves back to the server certificate and authorizes as `ClusterAdmin`. The identity is the server's own and identical for every document in the batch, so it is computed once and shared.

The added test `RavenDB_26951` exercises the real `GenAiTask` ETL using an `AddToInitialContext` query (executed server-side during initial context build, before any model call) with the model pointed at an unreachable endpoint. It is a theory over `with2Eku`: `false` (server-auth-only cert) reproduces the bug and previously failed on `"unknown to the server"`; `true` (cert already has the client-auth EKU) is the control that passed before the fix. Both pass with the fix.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
