### PR TITLE
RavenDB-27118 Add `rvn dns update` command to update DNS records for a domain

### DIFF
--- a/src/Raven.Server/Commercial/SetupInfo.cs
+++ b/src/Raven.Server/Commercial/SetupInfo.cs
@@ -495,6 +495,10 @@ namespace Raven.Server.Commercial
                     break;
                 case SetupMode.LetsEncrypt:
                     break;
+                case SetupMode.None:
+                    foreach (var step in StepsByConfigurationStepType.Values)
+                        step.SetState(State.NotApplicable);
+                    break;
                 default:
                     throw new NotSupportedException($"Setup mode {mode} is not supported for tracking progress.");
             }

--- a/tools/rvn/CommandLineApp.cs
+++ b/tools/rvn/CommandLineApp.cs
@@ -56,6 +56,7 @@ namespace rvn
             ConfigureSetupPackage();
             ConfigureInitSetupParams();
             ConfigurePutClientCertificateCommand();
+            ConfigureDnsCommand();
 
             _app.OnExecute(() =>
             {
@@ -319,6 +320,72 @@ namespace rvn
                         logStream.Connect().Wait();
 
                     return 0;
+                });
+            });
+        }
+
+        private static void ConfigureDnsCommand()
+        {
+            _app.Command("dns", cmd =>
+            {
+                cmd.Description = "Manage DNS records for a licensed RavenDB domain through api.ravendb.net.";
+                cmd.HelpOption(HelpOptionString);
+
+                cmd.Command("update", subcmd =>
+                {
+                    subcmd.Description = "Register/update DNS record(s) for a licensed RavenDB domain using a license.json file.";
+                    subcmd.ExtendedHelpText =
+                        """
+
+                        Usage examples:
+                        rvn dns update -l license.json -d mycompany.development.run -n 10.0.0.1=a -n 10.0.0.2,2001:db8::1=b
+                        rvn dns update -l license.json -d mycompany.development.run -n 10.0.0.2=dashboard,db
+
+                        The first registers a.mycompany.development.run and b.mycompany.development.run (b with two IPs).
+                        The second points both dashboard.mycompany.development.run and db.mycompany.development.run at 10.0.0.2.
+                        Each -n|--node maps IP address(es) to one or more subdomains.
+
+                        """;
+                    subcmd.HelpOption(HelpOptionString);
+
+                    var licenseOpt = subcmd.Option("-l|--license", "Path to the license.json file.", CommandOptionType.SingleValue);
+                    var domainOpt = subcmd.Option("-d|--domain", "The full domain to update, e.g. 'mycompany.development.run'.", CommandOptionType.SingleValue);
+                    var nodeOpt = subcmd.Option("-n|--node", "A record in the form <ip>[,<ip>...]=<subdomain>[,<subdomain>...]. Can be specified multiple times, e.g. -n 10.0.0.1=a -n 10.0.0.2=dashboard,db -n 12.23.1.2,2001:db8::1=web.", CommandOptionType.MultipleValue);
+                    var registerTcpOpt = subcmd.Option("--register-tcp", "Also register the '<subdomain>-tcp' DNS record(s) for each node.", CommandOptionType.NoValue);
+
+                    subcmd.OnExecuteAsync(async token =>
+                    {
+                        if (licenseOpt.HasValue() == false)
+                            return ExitWithError("-l|--license must be provided.", subcmd);
+
+                        if (domainOpt.HasValue() == false)
+                            return ExitWithError("-d|--domain must be provided.", subcmd);
+
+                        if (nodeOpt.HasValue() == false)
+                            return ExitWithError("At least one -n|--node <ip>[,<ip>...]=<subdomain>[,<subdomain>...] must be provided.", subcmd);
+
+                        try
+                        {
+                            await DnsRecordUpdate.RunAsync(
+                                licenseOpt.Value(),
+                                domainOpt.Value(),
+                                nodeOpt.Values,
+                                registerTcpOpt.HasValue(),
+                                token);
+
+                            return 0;
+                        }
+                        catch (Exception e)
+                        {
+                            return ExitWithError(e.ToString(), subcmd);
+                        }
+                    });
+                });
+
+                cmd.OnExecute(() =>
+                {
+                    cmd.ShowHelp();
+                    return 1;
                 });
             });
         }

