### PR TITLE
RavenDB-26932 CDC - Use ConcurrentQueue for values pool

### DIFF
--- a/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
@@ -303,16 +303,6 @@ public class CdcSinkDocumentProcessor
     }
 
     /// <summary>
-    /// Clears the contents of pooled arrays (releases references for GC) but keeps
-    /// the arrays in the pool for reuse. Use when idle for a short period.
-    /// </summary>
-    public void ClearValuePoolArrays()
-    {
-        foreach (var (_, processor) in _tableIndex)
-            processor.ClearPoolArrays();
-    }
-
-    /// <summary>
     /// Releases all pooled arrays entirely. Use when idle for a longer period.
     /// </summary>
     public void ClearValuePools()

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -634,9 +634,9 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             if (completedCheckpoint is not null)
                 await OnBatchFlushed(completedCheckpoint, rows);
 
-            // Return values from the completed batch back to per-table pools.
-            // Done here (after await) rather than inside SubmitBatch so that pool
-            // access stays on the caller's flow and never races with RentValues.
+            // Return values from the completed batch back to per-table pools. Must happen
+            // after `await lastBatch`: the ops reference these arrays until the TxMerger
+            // is done with them.
             ReturnBatchValuesAndClear(ref lastBatchOps);
 
             // previousCtx (if any) backed batches that are all guaranteed complete now - we just
