### PR TITLE
RavenDB-26955 CDC Sink: preserve Postgres time full precision in NormalizeForJson

### DIFF
--- a/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
@@ -337,6 +337,9 @@ public class CdcSinkTableProcessor
             // Primitive types that ObjectJsonParser handles natively
             bool or int or long or float or double or decimal
                 or DateTime or DateOnly or DateTimeOffset => value,
+            // Postgres time: ObjectJsonParser has no native TimeOnly handling, so render it
+            // in round-trip format ("HH:mm:ss.fffffff") to preserve full precision.
+            TimeOnly time => time.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
             // JSON columns: parse the string into a blittable object/array using the parent context
             string s when isJsonColumn && context != null => ParseJsonColumnValue(s, context),
             string s => s,

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
@@ -334,12 +334,9 @@ public class CdcSinkTableProcessor
             null or DBNull => null,
             byte[] bytes => Convert.ToBase64String(bytes),
             Guid guid => guid.ToString(),
-            // Primitive types that ObjectJsonParser handles natively
+            // Primitive types that ObjectJsonParser handles natively.
             bool or int or long or float or double or decimal
-                or DateTime or DateOnly or DateTimeOffset => value,
-            // Postgres time: ObjectJsonParser has no native TimeOnly handling, so render it
-            // in round-trip format ("HH:mm:ss.fffffff") to preserve full precision.
-            TimeOnly time => time.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+                or DateTime or DateOnly or DateTimeOffset or TimeOnly => value,
             // JSON columns: parse the string into a blittable object/array using the parent context
             string s when isJsonColumn && context != null => ParseJsonColumnValue(s, context),
             string s => s,

--- a/test/SlowTests.Issues/Issues/RavenDB-26955.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26955.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Operations.CdcSink;
+using Raven.Server.Documents.CdcSink;
+using Raven.Server.Documents.CdcSink.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26955 : RavenTestBase
+{
+    public RavenDB_26955(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Sinks)]
+    public async Task TimeColumn_PreservesSecondsAndSubSeconds()
+    {
+        using var store = GetDocumentStore();
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+        var config = new CdcSinkTableConfig
+        {
+            CollectionName = "Events",
+            SourceTableSchema = "public",
+            SourceTableName = "events",
+            Columns = new List<CdcColumnMapping>
+            {
+                new CdcColumnMapping { Column = "id", Name = "Id" },
+                new CdcColumnMapping { Column = "start_time", Name = "StartTime" },
+                new CdcColumnMapping { Column = "end_time", Name = "EndTime" },
+                new CdcColumnMapping { Column = "precise_time", Name = "PreciseTime" }
+            },
+            PrimaryKeyColumns = new List<string> { "id" }
+        };
+
+        var sinkConfig = new CdcSinkConfiguration
+        {
+            Name = "test-config",
+            Tables = new List<CdcSinkTableConfig> { config }
+        };
+        var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
+        var processor = docProcessor.GetProcessor("public", "events");
+
+        // Npgsql returns Postgres 'time without time zone' as a TimeOnly.
+        var columnNames = new[] { "id", "start_time", "end_time", "precise_time" };
+        var rawValues = new object[]
+        {
+            (long)1,
+            new TimeOnly(12, 34, 56),        // seconds must survive
+            new TimeOnly(1, 2, 3),
+            new TimeOnly(23, 59, 59, 999),   // sub-seconds must survive
+        };
+
+        DynamicJsonValue mappedData;
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext jsonCtx))
+        {
+            processor.SetSourceColumnNames(columnNames);
+            mappedData = processor.MapColumns(rawValues, jsonCtx);
+            mappedData[Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                { [Constants.Documents.Metadata.Collection] = "Events" };
+
+            var ops = new List<CdcSinkDocumentOp>
+            {
+                new CdcSinkDocumentOp
+                {
+                    Type = CdcSinkDocumentOpType.Put,
+                    DocumentId = "Events/1",
+                    Processor = processor,
+                    MappedData = mappedData,
+                    RawValues = rawValues,
+                    Operation = CdcSinkOperation.Upsert
+                }
+            };
+
+            var command = new CdcSinkBatchCommand(database, ops, "test-config", null, null, null, null, null, null);
+            await database.TxMerger.Enqueue(command);
+        }
+
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext readCtx))
+        using (readCtx.OpenReadTransaction())
+        {
+            var doc = database.DocumentsStorage.Get(readCtx, "Events/1");
+            Assert.NotNull(doc);
+
+            // Full-precision round-trip format: HH:mm:ss.fffffff (never truncated to HH:mm).
+            doc.Data.TryGet("StartTime", out string startTime);
+            Assert.Equal("12:34:56.0000000", startTime);
+
+            doc.Data.TryGet("EndTime", out string endTime);
+            Assert.Equal("01:02:03.0000000", endTime);
+
+            doc.Data.TryGet("PreciseTime", out string preciseTime);
+            Assert.Equal("23:59:59.9990000", preciseTime);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26955/CDC-Sink-Postgres-data-type-fidelity-issues-time-truncation-numeric-precision-overflow-json-jsonb-as-string-NaN-Infinity-as

### Additional description

Full precision preservation for PostgreSQL `time`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
