### PR TITLE
RavenDB-27031: Add source and nightly build modes for Quill Docker image

### DIFF
--- a/docker/quill/Dockerfile.source
+++ b/docker/quill/Dockerfile.source
@@ -1,0 +1,171 @@
+# syntax=docker/dockerfile:1.7
+
+ARG SDK_IMAGE=mcr.microsoft.com/dotnet/sdk:10.0.301
+ARG RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:10.0.9
+ARG NODE_IMAGE=node:24-bookworm-slim
+ARG STUDIO_NODE_MAJOR=24
+ARG PNPM_VERSION=11.2.2
+ARG S6_OVERLAY_VERSION=3.2.1.0
+
+
+# Stage 0: build Raven.Server from source.
+FROM ${SDK_IMAGE} AS ravendb-server-build
+ARG TARGETARCH
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked \
+    . docker/quill/scripts/dotnet-rid.sh \
+    && dotnet publish src/Raven.Server/Raven.Server.csproj \
+        -c Release \
+        -r "$DOTNET_RID" \
+        --self-contained false \
+        -o /publish/raven \
+        --nologo
+
+FROM --platform=$BUILDPLATFORM ${SDK_IMAGE} AS ravendb-studio-build
+ARG STUDIO_NODE_MAJOR
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+    && curl -fsSL "https://deb.nodesource.com/setup_${STUDIO_NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked \
+    dotnet build tools/TypingsGenerator/TypingsGenerator.csproj \
+        -c Release \
+        --nologo
+
+WORKDIR /src/src/Raven.Studio
+RUN VERSION_PREFIX=$(sed -n 's/.*AssemblyVersion("\([^"]*\)").*/\1/p' /src/src/CommonAssemblyInfo.cs) \
+    && printf '{ "Version": "%s-custom-72" }\n' "$VERSION_PREFIX" > wwwroot/version.txt \
+    && cat wwwroot/version.txt
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+RUN --mount=type=cache,target=/root/.npm \
+    npm run release
+
+
+# Stage 2: build the backend just enough to emit the OpenAPI doc (consumed by Stage 3).
+FROM ${SDK_IMAGE} AS quill-openapi-build
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked \
+    dotnet build src/Raven.Quill/Raven.Quill.csproj \
+        -c Release \
+        --nologo \
+        --tl:off
+
+
+# Stage 3: build the React/Vite frontend (consumes the OpenAPI doc from Stage 2).
+FROM ${NODE_IMAGE} AS quill-frontend-build
+ARG PNPM_VERSION
+WORKDIR /workspace
+
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+COPY src/Raven.Quill.Web/package.json \
+     src/Raven.Quill.Web/pnpm-lock.yaml \
+     src/Raven.Quill.Web/pnpm-workspace.yaml \
+    ./src/Raven.Quill.Web/
+
+WORKDIR /workspace/src/Raven.Quill.Web
+
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
+    pnpm install --frozen-lockfile
+
+WORKDIR /workspace
+
+COPY --from=quill-openapi-build /src/src/Raven.Quill/obj/openapi/quill.json ./src/Raven.Quill/obj/openapi/quill.json
+COPY src/Raven.Quill.Web/ ./src/Raven.Quill.Web/
+
+WORKDIR /workspace/src/Raven.Quill.Web
+ENV RAVEN_QUILL_OPENAPI_SKIP_SPEC_BUILD=1
+RUN pnpm build
+
+
+# Stage 4: publish the backend and overlay the Vite output into wwwroot.
+FROM ${SDK_IMAGE} AS web-build
+ARG TARGETARCH
+WORKDIR /src
+COPY . .
+
+RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked \
+    . docker/quill/scripts/dotnet-rid.sh \
+    && dotnet publish src/Raven.Quill/Raven.Quill.csproj \
+        -c Release \
+        -r "$DOTNET_RID" \
+        --self-contained false \
+        -o /publish/web \
+        --nologo \
+    && rm -rf /publish/web/wwwroot
+
+COPY --from=quill-frontend-build /workspace/src/Raven.Quill.Web/dist /publish/web/wwwroot
+
+
+# Stage 5: runtime - aspnet base + s6-overlay supervising RavenDB, the web app, and nginx.
+FROM ${RUNTIME_IMAGE} AS runtime
+ARG S6_OVERLAY_VERSION
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends xz-utils curl ca-certificates nginx-full openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN <<EOF
+set -eu
+cd /tmp
+
+case "$TARGETARCH" in
+  amd64) S6_ARCH=x86_64 ;;
+  arm64) S6_ARCH=aarch64 ;;
+  arm)   S6_ARCH=arm ;;
+  *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;;
+esac
+
+S6_URL="https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}"
+
+for part in noarch "$S6_ARCH"; do
+  curl -fsSLO "${S6_URL}/s6-overlay-${part}.tar.xz"
+  curl -fsSLO "${S6_URL}/s6-overlay-${part}.tar.xz.sha256"
+done
+
+sha256sum -c s6-overlay-*.sha256
+tar -C / -Jxpf s6-overlay-noarch.tar.xz
+tar -C / -Jxpf "s6-overlay-${S6_ARCH}.tar.xz"
+rm s6-overlay-*
+EOF
+
+COPY --from=ravendb-server-build /publish/raven /app/ravendb
+COPY --from=ravendb-studio-build /src/src/Raven.Studio/wwwroot/dist/Raven.Studio.zip /app/ravendb/
+COPY --from=web-build            /publish/web   /app/web
+COPY docker/quill/ravendb-settings.json /app/ravendb/settings.json
+COPY docker/quill/nginx.conf /etc/nginx/nginx.conf
+
+COPY docker/quill/s6-rc.d/ /etc/s6-overlay/s6-rc.d/
+RUN chmod +x /etc/s6-overlay/s6-rc.d/01-ravendb/run \
+             /etc/s6-overlay/s6-rc.d/02-web/run \
+             /etc/s6-overlay/s6-rc.d/03-proxy/run
+
+EXPOSE 443
+
+VOLUME /var/lib/quill
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=180s \
+    CMD curl -fsk https://127.0.0.1/healthz && curl -fs http://127.0.0.1:5000/healthz
+
+ENV RAVEN_QUILL_RAVEN_URL=http://127.0.0.1:8080 \
+    RAVEN_QUILL_WEB_LISTEN_URL=http://0.0.0.0:5000 \
+    RAVEN_QUILL_CONFIG_DB=quill-config \
+    RAVEN_QUILL_SETUP_PACKAGE_PATH=/var/lib/quill/setup \
+    RAVEN_QUILL_RAVENDB_S6_SERVICE=/run/service/01-ravendb \
+    RAVEN_QUILL_RAVENDB_INTERNAL_PORT=8443 \
+    RAVEN_DataDir=/var/lib/quill/ravendb
+
+ENTRYPOINT ["/init"]

