### PR TITLE
RavenDB-27008 External replication: strip sharded revision change vector to version-only for pre-6.0 peers

### DIFF
--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -701,6 +701,11 @@ namespace Raven.Server.Documents.Replication.Senders
 
         protected virtual void WriteReplicationItem(DocumentsOperationContext documentsContext, ReplicationBatchItem item, OutgoingReplicationStatsScope stats)
         {
+            // pre-6.0  stored revisions with the full CV as the key (6.0+ always use cv.Version).
+            // to avoid duplicate revisions for pre-6.0 we need to send only the version
+            if (_parent.SupportedFeatures.Replication.RevisionTombstonesWithId == false && IsRevisionItem(item))
+                item.ChangeVector = documentsContext.GetChangeVector(item.ChangeVector).Version;
+
             // we will dispose item when we are done with writing the stream in the loop below
             using (item is AttachmentReplicationItem ? item : null)
             using (Slice.From(documentsContext.Allocator, item.ChangeVector, out var cv))
@@ -708,6 +713,11 @@ namespace Raven.Server.Documents.Replication.Senders
                 item.Write(cv, _stream, _tempBuffer, stats);
             }
         }
+
+        private static bool IsRevisionItem(ReplicationBatchItem item) =>
+            item is RevisionTombstoneReplicationItem ||
+            (item is DocumentReplicationItem doc &&
+             (doc.Flags.Contain(DocumentFlags.Revision) || doc.Flags.Contain(DocumentFlags.DeleteRevision)));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void EnsureValidStats(OutgoingReplicationStatsScope stats)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27008

### Additional description

Bidirectional external replication between a **sharded** database and a **pre-6.0** peer duplicates the revisions on the pre-6.0 side (revision count doubles on every round-trip; other stats are unaffected).

Root cause: a sharded source stamps a shard-local *order* component onto every replicated item, so revisions leave with a composite `order|version` change vector. Pre-6.0 servers key revisions on the **full** CV, whereas 6.0+ always reduce to `cv.Version`. So when the round-tripped revision comes back to the pre-6.0 peer, its composite CV is seen as a new key and the revision is stored again.

Fix: in `ReplicationDocumentSenderBase.WriteReplicationItem`, when the destination lacks the `RevisionTombstonesWithId` capability (i.e. is pre-6.0), send revision / delete-revision / revision-tombstone items with their `cv.Version` only. The strip happens at the wire seam, after the frontier is computed from the full CV, so replication progress tracking is unaffected. Non-sharded sources are a no-op (no order component to strip); 6.0+ peers are unchanged.

Verified with the existing `ExternalReplicationBetween54XAndCurrent` test: the `Sharded` variant went red → green, and the `Single` variant plus a `7.2.0`-vs-current run stayed green.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

Behavior is gated on the negotiated `RevisionTombstonesWithId` replication feature: only pre-6.0 destinations receive the version-only CV (restoring the form they were built to handle); 6.0+ destinations are unaffected.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