--- a/tools/rvn/DnsRecordUpdate.cs
+++ b/tools/rvn/DnsRecordUpdate.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Raven.Server.Commercial;
+using Raven.Server.Commercial.LetsEncrypt;
+
+namespace rvn
+{
+    internal static class DnsRecordUpdate
+    {
+        public static async Task RunAsync(
+            string licensePath,
+            string fullDomain,
+            IReadOnlyList<string> nodeSpecs,
+            bool registerTcpDnsRecords,
+            CancellationToken token)
+        {
+            var license = ReadLicense(licensePath);
+
+            fullDomain = fullDomain.Trim().ToLowerInvariant();
+            var firstDot = fullDomain.IndexOf('.');
+            if (firstDot <= 0 || firstDot == fullDomain.Length - 1)
+                throw new InvalidOperationException($"Invalid domain '{fullDomain}'. Expected a full domain such as 'mycompany.development.run'.");
+
+            var domain = fullDomain.Substring(0, firstDot);
+            var rootDomain = fullDomain.Substring(firstDot + 1);
+
+            var nodeSetupInfos = ParseNodes(nodeSpecs);
+
+            var setupInfo = new SetupInfo
+            {
+                License = license,
+                Domain = domain,
+                RootDomain = rootDomain,
+                LocalNodeTag = null,
+                NodeSetupInfos = nodeSetupInfos
+            };
+
+            var progress = new SetupProgressAndResult(tuple =>
+            {
+                if (tuple.Message != null)
+                    Console.WriteLine(tuple.Message);
+
+                if (tuple.Exception != null)
+                    Console.Error.WriteLine(tuple.Exception);
+            }, SetupMode.None);
+
+            await RavenDnsRecordHelper.UpdateDnsRecordsTask(new UpdateDnsRecordParameters
+            {
+                Challenge = null,
+                SetupInfo = setupInfo,
+                Progress = progress,
+                RegisterTcpDnsRecords = registerTcpDnsRecords,
+                Token = token
+            });
+
+            Console.WriteLine($"Successfully registered DNS record(s) for '{fullDomain}' in api.ravendb.net.");
+        }
+
+        private static License ReadLicense(string licensePath)
+        {
+            if (File.Exists(licensePath) == false)
+                throw new InvalidOperationException($"License file was not found at '{Path.GetFullPath(licensePath)}'.");
+
+            License license;
+            try
+            {
+                license = JsonConvert.DeserializeObject<License>(File.ReadAllText(licensePath));
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException($"Failed to read the license file at '{Path.GetFullPath(licensePath)}'. It is not valid license JSON: {e.Message}", e);
+            }
+
+            return license ?? throw new InvalidOperationException($"The license file at '{Path.GetFullPath(licensePath)}' is empty or not a valid license.");
+        }
+
+        private static Dictionary<string, NodeInfo> ParseNodes(IReadOnlyList<string> nodeSpecs)
+        {
+            if (nodeSpecs == null || nodeSpecs.Count == 0)
+                throw new InvalidOperationException("At least one record must be provided using -n|--node <ip>[,<ip>...]=<subdomain>[,<subdomain>...].");
+
+            var nodes = new Dictionary<string, NodeInfo>(StringComparer.OrdinalIgnoreCase);
+            foreach (var spec in nodeSpecs)
+            {
+                var separatorIndex = spec.IndexOf('=');
+                if (separatorIndex <= 0)
+                    throw new InvalidOperationException(
+                        $"Invalid record '{spec}'. Expected format is <ip>[,<ip>...]=<subdomain>[,<subdomain>...], for example 10.0.0.1=a, 10.0.0.2=dashboard,db or 10.0.0.3,2001:db8::1=web.");
+
+                var ipsPart = spec.Substring(0, separatorIndex).Trim();
+                var subdomainsPart = spec.Substring(separatorIndex + 1).Trim();
+
+                var addresses = new List<string>();
+                foreach (var rawIp in ipsPart.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                {
+                    if (IPAddress.TryParse(rawIp, out var parsed) == false)
+                        throw new InvalidOperationException($"Invalid IP address '{rawIp}' in '{spec}'.");
+
+                    addresses.Add(parsed.ToString());
+                }
+
+                if (addresses.Count == 0)
+                    throw new InvalidOperationException(
+                        $"No IP address was provided in '{spec}'. Expected format is <ip>[,<ip>...]=<subdomain>[,<subdomain>...].");
+
+                var subdomains = subdomainsPart.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (subdomains.Length == 0)
+                    throw new InvalidOperationException(
+                        $"No subdomain was provided in '{spec}'. Expected format is <ip>[,<ip>...]=<subdomain>[,<subdomain>...].");
+
+                foreach (var rawSubdomain in subdomains)
+                {
+                    var subdomain = rawSubdomain.ToLowerInvariant();
+                    if (nodes.ContainsKey(subdomain))
+                        throw new InvalidOperationException($"Subdomain '{subdomain}' was specified more than once.");
+
+                    nodes[subdomain] = new NodeInfo
+                    {
+                        Addresses = new List<string>(addresses)
+                    };
+                }
+            }
+
+            return nodes;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27118
### Additional description

Adds a `dns` command group to the rvn CLI with an `update` subcommand that registers/updates DNS record(s) for a licensed RavenDB domain via api.ravendb.net, driven from a license.json file.

Usage:
  rvn dns update -l license.json -d mycompany.development.run \
    -n 10.0.0.1=a -n 10.0.0.2=dashboard,db -n 12.23.1.2,2001:db8::1=web [--register-tcp] [--wait]


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
