### PR TITLE
RavenDB-27010 Fix flaky InPlaceClusterUpgradeAllEntitiesTests by waiting for replication to fully drain

### DIFF
--- a/test/InterversionTests/Revisions/InPlaceClusterUpgradeAllEntitiesTests.cs
+++ b/test/InterversionTests/Revisions/InPlaceClusterUpgradeAllEntitiesTests.cs
@@ -44,48 +44,49 @@ namespace InterversionTests.Revisions
             var node2 = cluster[1];
 
             var dbName = GetDatabaseName();
-            using var bootstrapStore = PinnedStore(node1.Url, dbName);
+            using var store1 = PinnedStore(node1.Url, dbName);
+            using var store2 = PinnedStore(node2.Url, dbName);
 
-            await bootstrapStore.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(dbName)
+            await store1.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(dbName)
             {
                 Settings = { [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false" }
             }, replicationFactor: 2));
 
-            await ConfigureRevisionsAsync(bootstrapStore, minToKeep: 2);
+            await ConfigureRevisionsAsync(store1, minToKeep: 2);
 
             var allDocs = new List<DocSnapshot>();
 
             // STAGE 1: both old
-            allDocs.Add(await CascadeOnNodeAsync(node1, dbName, "users/n1-stage1"));
-            allDocs.Add(await CascadeOnNodeAsync(node2, dbName, "users/n2-stage1"));
+            allDocs.Add(await CascadeOnNodeAsync(store1, "users/n1-stage1"));
+            allDocs.Add(await CascadeOnNodeAsync(store2, "users/n2-stage1"));
 
-            await WaitForReplicationConvergenceAsync(node1, node2, dbName, allDocs);
+            await WaitForReplicationConvergenceAsync(store1, store2);
 
-            await AssertAllEntitiesReachableAsync(node1, dbName, allDocs, label: "STAGE 1 on node1 (old)");
-            await AssertAllEntitiesReachableAsync(node2, dbName, allDocs, label: "STAGE 1 on node2 (old)");
+            await AssertAllEntitiesReachableAsync(store1, allDocs, label: "STAGE 1 on node1 (old)");
+            await AssertAllEntitiesReachableAsync(store2, allDocs, label: "STAGE 1 on node2 (old)");
 
             // STAGE 2: node1 upgraded
             await UpgradeServerAsync(toVersion: "current", node1, customSettings);
 
-            allDocs.Add(await CascadeOnNodeAsync(node1, dbName, "users/n1-stage2"));
-            allDocs.Add(await CascadeOnNodeAsync(node2, dbName, "users/n2-stage2"));
+            allDocs.Add(await CascadeOnNodeAsync(store1, "users/n1-stage2"));
+            allDocs.Add(await CascadeOnNodeAsync(store2, "users/n2-stage2"));
 
-            await WaitForReplicationConvergenceAsync(node1, node2, dbName, allDocs);
+            await WaitForReplicationConvergenceAsync(store1, store2);
 
-            await AssertExactRevisionCountAsync(node1, dbName, allDocs, expected: 2, label: "STAGE 2 on node1 (current, mixed cluster)");
-            await AssertExactRevisionCountAsync(node2, dbName, allDocs, expected: 2, label: "STAGE 2 on node2 (old, mixed cluster)");
+            await AssertExactRevisionCountAsync(store1, allDocs, expected: 2, label: "STAGE 2 on node1 (current, mixed cluster)");
+            await AssertExactRevisionCountAsync(store2, allDocs, expected: 2, label: "STAGE 2 on node2 (old, mixed cluster)");
 
             // STAGE 3: node2 upgraded
             await UpgradeServerAsync(toVersion: "current", node2, customSettings);
 
             await Task.Delay(2000);
 
