### PR TITLE
RavenDB-27052 - Fix Lucene exact() matching on DateTime/DateTimeOffset fields

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -195,12 +195,12 @@ namespace Raven.Server.Documents.Indexes
             public const long CoraxPagingBasedOnEntriesId_62 = 62_006; // RavenDB-23100
             public const long CoraxUnicodeLengthAnalyzers_62 = 62_007; // RavenDB-24423
             public const long CoraxNumericTreesWithoutFrequencies_62 = 62_008; // RavenDB-27171
-            public const long ExactDatesUseTimeTicks_62 = 62_009; // RavenDB-27052
+            public const long LuceneExactDatesUseTimeTicks_62 = 62_009; // RavenDB-27052
 
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = ExactDatesUseTimeTicks_62;
+            public const long CurrentVersion = LuceneExactDatesUseTimeTicks_62;
 
             public static bool IsLowerCasedReferencesSupported(long indexVersion)
             {

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -247,6 +247,11 @@ namespace Raven.Server.Documents.Indexes
             {
                 return indexVersion >= CoraxNumericTreesWithoutFrequencies_62;
             }
+
+            public static bool IsLuceneExactDatesUseTimeTicksSupported(long indexVersion)
+            {
+                return indexVersion >= LuceneExactDatesUseTimeTicks_62;
+            }
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -195,11 +195,12 @@ namespace Raven.Server.Documents.Indexes
             public const long CoraxPagingBasedOnEntriesId_62 = 62_006; // RavenDB-23100
             public const long CoraxUnicodeLengthAnalyzers_62 = 62_007; // RavenDB-24423
             public const long CoraxNumericTreesWithoutFrequencies_62 = 62_008; // RavenDB-27171
+            public const long ExactDatesUseTimeTicks_62 = 62_009; // RavenDB-27052
 
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = CoraxNumericTreesWithoutFrequencies_62;
+            public const long CurrentVersion = ExactDatesUseTimeTicks_62;
 
             public static bool IsLowerCasedReferencesSupported(long indexVersion)
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
@@ -319,7 +319,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
                 // Legacy exact/non-analyzed indexes stored the round-trip ("o") form (offset preserved, no _Time field),
                 // which made exact() queries match by literal string and diverge from Corax. From LuceneExactDatesUseTimeTicks_62
                 // onwards DateTimeOffset is always normalized to UTC and gets the numeric _Time field so exact() matches by instant.
-                var useLegacyExactDateTimeOffsetFormat = _index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.LuceneExactDatesUseTimeTicks_62;
+                var useLegacyExactDateTimeOffsetFormat = IndexDefinitionBaseServerSide.IndexVersion.IsLuceneExactDatesUseTimeTicksSupported(_index.Definition.Version) == false;
 
                 string dateAsString;
                 if (useLegacyExactDateTimeOffsetFormat && field.Indexing != FieldIndexing.Default && (indexing == Field.Index.NOT_ANALYZED || indexing == Field.Index.NOT_ANALYZED_NO_NORMS))

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
@@ -317,9 +317,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
                 var dateTimeOffset = (DateTimeOffset)value;
 
                 // Legacy exact/non-analyzed indexes stored the round-trip ("o") form (offset preserved, no _Time field),
-                // which made exact() queries match by literal string and diverge from Corax. From ExactDatesUseTimeTicks_62
+                // which made exact() queries match by literal string and diverge from Corax. From LuceneExactDatesUseTimeTicks_62
                 // onwards DateTimeOffset is always normalized to UTC and gets the numeric _Time field so exact() matches by instant.
-                var useLegacyExactDateTimeOffsetFormat = _index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.ExactDatesUseTimeTicks_62;
+                var useLegacyExactDateTimeOffsetFormat = _index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.LuceneExactDatesUseTimeTicks_62;
 
                 string dateAsString;
                 if (useLegacyExactDateTimeOffsetFormat && field.Indexing != FieldIndexing.Default && (indexing == Field.Index.NOT_ANALYZED || indexing == Field.Index.NOT_ANALYZED_NO_NORMS))

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
@@ -316,8 +316,13 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
             {
                 var dateTimeOffset = (DateTimeOffset)value;
 
+                // Legacy exact/non-analyzed indexes stored the round-trip ("o") form (offset preserved, no _Time field),
+                // which made exact() queries match by literal string and diverge from Corax. From ExactDatesUseTimeTicks_62
+                // onwards DateTimeOffset is always normalized to UTC and gets the numeric _Time field so exact() matches by instant.
+                var useLegacyExactDateTimeOffsetFormat = _index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.ExactDatesUseTimeTicks_62;
+
                 string dateAsString;
-                if (field.Indexing != FieldIndexing.Default && (indexing == Field.Index.NOT_ANALYZED || indexing == Field.Index.NOT_ANALYZED_NO_NORMS))
+                if (useLegacyExactDateTimeOffsetFormat && field.Indexing != FieldIndexing.Default && (indexing == Field.Index.NOT_ANALYZED || indexing == Field.Index.NOT_ANALYZED_NO_NORMS))
                     dateAsString = dateTimeOffset.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite, CultureInfo.InvariantCulture);
                 else
                 {

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -708,7 +708,12 @@ public static class QueryBuilderHelper
         ticksFirst = -1;
         ticksSecond = -1;
 
-        if (exact || index == null || valueFirst == null || valueSecond == null || index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.TimeTicks)
+        if (index == null || valueFirst == null || valueSecond == null || index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.TimeTicks)
+            return false;
+
+        // exact matching on a date field means "the same instant"; match via ticks like the non-exact path.
+        // Older indexes preserve the legacy literal-string behavior for exact until they are reindexed.
+        if (exact && index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.ExactDatesUseTimeTicks_62)
             return false;
 
         if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index, valueFirst, out ticksFirst) && TryGetTime(index, valueSecond, out ticksSecond))
