### PR TITLE
RavenDB-27109 - Stop cluster transaction executor from deserializing other databases' commands

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -823,6 +823,18 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
+        // 'startAfter' is exclusive, so we seek after (fromCount - 1) to include the command at exactly 'fromCount' (counts are discrete).
+        // For fromCount null/0 there is nothing to skip: return an empty slice (seek from the database start) and a no-op scope.
+        private static ByteStringContext.InternalScope GetStartAfterPrefix<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, out Slice startAfter)
+            where TTransaction : RavenTransaction
+        {
+            if (fromCount is > 0)
+                return GetPrefix(context, database, out startAfter, fromCount.Value - 1);
+
+            startAfter = Slices.Empty;
+            return default;
+        }
+
         public sealed class SingleClusterDatabaseCommand : IDynamicJson, IDisposable
         {
             public ClusterTransactionOptions Options;
@@ -891,57 +903,48 @@ namespace Raven.Server.ServerWide.Commands
             var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
 
             using (GetPrefix(context, database, out Slice databasePrefix))
+            using (GetStartAfterPrefix(context, database, fromCount, out var startAfter))
             {
-                // 'startAfter' is exclusive, so we seek after (fromCount - 1) in order to include the command at
-                // exactly 'fromCount'. Counts are discrete, so excluding (fromCount - 1) starts inclusively at 'fromCount'.
-                var startAfter = Slices.Empty;
-                IDisposable startAfterScope = null;
-                if (fromCount is > 0)
-                    startAfterScope = GetPrefix(context, database, out startAfter, fromCount.Value - 1);
-
-                using (startAfterScope)
+                var readSize = 0;
+                var commandsBulk = items.SeekByPrimaryKeyPrefix(databasePrefix, startAfter, 0);
+                foreach (var command in commandsBulk)
                 {
-                    var readSize = 0;
-                    var commandsBulk = items.SeekByPrimaryKeyPrefix(databasePrefix, startAfter, 0);
-                    foreach (var command in commandsBulk)
+                    if (take <= 0)
+                        yield break;
+
+                    var reader = command.Value.Reader;
+                    var result = ReadCommand(context, reader);
+                    if (result == null)
+                        yield break;
+
+                    Debug.Assert(result.Database == lowerDb);
+                    Debug.Assert(result.PreviousCount >= fromCount);
+
+                    if (result.Database != lowerDb)
                     {
-                        if (take <= 0)
-                            yield break;
-
-                        var reader = command.Value.Reader;
-                        var result = ReadCommand(context, reader);
-                        if (result == null)
-                            yield break;
-
-                        Debug.Assert(result.Database == lowerDb);
-                        Debug.Assert(result.PreviousCount >= fromCount);
-
-                        if (result.Database != lowerDb)
-                        {
-                            // beware of reading commands of other databases.
-                            result.Dispose();
-                            continue;
-                        }
-
-                        if (result.PreviousCount < fromCount)
-                        {
-                            result.Dispose();
-                            continue;
-                        }
-
-                        if (lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
-                        {
-                            result.Dispose();
-                            continue;
-                        }
-
-                        take--;
-                        yield return result;
-
-                        readSize += reader.Size;
-                        if (readSize > maxBytesToRead)
-                            yield break;
+                        // beware of reading commands of other databases.
+                        result.Dispose();
+                        continue;
                     }
+
+                    if (result.PreviousCount < fromCount)
+                    {
+                        result.Dispose();
+                        continue;
+                    }
+
+                    if (lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
+                    {
+                        result.Dispose();
+                        continue;
+                    }
+
+                    take--;
+                    yield return result;
+
+                    readSize += reader.Size;
+                    if (readSize > maxBytesToRead)
+                        yield break;
                 }
             }
         }

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -913,6 +913,9 @@ namespace Raven.Server.ServerWide.Commands
                         if (result == null)
                             yield break;
 
+                        Debug.Assert(result.Database == lowerDb);
+                        Debug.Assert(result.PreviousCount >= fromCount);
+
                         if (result.Database != lowerDb)
                         {
                             // beware of reading commands of other databases.

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -890,8 +890,6 @@ namespace Raven.Server.ServerWide.Commands
             var lowerDb = database.ToLowerInvariant();
             var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
 
-            // The required prefix is the database only, so the iterator stops at the database boundary
-            // and doesn't read (and deserialize) commands that belong to other databases.
             using (GetPrefix(context, database, out Slice databasePrefix))
             {
                 // 'startAfter' is exclusive, so we seek after (fromCount - 1) in order to include the command at

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -889,45 +889,58 @@ namespace Raven.Server.ServerWide.Commands
         {
             var lowerDb = database.ToLowerInvariant();
             var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
-            using (GetPrefix(context, database, out Slice prefixSlice, fromCount))
+
+            // The required prefix is the database only, so the iterator stops at the database boundary
+            // and doesn't read (and deserialize) commands that belong to other databases.
+            using (GetPrefix(context, database, out Slice databasePrefix))
             {
-                var readSize = 0;
-                var commandsBulk = items.SeekByPrimaryKey(prefixSlice, 0);
-                foreach (var command in commandsBulk)
+                // 'startAfter' is exclusive, so we seek after (fromCount - 1) in order to include the command at
+                // exactly 'fromCount'. Counts are discrete, so excluding (fromCount - 1) starts inclusively at 'fromCount'.
+                var startAfter = Slices.Empty;
+                IDisposable startAfterScope = null;
+                if (fromCount is > 0)
+                    startAfterScope = GetPrefix(context, database, out startAfter, fromCount.Value - 1);
+
+                using (startAfterScope)
                 {
-                    if (take <= 0)
-                        yield break;
-
-                    var reader = command.Reader;
-                    var result = ReadCommand(context, reader);
-                    if (result == null)
-                        yield break;
-
-                    if (result.Database != lowerDb)
+                    var readSize = 0;
+                    var commandsBulk = items.SeekByPrimaryKeyPrefix(databasePrefix, startAfter, 0);
+                    foreach (var command in commandsBulk)
                     {
-                        // beware of reading commands of other databases.
-                        result.Dispose();
-                        continue;
+                        if (take <= 0)
+                            yield break;
+
+                        var reader = command.Value.Reader;
+                        var result = ReadCommand(context, reader);
+                        if (result == null)
+                            yield break;
+
+                        if (result.Database != lowerDb)
+                        {
+                            // beware of reading commands of other databases.
+                            result.Dispose();
+                            continue;
+                        }
+
+                        if (result.PreviousCount < fromCount)
+                        {
+                            result.Dispose();
+                            continue;
+                        }
+
+                        if (lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
+                        {
+                            result.Dispose();
+                            continue;
+                        }
+
+                        take--;
+                        yield return result;
+
+                        readSize += reader.Size;
+                        if (readSize > maxBytesToRead)
+                            yield break;
                     }
-
-                    if (result.PreviousCount < fromCount)
-                    {
-                        result.Dispose();
-                        continue;
-                    }
-
-                    if (lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
-                    {
-                        result.Dispose();
-                        continue;
-                    }
-
-                    take--;
-                    yield return result;
-
-                    readSize += reader.Size;
-                    if(readSize > maxBytesToRead)
-                        yield break;
                 }
             }
         }

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -918,7 +918,7 @@ namespace Raven.Server.ServerWide.Commands
                         yield break;
 
                     Debug.Assert(result.Database == lowerDb);
-                    Debug.Assert(result.PreviousCount >= fromCount);
+                    Debug.Assert(fromCount == null || result.PreviousCount >= fromCount);
 
                     if (result.Database != lowerDb)
                     {

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -29,13 +29,17 @@ using Raven.Server.Config.Settings;
 using Raven.Server.Documents;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Rachis;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Tables;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -2393,7 +2397,142 @@ select incl(c)"
                 Assert.Equal(count, await session.Query<TestObj>().CountAsync());
             }
         }
-        
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ReadCommandsBatch_ShouldReturnAllDatabaseCommands_RespectingFromCountAndTake()
+        {
+            const int count = 20;
+
+            using var store = GetDocumentStore();
+
+            var database = await GetDatabase(store.Database);
+
+            // Block the database tx-merger so the cluster-transaction executor cannot drain (and clean up)
+            // the commands. This keeps them in the cluster-storage table while we read them back.
+            using var mre = new ManualResetEvent(false);
+            var blockerTask = database.TxMerger.Enqueue(new TestCommand(mre, TimeSpan.FromSeconds(30)));
+
+            // The rows are written to the cluster-storage table when the raft command is applied, but the
+            // client-side await of a cluster-wide tx only completes once the (blocked) database applies it -
+            // so we fire the transactions here and await them only after releasing the merger.
+            var tasks = Task.WhenAll(Enumerable.Range(0, count).Select(async i =>
+            {
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                await session.SaveChangesAsync();
+            }));
+
+            try
+            {
+                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                {
+                    // wait until all the commands were persisted to the cluster-storage table
+                    await AssertWaitForTrueAsync(() =>
+                    {
+                        using (context.OpenReadTransaction())
+                            return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() == count);
+                    });
+
+                    using (context.OpenReadTransaction())
+                    {
+                        // reading from the beginning must return every command of the database, in ascending order
+                        var all = ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).ToList();
+                        Assert.Equal(count, all.Count);
+                        Assert.All(all, c => Assert.Equal(store.Database.ToLowerInvariant(), c.Database));
+                        Assert.Equal(all.Select(c => c.PreviousCount).OrderBy(x => x), all.Select(c => c.PreviousCount));
+
+                        // 'take' must bound the number of commands returned
+                        var firstFive = ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: 5).ToList();
+                        Assert.Equal(5, firstFive.Count);
+                        Assert.Equal(all.Take(5).Select(c => c.PreviousCount), firstFive.Select(c => c.PreviousCount));
+
+                        // 'fromCount' must return the tail starting at the requested count (inclusive)
+                        var from = all[12].PreviousCount;
+                        var tail = ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: from, take: long.MaxValue).ToList();
+                        Assert.Equal(count - 12, tail.Count);
+                        Assert.Equal(from, tail[0].PreviousCount);
+                        Assert.Equal(all.Skip(12).Select(c => c.PreviousCount), tail.Select(c => c.PreviousCount));
+                    }
+                }
+            }
+            finally
+            {
+                mre.Set();
+            }
+
+            await blockerTask;
+            await tasks;
+
+            using (var session = store.OpenAsyncSession())
+                Assert.Equal(count, await session.Query<TestObj>().CountAsync());
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public void ReadCommandsBatch_ShouldSeekCorrectly_WithLargePreviousCount()
+        {
+            // Bootstrap the single-node cluster so the cluster-storage schema (the TransactionCommands table) exists.
+            using var store = GetDocumentStore();
+            const string database = "read-commands-batch-large-count";
+
+            // PreviousCount values chosen to exercise the big-endian key ordering, including values above
+            // int.MaxValue and around the 2^32 byte-carry boundary (where 'fromCount - 1' borrows across bytes).
+            var counts = new[]
+            {
+                0L,
+                1L,
+                int.MaxValue,            // 2^31 - 1
+                (long)int.MaxValue + 1,  // 2^31
+                (1L << 32) - 1,          // 2^32 - 1  (the lower 4 bytes are all 0xFF)
+                1L << 32,                // 2^32      (carry into the 5th byte)
+                1_000_000_000_000L       // 10^12
+            };
+
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
+                    foreach (var previousCount in counts)
+                        InsertTransactionCommand(context, items, database, previousCount);
+
+                    tx.Commit();
+                }
+
+                using (context.OpenReadTransaction())
+                {
+                    // reading from 0 must return every row in ascending order - validates big-endian key ordering at large values
+                    var all = ClusterTransactionCommand.ReadCommandsBatch(context, database, fromCount: 0, take: long.MaxValue).ToList();
+                    Assert.Equal(counts.OrderBy(x => x).ToArray(), all.Select(c => c.PreviousCount).ToArray());
+
+                    // a 'fromCount' that exactly matches a large row must include that row.
+                    // Here fromCount - 1 == (2^32 - 1), which is itself a present row and borrows across a byte boundary.
+                    const long fromExact = 1L << 32; // 2^32
+                    var tailExact = ClusterTransactionCommand.ReadCommandsBatch(context, database, fromCount: fromExact, take: long.MaxValue).ToList();
+                    Assert.Equal(counts.Where(c => c >= fromExact).OrderBy(x => x).ToArray(), tailExact.Select(c => c.PreviousCount).ToArray());
+                    Assert.Equal(fromExact, tailExact[0].PreviousCount);
+
+                    // a 'fromCount' that falls between two large rows (no exact match) must return only the next-higher rows
+                    const long fromBetween = 4_000_000_000L; // between 2^31 and (2^32 - 1)
+                    var tailBetween = ClusterTransactionCommand.ReadCommandsBatch(context, database, fromCount: fromBetween, take: long.MaxValue).ToList();
+                    Assert.Equal(counts.Where(c => c >= fromBetween).OrderBy(x => x).ToArray(), tailBetween.Select(c => c.PreviousCount).ToArray());
+                }
+            }
+        }
+
+        private static unsafe void InsertTransactionCommand(TransactionOperationContext context, Table items, string database, long previousCount)
+        {
+            // mirrors ClusterTransactionCommand.SaveCommandBatch: Key = db <sep> big-endian(previousCount), then the commands blittable and the raft index.
+            using (ClusterTransactionCommand.GetPrefix(context, database, out Slice keySlice, previousCount))
+            using (var commands = context.ReadObject(new DynamicJsonValue { ["DatabaseCommands"] = new DynamicJsonArray() }, "cmd"))
+            using (items.Allocate(out TableValueBuilder tvb))
+            {
+                tvb.Add(keySlice.Content.Ptr, keySlice.Size);
+                tvb.Add(commands.BasePointer, commands.Size);
+                tvb.Add(previousCount); // RaftIndex - unique per row, not asserted on
+                items.Insert(tvb);
+            }
+        }
+
         [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task TestCase()
         {

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2471,7 +2471,6 @@ select incl(c)"
         public void ReadCommandsBatch_ShouldSeekCorrectly_WithLargePreviousCount()
         {
             // Bootstrap the single-node cluster so the cluster-storage schema (the TransactionCommands table) exists.
-            using var store = GetDocumentStore();
             const string database = "read-commands-batch-large-count";
 
             // PreviousCount values chosen to exercise the big-endian key ordering, including values above
@@ -2487,7 +2486,8 @@ select incl(c)"
                 1_000_000_000_000L       // 10^12
             };
 
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using var server = GetNewServer();
+            using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 using (var tx = context.OpenWriteTransaction())
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27109/Cluster-transaction-executor-reads-and-deserializes-other-databases-commands-causing-high-CPU

### Additional description

#### Problem
`ClusterTransactionCommand.ReadCommandsBatch` seeked the shared `TransactionCommands`
table with `SeekByPrimaryKey` and iterated to the end of the table. Because the
primary key is "<database><separator><PreviousCount>", once the target database's
rows were exhausted the iterator kept going into other databases' rows, fully
deserializing (and cloning) each one only to discard it via the
"result.Database != lowerDb" filter.

This showed up in the field as a per-database cluster-transaction executor thread
pinned on CPU (no disk I/O), stuck in `BlittableJsonReaderObject.ConvertType`, and
got worse the larger the transaction-command backlog and the earlier the database
sorts.

#### Fix
- Use `SeekByPrimaryKeyPrefix` with a database-only required prefix, so the iterator
  stops at the database boundary and never touches other databases' commands.
- Preserve inclusive `fromCount` semantics by passing `startAfter = fromCount - 1`
  (counts are discrete, non-negative integers, so excluding `fromCount` - 1 starts
  inclusively at `fromCount`); when `fromCount` is null or 0 we seek to the start of
  the database. This keeps the read at O(log N) + take, with no cross-database
  scan and no within-database rescan.

#### Tests
Added to SlowTests.Cluster.ClusterTransactionTests:
- `ReadCommandsBatch_ShouldReturnAllDatabaseCommands_RespectingFromCountAndTake` -
  verifies all of a database's commands are returned in order, and that take and
  fromCount are honored.
- `ReadCommandsBatch_ShouldSeekCorrectly_WithLargePreviousCount` - verifies the
  big-endian key ordering and inclusive fromCount seek at large counts, including
  the 2^32 byte-carry boundary.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
