### PR TITLE
RavenDB-27043 Move quill/usage route under /admin to satisfy authorization-route convention

### DIFF
--- a/src/Raven.Quill/Licensing/LicenseStatsProvider.cs
+++ b/src/Raven.Quill/Licensing/LicenseStatsProvider.cs
@@ -34,7 +34,7 @@ internal sealed class LicenseStatsProvider : ILicenseStatsProvider
 
     public async Task<QuillUsageResponse> GetUsageAsync(int year, int? month, int? day, CancellationToken token)
     {
-        var usage = await _ravendb.SendAsync("/license/quill/usage", "POST", new
+        var usage = await _ravendb.SendAsync("/admin/license/quill/usage", "POST", new
         {
             Month = month,
             Year = year,

--- a/src/Raven.Server/Web/Studio/LicenseHandler.cs
+++ b/src/Raven.Server/Web/Studio/LicenseHandler.cs
@@ -302,7 +302,7 @@ namespace Raven.Server.Web.Studio
             }
         }
 
-        [RavenAction("/license/quill/usage", "POST", AuthorizationStatus.Operator)]
+        [RavenAction("/admin/license/quill/usage", "POST", AuthorizationStatus.Operator)]
         public async Task GetQuillUsage()
         {
             var licenseType = ServerStore.LicenseManager.LicenseStatus.Type;

--- a/test/QuillTests/SettingsEndpointsTests.cs
+++ b/test/QuillTests/SettingsEndpointsTests.cs
@@ -20,7 +20,7 @@ namespace QuillTests;
 /// <c>GET /api/settings/usage</c>. Both are RavenDB-backed (see
 /// <c>LicenseStatsProvider</c>): license proxies the server's <c>/license/status</c> +
 /// <c>/license-server/connectivity</c> and appends the static plan catalog; usage
-/// proxies <c>/license/quill/usage</c>. Assertions target the response shape and
+/// proxies <c>/admin/license/quill/usage</c>. Assertions target the response shape and
 /// environment-stable fields, not license-specific values (which vary with whatever
 /// license the test server runs under).
 /// </summary>
@@ -58,7 +58,7 @@ public class SettingsEndpointsTests(ITestOutputHelper output) : ApplianceMetrics
         using var factory = NewApplianceFactory(store);
         var client = factory.CreateClient();
 
-        // ?year=&month=[&day=] — forwarded to RavenDB's /license/quill/usage as year+month.
+        // ?year=&month=[&day=] — forwarded to RavenDB's /admin/license/quill/usage as year+month.
         var resp = await client.GetAsync("/api/settings/usage?year=2026&month=5");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
@@ -76,7 +76,7 @@ public class SettingsEndpointsTests(ITestOutputHelper output) : ApplianceMetrics
         using var factory = NewApplianceFactory(store);
         var client = factory.CreateClient();
 
-        // year only → the whole-year view; like the month view it proxies straight to /license/quill/usage.
+        // year only → the whole-year view; like the month view it proxies straight to /admin/license/quill/usage.
         var resp = await client.GetAsync("/api/settings/usage?year=2026");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
     }


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27043

### Additional description

This pull request updates the Quill usage endpoint across the codebase to use the new `/admin/license/quill/usage` path instead of the previous `/license/quill/usage`. This ensures consistent routing, aligns with server-side changes, and updates related documentation and tests.

**Endpoint path updates:**

* Changed the route in the `LicenseHandler` controller from `/license/quill/usage` to `/admin/license/quill/usage` to match the new API structure.
* Updated the `LicenseStatsProvider` to send usage requests to `/admin/license/quill/usage` instead of the old path.

**Documentation and test updates:**

* Updated comments and documentation in `SettingsEndpointsTests.cs` to reference the new endpoint path.
* Changed test descriptions in `Usage_returns_quill_usage_payload` and `Usage_supports_the_year_view` to match the new endpoint. [[1]](diffhunk://#diff-d149d5c738828d6ebd622c3ddecfdeb0eb817858a3476da00b4d28cbb359dd0dL61-R61) [[2]](diffhunk://#diff-d149d5c738828d6ebd622c3ddecfdeb0eb817858a3476da00b4d28cbb359dd0dL79-R79)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
