### PR TITLE
RavenDB-26897 - Fix filtered pull replication database change vector assertions

### DIFF
--- a/test/SlowTests.Issues/Issues/RavenDB-26295/FilteredPullDualClusterFirstAndSecondHopTests.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26295/FilteredPullDualClusterFirstAndSecondHopTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Utils;
+using SlowTests.Issues.RavenDB_26295.Tools;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -42,7 +43,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
 
         // Verify the filtered pass into node A does not advance node B in the database change vector.
         var nodeADbCvAfterPass = lab.GetDatabaseChangeVector(LabNode.A);
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered document pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeADocument.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered document pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeADocument.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered document pass", nodeADbCvAfterPass, nodeADocument.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
 
         await lab.WaitForFilteredRoundTripFirstHopHeartbeatAsync();
@@ -70,7 +71,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
 
         // Verify node C also keeps node B lineage in document Version only after the internal hop.
         var nodeCDbCvAfterPass = lab.GetDatabaseChangeVector(LabNode.C);
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered document internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCDocument.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered document internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCDocument.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered document after internal hop", nodeCDocument.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered document after internal hop", nodeCDocument.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered document after internal hop", nodeCDbCvAfterPass, nodeCDocument.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -143,7 +144,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
         Assert.True(hubADocument.Exists, $"Expected asymmetric pass document '{lab.FilteredRoundTripTicketId}' to reach HA.");
 
         var hubADbCvAfterPass = lab.GetDatabaseChangeVector(ClusterSide.Hub, LabNode.A);
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "asymmetric filtered/unfiltered document pass", hubADbCvBeforePass, hubADbCvAfterPass, hubADocument.ChangeVector, originalIncomingChangeVector, hubBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "asymmetric filtered/unfiltered document pass", hubADbCvBeforePass, hubADbCvAfterPass, hubADocument.ChangeVector, originalIncomingChangeVector, hubBDatabaseId);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "asymmetric filtered/unfiltered document pass", hubADbCvAfterPass, hubADocument.ChangeVector, originalIncomingChangeVector, hubBDatabaseId, hubBEtagInPassedChangeCv);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "asymmetric filtered/unfiltered document pass", hubADocument.ChangeVector, originalIncomingChangeVector, hubBDatabaseId, hubBEtagInPassedChangeCv);
         AssertItemOrderCoversLocalDatabaseId(filteredPassReceiveSide, LabNode.A, "asymmetric filtered/unfiltered document pass", hubADocument.ChangeVector, hubADatabaseId);