@@ -721,7 +726,12 @@ public static class QueryBuilderHelper
     {
         ticks = -1;
 
-        if (exact || index == null || value == null || index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.TimeTicks)
+        if (index == null || value == null || index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.TimeTicks)
+            return false;
+
+        // exact matching on a date field means "the same instant"; match via ticks like the non-exact path.
+        // Older indexes preserve the legacy literal-string behavior for exact until they are reindexed.
+        if (exact && index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.ExactDatesUseTimeTicks_62)
             return false;
 
         if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index, value, out ticks))

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -713,7 +713,7 @@ public static class QueryBuilderHelper
 
         // exact matching on a date field means "the same instant"; match via ticks like the non-exact path.
         // Older indexes preserve the legacy literal-string behavior for exact until they are reindexed.
-        if (exact && index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.LuceneExactDatesUseTimeTicks_62)
+        if (exact && IndexDefinitionBaseServerSide.IndexVersion.IsLuceneExactDatesUseTimeTicksSupported(index.Definition.Version) == false)
             return false;
 
         if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index, valueFirst, out ticksFirst) && TryGetTime(index, valueSecond, out ticksSecond))
@@ -731,7 +731,7 @@ public static class QueryBuilderHelper
 
         // exact matching on a date field means "the same instant"; match via ticks like the non-exact path.
         // Older indexes preserve the legacy literal-string behavior for exact until they are reindexed.
-        if (exact && index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.LuceneExactDatesUseTimeTicks_62)
+        if (exact && IndexDefinitionBaseServerSide.IndexVersion.IsLuceneExactDatesUseTimeTicksSupported(index.Definition.Version) == false)
             return false;
 
         if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index, value, out ticks))

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -713,7 +713,7 @@ public static class QueryBuilderHelper
 
         // exact matching on a date field means "the same instant"; match via ticks like the non-exact path.
         // Older indexes preserve the legacy literal-string behavior for exact until they are reindexed.
-        if (exact && index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.ExactDatesUseTimeTicks_62)
+        if (exact && index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.LuceneExactDatesUseTimeTicks_62)
             return false;
 
         if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index, valueFirst, out ticksFirst) && TryGetTime(index, valueSecond, out ticksSecond))
@@ -731,7 +731,7 @@ public static class QueryBuilderHelper
 
         // exact matching on a date field means "the same instant"; match via ticks like the non-exact path.
         // Older indexes preserve the legacy literal-string behavior for exact until they are reindexed.
-        if (exact && index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.ExactDatesUseTimeTicks_62)
+        if (exact && index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.LuceneExactDatesUseTimeTicks_62)
             return false;
 
         if (index.IndexFieldsPersistence.HasTimeValues(fieldName) && TryGetTime(index, value, out ticks))

