### PR TITLE
RavenDB-27104 Give the AI assist HttpClient a configurable timeout to fix InternalError on slow generation

### DIFF
--- a/src/Raven.Quill/Hosting/ApplianceOptions.cs
+++ b/src/Raven.Quill/Hosting/ApplianceOptions.cs
@@ -34,4 +34,6 @@ public sealed class ApplianceOptions
 
     public TimeSpan ReadinessAttemptTimeout { get; set; } = TimeSpan.FromSeconds(2);
     public TimeSpan ReadinessOverallTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    public TimeSpan AiAssistTimeout { get; set; } = TimeSpan.FromMinutes(5);
 }

--- a/src/Raven.Quill/Program.cs
+++ b/src/Raven.Quill/Program.cs
@@ -80,6 +80,10 @@ builder.Services.AddOptions<ApplianceOptions>()
         {
             if (int.TryParse(v, out var p)) options.RavenInternalPort = p;
         });
+        ReadEnv("RAVEN_QUILL_AI_ASSIST_TIMEOUT_SECONDS", v =>
+        {
+            if (int.TryParse(v, out var s) && s > 0) options.AiAssistTimeout = TimeSpan.FromSeconds(s);
+        });
     })
     .ValidateDataAnnotations()
     .ValidateOnStart();
@@ -106,6 +110,7 @@ builder.Services.AddHttpClient<IAiHelperClient, AiHelperInternalClient>(static (
         var opts = sp.GetRequiredService<IOptions<ApplianceOptions>>().Value;
         var store = sp.GetRequiredService<IDocumentStore>();
         http.BaseAddress = new Uri(string.IsNullOrEmpty(opts.AiApiUrl) ? store.Urls[0] : opts.AiApiUrl);
+        http.Timeout = opts.AiAssistTimeout;
     })
     .ConfigurePrimaryHttpMessageHandler(static sp =>
     {

--- a/test/QuillTests/AiHelperSuggestAgentEndpointTests.cs
+++ b/test/QuillTests/AiHelperSuggestAgentEndpointTests.cs
@@ -219,6 +219,28 @@ public class AiHelperSuggestAgentEndpointTests(ITestOutputHelper output) : Raven
         Assert.Equal(1, mockAi.GiveConsentCallCount);
     }
 
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Slow_generation_within_timeout_returns_success()
+    {
+        var store = GetDocumentStore();
+        await using var mockAi = await MockAiApi.StartAsync();
+        mockAi.AgentResponse = (200, AiHelperSamples.AgentEnvelope(AiHelperSamples.BuildAgentConfig()));
+        mockAi.AssistDelay = TimeSpan.FromSeconds(2);
+
+        using var appCleanup = await SeedProvisionedAppAsync(store, "shop", withCdc: false);
+
+        using var factory = NewApplianceFactory(store, mockAi.BaseAddress, aiAssistTimeout: TimeSpan.FromSeconds(30));
+        var client = factory.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/api/apps/shop/suggest/agent",
+            new { mode = "from-prompt", intentPrompt = "help shoppers find orders" });
+        Assert.True(resp.IsSuccessStatusCode, await resp.Content.ReadAsStringAsync());
+
+        var node = JsonNode.Parse(await resp.Content.ReadAsStringAsync())!;
+        Assert.Equal("Success", (string?)node["status"]);
+        Assert.Single(node["configurations"]!.AsArray());
+    }
+
     private async Task<IDisposable> SeedProvisionedAppAsync(IDocumentStore store, string slug, bool withCdc)
     {
         var perAppDb = "app-" + Guid.NewGuid().ToString("N");
@@ -262,7 +284,7 @@ public class AiHelperSuggestAgentEndpointTests(ITestOutputHelper output) : Raven
         return cleanup;
     }
 
-    private ApplianceWebApplicationFactory NewApplianceFactory(IDocumentStore store, string aiApiUrl)
+    private ApplianceWebApplicationFactory NewApplianceFactory(IDocumentStore store, string aiApiUrl, TimeSpan? aiAssistTimeout = null)
     {
         var setupPath = NewDataPath(forceCreateDir: true);
 
@@ -274,6 +296,8 @@ public class AiHelperSuggestAgentEndpointTests(ITestOutputHelper output) : Raven
             {
                 opts.ConfigDatabase = store.Database;
                 opts.AiApiUrl = aiApiUrl;
+                if (aiAssistTimeout is not null)
+                    opts.AiAssistTimeout = aiAssistTimeout.Value;
             });
     }
 }

