### PR TITLE
RavenDB-26922 Connection string views: Add links to documentation

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStringsInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStringsInfoHub.tsx
@@ -2,9 +2,14 @@ import { AboutViewAnchored, AccordionItemWrapper } from "components/common/About
 import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
 import useConnectionStringsLicense from "./useConnectionStringsLicense";
 import appUrl from "common/appUrl";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "hooks/useRavenLink";
 
 export function ConnectionStringsInfoHub() {
     const { hasAll, featureAvailability } = useConnectionStringsLicense();
+
+    const connectionStringsOverviewDocsLink = useRavenLink({ hash: "P5XJOV" });
+    const connectionStringsPerDatabaseDocsLink = useRavenLink({ hash: "BOYDGL" });
 
     return (
         <AboutViewAnchored defaultOpen={hasAll ? null : "licensing"}>
@@ -36,6 +41,15 @@ export function ConnectionStringsInfoHub() {
                             databases are excluded.
                         </li>
                     </ul>
+                    <hr />
+                    <div className="small-label mb-2">useful links</div>
+                    <a href={connectionStringsOverviewDocsLink} target="_blank">
+                        <Icon icon="newtab" /> Docs - Connection Strings Overview
+                    </a>
+                    <br />
+                    <a href={connectionStringsPerDatabaseDocsLink} target="_blank">
+                        <Icon icon="newtab" /> Docs - Connection Strings Per Database
+                    </a>
                 </div>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideConnectionStrings/ServerWideConnectionStringsInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideConnectionStrings/ServerWideConnectionStringsInfoHub.tsx
@@ -1,9 +1,14 @@
 import { AboutViewAnchored, AccordionItemWrapper } from "components/common/AboutView";
 import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
 import useConnectionStringsLicense from "components/pages/database/settings/connectionStrings/useConnectionStringsLicense";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "hooks/useRavenLink";
 
 export default function ServerWideConnectionStringsInfoHub() {
     const { hasAll, featureAvailability } = useConnectionStringsLicense();
+
+    const connectionStringsOverviewDocsLink = useRavenLink({ hash: "P5XJOV" });
+    const connectionStringsServerwideDocsLink = useRavenLink({ hash: "5AQ7XL" });
 
     return (
         <AboutViewAnchored defaultOpen={hasAll ? null : "licensing"}>
@@ -33,6 +38,15 @@ export default function ServerWideConnectionStringsInfoHub() {
                             from backup.
                         </li>
                     </ul>
+                    <hr />
+                    <div className="small-label mb-2">useful links</div>
+                    <a href={connectionStringsOverviewDocsLink} target="_blank">
+                        <Icon icon="newtab" /> Docs - Connection Strings Overview
+                    </a>
+                    <br />
+                    <a href={connectionStringsServerwideDocsLink} target="_blank">
+                        <Icon icon="newtab" /> Docs - Connection Strings Server-wide
+                    </a>
                 </div>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26922/Connection-string-views-Add-a-link-to-the-documentation

### Additional description
Add a link to the new documentation in "About this view" in:
* Per-database connection strings view
* Server-wide connection strings view

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
