### PR TITLE
RavenDB-27049 Persist SupportedFeatures in the documents storage (write-once at first load) and restore it instead of using defaults when a database is created over an existing data directory

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -445,6 +445,7 @@ namespace Raven.Server.Documents
                 OnDatabaseRecordChanged(record);
 
                 SupportedFeatures = new SupportedFeature(record);
+                DocumentsStorage.PersistSupportedFeatures(record.SupportedFeatures);
 
                 ReplicationLoader = CreateReplicationLoader();
                 PeriodicBackupRunner = new PeriodicBackupRunner(this, _serverStore, wakeup);

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -88,6 +88,7 @@ namespace Raven.Server.Documents
         public static readonly Slice GlobalTreeSlice;
         private static readonly Slice GlobalChangeVectorSlice;
         private static readonly Slice GlobalFullChangeVectorSlice;
+        public static readonly Slice SupportedFeaturesSlice;
         private readonly Action<LogLevel, string> _addToInitLog;
 
         protected readonly RavenLogger _logger;
@@ -116,6 +117,7 @@ namespace Raven.Server.Documents
                 Slice.From(ctx, "GlobalTree", ByteStringType.Immutable, out GlobalTreeSlice);
                 Slice.From(ctx, "GlobalChangeVector", ByteStringType.Immutable, out GlobalChangeVectorSlice);
                 Slice.From(ctx, "GlobalFullChangeVector", ByteStringType.Immutable, out GlobalFullChangeVectorSlice);
+                Slice.From(ctx, "SupportedFeatures", ByteStringType.Immutable, out SupportedFeaturesSlice);
                 Slice.From(ctx, "FixCountersLastKeySlice", ByteStringType.Immutable, out FixCountersLastKeySlice);
 
             }
@@ -473,6 +475,32 @@ namespace Raven.Server.Documents
             using (Slice.From(context.Allocator, fullChangeVector, out var slice))
             {
                 tree.Add(GlobalFullChangeVectorSlice, slice);
+            }
+        }
+
+        public static List<string> ReadSupportedFeatures(Transaction tx)
+        {
+            if (tx.ReadTree(GlobalTreeSlice).TryRead(SupportedFeaturesSlice, out var reader) == false || reader.Length == 0)
+                return [];
+
+            return Encodings.Utf8.GetString(reader.Base, reader.Length).Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
+        }
+
+        public void PersistSupportedFeatures(IReadOnlyList<string> features)
+        {
+            if (features == null || features.Count == 0)
+                return;
+
+            using (var tx = Environment.ReadTransaction())
+            {
+                if (tx.ReadTree(GlobalTreeSlice).TryRead(SupportedFeaturesSlice, out _))
+                    return;
+            }
+
+            using (var tx = Environment.WriteTransaction())
+            {
+                tx.ReadTree(GlobalTreeSlice).Add(SupportedFeaturesSlice, Encodings.Utf8.GetBytes(string.Join(",", features)));
+                tx.Commit();
             }
         }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -88,7 +88,7 @@ namespace Raven.Server.Documents
         public static readonly Slice GlobalTreeSlice;
         private static readonly Slice GlobalChangeVectorSlice;
         private static readonly Slice GlobalFullChangeVectorSlice;
-        public static readonly Slice SupportedFeaturesSlice;
+        public const string SupportedFeaturesKey = "SupportedFeatures";
         private readonly Action<LogLevel, string> _addToInitLog;
 
         protected readonly RavenLogger _logger;
@@ -117,7 +117,6 @@ namespace Raven.Server.Documents
                 Slice.From(ctx, "GlobalTree", ByteStringType.Immutable, out GlobalTreeSlice);
                 Slice.From(ctx, "GlobalChangeVector", ByteStringType.Immutable, out GlobalChangeVectorSlice);
                 Slice.From(ctx, "GlobalFullChangeVector", ByteStringType.Immutable, out GlobalFullChangeVectorSlice);