@@ -156,7 +157,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
         Assert.True(hubCDocument.Exists, $"Expected asymmetric pass document '{lab.FilteredRoundTripTicketId}' to reach HC through internal replication.");
 
         var hubCDbCvAfterPass = lab.GetDatabaseChangeVector(ClusterSide.Hub, LabNode.C);
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "asymmetric filtered/unfiltered document internal hop", hubCDbCvBeforePass, hubCDbCvAfterPass, hubCDocument.ChangeVector, originalIncomingChangeVector, hubBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "asymmetric filtered/unfiltered document internal hop", hubCDbCvBeforePass, hubCDbCvAfterPass, hubCDocument.ChangeVector, originalIncomingChangeVector, hubBDatabaseId);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "asymmetric filtered/unfiltered document internal hop", hubCDbCvAfterPass, hubCDocument.ChangeVector, originalIncomingChangeVector, hubBDatabaseId, hubBEtagInPassedChangeCv);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "asymmetric filtered/unfiltered document internal hop", hubCDocument.ChangeVector, originalIncomingChangeVector, hubBDatabaseId, hubBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryDatabaseId(filteredPassReceiveSide, LabNode.C, "asymmetric filtered/unfiltered document internal hop", hubCDocument.ChangeVector, sinkADatabaseId, "SA");
@@ -219,7 +220,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
         Assert.NotNull(nodeAConflict);
 
         // Verify the filtered pass into node A keeps conflict lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered conflict pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeAConflict.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered conflict pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeAConflict.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered conflict after pass", nodeAConflict.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered conflict after pass", nodeAConflict.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered conflict pass", nodeADbCvAfterPass, nodeAConflict.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -242,7 +243,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
         Assert.NotNull(nodeCConflict);
 
         // Verify node C also keeps node B lineage in conflict Version only after the internal hop.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered conflict internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCConflict.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered conflict internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCConflict.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered conflict after internal hop", nodeCConflict.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered conflict after internal hop", nodeCConflict.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered conflict internal hop", nodeCDbCvAfterPass, nodeCConflict.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -341,7 +342,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"nodeATombstoneExists={nodeATombstone.Exists}, nodeATombstoneCV='{nodeATombstone.ChangeVector ?? "<null>"}'.");
 
         // Verify the filtered pass into node A keeps tombstone lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered document tombstone pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered document tombstone pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered document tombstone after pass", nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered document tombstone after pass", nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered document tombstone pass", nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -365,7 +366,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"nodeCTombstoneExists={nodeCTombstone.Exists}, nodeCTombstoneCV='{nodeCTombstone.ChangeVector ?? "<null>"}'.");
 
         // Verify node C also keeps node B lineage in tombstone Version only after the internal hop.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered document tombstone internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered document tombstone internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered document tombstone after internal hop", nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered document tombstone after internal hop", nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered document tombstone internal hop", nodeCDbCvAfterPass, nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -479,7 +480,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"actualName='{nodeARevision.Name ?? "<null>"}', CV='{nodeARevision.ChangeVector ?? "<null>"}'.");
 
         // Verify the filtered pass into node A keeps revision lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered revision document pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeARevision.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered revision document pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeARevision.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered revision after pass", nodeARevision.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered revision after pass", nodeARevision.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered revision document pass", nodeADbCvAfterPass, nodeARevision.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -507,7 +508,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"actualName='{nodeCRevision.Name ?? "<null>"}', CV='{nodeCRevision.ChangeVector ?? "<null>"}'.");
 
         // Verify node C also keeps node B lineage in revision Version only after the internal hop.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered revision document internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCRevision.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered revision document internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCRevision.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered revision after internal hop", nodeCRevision.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered revision after internal hop", nodeCRevision.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered revision document internal hop", nodeCDbCvAfterPass, nodeCRevision.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -635,7 +636,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
         Assert.NotNull(nodeATombstone);
 
         // Verify the filtered pass into node A keeps revision tombstone lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered revision tombstone pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered revision tombstone pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered revision tombstone after pass", nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered revision tombstone after pass", nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered revision tombstone pass", nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -656,7 +657,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
         Assert.NotNull(nodeCTombstone);
 
         // Verify node C also keeps node B lineage in revision tombstone Version only after the internal hop.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered revision tombstone internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered revision tombstone internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered revision tombstone after internal hop", nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered revision tombstone after internal hop", nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered revision tombstone internal hop", nodeCDbCvAfterPass, nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -743,7 +744,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"actualValue={nodeACounter.Value}, counterCV='{nodeACounter.ChangeVector ?? "<null>"}'.");
 
         // Verify the filtered pass into node A keeps counter lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered counter pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeACounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered counter pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeACounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered counter after pass", nodeACounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered counter after pass", nodeACounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered counter pass", nodeADbCvAfterPass, nodeACounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -767,7 +768,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"actualValue={nodeCCounter.Value}, counterCV='{nodeCCounter.ChangeVector ?? "<null>"}'.");
 
         // Verify node C also keeps node B lineage in counter Version only after the internal hop.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered counter internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered counter internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered counter after internal hop", nodeCCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered counter after internal hop", nodeCCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered counter internal hop", nodeCDbCvAfterPass, nodeCCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -891,7 +892,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"Expected counter deletion '{counterName}' on '{lab.FilteredRoundTripTicketId}' to reach {NodeTag(filteredPassReceiveSide, LabNode.A)} and remove the live counter. " +
             $"nodeACounterExists={nodeACounter.Exists}, nodeARetainedCounterCV='{nodeARetainedCounter.ChangeVector ?? "<null>"}'.");
 
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered counter deletion pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeARetainedCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered counter deletion pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeARetainedCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered counter deletion after pass", nodeARetainedCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered counter deletion after pass", nodeARetainedCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered counter deletion pass", nodeADbCvAfterPass, nodeARetainedCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -916,7 +917,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"nodeCRetainedCounter: exists={nodeCRetainedCounter.Exists}, value={nodeCRetainedCounter.Value}, CV='{nodeCRetainedCounter.ChangeVector ?? "<null>"}'. " +
             $"nodeARetainedCounterCV='{nodeARetainedCounter.ChangeVector ?? "<null>"}', nodeBRetainedCounterAfterDeleteCV='{nodeBRetainedCounterAfterDelete.ChangeVector ?? "<null>"}'.");
 
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered counter deletion internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCRetainedCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered counter deletion internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCRetainedCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered counter deletion after internal hop", nodeCRetainedCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered counter deletion after internal hop", nodeCRetainedCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered counter deletion internal hop", nodeCDbCvAfterPass, nodeCRetainedCounter.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -988,7 +989,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"actualSize={nodeAAttachment.Size}, CV='{nodeAAttachment.ChangeVector ?? "<null>"}'.");
 
         // Verify the filtered pass into node A keeps attachment lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered attachment pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeAAttachment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered attachment pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeAAttachment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered attachment after pass", nodeAAttachment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered attachment after pass", nodeAAttachment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered attachment pass", nodeADbCvAfterPass, nodeAAttachment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1016,7 +1017,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"actualSize={nodeCAttachment.Size}, CV='{nodeCAttachment.ChangeVector ?? "<null>"}'.");
 
         // Verify node C also keeps node B lineage in attachment Version only after the internal hop.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered attachment internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCAttachment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered attachment internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCAttachment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered attachment after internal hop", nodeCAttachment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered attachment after internal hop", nodeCAttachment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered attachment internal hop", nodeCDbCvAfterPass, nodeCAttachment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1130,7 +1131,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"nodeATombstoneExists={nodeATombstone.Exists}, nodeATombstoneCV='{nodeATombstone.ChangeVector ?? "<null>"}'.");
 
         // Verify the filtered pass into node A keeps attachment tombstone lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered attachment tombstone pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered attachment tombstone pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered attachment tombstone after pass", nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered attachment tombstone after pass", nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered attachment tombstone pass", nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1156,7 +1157,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"nodeCTombstoneExists={nodeCTombstone.Exists}, nodeCTombstoneCV='{nodeCTombstone.ChangeVector ?? "<null>"}'.");
 
         // Verify node C also keeps node B lineage in attachment tombstone Version only after the internal hop.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered attachment tombstone internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered attachment tombstone internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered attachment tombstone after internal hop", nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered attachment tombstone after internal hop", nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered attachment tombstone internal hop", nodeCDbCvAfterPass, nodeCTombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1270,7 +1271,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"nodeATombstoneExists={nodeATombstone.Exists}, nodeATombstoneCV='{nodeATombstone.ChangeVector ?? "<null>"}'.");
 
         // Verify the filtered pass into node A keeps attachment tombstone lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered attachment tombstone before revision revert", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered attachment tombstone before revision revert", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered attachment tombstone before revision revert", nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered attachment tombstone before revision revert", nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered attachment tombstone before revision revert", nodeADbCvAfterPass, nodeATombstone.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1386,7 +1387,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"actualValueCount={nodeASegment.ValueCount}, segmentCV='{nodeASegment.ChangeVector ?? "<null>"}'.");
 
         // Verify the filtered pass into node A keeps time series segment lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered time series segment pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeASegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered time series segment pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeASegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered time series segment after pass", nodeASegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered time series segment after pass", nodeASegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered time series segment pass", nodeADbCvAfterPass, nodeASegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1410,7 +1411,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"actualValueCount={nodeCSegment.ValueCount}, segmentCV='{nodeCSegment.ChangeVector ?? "<null>"}'.");
 
         // Verify node C also keeps node B lineage in time series segment Version only after the internal hop.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered time series segment internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCSegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered time series segment internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCSegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered time series segment after internal hop", nodeCSegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered time series segment after internal hop", nodeCSegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered time series segment internal hop", nodeCDbCvAfterPass, nodeCSegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1513,7 +1514,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"actualValueCount={nodeASegment.ValueCount}, segmentCV='{nodeASegment.ChangeVector ?? "<null>"}'.");
 
         // Verify the filtered pass into node A keeps updated time series segment lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered updated time series segment pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeASegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered updated time series segment pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeASegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered updated time series segment after pass", nodeASegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered updated time series segment after pass", nodeASegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered updated time series segment pass", nodeADbCvAfterPass, nodeASegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1537,7 +1538,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"actualValueCount={nodeCSegment.ValueCount}, segmentCV='{nodeCSegment.ChangeVector ?? "<null>"}'.");
 
         // Verify node C also keeps node B lineage in updated time series segment Version only after the internal hop.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered updated time series segment internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCSegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered updated time series segment internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCSegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered updated time series segment after internal hop", nodeCSegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered updated time series segment after internal hop", nodeCSegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered updated time series segment internal hop", nodeCDbCvAfterPass, nodeCSegment.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1629,7 +1630,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
         Assert.True(nodeADeletedRange.Exists, $"Expected deleted time series range '{timeSeriesName}' on '{lab.FilteredRoundTripTicketId}' to reach {NodeTag(filteredPassReceiveSide, LabNode.A)}.");
 
         // Verify the filtered pass into node A keeps deleted range lineage in Version only.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.A, "filtered deleted time series range pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeADeletedRange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.A, "filtered deleted time series range pass", nodeADbCvBeforePass, nodeADbCvAfterPass, nodeADeletedRange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered deleted time series range after pass", nodeADeletedRange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered deleted time series range after pass", nodeADeletedRange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.A, "filtered deleted time series range pass", nodeADbCvAfterPass, nodeADeletedRange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -1649,7 +1650,7 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"nodeADeletedRangeCV='{nodeADeletedRange.ChangeVector ?? "<null>"}', nodeBDeletedRangeCV='{nodeBDeletedRange.ChangeVector ?? "<null>"}'.");
 
         // Verify node C also keeps node B lineage in deleted range Version only after the internal hop.
