### PR TITLE
RavenDB-27070: server monitoring Etls metrics group should exclude AI tasks

### DIFF
--- a/src/Raven.Server/Monitoring/MetricsProvider.cs
+++ b/src/Raven.Server/Monitoring/MetricsProvider.cs
@@ -324,11 +324,13 @@ public sealed class MetricsProvider
         
         foreach (var dbResult in _serverStore.DatabasesLandlord.GetLoadedDatabases())
         {
-            etlsCount += dbResult.EtlLoader.Processes.Length;
+            var etls = dbResult.EtlLoader.GetEtlProcesses();
+
+            etlsCount += etls.Length;
             errorsCount += dbResult.TaskErrorsStorage.ReadTotalErrorsCount(TaskCategory.Etl);
-            healthyEtlsCount += dbResult.EtlLoader.Processes.Count(x => x.Statistics.HealthStatus == OngoingTaskHealthStatus.Healthy);
-            impairedEtlsCount += dbResult.EtlLoader.Processes.Count(x => x.Statistics.HealthStatus == OngoingTaskHealthStatus.Impaired);
-            failedEtlsCount += dbResult.EtlLoader.Processes.Count(x => x.Statistics.HealthStatus == OngoingTaskHealthStatus.Failed);
+            healthyEtlsCount += etls.Count(x => x.Statistics.HealthStatus == OngoingTaskHealthStatus.Healthy);
+            impairedEtlsCount += etls.Count(x => x.Statistics.HealthStatus == OngoingTaskHealthStatus.Impaired);
+            failedEtlsCount += etls.Count(x => x.Statistics.HealthStatus == OngoingTaskHealthStatus.Failed);
         }
 
         result.Count = etlsCount;


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27070

### Additional description

Fixed incorrect metrics calculation

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