--- a/test/QuillTests/AiHelperSuggestCdcEndpointTests.cs
+++ b/test/QuillTests/AiHelperSuggestCdcEndpointTests.cs
@@ -273,6 +273,45 @@ public class AiHelperSuggestCdcEndpointTests(ITestOutputHelper output) : RavenTe
         Assert.Equal(1, mockAi.GiveConsentCallCount);
     }
 
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Slow_generation_within_timeout_returns_success()
+    {
+        var store = GetDocumentStore();
+        await using var mockAi = await MockAiApi.StartAsync();
+        mockAi.CdcResponse = (200, AiHelperSamples.CdcEnvelope(AiHelperSamples.BuildCdcConfig()));
+        mockAi.AssistDelay = TimeSpan.FromSeconds(2);
+
+        using var factory = NewApplianceFactory(store, mockAi.BaseAddress, aiAssistTimeout: TimeSpan.FromSeconds(30));
+        var client = factory.CreateClient();
+        await SeedDiscoveredSchemaAsync(client);
+
+        var resp = await client.PostAsJsonAsync("/api/setup/suggest/cdc", new { intentPrompt = "shopping cart assistant" });
+        Assert.True(resp.IsSuccessStatusCode, await resp.Content.ReadAsStringAsync());
+
+        var node = JsonNode.Parse(await resp.Content.ReadAsStringAsync())!;
+        Assert.Equal("Success", (string?)node["status"]);
+        Assert.Equal("shop-cdc", (string?)node["configuration"]!["name"]);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Generation_exceeding_timeout_surfaces_internal_error()
+    {
+        var store = GetDocumentStore();
+        await using var mockAi = await MockAiApi.StartAsync();
+        mockAi.CdcResponse = (200, AiHelperSamples.CdcEnvelope(AiHelperSamples.BuildCdcConfig()));
+        mockAi.AssistDelay = TimeSpan.FromSeconds(10);
+
+        using var factory = NewApplianceFactory(store, mockAi.BaseAddress, aiAssistTimeout: TimeSpan.FromSeconds(1));
+        var client = factory.CreateClient();
+        await SeedDiscoveredSchemaAsync(client);
+
+        var resp = await client.PostAsJsonAsync("/api/setup/suggest/cdc", new { intentPrompt = "x" });
+        Assert.True(resp.IsSuccessStatusCode, await resp.Content.ReadAsStringAsync());
+
+        var node = JsonNode.Parse(await resp.Content.ReadAsStringAsync())!;
+        Assert.Equal("InternalError", (string?)node["status"]);
+    }
+
     private static async Task SeedDiscoveredSchemaAsync(HttpClient client)
     {
         // Discovering with an invalid connection string persists a non-null error schema,
@@ -283,7 +322,7 @@ public class AiHelperSuggestCdcEndpointTests(ITestOutputHelper output) : RavenTe
         Assert.True(resp.IsSuccessStatusCode, await resp.Content.ReadAsStringAsync());
     }
 
-    private ApplianceWebApplicationFactory NewApplianceFactory(IDocumentStore store, string aiApiUrl)
+    private ApplianceWebApplicationFactory NewApplianceFactory(IDocumentStore store, string aiApiUrl, TimeSpan? aiAssistTimeout = null)
     {
         var setupPath = NewDataPath(forceCreateDir: true);
 
@@ -295,6 +334,8 @@ public class AiHelperSuggestCdcEndpointTests(ITestOutputHelper output) : RavenTe
             {
                 opts.ConfigDatabase = store.Database;
                 opts.AiApiUrl = aiApiUrl;
+                if (aiAssistTimeout is not null)
+                    opts.AiAssistTimeout = aiAssistTimeout.Value;
             });
     }
 }

--- a/test/QuillTests/E2E/Fixtures/MockAiApi.cs
+++ b/test/QuillTests/E2E/Fixtures/MockAiApi.cs
@@ -36,6 +36,9 @@ public sealed class MockAiApi : IAsyncDisposable
     /// Response served for the CdcBasedAgentConfigSetup operation (HTTP status code + JSON body).
     public (int Status, string Body) AgentResponse { get; set; } = (200, "{}");
 
+    /// Delay applied before serving any /assistant/assist response — simulates slow LLM generation.
+    public TimeSpan AssistDelay { get; set; }
+
     /// When true, assist returns 401 ConsentRequired until give-consent is called — mirrors the real
     /// service gating each assist on a per-(license, cert) consent document.
     public bool RequireConsentForAssist { get; set; }
@@ -92,6 +95,9 @@ public sealed class MockAiApi : IAsyncDisposable
                 // bad-input 400 the default branch already models instead of a 500.
                 return Results.BadRequest("Malformed JSON body.");
             }
+
+            if (instance.AssistDelay > TimeSpan.Zero)
+                await Task.Delay(instance.AssistDelay, ctx.RequestAborted);
 
             switch (operationType)
             {


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27104

### Additional description

This pull request introduces configurable timeouts for AI Assist operations, improves test coverage for timeout scenarios, and enhances the AI API test fixture to better simulate slow responses. The main focus is on making the AI Assist timeout configurable via both code and environment variables, and ensuring robust handling and testing of slow or unresponsive AI backends.

**Configurable AI Assist Timeout**

* Added an `AiAssistTimeout` property to `ApplianceOptions`, defaulting to 5 minutes, and made it configurable via the `RAVEN_QUILL_AI_ASSIST_TIMEOUT_SECONDS` environment variable in `Program.cs`. The HTTP client used for AI Assist now respects this timeout. [[1]](diffhunk://#diff-9a65a78715c13c59c87d06190ac0deabd23f9a667ba1a7bf4d05a856e995e6c8R37-R38) [[2]](diffhunk://#diff-a9ab560d427cff58b8a8b2f548432e4bfed5393c24b898a30866e3781ac4f8e2R83-R86) [[3]](diffhunk://#diff-a9ab560d427cff58b8a8b2f548432e4bfed5393c24b898a30866e3781ac4f8e2R113)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