-                Slice.From(ctx, "SupportedFeatures", ByteStringType.Immutable, out SupportedFeaturesSlice);
                 Slice.From(ctx, "FixCountersLastKeySlice", ByteStringType.Immutable, out FixCountersLastKeySlice);
 
             }
@@ -480,10 +479,10 @@ namespace Raven.Server.Documents
 
         public static List<string> ReadSupportedFeatures(Transaction tx)
         {
-            if (tx.ReadTree(GlobalTreeSlice).TryRead(SupportedFeaturesSlice, out var reader) == false || reader.Length == 0)
+            if (tx.ReadTree(GlobalTreeSlice).TryRead(SupportedFeaturesKey, out var reader) == false || reader.Length == 0)
                 return [];
 
-            return Encodings.Utf8.GetString(reader.Base, reader.Length).Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
+            return reader.ToStringValue().Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
         }
 
         public void PersistSupportedFeatures(IReadOnlyList<string> features)
@@ -493,13 +492,13 @@ namespace Raven.Server.Documents
 
             using (var tx = Environment.ReadTransaction())
             {
-                if (tx.ReadTree(GlobalTreeSlice).TryRead(SupportedFeaturesSlice, out _))
+                if (tx.ReadTree(GlobalTreeSlice).TryRead(SupportedFeaturesKey, out _))
                     return;
             }
 
             using (var tx = Environment.WriteTransaction())
             {
-                tx.ReadTree(GlobalTreeSlice).Add(SupportedFeaturesSlice, Encodings.Utf8.GetBytes(string.Join(",", features)));
+                tx.ReadTree(GlobalTreeSlice).Add(SupportedFeaturesKey, string.Join(",", features));
                 tx.Commit();
             }
         }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -274,6 +274,8 @@ namespace Raven.Server.Web.System
                                                             $"To use Prefixed Sharding, all cluster nodes must be running version 6.2 or later.");
                 }
 
+                var dataAlreadyExists = false;
+
                 using (var raw = new RawDatabaseRecord(context, json))
                 {
                     foreach (var rawDatabaseRecord in raw.AsShardsOrNormal())
@@ -282,12 +284,15 @@ namespace Raven.Server.Web.System
                             && Server.ServerStore.Cluster.DatabaseExists(rawDatabaseRecord.DatabaseName) == false)
                         {
                             using (await ServerStore.DatabasesLandlord.UnloadAndLockDatabase(rawDatabaseRecord.DatabaseName, "Checking if database state needs to be updated (including recreating indexes)"))
-                                RecreateDatabase(rawDatabaseRecord.DatabaseName, databaseRecord, rawDatabaseRecord.Settings);
+                            {
+                                RecreateDatabase(rawDatabaseRecord.DatabaseName, databaseRecord, rawDatabaseRecord.Settings, out var exists);
+                                dataAlreadyExists |= exists;
+                            }
                         }
                     }
                 }
 
