### PR TITLE
RavenDB-27117 Return matching chunk source text from a vector search with highlighting

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -66,6 +66,12 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
     /// </summary>
     public TimeSpan EmbeddingsCacheForQueryingExpiration { get; set; } = TimeSpan.FromDays(14);
 
+    /// <summary>
+    /// Store the text of each chunk in the database alongside its embedding. 
+    /// Useful for debugging or highlighting, but increases storage requirements. Defaults to false.
+    /// </summary>
+    public bool StoreChunkText { get; set; }
+
     private const string PathsTransformationName = "embeddings-from-paths";
     private const string ScriptTransformationName = "embeddings-transform-script";
 
@@ -218,6 +224,7 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
         json[nameof(EmbeddingsCacheExpiration)] = EmbeddingsCacheExpiration;
         json[nameof(ChunkingOptionsForQuerying)] = ChunkingOptionsForQuerying;
         json[nameof(EmbeddingsCacheForQueryingExpiration)] = EmbeddingsCacheForQueryingExpiration;
+        json[nameof(StoreChunkText)] = StoreChunkText;
 
         return json;
     }
@@ -241,6 +248,7 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
 
         if (Collection != other.Collection ||
             Quantization != other.Quantization ||
+            StoreChunkText != other.StoreChunkText ||
             EmbeddingsCacheExpiration != other.EmbeddingsCacheExpiration ||
             EmbeddingsCacheForQueryingExpiration != other.EmbeddingsCacheForQueryingExpiration ||
             EmbeddingsTransformation.AreEqual(EmbeddingsTransformation, other.EmbeddingsTransformation) == false ||

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -65,7 +65,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
 
     private record GenerateEmbeddings(
         AiConnectionStringIdentifier ConnectionStringId,
-        TimeSpan CacheDuration, 
+        TimeSpan CacheDuration,
         List<string> Values,
         List<ReadOnlyMemory<byte>> Embeddings,
         string CacheKey,
@@ -73,6 +73,18 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
         )
     {
         public readonly TaskCompletionSource TaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<string> CachedValues { get; init; }
+
+        public string TextForEmbeddingAt(int index)
+        {
+            var cachedCount = CachedValues?.Count ?? 0;
+            if (index < cachedCount)
+                return CachedValues[index]; // it came from the cache
+
+            var pendingIndex = index - cachedCount; // it is a new value that we are generating embeddings for
+            return pendingIndex >= 0 && pendingIndex < Values.Count ? Values[pendingIndex] : null;
+        }
     }
 
     private class AiWorker : ILowMemoryHandler
@@ -133,6 +145,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
          {
              Dictionary<string, HashSet<GenerateEmbeddings>> embeddingsByName = new();
              var cacheDuration = Configuration.EmbeddingsCacheExpiration;
+             var storeChunkText = Configuration.StoreChunkText; 
              List<(string DocId, string Value)> expirationRefresh = null;
              foreach (var (name, field) in props)
              {
@@ -141,14 +154,17 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                  {
                      List<string> pending = [];
                      List<ReadOnlyMemory<byte>> cachedEmbeddingsBuffers = [];
+                     List<string> cachedTexts = null;
                      foreach (var chunkedValue in TextChunker.Chunk(value, chunking, _prefixTokenCounts))
                      {
                          if (string.IsNullOrWhiteSpace(chunkedValue))
                              continue; // this can happen if we have just spaces, or if we have an HTML with just <img/>, etc.
-                         
+
                          if (TryGetFromCache(documentsContext, chunkedValue, cacheDuration, ref expirationRefresh, out var cachedEntry))
                          {
                              cachedEmbeddingsBuffers.Add(cachedEntry);
+                             if (storeChunkText)
+                                 (cachedTexts ??= []).Add(chunkedValue); // kept aligned with cachedEmbeddingsBuffers
                              cachedEmbeddings.Value++;
                          }
                          else
@@ -156,7 +172,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                              pending.Add(chunkedValue);
                          }
                      }
-                     var generateEmbeddings = RegisterPendingEmbeddings(pending, cachedEmbeddingsBuffers, value, cacheDuration);
+                     var generateEmbeddings = RegisterPendingEmbeddings(pending, cachedEmbeddingsBuffers, value, cacheDuration, cachedTexts);
                      tasks.Add(generateEmbeddings.TaskCompletionSource.Task);
                      hashes.Add(generateEmbeddings);
                  }
@@ -220,9 +236,9 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
             }
         }
         