-        AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(filteredPassReceiveSide, LabNode.C, "filtered deleted time series range internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCDeletedRange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
+        AssertDatabaseChangeVectorDidNotReachFilteredOutUser(lab, filteredPassReceiveSide, LabNode.C, "filtered deleted time series range internal hop", nodeCDbCvBeforePass, nodeCDbCvAfterPass, nodeCDeletedRange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId);
         AssertItemVersionPreservesPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered deleted time series range after internal hop", nodeCDeletedRange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertItemOrderDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered deleted time series range after internal hop", nodeCDeletedRange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
         AssertDatabaseChangeVectorDoesNotCarryPassedLineage(filteredPassReceiveSide, LabNode.C, "filtered deleted time series range internal hop", nodeCDbCvAfterPass, nodeCDeletedRange.ChangeVector, originalIncomingChangeVector, nodeBDatabaseId, nodeBEtagInPassedChangeCv);
@@ -2045,7 +2046,8 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
             $"dbCV='{databaseChangeVector ?? "<null>"}'.");
     }
 
-    private static void AssertDatabaseChangeVectorDidNotAdvancePastAllowedTicketBeforeFilteredOutUser(
+    private static void AssertDatabaseChangeVectorDidNotReachFilteredOutUser(
+        DualClusterLab lab,
         ClusterSide filteredPassReceiveSide,
         LabNode node,
         string itemDescription,
@@ -2057,14 +2059,27 @@ public class FilteredPullDualClusterFirstAndSecondHopTests : FilteredPullDualClu
     {
         var beforePassEtag = GetEtag(databaseChangeVectorBeforePass, nodeBDatabaseId);
         var afterPassEtag = GetEtag(databaseChangeVectorAfterPass, nodeBDatabaseId);
-        var allowedTicketBeforeFilteredOutUserEtag = beforePassEtag + 1;
+        var allowedTicketChangeVector = lab.GetAllowedTicketBeforeFilteredOutUser(LabNode.B).ChangeVector;
+        var filteredOutUserChangeVector = lab.GetFilteredOutUser(LabNode.B).ChangeVector;
+        var allowedTicketEtag = GetEtag(allowedTicketChangeVector, nodeBDatabaseId);
+        var filteredOutUserEtag = GetEtag(filteredOutUserChangeVector, nodeBDatabaseId);
+        var passedItemEtag = GetVersionEtag(originalIncomingChangeVector, nodeBDatabaseId);
 
         Assert.True(
-            afterPassEtag <= allowedTicketBeforeFilteredOutUserEtag,
-            $"Expected {NodeTag(filteredPassReceiveSide, node)} DB CV after {itemDescription} not to advance {NodeTag(filteredPassReceiveSide, LabNode.B)} beyond the allowed ticket stored before the filtered-out user. " +
-            $"Expected after-pass etag <= allowed ticket etag, before-pass etag={beforePassEtag}, allowed ticket etag={allowedTicketBeforeFilteredOutUserEtag}, after-pass etag={afterPassEtag}. " +
+            beforePassEtag < allowedTicketEtag && allowedTicketEtag < filteredOutUserEtag && filteredOutUserEtag < passedItemEtag,
+            $"Expected test setup order before DB CV assertion to be: before-pass < allowed ticket < filtered-out user < passed item. " +
+            $"beforePassEtag={beforePassEtag}, allowedTicketEtag={allowedTicketEtag}, filteredOutUserEtag={filteredOutUserEtag}, passedItemEtag={passedItemEtag}. " +
+            $"dbCVBefore='{databaseChangeVectorBeforePass ?? "<null>"}', allowedTicketCV='{allowedTicketChangeVector ?? "<null>"}', " +
+            $"filteredOutUserCV='{filteredOutUserChangeVector ?? "<null>"}', originalIncomingCV='{originalIncomingChangeVector ?? "<null>"}'.");
+
+        Assert.True(
+            afterPassEtag < filteredOutUserEtag,
+            $"Expected {NodeTag(filteredPassReceiveSide, node)} DB CV after {itemDescription} not to reach the filtered-out user on {NodeTag(filteredPassReceiveSide, LabNode.B)}. " +
+            $"Expected after-pass etag < filtered-out user etag, before-pass etag={beforePassEtag}, allowed ticket etag={allowedTicketEtag}, " +
+            $"filtered-out user etag={filteredOutUserEtag}, after-pass etag={afterPassEtag}. " +
             $"This points to filtered-out user or later filtered item lineage being merged as regular database progress. " +
             $"dbCVBefore='{databaseChangeVectorBeforePass ?? "<null>"}', dbCVAfter='{databaseChangeVectorAfterPass ?? "<null>"}', " +
+            $"allowedTicketCV='{allowedTicketChangeVector ?? "<null>"}', filteredOutUserCV='{filteredOutUserChangeVector ?? "<null>"}', " +
             $"itemCV='{itemChangeVector ?? "<null>"}', originalIncomingCV='{originalIncomingChangeVector ?? "<null>"}'.");
     }
 

--- a/test/SlowTests.Issues/Issues/RavenDB-26295/Tools/DualClusterLab.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26295/Tools/DualClusterLab.cs
@@ -263,6 +263,12 @@ public sealed class DualClusterLab : IAsyncDisposable
     public DocumentSnapshot GetFilteredRoundTripDocument(LabNode node) =>
         GetDocumentById(RequiredFilteredPassReceiveSide, node, RequiredFilteredRoundTripTicketId);
 
+    public DocumentSnapshot GetAllowedTicketBeforeFilteredOutUser(LabNode node) =>
+        GetDocumentById(RequiredFilteredPassReceiveSide, node, RequiredAllowedTicketBeforeFilteredOutUserId);
+
+    public DocumentSnapshot GetFilteredOutUser(LabNode node) =>
+        GetDocumentById(RequiredFilteredPassReceiveSide, node, RequiredFilteredOutUserDocumentId);
+
     public List<ConflictSnapshot> GetFilteredRoundTripConflicts(LabNode node) =>
         GetConflicts(RequiredFilteredPassReceiveSide, node, RequiredFilteredRoundTripTicketId);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26897

### Additional description

Follow-up to #23066.

The previous fix removed the flaky database change-vector assertion only for node C. The same incorrect assumption remained in the shared helper: it treated `beforePassEtag + 1` as the filtered-out user boundary.

This PR uses the filtered-out user's actual change vector instead and applies the correction to all 27 call sites.

Test-only change; production code is unaffected.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