-                if (databaseRecord.SupportedFeatures == null || databaseRecord.SupportedFeatures.Count == 0)
+                if (dataAlreadyExists == false && (databaseRecord.SupportedFeatures == null || databaseRecord.SupportedFeatures.Count == 0))
                 {
                     databaseRecord.SupportedFeatures = new List<string>
                     {
@@ -348,8 +353,10 @@ namespace Raven.Server.Web.System
             return false;
         }
 
-        private void RecreateDatabase(string databaseName, DatabaseRecord databaseRecord, Dictionary<string, string> settings)
+        private void RecreateDatabase(string databaseName, DatabaseRecord databaseRecord, Dictionary<string, string> settings, out bool dataAlreadyExists)
         {
+            dataAlreadyExists = false;
+
             if (Server.ServerStore.Cluster.DatabaseExists(databaseName))
                 return;
 
@@ -390,6 +397,23 @@ namespace Raven.Server.Web.System
                 documentDatabase.Initialize(options);
 
                 documentDatabase.DocumentsStorage.ResetLastCompletedClusterTransactionIndex();
+
+                if (documentDatabase.DocumentsStorage.Environment.IsNew == false)
+                {
+                    dataAlreadyExists = true;
+
+                    using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        var persisted = DocumentsStorage.ReadSupportedFeatures(ctx.Transaction.InnerTransaction);
+
+                        if (databaseRecord.SupportedFeatures == null || databaseRecord.SupportedFeatures.Count == 0)
+                            databaseRecord.SupportedFeatures = persisted;
+
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info($"Database '{databaseName}' is being created over existing data. Restored SupportedFeatures from storage: [{string.Join(", ", databaseRecord.SupportedFeatures)}]");
+                    }
+                }
 
                 // recrate the indexes on the new database
                 if (databaseConfiguration.Indexing.RunInMemory || Directory.Exists(databaseConfiguration.Indexing.StoragePath.FullPath) == false)

--- a/test/SlowTests.Issues/Issues/RavenDB_27049.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27049.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27049 : RavenTestBase
+    {
+        public RavenDB_27049(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task CreateDatabaseOverExistingData_RestoresPersistedSupportedFeatures()
+        {
+            var path = NewDataPath();
+
+            using (var store = GetDocumentStore(new Options { RunInMemory = false, Path = path }))
+            {
+                var original = (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).SupportedFeatures;
+                Assert.Contains(Constants.DatabaseRecord.SupportedFeatures.ThrowRevisionKeyTooBigFix, original);
+
+                // Load the database so the birth feature list is persisted into the documents env.
+                DocumentDatabase database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                Assert.Equal(original.OrderBy(x => x), ReadPersistedSupportedFeatures(database).OrderBy(x => x));
+
+                await SoftDeleteAndRecreateAsync(store, path);
+
+                var adopted = (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).SupportedFeatures;
+                Assert.Equal(original.OrderBy(x => x), adopted.OrderBy(x => x));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task CreateDatabaseOverExistingDataWithControlCharacterIds_UpdatesKeepWorking()
+        {
+            const string idWithControlCharacter = "users/1\u0001";
+            var path = NewDataPath();
+
+            using (var store = GetDocumentStore(AllowControlCharactersInIdentifier(new Options { RunInMemory = false, Path = path })))
+            {
+                using (IAsyncDocumentSession session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Legacy" }, idWithControlCharacter);
+                    await session.SaveChangesAsync();
+                }
+
+                await SoftDeleteAndRecreateAsync(store, path);
+
+                // Without adoption the stamped defaults would include ThrowControlCharactersInIdentifier
+                // and any further write to this id would throw.
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                Assert.DoesNotContain(Constants.DatabaseRecord.SupportedFeatures.ThrowControlCharactersInIdentifier, record.SupportedFeatures);
+                Assert.Contains(Constants.DatabaseRecord.SupportedFeatures.ThrowRevisionKeyTooBigFix, record.SupportedFeatures);
+
+                DocumentDatabase database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                Assert.False(database.SupportedFeatures.SupportedFeatureTypes.ThrowControlCharactersInIdentifier);
+
+                using (IAsyncDocumentSession session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(idWithControlCharacter);
+                    Assert.NotNull(user);
+
+                    user.Name = "Updated";
+                    await session.SaveChangesAsync();
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task CreateDatabaseOverPreFixData_AdoptsEmptyFeatures()
+        {
+            var path = NewDataPath();
+
+            using (var store = GetDocumentStore(new Options { RunInMemory = false, Path = path }))
+            {
+                DocumentDatabase database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                // Simulate data written by builds that predate the persisted feature list.
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    context.Transaction.InnerTransaction.ReadTree(DocumentsStorage.GlobalTreeSlice).Delete(DocumentsStorage.SupportedFeaturesSlice);
+                    tx.Commit();
+                }
+
+                await SoftDeleteAndRecreateAsync(store, path);
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                Assert.True(record.SupportedFeatures == null || record.SupportedFeatures.Count == 0,
+                    $"Expected no features on the adopted record but got: [{string.Join(", ", record.SupportedFeatures ?? new List<string>())}]");
+
+                database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                Assert.False(database.SupportedFeatures.SupportedFeatureTypes.ThrowControlCharactersInIdentifier);
+
+                // The adopted database declares no features, so nothing gets persisted - absent stays the marker.
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var tree = context.Transaction.InnerTransaction.ReadTree(DocumentsStorage.GlobalTreeSlice);
+                    Assert.False(tree.TryRead(DocumentsStorage.SupportedFeaturesSlice, out _));
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task PersistedSupportedFeatures_AreWriteOnce()
+        {
+            var path = NewDataPath();
+
+            using (var store = GetDocumentStore(new Options { RunInMemory = false, Path = path }))
+            {
+                DocumentDatabase database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                Assert.Contains(Constants.DatabaseRecord.SupportedFeatures.ThrowControlCharactersInIdentifier, ReadPersistedSupportedFeatures(database));
+
+                // Make the persisted list diverge from the record.
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    var tree = context.Transaction.InnerTransaction.ReadTree(DocumentsStorage.GlobalTreeSlice);
+                    using (Slice.From(context.Allocator, Constants.DatabaseRecord.SupportedFeatures.ThrowRevisionKeyTooBigFix, out var value))
+                        tree.Add(DocumentsStorage.SupportedFeaturesSlice, value);
+                    tx.Commit();
+                }
+
+                // Reload: PersistSupportedFeatures must not overwrite an already-present list with the record's.
+                Server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+                database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                Assert.Equal(new[] { Constants.DatabaseRecord.SupportedFeatures.ThrowRevisionKeyTooBigFix }, ReadPersistedSupportedFeatures(database));
+            }
+        }
+
+        private async Task SoftDeleteAndRecreateAsync(DocumentStore store, string path)
+        {
+            await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, hardDelete: false));
+
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(store.Database)
+            {
+                Settings =
+                {
+                    { RavenConfiguration.GetKey(x => x.Core.RunInMemory), "false" },
+                    { RavenConfiguration.GetKey(x => x.Core.DataDirectory), path }
+                }
+            }));
+        }
+
+        private static List<string> ReadPersistedSupportedFeatures(DocumentDatabase database)
+        {
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+                return DocumentsStorage.ReadSupportedFeatures(context.Transaction.InnerTransaction);
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_27049.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27049.cs
@@ -12,7 +12,6 @@ using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
-using Voron;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -94,7 +93,7 @@ namespace SlowTests.Issues
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    context.Transaction.InnerTransaction.ReadTree(DocumentsStorage.GlobalTreeSlice).Delete(DocumentsStorage.SupportedFeaturesSlice);
+                    context.Transaction.InnerTransaction.ReadTree(DocumentsStorage.GlobalTreeSlice).Delete(DocumentsStorage.SupportedFeaturesKey);
                     tx.Commit();
                 }
 
@@ -112,7 +111,7 @@ namespace SlowTests.Issues
                 using (context.OpenReadTransaction())
                 {
                     var tree = context.Transaction.InnerTransaction.ReadTree(DocumentsStorage.GlobalTreeSlice);
-                    Assert.False(tree.TryRead(DocumentsStorage.SupportedFeaturesSlice, out _));
+                    Assert.False(tree.TryRead(DocumentsStorage.SupportedFeaturesKey, out _));
                 }
             }
         }
@@ -131,9 +130,8 @@ namespace SlowTests.Issues
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    var tree = context.Transaction.InnerTransaction.ReadTree(DocumentsStorage.GlobalTreeSlice);
-                    using (Slice.From(context.Allocator, Constants.DatabaseRecord.SupportedFeatures.ThrowRevisionKeyTooBigFix, out var value))
-                        tree.Add(DocumentsStorage.SupportedFeaturesSlice, value);
+                    context.Transaction.InnerTransaction.ReadTree(DocumentsStorage.GlobalTreeSlice)
+                        .Add(DocumentsStorage.SupportedFeaturesKey, Constants.DatabaseRecord.SupportedFeatures.ThrowRevisionKeyTooBigFix);
                     tx.Commit();
                 }
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27049

### Additional description


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