--- a/test/SlowTests/Issues/RavenDB-27052.cs
+++ b/test/SlowTests/Issues/RavenDB-27052.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27052 : RavenTestBase
+    {
+        public RavenDB_27052(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Event
+        {
+            public string Id { get; set; }
+
+            public DateTimeOffset ControllerResultDateTime { get; set; }
+        }
+
+        private class Events_ByControllerResultDateTime : AbstractIndexCreationTask<Event>
+        {
+            public Events_ByControllerResultDateTime()
+            {
+                Map = events => from e in events
+                                select new
+                                {
+                                    e.ControllerResultDateTime
+                                };
+
+                // Exact indexing forces the KeywordAnalyzer and, on Lucene, stores the DateTimeOffset
+                // via the round-trip "o" format (offset preserved, 7 fractional digits) with no numeric
+                // _Time companion field.
+                Index(x => x.ControllerResultDateTime, FieldIndexing.Exact);
+            }
+        }
+
+        // The document stores a DateTimeOffset with a non-zero offset and no fractional seconds:
+        //   2026-07-10T15:24:46+02:00
+        // Lucene + Exact indexes the term as the round-trip form "2026-07-10T15:24:46.0000000+02:00".
+        // Corax normalizes any DateTimeOffset to UTC ("...Z") regardless of Exact.
+        private static readonly DateTimeOffset Value = new DateTimeOffset(2026, 7, 10, 15, 24, 46, TimeSpan.FromHours(2));
+
+        // The value the way a client would naturally write it - offset preserved, no fractional part.
+        private const string QueryWithoutFractionalSeconds = "2026-07-10T15:24:46+02:00";
+
+        // The exact round-trip ("o") form that Lucene actually stores as the index term.
+        private const string QueryWithFractionalSeconds = "2026-07-10T15:24:46.0000000+02:00";
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Exact_query_on_DateTimeOffset_should_be_consistent_across_engines(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                new Events_ByControllerResultDateTime().Execute(store);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Event { ControllerResultDateTime = Value });
+                    session.SaveChanges();
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                // The full round-trip form matches on both engines.
+                AssertCount(store, QueryWithFractionalSeconds, expected: 1);
+
+                // The natural form (no fractional seconds) must also match on both engines. exact() on a date field
+                // matches by instant (UTC ticks), so the offset and the missing fractional part are irrelevant.
+                // Before the fix (IndexVersion < ExactDatesUseTimeTicks_62) this returned 0 on Lucene because the
+                // stored Exact term kept the ".0000000+02:00" round-trip form and exact bypassed the tick-based match.
+                AssertCount(store, QueryWithoutFractionalSeconds, expected: 1);
+            }
+        }
+
+        private static void AssertCount(IDocumentStore store, string value, int expected)
+        {
+            using (var session = store.OpenSession())
+            {
+                var count = session.Advanced
+                    .RawQuery<Event>($"from index '{new Events_ByControllerResultDateTime().IndexName}' where exact(ControllerResultDateTime == $p0)")
+                    .AddParameter("p0", value)
+                    .ToList()
+                    .Count;
+
+                Assert.Equal(expected, count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27052/Lucene-exact-queries-on-DateTimeOffset-DateTime-fields-fail-unless-the-query-string-matches-the-indexed-format-byte-for-byte

### Additional description

#### Problem

On Lucene, `FieldIndexing.Exact` on a `DateTimeOffset` stores the round-trip `"o"` term
(offset preserved, `.0000000`) with no `_Time` field, and `exact()` queries match that
term as a **literal string** instead of by instant. So `…46+02:00` misses while
`…46.0000000+02:00` matches, and `exact()` on `DateTime` hits the same fractional-seconds
mismatch. Corax always matches dates by UTC instant, so the engines disagree on identical
data.

#### Fix

Make Lucene `exact()` dates match by instant, like Corax, gated behind a new index version
(`ExactDatesUseTimeTicks_62`):

- **Index** - `DateTimeOffset` is always UTC-normalized and gets the numeric `_Time` field
  (`LuceneDocumentConverterBase`); the legacy `"o"` branch only applies to older index
  versions.
- **Query** - `TryUseTime` no longer bails on `exact` for date fields, so `exact()` uses
  the ticks path (`QueryBuilderHelper`).
- **Version** - `IndexVersion` bumped; `CurrentVersion` updated.

#### Compatibility

Not a breaking change. Existing indexes keep their persisted version and behave exactly as
before - **no forced reindex**. The fix applies to newly created or reset indexes - resetting an affected index picks it up.

#### Tests

- Added `RavenDB-27052`: a `[RavenTheory]` over both engines
  asserting `exact()` on a `DateTimeOffset` matches for both the natural and
  full-fractional forms. **Fails on Lucene before the fix, passes on both after.**
- Existing exact/date tests still pass: `RavenDB_13759`, `ExactNotUsedInIndexing`, `DateTimeOffsets`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured.
Every changed path (`TryUseTime` and the `DateTimeOffset` branch in `LuceneDocumentConverterBase`) is gated by `IsLuceneExactDatesUseTimeTicksSupported(index.Definition.Version)`. An existing index keeps its persisted version on load (read via `ReadVersion`, never auto-bumped), so the helper returns `false` and its behavior is unchanged — offset-preserving term, `exact()` matched as a literal string.

Only a newly created or **reset** index gets `CurrentVersion` (`LuceneExactDatesUseTimeTicks_62`), where the helper returns `true` and the new instant / UTC-ticks behavior applies. So nothing changes for running indexes on upgrade; the fix takes effect only on rebuild, which is already a full re-index.

- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