@@ -701,11 +701,8 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
 
                         if (moveTask.IsCompleted == false)
                         {
-                            // Source is idle - clear array contents immediately to release
-                            // references for GC, but keep the arrays in the pool for reuse.
-                            DocumentProcessor.ClearValuePoolArrays();
-
-                            // If still idle after 1 minute, release the pooled arrays entirely.
+                            // Source is idle. Pooled arrays are cleared on return so they hold no
+                            // row references; if still idle after 1 minute, release them entirely.
                             var completed = await moveTask.WaitFor(TimeSpan.FromMinutes(1), ct);
                             if (completed != moveTask)
                                 DocumentProcessor.ClearValuePools();

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
 using Raven.Client.Documents.Operations.CdcSink;
@@ -133,45 +134,27 @@ public class CdcSinkTableProcessor
     /// </summary>
     public List<CdcSinkLinkedTableConfig> LinkedTables { get; init; }
 
-    private readonly Queue<object[]> _valuesPool = new();
-
-    // Guards _valuesPool: streaming decode rents on a thread-pool continuation (Task.WhenAny
-    // in ProcessCdcStream) while the stream thread returns/clears pooled arrays, so all pool
-    // access must be serialized.
-    private readonly object _valuesPoolLock = new();
+    // ConcurrentQueue: streaming decode rents on a thread-pool continuation (Task.WhenAny in
+    // ProcessCdcStream) while the stream thread returns/releases arrays. Arrays are cleared on
+    // return, so pooled arrays never retain row references and are never mutated while pooled.
+    private readonly ConcurrentQueue<object[]> _valuesPool = new();
 
     public object[] RentValues()
     {
         var expectedLen = SourceColumnNames.Length;
-        lock (_valuesPoolLock)
+        while (_valuesPool.TryDequeue(out var arr))
         {
-            while (_valuesPool.TryDequeue(out var arr))
-            {
-                if (arr.Length == expectedLen)
-                    return arr;
-                // Discard stale array from before a schema change (wrong size)
-            }
+            if (arr.Length == expectedLen)
+                return arr;
+            // Discard stale array from before a schema change (wrong size)
         }
         return new object[expectedLen];
     }
 
     public void ReturnValues(object[] arr)
     {
-        lock (_valuesPoolLock)
-            _valuesPool.Enqueue(arr);
-    }
-
-    /// <summary>
-    /// Clears array contents to release references for GC, but keeps
-    /// the arrays in the pool for reuse on the next burst.
-    /// </summary>
-    public void ClearPoolArrays()
-    {
-        lock (_valuesPoolLock)
-        {
-            foreach (var arr in _valuesPool)
-                Array.Clear(arr, 0, arr.Length);
-        }
+        Array.Clear(arr, 0, arr.Length);
+        _valuesPool.Enqueue(arr);
     }
 
     /// <summary>
@@ -179,8 +162,7 @@ public class CdcSinkTableProcessor
     /// </summary>
     public void ClearPool()
     {
-        lock (_valuesPoolLock)
-            _valuesPool.Clear();
+        _valuesPool.Clear();
     }
 
     /// <summary>
@@ -195,10 +177,7 @@ public class CdcSinkTableProcessor
     public void SetSourceColumnNames(string[] names)
     {
         if (SourceColumnNames?.Length != names.Length)
-        {
-            lock (_valuesPoolLock)
-                _valuesPool.Clear();
-        }
+            _valuesPool.Clear();
 
         SourceColumnNames = names;
 

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
@@ -135,21 +135,30 @@ public class CdcSinkTableProcessor
 
     private readonly Queue<object[]> _valuesPool = new();
 
+    // Guards _valuesPool: streaming decode rents on a thread-pool continuation (Task.WhenAny
+    // in ProcessCdcStream) while the stream thread returns/clears pooled arrays, so all pool
+    // access must be serialized.
+    private readonly object _valuesPoolLock = new();
+
     public object[] RentValues()
     {
         var expectedLen = SourceColumnNames.Length;
-        while (_valuesPool.TryDequeue(out var arr))
+        lock (_valuesPoolLock)
         {
-            if (arr.Length == expectedLen)
-                return arr;
-            // Discard stale array from before a schema change (wrong size)
+            while (_valuesPool.TryDequeue(out var arr))
+            {
+                if (arr.Length == expectedLen)
+                    return arr;
+                // Discard stale array from before a schema change (wrong size)
+            }
         }
         return new object[expectedLen];
     }
 
     public void ReturnValues(object[] arr)
     {
-        _valuesPool.Enqueue(arr);
+        lock (_valuesPoolLock)
+            _valuesPool.Enqueue(arr);
     }
 
     /// <summary>
@@ -158,8 +167,11 @@ public class CdcSinkTableProcessor
     /// </summary>
     public void ClearPoolArrays()
     {
-        foreach (var arr in _valuesPool)
-            Array.Clear(arr, 0, arr.Length);
+        lock (_valuesPoolLock)
+        {
+            foreach (var arr in _valuesPool)
+                Array.Clear(arr, 0, arr.Length);
+        }
     }
 
     /// <summary>
@@ -167,7 +179,8 @@ public class CdcSinkTableProcessor
     /// </summary>
     public void ClearPool()
     {
-        _valuesPool.Clear();
+        lock (_valuesPoolLock)
+            _valuesPool.Clear();
     }
 
     /// <summary>
@@ -182,7 +195,10 @@ public class CdcSinkTableProcessor
     public void SetSourceColumnNames(string[] names)
     {
         if (SourceColumnNames?.Length != names.Length)
-            _valuesPool.Clear();
+        {
+            lock (_valuesPoolLock)
+                _valuesPool.Clear();
+        }
 
         SourceColumnNames = names;
 

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkResilienceSqlServerTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkResilienceSqlServerTests.cs
@@ -250,6 +250,8 @@ namespace SlowTests.Server.Documents.CdcSink
 
             ExecuteMsSql(connectionString, "INSERT INTO items (id, name) VALUES (1, 'Before Kill')");
 
+            await WaitForCdcCapture(connectionString);
+
             var sqlCs = SetupSqlConnectionString(store, connectionString);
             var config = new CdcSinkConfiguration
             {
@@ -276,6 +278,8 @@ namespace SlowTests.Server.Documents.CdcSink
 
             var doc = await WaitForDocumentAsync<Item>(store, "Items/1", timeoutMs: 60_000);
             Assert.NotNull(doc);
+
+            await WaitForCdcInitialLoadAsync(store, "test-conn-failure");
 
             // SQL Server poll-based CDC doesn't hold a persistent connection,
             // so killing a session has limited impact — the next poll opens a new connection.

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkResilienceSqlServerTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkResilienceSqlServerTests.cs
@@ -22,11 +22,23 @@ namespace SlowTests.Server.Documents.CdcSink
 
         private void ExecuteMsSql(string connectionString, string sql)
         {
-            using var connection = new SqlConnection(connectionString);
-            connection.Open();
-            using var cmd = new SqlCommand(sql, connection);
-            cmd.CommandTimeout = 120;
-            cmd.ExecuteNonQuery();
+            const int maxAttempts = 5;
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    using var connection = new SqlConnection(connectionString);
+                    connection.Open();
+                    using var cmd = new SqlCommand(sql, connection);
+                    cmd.CommandTimeout = 120;
+                    cmd.ExecuteNonQuery();
+                    return;
+                }
+                catch (SqlException e) when (CdcSqlServerFixture.IsDeadlock(e) && attempt < maxAttempts)
+                {
+                    System.Threading.Thread.Sleep(500 * attempt);
+                }
+            }
         }
 
         private void EnableCdc(string connectionString)

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
@@ -29,10 +29,28 @@ namespace SlowTests.Server.Documents.CdcSink
 
         public CdcSqlServerFixture()
         {
-            _databaseName = "CdcTest_" + Guid.NewGuid();
             var masterCs = MsSqlConnectionString.Instance.VerifiedConnectionString.Value;
-            ConnectionString = masterCs + $";Initial Catalog={_databaseName}";
+            
+            const int maxAttempts = 5;
+            for (var attempt = 1; ; attempt++)
+            {
+                _databaseName = "CdcTest_" + Guid.NewGuid();
+                ConnectionString = masterCs + $";Initial Catalog={_databaseName}";
+                try
+                {
+                    BootstrapDatabase(masterCs);
+                    return;
+                }
+                catch (SqlException e) when (IsDeadlock(e) && attempt < maxAttempts)
+                {
+                    DropDatabase(masterCs); // best-effort — free the half-created DB before retrying
+                    System.Threading.Thread.Sleep(500 * attempt);
+                }
+            }
+        }
 
+        private void BootstrapDatabase(string masterCs)
+        {
             using (var conn = new SqlConnection(masterCs))
             {
                 conn.Open();
@@ -63,16 +81,18 @@ namespace SlowTests.Server.Documents.CdcSink
                 }
             }
         }
+        
+        internal static bool IsDeadlock(SqlException e) =>
+            e.Number == 1205 || e.Message.Contains("deadlock", StringComparison.OrdinalIgnoreCase);
 
-        public void Dispose()
+        private void DropDatabase(string masterCs)
         {
             try
             {
-                var masterCs = MsSqlConnectionString.Instance.VerifiedConnectionString.Value;
                 using var conn = new SqlConnection(masterCs);
                 conn.Open();
                 using var cmd = new SqlCommand(
-                    $"ALTER DATABASE [{_databaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{_databaseName}]", conn);
+                    $"IF DB_ID('{_databaseName}') IS NOT NULL BEGIN ALTER DATABASE [{_databaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{_databaseName}]; END", conn);
                 cmd.CommandTimeout = 120;
                 cmd.ExecuteNonQuery();
             }
@@ -80,6 +100,11 @@ namespace SlowTests.Server.Documents.CdcSink
             {
                 // best-effort cleanup
             }
+        }
+
+        public void Dispose()
+        {
+            DropDatabase(MsSqlConnectionString.Instance.VerifiedConnectionString.Value);
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26932/CDC-Sink-ClearValuePoolArrays-races-the-in-flight-batch-during-streaming-Collection-was-modified-crashes-the-stream

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