-        GenerateEmbeddings RegisterPendingEmbeddings(List<string> pending, List<ReadOnlyMemory<byte>> cachedEmbeddings, string value, TimeSpan cacheDuration)
+        GenerateEmbeddings RegisterPendingEmbeddings(List<string> pending, List<ReadOnlyMemory<byte>> cachedEmbeddings, string value, TimeSpan cacheDuration, List<string> cachedValues = null)
         {
-            var newGen = new GenerateEmbeddings(_connectionStringIdentifier, cacheDuration, pending,  cachedEmbeddings,value, this);
+            var newGen = new GenerateEmbeddings(_connectionStringIdentifier, cacheDuration, pending,  cachedEmbeddings,value, this) { CachedValues = cachedValues };
             if (pending.Count == 0) // all from the cache
             {
                 newGen.TaskCompletionSource.TrySetResult();
@@ -904,28 +920,39 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                 documentsStorage.Delete(context, embeddingDocId, null);
             }
 
+            var storeChunkText = _worker.Configuration.StoreChunkText;
             foreach (var pde in _results)
             {
                 var embeddingDocId = EmbeddingsHelper.GetEmbeddingDocumentId(pde.DocumentId);
                 Dictionary<string, HashSet<string>> hashesByName = [];
                 Dictionary<string, ReadOnlyMemory<byte>> attachments = [];
+                Dictionary<string, string> textByHash = storeChunkText ? [] : null;
                 foreach (var (name, embeddings) in pde.Data)
                 {
                     HashSet<string> hashes = [];
                     foreach (var generatedEmbeddings in embeddings)
                     {
-                        foreach (var embedding in generatedEmbeddings.Embeddings)
+                        var generated = generatedEmbeddings.Embeddings;
+                        for (int i = 0; i < generated.Count; i++)
                         {
+                            var embedding = generated[i];
                             string embeddingHash = AttachmentsStorageHelper.CalculateHash(embedding.Span);
                             hashes.Add(embeddingHash);
                             attachments[embeddingHash] = embedding;
+
+                            if (textByHash is not null)
+                            {
+                                var chunkText = generatedEmbeddings.TextForEmbeddingAt(i);
+                                if (chunkText is not null)
+                                    textByHash.TryAdd(embeddingHash, chunkText);
+                            }
                         }
                     }
 
                     hashesByName[name] = hashes;
                 }
 
-                using var updatedDoc = CreateOrUpdateDocumentEmbeddingDoc(embeddingDocId, pde, hashesByName, out var attachmentsToRemove);
+                using var updatedDoc = CreateOrUpdateDocumentEmbeddingDoc(embeddingDocId, pde, hashesByName, textByHash, out var attachmentsToRemove);
                 documentsStorage.Put(context, embeddingDocId, null, updatedDoc);
                 foreach (var (embeddingHash, embedding) in attachments)
                 {
@@ -943,7 +970,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
 
             return operations;
 
-            BlittableJsonReaderObject CreateOrUpdateDocumentEmbeddingDoc(string embeddingDocId, PutDocumentEmbeddings pde, Dictionary<string, HashSet<string>> hashesByName, out HashSet<string> attachmentsToRemove)
+            BlittableJsonReaderObject CreateOrUpdateDocumentEmbeddingDoc(string embeddingDocId, PutDocumentEmbeddings pde, Dictionary<string, HashSet<string>> hashesByName, Dictionary<string, string> textByHash, out HashSet<string> attachmentsToRemove)
             {
                 using Document document = documentsStorage.Get(context, embeddingDocId);
                 DynamicJsonValue modifications;
@@ -973,6 +1000,15 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                     attachmentsToRemove.ExceptWith(hashes);
                     djv[name] = new DynamicJsonArray(hashes);
                 }
+
+                if (textByHash is { Count: > 0 })
+                {
+                    var chunkText = new DynamicJsonValue();
+                    foreach (var (hash, text) in textByHash)
+                        chunkText[hash] = text;
+                    djv[EmbeddingsHelper.ChunkTextPropertyName] = chunkText;
+                }
+
                 if (document != null)
                 {
                     RetainAttachmentsFromOtherTasks(document.Data, pde, attachmentsToRemove);

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsHelper.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsHelper.cs
@@ -51,7 +51,9 @@ public static class EmbeddingsHelper
         return Convert.ToBase64String(hashBuffer);
     }
     
-    public const string ChunkTextPropertyName = "Text";
+    // '@'-prefixed so it lives in the reserved namespace (like @quantization) and can never collide with a
+    // user embedding field path written as a sibling into the same per-task object.
+    public const string ChunkTextPropertyName = "@chunk-text";
 
     public static string GetEmbeddingDocumentId(string documentId)
     {

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsHelper.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsHelper.cs
@@ -51,6 +51,8 @@ public static class EmbeddingsHelper
         return Convert.ToBase64String(hashBuffer);
     }
     
+    public const string ChunkTextPropertyName = "Text";
+
     public static string GetEmbeddingDocumentId(string documentId)
     {
         return $"embeddings/{documentId}";

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -99,6 +99,16 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         internal void CaptureVectorChunkHighlighting(string fieldName, string taskId, List<byte[]> queryVectors)
         {
             _vectorChunkHighlightings ??= new Dictionary<string, VectorChunkHighlightingCapture>(StringComparer.OrdinalIgnoreCase);
+
+            // Multiple vector.search() calls can target the same field (e.g. searching for several query texts). They all
+            // resolve against the same embeddings, so merge their query vectors instead of letting the last call overwrite
+            // the earlier ones - otherwise only chunks near the last query text would be surfaced.
+            if (_vectorChunkHighlightings.TryGetValue(fieldName, out VectorChunkHighlightingCapture existing) && existing.TaskId == taskId)
+            {
+                existing.QueryVectors.AddRange(queryVectors);
+                return;
+            }
+
             _vectorChunkHighlightings[fieldName] = new VectorChunkHighlightingCapture(fieldName, taskId, queryVectors);
         }
         private readonly ByteStringContext _allocator;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -96,7 +96,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
         private Dictionary<string, VectorChunkHighlightingCapture> _vectorChunkHighlightings;
 
-        internal void CaptureVectorChunkHighlighting(string fieldName, string taskId, List<byte[]> queryVectors)
+        internal void CaptureVectorChunkHighlighting(string fieldName, string taskId, float minimumSimilarity, List<byte[]> queryVectors)
         {
             _vectorChunkHighlightings ??= new Dictionary<string, VectorChunkHighlightingCapture>(StringComparer.OrdinalIgnoreCase);
 
@@ -106,10 +106,13 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             if (_vectorChunkHighlightings.TryGetValue(fieldName, out VectorChunkHighlightingCapture existing) && existing.TaskId == taskId)
             {
                 existing.QueryVectors.AddRange(queryVectors);
+                // The merged vectors are matched as a union (nearest of any of them), so keep the least restrictive
+                // threshold - a chunk that satisfied one of the clauses must not be dropped because another was stricter.
+                existing.RelaxMinimumSimilarity(minimumSimilarity);
                 return;
             }
 
-            _vectorChunkHighlightings[fieldName] = new VectorChunkHighlightingCapture(fieldName, taskId, queryVectors);
+            _vectorChunkHighlightings[fieldName] = new VectorChunkHighlightingCapture(fieldName, taskId, minimumSimilarity, queryVectors);
         }
         private readonly ByteStringContext _allocator;
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -93,6 +93,14 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
         protected readonly IndexSearcher IndexSearcher;
 
         private readonly IndexFieldsMapping _fieldMappings;
+
+        private Dictionary<string, VectorChunkHighlightingCapture> _vectorChunkHighlightings;
+
+        internal void CaptureVectorChunkHighlighting(string fieldName, string taskId, List<byte[]> queryVectors)
+        {
+            _vectorChunkHighlightings ??= new Dictionary<string, VectorChunkHighlightingCapture>(StringComparer.OrdinalIgnoreCase);
+            _vectorChunkHighlightings[fieldName] = new VectorChunkHighlightingCapture(fieldName, taskId, queryVectors);
+        }
         private readonly ByteStringContext _allocator;
 
         private readonly int _maxNumberOfOutputsPerDocument;
@@ -630,6 +638,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             THasProjection hasProjections = default;
             THighlighting highlightings = default;
             highlightings.Initialize(query, queryTimings);
+            _vectorChunkHighlightings = null;
 
             long docsToLoad = pageSize;
             bool runQuery = true;
@@ -899,10 +908,18 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 return default;
             }
 
+            var highlightingResult = highlightings.Execute(query, documentsContext, _fieldMappings, ref entryReader, highlightingFields, document, IndexSearcher);
+
+            if (_vectorChunkHighlightings is { Count: > 0 } && document != null)
+            {
+                highlightingResult ??= new Dictionary<string, Dictionary<string, string[]>>(StringComparer.OrdinalIgnoreCase);
+                CoraxVectorChunkHighlighter.Apply(highlightingResult, _vectorChunkHighlightings, query, document, documentsContext, _index.DocumentDatabase);
+            }
+
             return new QueryResult
             {
                 Result = document,
-                Highlightings = highlightings.Execute(query, documentsContext, _fieldMappings, ref entryReader, highlightingFields, document, IndexSearcher),
+                Highlightings = highlightingResult,
             };
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -33,17 +33,17 @@ public static partial class CoraxQueryBuilder
         if (builderParameters.Metadata.HasHighlightings == false)
             return;
 
-        if (builderParameters.IndexReadOperation is not CoraxIndexReadOperation readOperation)
-            return;
+        // vector search runs on Corax only; a non-Corax read operation here would have failed far earlier.
+        Debug.Assert(builderParameters.IndexReadOperation is CoraxIndexReadOperation, "vector search is only supported on Corax indexes");
+        CoraxIndexReadOperation readOperation = (CoraxIndexReadOperation)builderParameters.IndexReadOperation;
 
-
-        var queryVectors = new List<byte[]>();
+        List<byte[]> queryVectors = new();
         if (singleVector is { IsNull: false } single)
             queryVectors.Add(single.GetEmbedding().ToArray());
 
         if (multiVector is not null)
         {
-            foreach (var vector in multiVector)
+            foreach (VectorValue vector in multiVector)
             {
                 if (vector.IsNull == false)
                     queryVectors.Add(vector.GetEmbedding().ToArray());
@@ -53,7 +53,7 @@ public static partial class CoraxQueryBuilder
         if (queryVectors.Count == 0)
             return;
 
-        var highlightFieldName = builderParameters.Metadata.GetVectorSourceFieldName(fieldName, me, builderParameters.QueryParameters);
+        string highlightFieldName = builderParameters.Metadata.GetVectorSourceFieldName(fieldName, me, builderParameters.QueryParameters);
         readOperation.CaptureVectorChunkHighlighting(highlightFieldName, embeddingsGenerationTaskIdentifier, queryVectors);
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -23,6 +24,39 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax;
 
 public static partial class CoraxQueryBuilder
 {
+    private static void CaptureVectorHighlighting(Parameters builderParameters, MethodExpression me, string fieldName, string embeddingsGenerationTaskIdentifier,
+        VectorValue? singleVector, VectorValue[] multiVector)
+    {
+        if (embeddingsGenerationTaskIdentifier is null)
+            return; // chunk text is only stored for embeddings-generation tasks
+
+        if (builderParameters.Metadata.HasHighlightings == false)
+            return;
+
+        if (builderParameters.IndexReadOperation is not CoraxIndexReadOperation readOperation)
+            return;
+
+
+        var queryVectors = new List<byte[]>();
+        if (singleVector is { IsNull: false } single)
+            queryVectors.Add(single.GetEmbedding().ToArray());
+
+        if (multiVector is not null)
+        {
+            foreach (var vector in multiVector)
+            {
+                if (vector.IsNull == false)
+                    queryVectors.Add(vector.GetEmbedding().ToArray());
+            }
+        }
+
+        if (queryVectors.Count == 0)
+            return;
+
+        var highlightFieldName = builderParameters.Metadata.GetVectorSourceFieldName(fieldName, me, builderParameters.QueryParameters);
+        readOperation.CaptureVectorChunkHighlighting(highlightFieldName, embeddingsGenerationTaskIdentifier, queryVectors);
+    }
+
     private static CoraxVectorItem HandleVector(Parameters builderParameters, MethodExpression me, bool exact)
     {
         var metadata = builderParameters.Metadata;
@@ -116,6 +150,8 @@ public static partial class CoraxQueryBuilder
             
             var vector = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueTokenType, methodParameter, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
 
+            CaptureVectorHighlighting(builderParameters, me, fieldName, embeddingsGenerationTaskIdentifier, vector.SingleVector, vector.MultiVector);
+
             if (vector.SingleVector != null)
             {
                 return CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata, vector.SingleVector.Value, numberOfCandidates, minimumMatch, exact);
@@ -134,6 +170,7 @@ public static partial class CoraxQueryBuilder
         {
             var vectorOptions = VectorHelpers.GetExplicitVectorOptions(builderParameters, fieldName, out indexField);
             transformedEmbeddings = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueType, value, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
+            CaptureVectorHighlighting(builderParameters, me, fieldName, embeddingsGenerationTaskIdentifier, transformedEmbeddings.SingleVector, transformedEmbeddings.MultiVector);
         }
         else
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax;
 public static partial class CoraxQueryBuilder
 {
     private static void CaptureVectorHighlighting(Parameters builderParameters, MethodExpression me, string fieldName, string embeddingsGenerationTaskIdentifier,
-        VectorValue? singleVector, VectorValue[] multiVector)
+        float minimumMatch, VectorValue? singleVector, VectorValue[] multiVector)
     {
         if (embeddingsGenerationTaskIdentifier is null)
             return; // chunk text is only stored for embeddings-generation tasks
@@ -54,7 +54,7 @@ public static partial class CoraxQueryBuilder
             return;
 
         string highlightFieldName = builderParameters.Metadata.GetVectorSourceFieldName(fieldName, me, builderParameters.QueryParameters);
-        readOperation.CaptureVectorChunkHighlighting(highlightFieldName, embeddingsGenerationTaskIdentifier, queryVectors);
+        readOperation.CaptureVectorChunkHighlighting(highlightFieldName, embeddingsGenerationTaskIdentifier, minimumMatch, queryVectors);
     }
 
     private static CoraxVectorItem HandleVector(Parameters builderParameters, MethodExpression me, bool exact)
@@ -150,7 +150,7 @@ public static partial class CoraxQueryBuilder
             
             var vector = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueTokenType, methodParameter, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
 
-            CaptureVectorHighlighting(builderParameters, me, fieldName, embeddingsGenerationTaskIdentifier, vector.SingleVector, vector.MultiVector);
+            CaptureVectorHighlighting(builderParameters, me, fieldName, embeddingsGenerationTaskIdentifier, minimumMatch, vector.SingleVector, vector.MultiVector);
 
             if (vector.SingleVector != null)
             {
@@ -170,7 +170,7 @@ public static partial class CoraxQueryBuilder
         {
             var vectorOptions = VectorHelpers.GetExplicitVectorOptions(builderParameters, fieldName, out indexField);
             transformedEmbeddings = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueType, value, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
-            CaptureVectorHighlighting(builderParameters, me, fieldName, embeddingsGenerationTaskIdentifier, transformedEmbeddings.SingleVector, transformedEmbeddings.MultiVector);
+            CaptureVectorHighlighting(builderParameters, me, fieldName, embeddingsGenerationTaskIdentifier, minimumMatch, transformedEmbeddings.SingleVector, transformedEmbeddings.MultiVector);
         }
         else
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxVectorChunkHighlighter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxVectorChunkHighlighter.cs
@@ -168,7 +168,6 @@ internal static class CoraxVectorChunkHighlighter
         return result;
     }
 
-    // Bounds the attachment size by a query vector's length as a side effect, keeping the cast to int at the call site in range.
     private static bool HasQueryVectorOfSize(List<byte[]> queryVectors, long size)
     {
         foreach (byte[] queryVector in queryVectors)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxVectorChunkHighlighter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxVectorChunkHighlighter.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using Raven.Client;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Server.Documents.AI.Embeddings;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Queries.Highlightings;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Hnsw = Voron.Data.Graphs.Hnsw;
+
+namespace Raven.Server.Documents.Indexes.Persistence.Corax;
+
+internal sealed class VectorChunkHighlightingCapture
+{
+    public readonly string FieldName;
+    public readonly string TaskId;
+    public readonly List<byte[]> QueryVectors;
+
+    public VectorChunkHighlightingCapture(string fieldName, string taskId, List<byte[]> queryVectors)
+    {
+        FieldName = fieldName;
+        TaskId = taskId;
+        QueryVectors = queryVectors;
+    }
+}
+
+internal static class CoraxVectorChunkHighlighter
+{
+    public static void Apply(
+        Dictionary<string, Dictionary<string, string[]>> highlightings,
+        IReadOnlyDictionary<string, VectorChunkHighlightingCapture> captures,
+        IndexQueryServerSide query,
+        Document document,
+        DocumentsOperationContext context,
+        DocumentDatabase database)
+    {
+        if (document?.Id == null || query.Metadata.Highlightings == null)
+            return;
+
+        PriorityQueue<string, float> scored = new();
+
+        foreach (var highlighting in query.Metadata.Highlightings)
+        {
+            var fieldName = highlighting.Field.Value;
+            if (captures.TryGetValue(fieldName, out var capture) == false)
+                continue; // this highlight field was not a vector search
+
+            scored.Clear();
+            var fragments = ComputeForDocument(scored, capture, highlighting, document, context, database);
+            if (fragments is not { Length: > 0 })
+                continue;
+
+            if (highlightings.TryGetValue(fieldName, out var perDocument) == false)
+                highlightings[fieldName] = perDocument = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+
+            // vector search never highlights the same field via the term path, so we do not expect an existing key here
+            perDocument[document.Id] = fragments;
+        }
+    }
+
+    private static string[] ComputeForDocument(PriorityQueue<string, float> scored, VectorChunkHighlightingCapture capture, HighlightingField highlighting, Document document,
+        DocumentsOperationContext context, DocumentDatabase database)
+    {
+        var embeddingDocumentId = EmbeddingsHelper.GetEmbeddingDocumentId(document.Id);
+
+        using var embeddingDocument = database.DocumentsStorage.Get(context, embeddingDocumentId);
+        if (embeddingDocument == null)
+            return null; // no embeddings stored for this document (e.g. deleted, manual vector, etc)
+
+        if (embeddingDocument.Data.TryGet(capture.TaskId, out BlittableJsonReaderObject taskObject) == false || taskObject == null)
+            return null; // this task produced no embeddings for the document
+
+        if (taskObject.TryGet(EmbeddingsHelper.ChunkTextPropertyName, out BlittableJsonReaderObject chunkTextByHash) == false || chunkTextByHash == null)
+            return null; // chunk text was not stored (StoreChunkText disabled, or data predates the feature)
+
+        var quantization = VectorEmbeddingType.Single;
+        if (taskObject.TryGet(Constants.Documents.Metadata.Quantization, out string quantizationValue) &&
+            Enum.TryParse(quantizationValue, out VectorEmbeddingType parsedQuantization))
+            quantization = parsedQuantization;
+
+        var attachmentsStorage = database.DocumentsStorage.AttachmentsStorage;
+
+        // Keep only the nearest FragmentCount chunks (all of them when FragmentCount <= 0). Priorities are the negated
+        // distance, so the default min-heap keeps the farthest kept chunk at the head - the one EnqueueDequeue evicts.
+        var capacity = highlighting.FragmentCount > 0 ? highlighting.FragmentCount : int.MaxValue;
+
+        // Text field is a map of chunk hash -> chunk text, vector data stored as attachment
+        BlittableJsonReaderObject.PropertyDetails property = default;
+        for (int i = 0; i < chunkTextByHash.Count; i++)
+        {
+            chunkTextByHash.GetPropertyByIndex(i, ref property);
+            var hash = property.Name?.ToString();
+            if (hash == null)
+                continue;
+
+            var text = property.Value?.ToString();
+            if (text == null)
+                continue; // no text stored for this chunk
+
+            var attachment = attachmentsStorage.GetAttachment(context, embeddingDocumentId, hash, AttachmentType.Document, changeVector: null);
+            if (attachment == null)
+                continue; // vector attachment is gone
+
+            float distance;
+            using (context.Allocator.Allocate((int)attachment.Size, out Span<byte> chunkVector))
+            {
+                attachment.Stream.ReadExactly(chunkVector);
+                distance = BestDistance(capture.QueryVectors, chunkVector, quantization);
+            }
+
+            if (scored.Count < capacity)
+                scored.Enqueue(text, -distance);
+            else
+                scored.EnqueueDequeue(text, -distance); // full: adds this chunk and drops the current farthest
+        }
+
+        var count = scored.Count;
+        if (count == 0)
+            return null;
+
+        // The queue dequeues farthest-first, fill in reverse
+        var result = new string[count];
+        for (int i = count - 1; i >= 0; i--)
+        {
+            var text = scored.Dequeue();
+            if (highlighting.FragmentLength > 0 && text.Length > highlighting.FragmentLength)
+                text = text.Substring(0, highlighting.FragmentLength);
+            result[i] = text;
+        }
+
+        return result;
+    }
+
+    private static float BestDistance(List<byte[]> queryVectors, ReadOnlySpan<byte> chunkVector, VectorEmbeddingType quantization)
+    {
+        var best = float.PositiveInfinity;
+        foreach (var queryVector in queryVectors)
+        {
+            var distance = Distance(quantization, queryVector, chunkVector);
+            if (distance < best)
+                best = distance;
+        }
+
+        return best;
+    }
+
+    private static float Distance(VectorEmbeddingType quantization, ReadOnlySpan<byte> query, ReadOnlySpan<byte> chunk)
+    {
+        if (query.Length != chunk.Length)
+            return float.PositiveInfinity; // mismatched dimensions/quantization; treat as no match
+
+        return quantization switch
+        {
+            VectorEmbeddingType.Single => Hnsw.CosineDistanceSingles(query, chunk),
+            VectorEmbeddingType.Int8 => Hnsw.CosineDistanceI8(query, chunk),
+            VectorEmbeddingType.Binary => Hnsw.HammingDistance(query, chunk),
+            _ => float.PositiveInfinity
+        };
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxVectorChunkHighlighter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxVectorChunkHighlighter.cs
@@ -101,6 +101,9 @@ internal static class CoraxVectorChunkHighlighter
             Enum.TryParse(quantizationValue, out VectorEmbeddingType parsedQuantization))
             quantization = parsedQuantization;
 
+        if (TryGetSimilarityMethod(quantization, out Hnsw.SimilarityMethod similarityMethod) == false)
+            return null; // not a quantization that vectors are stored in, so there is nothing to compare the chunks against
+
         AttachmentsStorage attachmentsStorage = database.DocumentsStorage.AttachmentsStorage;
 
         // Keep only the nearest FragmentCount chunks (all of them when FragmentCount <= 0). Priorities are the negated
@@ -124,15 +127,21 @@ internal static class CoraxVectorChunkHighlighter
             if (attachment == null)
                 continue; // vector attachment is gone
 
+            // A chunk is only comparable to a query vector of the same length (same dimensions and quantization), so an
+            // attachment that matches none of them cannot match at all - skip it before allocating and reading it.
+            if (HasQueryVectorOfSize(capture.QueryVectors, attachment.Size) == false)
+                continue;
+
             float distance;
             using (context.Allocator.Allocate((int)attachment.Size, out Span<byte> chunkVector))
             {
                 attachment.Stream.ReadExactly(chunkVector);
-                distance = BestDistance(capture.QueryVectors, chunkVector, quantization);
+                distance = BestDistance(capture.QueryVectors, chunkVector, similarityMethod);
 
                 // A document matches when any one of its chunks is near enough, so the rest of its chunks can be
                 // arbitrarily far from the query - without this the highlighter would return every stored chunk.
-                if (float.IsNaN(distance) || distance > MaximumDistance(quantization, capture.MinimumSimilarity, chunkVector.Length))
+                if (float.IsNaN(distance) ||
+                    distance > Hnsw.MinimumSimilarityToDistance(similarityMethod, chunkVector.Length, capture.MinimumSimilarity))
                     continue; // below the query's minimum similarity, or a degenerate vector
             }
 
@@ -159,12 +168,45 @@ internal static class CoraxVectorChunkHighlighter
         return result;
     }
 
-    private static float BestDistance(List<byte[]> queryVectors, ReadOnlySpan<byte> chunkVector, VectorEmbeddingType quantization)
+    // Bounds the attachment size by a query vector's length as a side effect, keeping the cast to int at the call site in range.
+    private static bool HasQueryVectorOfSize(List<byte[]> queryVectors, long size)
+    {
+        foreach (byte[] queryVector in queryVectors)
+        {
+            if (queryVector.Length == size)
+                return true;
+        }
+
+        return false;
+    }
+
+    // The quantization the chunks were stored with decides both the distance kernel and how a minimum similarity
+    // translates into a maximum distance, so it is mapped to Hnsw's own notion of that once, here.
+    private static bool TryGetSimilarityMethod(VectorEmbeddingType quantization, out Hnsw.SimilarityMethod similarityMethod)
+    {
+        switch (quantization)
+        {
+            case VectorEmbeddingType.Single:
+                similarityMethod = Hnsw.SimilarityMethod.CosineSimilaritySingles;
+                return true;
+            case VectorEmbeddingType.Int8:
+                similarityMethod = Hnsw.SimilarityMethod.CosineSimilarityI8;
+                return true;
+            case VectorEmbeddingType.Binary:
+                similarityMethod = Hnsw.SimilarityMethod.HammingDistance;
+                return true;
+            default:
+                similarityMethod = default; // Text is a source type only, vectors are never stored that way
+                return false;
+        }
+    }
+
+    private static float BestDistance(List<byte[]> queryVectors, ReadOnlySpan<byte> chunkVector, Hnsw.SimilarityMethod similarityMethod)
     {
         float best = float.PositiveInfinity;
         foreach (byte[] queryVector in queryVectors)
         {
-            float distance = Distance(quantization, queryVector, chunkVector);
+            float distance = Distance(similarityMethod, queryVector, chunkVector);
             if (distance < best)
                 best = distance;
         }
@@ -172,28 +214,18 @@ internal static class CoraxVectorChunkHighlighter
         return best;
     }
 
-    // Mirrors Hnsw.SearchState.MinimumSimilarityToDistance so a chunk that made the document match through the graph
-    // search is never rejected here. Kept inclusive (distance > max is rejected) to match Hnsw.VectorSearchRetriever.
-    private static float MaximumDistance(VectorEmbeddingType quantization, float minimumSimilarity, int vectorSizeInBytes)
-    {
-        return quantization switch
-        {
-            VectorEmbeddingType.Single or VectorEmbeddingType.Int8 => 2f * (1f - minimumSimilarity),
-            VectorEmbeddingType.Binary => vectorSizeInBytes * 8 * (1f - minimumSimilarity),
-            _ => float.PositiveInfinity
-        };
-    }
-
-    private static float Distance(VectorEmbeddingType quantization, ReadOnlySpan<byte> query, ReadOnlySpan<byte> chunk)
+    // These are the raw embedding blobs held in the attachments, not HNSW's on-disk vectors, so the version-dependent
+    // kernel selection in Hnsw.GetDistanceKernel (NormalizedTensor layout) does not apply to them.
+    private static float Distance(Hnsw.SimilarityMethod similarityMethod, ReadOnlySpan<byte> query, ReadOnlySpan<byte> chunk)
     {
         if (query.Length != chunk.Length)
             return float.PositiveInfinity; // mismatched dimensions/quantization; treat as no match
 
-        return quantization switch
+        return similarityMethod switch
         {
-            VectorEmbeddingType.Single => Hnsw.CosineDistanceSingles(query, chunk),
-            VectorEmbeddingType.Int8 => Hnsw.CosineDistanceI8(query, chunk),
-            VectorEmbeddingType.Binary => Hnsw.HammingDistance(query, chunk),
+            Hnsw.SimilarityMethod.CosineSimilaritySingles => Hnsw.CosineDistanceSingles(query, chunk),
+            Hnsw.SimilarityMethod.CosineSimilarityI8 => Hnsw.CosineDistanceI8(query, chunk),
+            Hnsw.SimilarityMethod.HammingDistance => Hnsw.HammingDistance(query, chunk),
             _ => float.PositiveInfinity
         };
     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxVectorChunkHighlighter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxVectorChunkHighlighter.cs
@@ -18,11 +18,20 @@ internal sealed class VectorChunkHighlightingCapture
     public readonly string TaskId;
     public readonly List<byte[]> QueryVectors;
 
-    public VectorChunkHighlightingCapture(string fieldName, string taskId, List<byte[]> queryVectors)
+    public float MinimumSimilarity { get; private set; }
+
+    public VectorChunkHighlightingCapture(string fieldName, string taskId, float minimumSimilarity, List<byte[]> queryVectors)
     {
         FieldName = fieldName;
         TaskId = taskId;
+        MinimumSimilarity = minimumSimilarity;
         QueryVectors = queryVectors;
+    }
+
+    public void RelaxMinimumSimilarity(float minimumSimilarity)
+    {
+        if (minimumSimilarity < MinimumSimilarity)
+            MinimumSimilarity = minimumSimilarity;
     }
 }
 
@@ -120,6 +129,11 @@ internal static class CoraxVectorChunkHighlighter
             {
                 attachment.Stream.ReadExactly(chunkVector);
                 distance = BestDistance(capture.QueryVectors, chunkVector, quantization);
+
+                // A document matches when any one of its chunks is near enough, so the rest of its chunks can be
+                // arbitrarily far from the query - without this the highlighter would return every stored chunk.
+                if (float.IsNaN(distance) || distance > MaximumDistance(quantization, capture.MinimumSimilarity, chunkVector.Length))
+                    continue; // below the query's minimum similarity, or a degenerate vector
             }
 
             if (scored.Count < capacity)
@@ -156,6 +170,18 @@ internal static class CoraxVectorChunkHighlighter
         }
 
         return best;
+    }
+
+    // Mirrors Hnsw.SearchState.MinimumSimilarityToDistance so a chunk that made the document match through the graph
+    // search is never rejected here. Kept inclusive (distance > max is rejected) to match Hnsw.VectorSearchRetriever.
+    private static float MaximumDistance(VectorEmbeddingType quantization, float minimumSimilarity, int vectorSizeInBytes)
+    {
+        return quantization switch
+        {
+            VectorEmbeddingType.Single or VectorEmbeddingType.Int8 => 2f * (1f - minimumSimilarity),
+            VectorEmbeddingType.Binary => vectorSizeInBytes * 8 * (1f - minimumSimilarity),
+            _ => float.PositiveInfinity
+        };
     }
 
     private static float Distance(VectorEmbeddingType quantization, ReadOnlySpan<byte> query, ReadOnlySpan<byte> chunk)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxVectorChunkHighlighter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxVectorChunkHighlighter.cs
@@ -41,31 +41,43 @@ internal static class CoraxVectorChunkHighlighter
 
         PriorityQueue<string, float> scored = new();
 
-        foreach (var highlighting in query.Metadata.Highlightings)
+        foreach (HighlightingField highlighting in query.Metadata.Highlightings)
         {
-            var fieldName = highlighting.Field.Value;
-            if (captures.TryGetValue(fieldName, out var capture) == false)
+            string fieldName = highlighting.Field.Value;
+            if (captures.TryGetValue(fieldName, out VectorChunkHighlightingCapture capture) == false)
                 continue; // this highlight field was not a vector search
 
             scored.Clear();
-            var fragments = ComputeForDocument(scored, capture, highlighting, document, context, database);
+            string[] fragments = ComputeForDocument(scored, capture, highlighting, document, context, database);
             if (fragments is not { Length: > 0 })
                 continue;
 
-            if (highlightings.TryGetValue(fieldName, out var perDocument) == false)
+            if (highlightings.TryGetValue(fieldName, out Dictionary<string, string[]> perDocument) == false)
                 highlightings[fieldName] = perDocument = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
 
-            // vector search never highlights the same field via the term path, so we do not expect an existing key here
-            perDocument[document.Id] = fragments;
+            // On a dynamic index the same source field can be both full-text searched and vector searched under a single
+            // highlight(), in which case the term highlighter has already stored its fragments here. Append the vector
+            // chunk fragments rather than overwriting so both survive.
+            if (perDocument.TryGetValue(document.Id, out string[] existing) && existing is { Length: > 0 })
+            {
+                int offset = existing.Length;
+                Array.Resize(ref existing, existing.Length + fragments.Length);
+                Array.Copy(fragments, 0, existing, offset, fragments.Length);
+                perDocument[document.Id] = existing;
+            }
+            else
+            {
+                perDocument[document.Id] = fragments;
+            }
         }
     }
 
     private static string[] ComputeForDocument(PriorityQueue<string, float> scored, VectorChunkHighlightingCapture capture, HighlightingField highlighting, Document document,
         DocumentsOperationContext context, DocumentDatabase database)
     {
-        var embeddingDocumentId = EmbeddingsHelper.GetEmbeddingDocumentId(document.Id);
+        string embeddingDocumentId = EmbeddingsHelper.GetEmbeddingDocumentId(document.Id);
 
-        using var embeddingDocument = database.DocumentsStorage.Get(context, embeddingDocumentId);
+        using Document embeddingDocument = database.DocumentsStorage.Get(context, embeddingDocumentId);
         if (embeddingDocument == null)
             return null; // no embeddings stored for this document (e.g. deleted, manual vector, etc)
 
@@ -75,31 +87,31 @@ internal static class CoraxVectorChunkHighlighter
         if (taskObject.TryGet(EmbeddingsHelper.ChunkTextPropertyName, out BlittableJsonReaderObject chunkTextByHash) == false || chunkTextByHash == null)
             return null; // chunk text was not stored (StoreChunkText disabled, or data predates the feature)
 
-        var quantization = VectorEmbeddingType.Single;
+        VectorEmbeddingType quantization = VectorEmbeddingType.Single;
         if (taskObject.TryGet(Constants.Documents.Metadata.Quantization, out string quantizationValue) &&
             Enum.TryParse(quantizationValue, out VectorEmbeddingType parsedQuantization))
             quantization = parsedQuantization;
 
-        var attachmentsStorage = database.DocumentsStorage.AttachmentsStorage;
+        AttachmentsStorage attachmentsStorage = database.DocumentsStorage.AttachmentsStorage;
 
         // Keep only the nearest FragmentCount chunks (all of them when FragmentCount <= 0). Priorities are the negated
         // distance, so the default min-heap keeps the farthest kept chunk at the head - the one EnqueueDequeue evicts.
-        var capacity = highlighting.FragmentCount > 0 ? highlighting.FragmentCount : int.MaxValue;
+        int capacity = highlighting.FragmentCount > 0 ? highlighting.FragmentCount : int.MaxValue;
 
         // Text field is a map of chunk hash -> chunk text, vector data stored as attachment
         BlittableJsonReaderObject.PropertyDetails property = default;
         for (int i = 0; i < chunkTextByHash.Count; i++)
         {
             chunkTextByHash.GetPropertyByIndex(i, ref property);
-            var hash = property.Name?.ToString();
+            string hash = property.Name?.ToString();
             if (hash == null)
                 continue;
 
-            var text = property.Value?.ToString();
+            string text = property.Value?.ToString();
             if (text == null)
                 continue; // no text stored for this chunk
 
-            var attachment = attachmentsStorage.GetAttachment(context, embeddingDocumentId, hash, AttachmentType.Document, changeVector: null);
+            Attachment attachment = attachmentsStorage.GetAttachment(context, embeddingDocumentId, hash, AttachmentType.Document, changeVector: null);
             if (attachment == null)
                 continue; // vector attachment is gone
 
@@ -116,15 +128,15 @@ internal static class CoraxVectorChunkHighlighter
                 scored.EnqueueDequeue(text, -distance); // full: adds this chunk and drops the current farthest
         }
 
-        var count = scored.Count;
+        int count = scored.Count;
         if (count == 0)
             return null;
 
         // The queue dequeues farthest-first, fill in reverse
-        var result = new string[count];
+        string[] result = new string[count];
         for (int i = count - 1; i >= 0; i--)
         {
-            var text = scored.Dequeue();
+            string text = scored.Dequeue();
             if (highlighting.FragmentLength > 0 && text.Length > highlighting.FragmentLength)
                 text = text.Substring(0, highlighting.FragmentLength);
             result[i] = text;
@@ -135,10 +147,10 @@ internal static class CoraxVectorChunkHighlighter
 
     private static float BestDistance(List<byte[]> queryVectors, ReadOnlySpan<byte> chunkVector, VectorEmbeddingType quantization)
     {
-        var best = float.PositiveInfinity;
-        foreach (var queryVector in queryVectors)
+        float best = float.PositiveInfinity;
+        foreach (byte[] queryVector in queryVectors)
         {
-            var distance = Distance(quantization, queryVector, chunkVector);
+            float distance = Distance(quantization, queryVector, chunkVector);
             if (distance < best)
                 best = distance;
         }

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -2916,6 +2916,19 @@ function execute(doc, args){
             return sb.ToString();
         }
         
+        internal string GetVectorSourceFieldName(string fieldName, MethodExpression vectorExpression, BlittableJsonReaderObject parameters)
+        {
+            if(IsDynamic == false)
+                return fieldName;
+                
+            // For "where vector.search(embedding.text(Name, ai.task('tasks/1')), $q)" this returns "Name",
+            // whereas GetVectorFieldName returns "vector.search(embedding.text(Name,ai.task('tasks/1')))".
+            if (vectorExpression.Arguments.Count > 0 && vectorExpression.Arguments[0] is MethodExpression innerExpression)
+                return ExtractFieldNameFromArgument(innerExpression.Arguments[0], withoutAlias: true, innerExpression.Name.Value, parameters, QueryText).Value;
+
+            return ExtractFieldNameFromArgument(vectorExpression.Arguments[0], withoutAlias: true, vectorExpression.Name.Value, parameters, QueryText).Value;
+        }
+
         internal string GetSpatialFieldName(MethodExpression spatialExpression, BlittableJsonReaderObject parameters)
         {
             var sb = new StringBuilder();

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEmbeddingsGenerationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEmbeddingsGenerationEditModel.ts
@@ -50,6 +50,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
     queryingMaxTokensPerChunk = ko.observable<number>(null);
     queryingOverlapTokens = ko.observable<number>(null);
     embeddingsCacheForQueryingExpiration = ko.observable<number>(defaultEmbeddingsCacheForQueryingExpiration);
+    storeChunkText = ko.observable<boolean>(false);
 
     quantizationType = ko.observable<Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType>("Single");
     quantizationTypeOptions: valueAndLabelItem<Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType, string>[] = [
@@ -443,6 +444,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
             if (configuration.EmbeddingsCacheForQueryingExpiration) {
                 this.embeddingsCacheForQueryingExpiration(genUtils.timeSpanToSeconds(configuration.EmbeddingsCacheForQueryingExpiration));
             }
+            this.storeChunkText(configuration.StoreChunkText ?? false);
             if (configuration.EmbeddingsPathConfigurations) {
                 this.embeddingPathConfigurations(configuration.EmbeddingsPathConfigurations);
             }
@@ -493,6 +495,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
                 ContextPrefix: null
             },
             Quantization: this.quantizationType(),
+            StoreChunkText: this.storeChunkText(),
             EmbeddingsTransformation: this.embeddingsSource() === "script" ? {
                 Script: this.script(), ChunkingOptions: { OverlapTokens: this.transformationOverlapTokens() ?? 0, MaxTokensPerChunk: this.transformationMaxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue(), ChunkingMethod: this.transformationChunkingMethod(), ContextPrefix: null }
             } : null,

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -468,6 +468,7 @@ export class TasksStubs {
                 ],
                 EmbeddingsTransformation: null,
                 Quantization: "Single",
+                StoreChunkText: false,
                 EmbeddingsCacheExpiration: "90.00:00:00",
                 ChunkingOptionsForQuerying: {
                     OverlapTokens: 0,

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -55,7 +55,7 @@ public partial class Hnsw
             _queryVectorScope = queryVectorScope;
             _postingListResults = new(_searchState.Llt.Allocator);
             _pforDecoder = new(searchState.Llt.Allocator);
-            _maximumDistance = searchState.MinimumSimilarityToDistance(minimumSimilarity);
+            _maximumDistance = MinimumSimilarityToDistance(searchState.Options.SimilarityMethod, searchState.Options.VectorSizeBytes, minimumSimilarity);
             _vectorsSearcher.MoveNextBatch(); // prime the first batch
         }
         

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -75,6 +75,25 @@ public unsafe partial class Hnsw
     }
 
     /// <summary>
+    /// Translates a minimum similarity on the [0, 1] scale into the maximum distance the similarity method reports for
+    /// it. Cosine distance is <c>1 - cos</c> over [0, 2] and similarity is <c>(cos + 1) / 2</c>, so the bound is
+    /// <c>2 * (1 - minimumSimilarity)</c>; Hamming distance counts differing bits, so its bound scales with the vector.
+    /// </summary>
+    internal static float MinimumSimilarityToDistance(SimilarityMethod similarityMethod, int vectorSizeBytes, float minimumSimilarity)
+    {
+        switch (similarityMethod)
+        {
+            case SimilarityMethod.CosineSimilaritySingles:
+            case SimilarityMethod.CosineSimilarityI8:
+                return 2f * (1.0f - minimumSimilarity);
+            case SimilarityMethod.HammingDistance:
+                return vectorSizeBytes * 8 * (1f - minimumSimilarity); // number_of_bits * minimum_similarity
+            default:
+                throw new InvalidDataException($"Unknown similarity method {similarityMethod}");
+        }
+    }
+
+    /// <summary>
     /// Returns the distance kernel to use for a given HNSW <see cref="Options"/>. For
     /// <see cref="SimilarityMethod.CosineSimilaritySingles"/> the kernel depends on the on-disk
     /// version: at or above <see cref="Constants.Graphs.HnswVersion.SinglesWithL2Norm"/> the
@@ -257,20 +276,6 @@ public unsafe partial class Hnsw
         }
 
         private const int InitialNodesCapacityWithCache = 256;
-
-        public float MinimumSimilarityToDistance(float minimumSimilarity)
-        {
-            switch (Options.SimilarityMethod)
-            {
-                case SimilarityMethod.CosineSimilaritySingles:
-                case SimilarityMethod.CosineSimilarityI8:
-                    return 2f * (1.0f - minimumSimilarity);
-                case SimilarityMethod.HammingDistance:
-                    return Options.VectorSizeBytes * 8 * (1f - minimumSimilarity); // number_of_bits * minimum_similarity
-                default:
-                    throw new InvalidDataException($"Unknown similarity method {Options.SimilarityMethod}");
-            }
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float DistanceToScore(float score)

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -77,7 +77,8 @@ public unsafe partial class Hnsw
     /// <summary>
     /// Translates a minimum similarity on the [0, 1] scale into the maximum distance the similarity method reports for
     /// it. Cosine distance is <c>1 - cos</c> over [0, 2] and similarity is <c>(cos + 1) / 2</c>, so the bound is
-    /// <c>2 * (1 - minimumSimilarity)</c>; Hamming distance counts differing bits, so its bound scales with the vector.
+    /// <c>2 * (1 - minimumSimilarity)</c>. Hamming distance counts differing bits and similarity is the fraction of
+    /// matching bits, so the bound is the number of bits that may differ: <c>numberOfBits * (1 - minimumSimilarity)</c>.
     /// </summary>
     internal static float MinimumSimilarityToDistance(SimilarityMethod similarityMethod, int vectorSizeBytes, float minimumSimilarity)
     {
@@ -87,7 +88,7 @@ public unsafe partial class Hnsw
             case SimilarityMethod.CosineSimilarityI8:
                 return 2f * (1.0f - minimumSimilarity);
             case SimilarityMethod.HammingDistance:
-                return vectorSizeBytes * 8 * (1f - minimumSimilarity); // number_of_bits * minimum_similarity
+                return vectorSizeBytes * 8 * (1f - minimumSimilarity); // number_of_bits * (1 - minimum_similarity) = allowed differing bits
             default:
                 throw new InvalidDataException($"Unknown similarity method {similarityMethod}");
         }

--- a/test/SlowTests/Server/Documents/AI/Embeddings/VectorChunkHighlightingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/VectorChunkHighlightingTests.cs
@@ -292,6 +292,52 @@ public class VectorChunkHighlightingTests(ITestOutputHelper output) : Embeddings
         }
     }
 
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task IncludeHighlightMergesWithTermHighlightingOnSameField(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Dto { TextualValue = MultiChunkText });
+            session.SaveChanges();
+        }
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        var configuration = CreateChunkingConfiguration(storeChunkText: true);
+        AddEmbeddingsGenerationTask(store, configuration);
+
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
+        using (var session = store.OpenSession())
+        {
+            // The same source field is both full-text searched ("banana") and vector searched ("fruit") under a single
+            // highlight(). The term highlighter runs first and stores its tagged fragments; the vector chunk highlighter
+            // must append its raw chunk fragments rather than overwrite them - both must survive.
+            var results = session.Advanced.DocumentQuery<Dto>()
+                .WaitForNonStaleResults()
+                .Search("TextualValue", "banana")
+                .AndAlso()
+                .VectorSearch(f => f.WithText(d => d.TextualValue).UsingTask(configuration.Identifier), v => v.ByText("fruit"), minimumSimilarity: 0.5f)
+                .Highlight("TextualValue", 2048, 5, out Highlightings highlightings)
+                .ToList();
+
+            Assert.NotEmpty(results);
+
+            var fragments = highlightings.GetFragments(results[0].Id);
+            Assert.NotEmpty(fragments);
+
+            // a term-highlight fragment (carries the closing markup tag) produced by the search("banana") clause
+            Assert.Contains(fragments, f => f.Contains("</b>"));
+            // a raw vector chunk fragment (no markup) produced by the vector search
+            Assert.Contains(fragments, f => f.Contains("</b>") == false);
+        }
+    }
+
     private static EmbeddingsGenerationConfiguration CreateMultiFieldChunkingConfiguration(bool storeChunkText)
     {
         var chunking = new ChunkingOptions { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 8 };

--- a/test/SlowTests/Server/Documents/AI/Embeddings/VectorChunkHighlightingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/VectorChunkHighlightingTests.cs
@@ -1,7 +1,6 @@
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Documents.Operations.AI;
@@ -336,6 +335,72 @@ public class VectorChunkHighlightingTests(ITestOutputHelper output) : Embeddings
             // a raw vector chunk fragment (no markup) produced by the vector search
             Assert.Contains(fragments, f => f.Contains("</b>") == false);
         }
+    }
+
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task DoesNotReturnChunksBelowMinimumSimilarity(Options options)
+    {
+        // The document matches as soon as one of its chunks is near enough to the query, so the highlighter must apply
+        // the query's minimumSimilarity itself - otherwise it would surface the document's unrelated chunks as well.
+        // The threshold is derived from the model's own scores rather than hard-coded, so the test does not depend on
+        // absolute similarity values: it sits between the near ("apple banana fruit") and far ("computer ...") chunk.
+        float nearSimilarity = NormalizedSimilarity("fruit", "apple banana fruit");
+        float farSimilarity = NormalizedSimilarity("fruit", "computer technology machine");
+        Assert.True(farSimilarity < nearSimilarity, $"far ({farSimilarity}) < near ({nearSimilarity})");
+        float minimumSimilarity = (nearSimilarity + farSimilarity) / 2f;
+
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Dto { TextualValue = MultiChunkText });
+            session.SaveChanges();
+        }
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        var configuration = CreateChunkingConfiguration(storeChunkText: true);
+        AddEmbeddingsGenerationTask(store, configuration);
+
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.DocumentQuery<Dto>()
+                .WaitForNonStaleResults()
+                .VectorSearch(f => f.WithText(d => d.TextualValue).UsingTask(configuration.Identifier), v => v.ByText("fruit"), minimumSimilarity: minimumSimilarity)
+                .Highlight("TextualValue", 2048, 5, out Highlightings highlightings)
+                .ToList();
+
+            Assert.NotEmpty(results);
+
+            var fragments = highlightings.GetFragments(results[0].Id);
+            Assert.NotEmpty(fragments);
+            Assert.Contains(fragments, f => f.Contains("apple"));
+            Assert.DoesNotContain(fragments, f => f.Contains("computer"));
+        }
+    }
+
+    // RavenDB reports vector similarity on a [0, 1] scale where 0.5 is orthogonal, i.e. (cosine + 1) / 2.
+    private float NormalizedSimilarity(string queryText, string chunkText)
+    {
+        float[] query = GenerateEmbeddingForTextViaOnnx(queryText);
+        float[] chunk = GenerateEmbeddingForTextViaOnnx(chunkText);
+        Assert.Equal(query.Length, chunk.Length);
+
+        float dot = 0f, querySquared = 0f, chunkSquared = 0f;
+        for (int i = 0; i < query.Length; i++)
+        {
+            dot += query[i] * chunk[i];
+            querySquared += query[i] * query[i];
+            chunkSquared += chunk[i] * chunk[i];
+        }
+
+        float cosine = dot / (MathF.Sqrt(querySquared) * MathF.Sqrt(chunkSquared));
+        return (cosine + 1f) / 2f;
     }
 
     private static EmbeddingsGenerationConfiguration CreateMultiFieldChunkingConfiguration(bool storeChunkText)

--- a/test/SlowTests/Server/Documents/AI/Embeddings/VectorChunkHighlightingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/VectorChunkHighlightingTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Queries.Highlighting;
 using Tests.Infrastructure;
 using Xunit;
@@ -271,6 +272,24 @@ public class VectorChunkHighlightingTests(ITestOutputHelper output) : Embeddings
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
 
+        using (var session = store.OpenSession())
+        {
+            // get the document into the index, with its chunk text, before taking that chunk text away
+            var results = session.Advanced.DocumentQuery<Dto>()
+                .WaitForNonStaleResults()
+                .VectorSearch(f => f.WithText(d => d.TextualValue).UsingTask(configuration.Identifier), v => v.ByText("fruit"), minimumSimilarity: 0.5f)
+                .Highlight("TextualValue", 2048, 5, out Highlightings highlightings)
+                .ToList();
+
+            Assert.NotEmpty(results);
+            Assert.NotEmpty(highlightings.GetFragments(results[0].Id));
+        }
+
+        // Deleting the embeddings document also drops the document from the vector index once indexing catches up, and a
+        // query that returns nothing would not exercise the highlighter at all. Stopping indexing first keeps the index
+        // entry in place while its chunk text source is gone - the state the highlighter has to survive.
+        store.Maintenance.Send(new StopIndexingOperation());
+
         // remove the per-document embeddings document that holds the chunk text
         using (var session = store.OpenSession())
         {
@@ -286,8 +305,9 @@ public class VectorChunkHighlightingTests(ITestOutputHelper output) : Embeddings
                 .Highlight("TextualValue", 2048, 5, out Highlightings highlightings)
                 .ToList();
 
-            foreach (var result in results)
-                Assert.Empty(highlightings.GetFragments(result.Id));
+            // the document is still indexed, so the highlighter does run - it just has no chunk text to report
+            Assert.NotEmpty(results);
+            Assert.Empty(highlightings.GetFragments(results[0].Id));
         }
     }
 

--- a/test/SlowTests/Server/Documents/AI/Embeddings/VectorChunkHighlightingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/VectorChunkHighlightingTests.cs
@@ -1,0 +1,356 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Queries.Highlighting;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.Embeddings;
+
+public class VectorChunkHighlightingTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    private const string MultiChunkText = "apple banana fruit\ncomputer technology machine";
+    private const string SecondaryChunkText = "ocean water sea\nmountain rock stone";
+
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task IncludeHighlightReturnsMatchingChunkText(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        var dto = new Dto { TextualValue = MultiChunkText };
+        using (var session = store.OpenSession())
+        {
+            session.Store(dto);
+            session.SaveChanges();
+        }
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        var configuration = CreateChunkingConfiguration(storeChunkText: true);
+        AddEmbeddingsGenerationTask(store, configuration);
+
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.DocumentQuery<Dto>()
+                .WaitForNonStaleResults()
+                .VectorSearch(f => f.WithText(d => d.TextualValue).UsingTask(configuration.Identifier), v => v.ByText("fruit"), minimumSimilarity: 0.5f)
+                .Highlight("TextualValue", 2048, 5, out Highlightings highlightings)
+                .ToList();
+
+            Assert.NotEmpty(results);
+
+            var fragments = highlightings.GetFragments(results[0].Id);
+            Assert.NotEmpty(fragments);
+            // the chunk nearest to "fruit" is the "apple banana fruit" line, not the "computer ..." one
+            Assert.Contains("apple", fragments[0]);
+        }
+    }
+
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task NoChunkTextWhenStoreChunkTextDisabled(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        var dto = new Dto { TextualValue = MultiChunkText };
+        using (var session = store.OpenSession())
+        {
+            session.Store(dto);
+            session.SaveChanges();
+        }
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        var configuration = CreateChunkingConfiguration(storeChunkText: false);
+        AddEmbeddingsGenerationTask(store, configuration);
+
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
+        using (var session = store.OpenSession())
+        {
+            // the query must still succeed and return the matching document; there is simply no chunk text to return
+            var results = session.Advanced.DocumentQuery<Dto>()
+                .WaitForNonStaleResults()
+                .VectorSearch(f => f.WithText(d => d.TextualValue).UsingTask(configuration.Identifier), v => v.ByText("fruit"), minimumSimilarity: 0.5f)
+                .Highlight("TextualValue", 2048, 5, out Highlightings highlightings)
+                .ToList();
+
+            Assert.NotEmpty(results);
+            Assert.Empty(highlightings.GetFragments(results[0].Id));
+        }
+    }
+
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task IncludeHighlightWorksWithInt8Quantization(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Dto { TextualValue = MultiChunkText });
+            session.SaveChanges();
+        }
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        var configuration = CreateChunkingConfiguration(storeChunkText: true, quantization: VectorEmbeddingType.Int8);
+        AddEmbeddingsGenerationTask(store, configuration);
+
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.DocumentQuery<Dto>()
+                .WaitForNonStaleResults()
+                .VectorSearch(f => f.WithText(d => d.TextualValue).UsingTask(configuration.Identifier).TargetQuantization(VectorEmbeddingType.Int8), v => v.ByText("fruit"), minimumSimilarity: 0.5f)
+                .Highlight("TextualValue", 2048, 5, out Highlightings highlightings)
+                .ToList();
+
+            Assert.NotEmpty(results);
+            var fragments = highlightings.GetFragments(results[0].Id);
+            Assert.NotEmpty(fragments);
+            Assert.Contains("apple", fragments[0]);
+        }
+    }
+
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task IncludeHighlightWorksWithMultipleQueryVectors(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Dto { TextualValue = MultiChunkText });
+            session.SaveChanges();
+        }
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        var configuration = CreateChunkingConfiguration(storeChunkText: true);
+        AddEmbeddingsGenerationTask(store, configuration);
+
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.DocumentQuery<Dto>()
+                .WaitForNonStaleResults()
+                .VectorSearch(f => f.WithText(d => d.TextualValue).UsingTask(configuration.Identifier), v => v.ByTexts(["fruit", "machine"]), minimumSimilarity: 0.5f)
+                .Highlight("TextualValue", 2048, 5, out Highlightings highlightings)
+                .ToList();
+
+            Assert.NotEmpty(results);
+            var fragments = highlightings.GetFragments(results[0].Id);
+            Assert.NotEmpty(fragments);
+        }
+    }
+
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task IncludeHighlightResolvesEachFieldWithMultipleVectorSearches(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Dto { TextualValue = MultiChunkText, SecondaryValue = SecondaryChunkText });
+            session.SaveChanges();
+        }
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        var configuration = CreateMultiFieldChunkingConfiguration(storeChunkText: true);
+        AddEmbeddingsGenerationTask(store, configuration);
+
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
+        using (var session = store.OpenSession())
+        {
+            // Two vector searches over two different fields on a dynamic (auto) index, each with its own highlight().
+            // Each highlight must resolve to its own captured query vector - previously only a single vector search
+            // per query could be highlighted (the field name was matched by cardinality, not by name).
+            var results = session.Advanced.DocumentQuery<Dto>()
+                .WaitForNonStaleResults()
+                .VectorSearch(f => f.WithText(d => d.TextualValue).UsingTask(configuration.Identifier), v => v.ByText("fruit"), minimumSimilarity: 0.5f)
+                .AndAlso()
+                .VectorSearch(f => f.WithText(d => d.SecondaryValue).UsingTask(configuration.Identifier), v => v.ByText("sea"), minimumSimilarity: 0.5f)
+                .Highlight("TextualValue", 2048, 5, out Highlightings textualHighlightings)
+                .Highlight("SecondaryValue", 2048, 5, out Highlightings secondaryHighlightings)
+                .ToList();
+
+            Assert.NotEmpty(results);
+
+            // each field is highlighted independently, against the query vector captured for that field
+            var textualFragments = textualHighlightings.GetFragments(results[0].Id);
+            Assert.NotEmpty(textualFragments);
+            Assert.Contains("apple", textualFragments[0]);
+
+            var secondaryFragments = secondaryHighlightings.GetFragments(results[0].Id);
+            Assert.NotEmpty(secondaryFragments);
+            Assert.Contains("ocean", secondaryFragments[0]);
+        }
+    }
+
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task IncludeHighlightWorksOnStaticIndex(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Dto { TextualValue = MultiChunkText });
+            session.SaveChanges();
+        }
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        var configuration = CreateChunkingConfiguration(storeChunkText: true);
+        AddEmbeddingsGenerationTask(store, configuration);
+
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
+        await new VectorViaLoadVectorIndex().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.DocumentQuery<Dto, VectorViaLoadVectorIndex>()
+                .VectorSearch(f => f.WithField("TextualValueVector"), v => v.ByText("fruit"), minimumSimilarity: 0.5f)
+                .Highlight("TextualValueVector", 2048, 5, out Highlightings highlightings)
+                .ToList();
+
+            Assert.NotEmpty(results);
+            var fragments = highlightings.GetFragments(results[0].Id);
+            Assert.NotEmpty(fragments);
+            Assert.Contains("apple", fragments[0]);
+        }
+    }
+
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task DoesNotThrowWhenEmbeddingsDocumentMissing(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        string dtoId;
+        using (var session = store.OpenSession())
+        {
+            var dto = new Dto { TextualValue = MultiChunkText };
+            session.Store(dto);
+            session.SaveChanges();
+            dtoId = dto.Id;
+        }
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        var configuration = CreateChunkingConfiguration(storeChunkText: true);
+        AddEmbeddingsGenerationTask(store, configuration);
+
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
+        // remove the per-document embeddings document that holds the chunk text
+        using (var session = store.OpenSession())
+        {
+            session.Delete("embeddings/" + dtoId);
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            // the query must not throw even though the chunk text source is gone; it simply yields no fragments
+            var results = session.Advanced.DocumentQuery<Dto>()
+                .VectorSearch(f => f.WithText(d => d.TextualValue).UsingTask(configuration.Identifier), v => v.ByText("fruit"), minimumSimilarity: 0.5f)
+                .Highlight("TextualValue", 2048, 5, out Highlightings highlightings)
+                .ToList();
+
+            foreach (var result in results)
+                Assert.Empty(highlightings.GetFragments(result.Id));
+        }
+    }
+
+    private static EmbeddingsGenerationConfiguration CreateMultiFieldChunkingConfiguration(bool storeChunkText)
+    {
+        var chunking = new ChunkingOptions { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 8 };
+        var configuration = new EmbeddingsGenerationConfiguration
+        {
+            Name = DefaultEmbeddingGenerationTaskName,
+            ConnectionStringName = DefaultConnectionStringName,
+            Collection = "Dtos",
+            EmbeddingsPathConfigurations =
+            [
+                new EmbeddingPathConfiguration { Path = "TextualValue", ChunkingOptions = chunking },
+                new EmbeddingPathConfiguration { Path = "SecondaryValue", ChunkingOptions = chunking }
+            ],
+            ChunkingOptionsForQuerying = chunking,
+            Quantization = VectorEmbeddingType.Single,
+            StoreChunkText = storeChunkText
+        };
+
+        configuration.Identifier = configuration.GenerateIdentifier();
+        return configuration;
+    }
+
+    private static EmbeddingsGenerationConfiguration CreateChunkingConfiguration(bool storeChunkText, VectorEmbeddingType quantization = VectorEmbeddingType.Single)
+    {
+        var configuration = new EmbeddingsGenerationConfiguration
+        {
+            Name = DefaultEmbeddingGenerationTaskName,
+            ConnectionStringName = DefaultConnectionStringName,
+            Collection = "Dtos",
+            EmbeddingsPathConfigurations =
+            [
+                new EmbeddingPathConfiguration
+                {
+                    Path = "TextualValue",
+                    ChunkingOptions = new ChunkingOptions { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 8 }
+                }
+            ],
+            ChunkingOptionsForQuerying = new ChunkingOptions { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 8 },
+            Quantization = quantization,
+            StoreChunkText = storeChunkText
+        };
+
+        configuration.Identifier = configuration.GenerateIdentifier();
+        return configuration;
+    }
+
+    private sealed class VectorViaLoadVectorIndex : AbstractIndexCreationTask<Dto>
+    {
+        public VectorViaLoadVectorIndex()
+        {
+            Map = dtos => from dto in dtos
+                          select new { TextualValueVector = LoadVector("TextualValue", "localaitask") };
+        }
+    }
+
+    private sealed class Dto
+    {
+        public string Id { get; set; }
+        public string TextualValue { get; set; }
+        public string SecondaryValue { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27117

### Additional description

A chunked vector search can now surface the source text of the chunk that actually matched, exposed through the existing include highlight(...) surface so callers reuse the same Highlightings API and wire format.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
