### PR TITLE
RavenDB-26867 - Fix failing test CanUseImageWithTheWrongFormat

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
@@ -92,7 +92,8 @@ ai.genContext({})
                 session.Advanced.Attachments.Store(FirstItemId, Image+actualFormat, file1);
                 await session.SaveChangesAsync();
             }
-            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30)));
+
+            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 65)), await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
 
             var transformationErrors = (await Etl.GetItemTransformationErrorsAsync(store.Database, config)).ToList();
             var loadErrors = (await Etl.GetItemLoadErrorsAsync(store.Database, config)).ToList();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26867/SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB24645.CanUseImageWithTheWrongFormatoptions-DatabaseMode-Single-config

### Additional description
Failing test:
```
SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB_24645.SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB_24645.CanUseImageWithTheWrongFormat(options:  DatabaseMode = Single, config: OpenAi_AiIntegrationTask, expectedFormat: "Jpeg", actualFormat: "webp")(options:  DatabaseMode = Single, config: OpenAi_AiIntegrationTask, expectedFormat: "Jpeg", actualFormat: "webp")
```
Enlarge the ETL  wait timeout to 65 sec (Gen AI batch timeout is 60) and add debug info
After many unsuccessful attempts to reproduce.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