--- a/docker/quill/README.md
+++ b/docker/quill/README.md
@@ -86,6 +86,20 @@ Build from source:
 
 Rebuild any time the Dockerfile or `src/Raven.Quill*` changes.
 
+The script supports two build modes via `--mode`:
+
+- **`source`** (default) — compile `Raven.Server` **and** `Raven.Studio` from the current repo state.
+  Uses `docker/quill/Dockerfile.source`. Slower (webpack + `dotnet publish`) but picks up any
+  in-progress RavenDB changes that live in `feature/ai-appliance` but haven't landed in a published
+  RavenDB image yet.
+- **`nightly`** — pull the RavenDB binaries + Studio.zip from `ravendb/ravendb-nightly:7.2-latest`
+  (no source compile of Raven.Server). Uses `docker/quill/Dockerfile`. Faster, but only correct once
+  the RavenDB changes Quill depends on have shipped to the nightly channel.
+
+```bash
+./docker/quill/scripts/build.sh --tag ravendb/quill:latest --mode nightly
+```
+
 **Post-release** — a published image exists on Docker Hub. Compose pulls it automatically on
 `docker compose up`, or you can prefetch:
 

--- a/docker/quill/scripts/build.sh
+++ b/docker/quill/scripts/build.sh
@@ -12,6 +12,11 @@ Options:
   --tag <name>          Image tag. Repeatable. (default: ravendb/quill:dev)
   --push                Push to registry instead of loading locally
   --platforms <list>    Comma-separated platforms (default: linux/amd64)
+  --mode <mode>         Build mode: source|nightly (default: source)
+                        source  -> docker/quill/Dockerfile.source (compile
+                                   Raven.Server + Raven.Studio from source)
+                        nightly -> docker/quill/Dockerfile (pull RavenDB
+                                   binaries from ravendb/ravendb-nightly)
   --no-cache            Force a full rebuild, ignoring layer cache
   --dry-run             Build locally without pushing (overrides --push)
   -h, --help            Show this help
@@ -21,11 +26,13 @@ Examples:
   $(basename "$0") --tag ravendb/quill:smoke
   $(basename "$0") --tag ravendb/quill:0.1.0 --tag ravendb/quill:latest --push
   $(basename "$0") --tag ravendb/quill:0.1.0 --platforms linux/amd64,linux/arm64 --push
+  $(basename "$0") --tag ravendb/quill:nightly --mode nightly --push
 EOF
 }
 
 TAGS=()
 PLATFORMS="linux/amd64"
+MODE="source"
 PUSH="false"
 NO_CACHE="false"
 DRY_RUN="false"
@@ -42,12 +49,19 @@ while [[ $# -gt 0 ]]; do
     --tag)       require_value --tag "$#";       TAGS+=("$2"); shift 2 ;;
     --push)      PUSH="true"; shift ;;
     --platforms) require_value --platforms "$#"; PLATFORMS="$2"; shift 2 ;;
+    --mode)      require_value --mode "$#";      MODE="$2"; shift 2 ;;
     --no-cache)  NO_CACHE="true"; shift ;;
     --dry-run)   DRY_RUN="true"; shift ;;
     -h|--help)   show_help; exit 0 ;;
     *) echo "Unknown flag: $1" >&2; show_help >&2; exit 1 ;;
   esac
 done
+
+case "$MODE" in
+  source)  DOCKERFILE="docker/quill/Dockerfile.source" ;;
+  nightly) DOCKERFILE="docker/quill/Dockerfile" ;;
+  *) echo "error: --mode must be source or nightly (got: $MODE)" >&2; exit 1 ;;
+esac
 
 # default tag if none was given
 if [ ${#TAGS[@]} -eq 0 ]; then
@@ -70,7 +84,7 @@ fi
 
 cd "$(git rev-parse --show-toplevel)"
 
-cmd=(docker buildx build --platform "$PLATFORMS" -f docker/quill/Dockerfile)
+cmd=(docker buildx build --platform "$PLATFORMS" -f "$DOCKERFILE")
 
 for tag in "${TAGS[@]}"; do
   cmd+=(-t "$tag")


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27031/Quill-build-on-top-of-a-published-RavenDB-image-align-release-cadence-with-RavenDB-post-GA

### Additional description

Introduce `docker/quill/Dockerfile.source` that compiles Raven.Server and Raven.Studio from the current repo state.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed