### PR TITLE
RavenDB-27009 Bump sharded revision-tombstone interversion test to 6.2 and assert against the source revision count

### DIFF
--- a/test/InterversionTests/ReplicationTests.cs
+++ b/test/InterversionTests/ReplicationTests.cs
@@ -239,7 +239,7 @@ namespace InterversionTests
         public async Task ExternalReplicationWithRevisionTombstones_ShardedToOldServer()
         {
             using (var store = Sharding.GetDocumentStore())
-            using (var oldStore = await GetDocumentStoreAsync(Server54Version))
+            using (var oldStore = await GetDocumentStoreAsync(Server62Version))
             {
                 await InsertData(store, "$users/1");
                 await InsertData(oldStore, "");
@@ -254,6 +254,13 @@ namespace InterversionTests
                 await EnsureReplicatingAsync(store, oldStore);
 
                 var location = await Sharding.GetShardNumberForAsync(store, id);
+
+                int sourceRevisions;
+                using (var s = store.OpenAsyncSession())
+                    sourceRevisions = (await s.Advanced.Revisions.GetMetadataForAsync(id, pageSize: 100)).Count;
+
+                const int expectedSourceRevisions = 2;
+                Assert.Equal(expectedSourceRevisions, sourceRevisions);
 
                 using (var s1 = store.OpenSession())
                 {
@@ -271,7 +278,6 @@ namespace InterversionTests
                 using (context.OpenReadTransaction())
                 {
                     var tombs = storage.GetTombstonesFrom(context, 0).ToList();
-                    Assert.Equal(5, tombs.Count);
 
                     int revisionTombsCount = 0, documentTombsCount = 0;
                     foreach (var item in tombs)
@@ -282,8 +288,9 @@ namespace InterversionTests
                             documentTombsCount++;
                     }
 
-                    Assert.Equal(4, revisionTombsCount);
+                    Assert.Equal(sourceRevisions, revisionTombsCount);
                     Assert.Equal(1, documentTombsCount);
+                    Assert.Equal(sourceRevisions + 1, tombs.Count);
                 }
 
                 await Task.Delay(3000);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27009

### Additional description

`InterversionTests.ReplicationTests.ExternalReplicationWithRevisionTombstones_ShardedToOldServer` used a **pre-6.0** peer (5.4), which made the test invalid for two independent, pre-6.0-only reasons:

1. With a pre-6.0 peer, the source shard's revisions are **duplicated on the bidirectional round-trip** (RavenDB-27008 / #23176 — pre-6.0 keys revisions on the full composite `order|version` CV, 6.0+ reduce to `cv.Version`). id1 is written twice, but the round-trip doubled it to 4 revisions, so the test hard-coded the inflated tombstone count (`5` = 4 revision-tombstones + 1 document-tombstone).
2. breaks sharded ↔ pre-6.0 revision-tombstone replication outright (the sharded orchestrator broadcasts a docId-less revision-tombstone to every shard, and non-owning shards throw).

We decided that we want to support only 6.2+ <-> sharded replication, so we changed the baseline version.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