-            await AssertExactRevisionCountAsync(node1, dbName, allDocs, expected: 2, label: "STAGE 3 on node1 (current)");
-            await AssertExactRevisionCountAsync(node2, dbName, allDocs, expected: 2, label: "STAGE 3 on node2 (current)");
+            await AssertExactRevisionCountAsync(store1, allDocs, expected: 2, label: "STAGE 3 on node1 (current)");
+            await AssertExactRevisionCountAsync(store2, allDocs, expected: 2, label: "STAGE 3 on node2 (current)");
 
             // Internal-Voron assertions only valid once both nodes are current bits.
-            await AssertStrictEntityRowsAsync(node1, dbName, allDocs, label: "STAGE 3 strict on node1");
-            await AssertStrictEntityRowsAsync(node2, dbName, allDocs, label: "STAGE 3 strict on node2");
+            await AssertStrictEntityRowsAsync(store1, allDocs, label: "STAGE 3 strict on node1");
+            await AssertStrictEntityRowsAsync(store2, allDocs, label: "STAGE 3 strict on node2");
         }
 
         private sealed class DocSnapshot
@@ -99,14 +100,12 @@ namespace InterversionTests.Revisions
             public string AttachmentTombstoneParentRevisionCV; // E4 parent (tombstone)
         }
         // Cap=2 means every step past the first two also produces a revision-tombstone, so the cascade fills all four tables.
-        private static async Task<DocSnapshot> CascadeOnNodeAsync(InterversionTestBase.ProcessNode node, string dbName, string docId)
+        private static async Task<DocSnapshot> CascadeOnNodeAsync(IDocumentStore store, string docId)
         {
-            using var store = PinnedStore(node.Url, dbName);
-
             var snapshot = new DocSnapshot
             {
                 DocId = docId,
-                CreatedOnNodeUrl = node.Url,
+                CreatedOnNodeUrl = store.Urls[0],
                 AttachmentName = "att-1",
                 AttachmentContentType = "application/octet-stream"
             };
@@ -165,52 +164,21 @@ namespace InterversionTests.Revisions
             store.Initialize();
             return store;
         }
-        private static async Task WaitForReplicationConvergenceAsync(
-            InterversionTestBase.ProcessNode node1,
-            InterversionTestBase.ProcessNode node2,
-            string dbName,
-            List<DocSnapshot> expectedDocs,
-            int timeoutMs = 60_000)
+        private static async Task WaitForReplicationConvergenceAsync(IDocumentStore store1, IDocumentStore store2, int timeoutMs = 60_000)
         {
-            using var s1 = PinnedStore(node1.Url, dbName);
-            using var s2 = PinnedStore(node2.Url, dbName);
+            var fromNode1 = $"sync/from-node1-{Guid.NewGuid():N}";
+            var fromNode2 = $"sync/from-node2-{Guid.NewGuid():N}";
 
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-            while (sw.ElapsedMilliseconds < timeoutMs)
-            {
-                bool allConverged = true;
-                foreach (var doc in expectedDocs)
-                {
-                    int c1 = await RevisionCountAsync(s1, doc.DocId);
-                    int c2 = await RevisionCountAsync(s2, doc.DocId);
-                    if (c1 < 1 || c2 < 1 || c1 != c2)
-                    {
-                        allConverged = false;
-                        break;
-                    }
-                }
-                if (allConverged)
-                    return;
-                await Task.Delay(500);
-            }
-        }
+            using (var s = store1.OpenAsyncSession()) { await s.StoreAsync(new User { Name = "sync" }, fromNode1); await s.SaveChangesAsync(); }
+            using (var s = store2.OpenAsyncSession()) { await s.StoreAsync(new User { Name = "sync" }, fromNode2); await s.SaveChangesAsync(); }
 
