### PR TITLE
RavenDB-27068 CDC Sink MySQL: expand composite keyset predicate to a PK range seek (fixes O(n^2) embedded initial load)

### DIFF
--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -2,6 +2,8 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MySqlCdc;
@@ -385,6 +387,36 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
         for (int i = 0; i < lastKeys.Length; i++)
             AddParameter(cmd, $"@k{i}", lastKeys[i]);
         return Task.CompletedTask;
+    }
+    
+    protected override string BuildBatchQuery(
+        CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
+        string[] lastKeys, int maxBatchSize)
+    {
+        var table = $"{CommandBuilder.QuoteIdentifier(tableInfo.Schema)}.{CommandBuilder.QuoteIdentifier(tableInfo.TableName)}";
+        var quotedCols = keyColumns.Select(c => CommandBuilder.QuoteIdentifier(c)).ToArray();
+        var keyColsList = string.Join(", ", quotedCols);
+
+        var where = string.Empty;
+        if (lastKeys != null)
+        {
+            // (c1,c2,c3) > (@k0,@k1,@k2)  is equivalent to
+            //   c1 > @k0
+            //   OR (c1 = @k0 AND c2 > @k1)
+            //   OR (c1 = @k0 AND c2 = @k1 AND c3 > @k2)
+            var disjuncts = new List<string>(quotedCols.Length);
+            for (int i = 0; i < quotedCols.Length; i++)
+            {
+                var sb = new StringBuilder();
+                for (int j = 0; j < i; j++)
+                    sb.Append(quotedCols[j]).Append(" = @k").Append(j).Append(" AND ");
+                sb.Append(quotedCols[i]).Append(" > @k").Append(i);
+                disjuncts.Add(quotedCols.Length == 1 ? sb.ToString() : "(" + sb + ")");
+            }
+            where = " WHERE " + string.Join(" OR ", disjuncts);
+        }
+
+        return $"SELECT * FROM {table}{where} ORDER BY {keyColsList} LIMIT {maxBatchSize}";
     }
     
     // Unique (non-PRIMARY) indexes with each column's nullability, joined to COLUMNS for IS_NULLABLE.


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27068/CDC-Sink-MySQL-embedded-composite-key-initial-load-is-On2-tuple-keyset-predicate-defeats-the-PK-index

### Additional description

Mirrors `BuildBatchQuery` override for SQL Server

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