-        private static async Task<int> RevisionCountAsync(IDocumentStore store, string docId)
-        {
-            try
-            {
-                using var session = store.OpenAsyncSession();
-                var md = await session.Advanced.Revisions.GetMetadataForAsync(docId, pageSize: 100);
-                return md.Count;
-            }
-            catch { return -1; }
+            await WaitForDocumentNameAsync(store2, fromNode1, "sync", timeoutMs);
+            await WaitForDocumentNameAsync(store1, fromNode2, "sync", timeoutMs);
         }
 
         private static async Task AssertExactRevisionCountAsync(
-            InterversionTestBase.ProcessNode node, string dbName, List<DocSnapshot> docs, int expected, string label)
+            IDocumentStore store, List<DocSnapshot> docs, int expected, string label)
         {
-            using var store = PinnedStore(node.Url, dbName);
-
             var mismatches = new List<string>();
             foreach (var doc in docs)
             {
@@ -223,15 +191,13 @@ namespace InterversionTests.Revisions
             }
 
             Assert.True(mismatches.Count == 0,
-                $"[{label}] revision-count mismatch on {node.Url}:\n" + string.Join("\n", mismatches));
+                $"[{label}] revision-count mismatch on {store.Urls[0]}:\n" + string.Join("\n", mismatches));
         }
 
         // Client-API check usable on either old or current bits.
         private static async Task AssertAllEntitiesReachableAsync(
-            InterversionTestBase.ProcessNode node, string dbName, List<DocSnapshot> docs, string label)
+            IDocumentStore store, List<DocSnapshot> docs, string label)
         {
-            using var store = PinnedStore(node.Url, dbName);
-
             foreach (var doc in docs)
             {
                 using var session = store.OpenAsyncSession();
@@ -246,10 +212,10 @@ namespace InterversionTests.Revisions
 
         // Current-bits only (requires DocumentDatabase access).
         private async Task AssertStrictEntityRowsAsync(
-            InterversionTestBase.ProcessNode node, string dbName, List<DocSnapshot> docs, string label)
+            IDocumentStore store, List<DocSnapshot> docs, string label)
         {
-            var server = Servers.Single(s => s.WebUrl == node.Url);
-            var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName);
+            var server = Servers.Single(s => s.WebUrl == store.Urls[0]);
+            var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
 
             using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
             using (ctx.OpenReadTransaction())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27010

### Additional description

Fixes a flaky failure in `InterversionTests.Revisions.InPlaceClusterUpgradeAllEntitiesTests.ClusterInPlaceUpgrade_AllFourEntities_AssertedAtEveryBinaryMix` (STAGE 1).

The test's `WaitForReplicationConvergenceAsync` waited only for revision **counts** to match across the two nodes. Because the test configures `minToKeep: 2`, the receiving node reaches count `2` from the first two replicated revisions — **before** the terminal delete-revision (the last op of every cascade) has replicated. Convergence therefore returned prematurely, and the following flags assertion (`md[0]` must be a `DeleteRevision`) could observe a pre-delete `HasRevisions, Revision, FromReplication` entry. Nothing regressed in the product; the test only started running on the v7.2 line when `feature/revisions` was merged, which is why it surfaced now.

**Fix:** replace the count-based wait with a bidirectional sentinel-marker wait. Replication ships items to a peer in etag order per source, so once a sentinel written after all prior writes is visible on the peer, every earlier item — including the delete-revision — has already replicated. The count-polling loop (and its `RevisionCountAsync` helper) is removed in favor of the existing `WaitForDocumentNameAsync`. The test is also simplified to create the two pinned stores once and pass them around instead of re-creating a store per helper call.

`minToKeep: 2` is intentional and left unchanged — it is what forces revision eviction so the cascade populates the revision-tombstone table that `AssertStrictEntityRowsAsync` asserts on.

**Verification:** a deterministic reproduction (a probe that reaches count-convergence with the delete not yet present) reproduced the exact reported signature `"HasRevisions, Revision, FromReplication"` / not found `"DeleteRevision"`, confirming the count-based wait was the cause. After the fix the test passes 10/10 locally, including across the in-place upgrade (which exercises the reused stores).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
