### PR TITLE
RavenDB-27034 CDC Sink: Fix tooltips & add link to docs

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/EditCdcSinkTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/partials/EditCdcSinkTaskInfoHub.tsx
@@ -6,12 +6,16 @@ import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabi
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "hooks/useRavenLink";
 
 export default function EditCdcSinkTaskInfoHub() {
     const { appUrl } = useAppUrls();
     const activeDatabaseName = useAppSelector(databaseSelectors.activeDatabaseName);
 
     const hasCdcSink = useAppSelector(licenseSelectors.statusValue("HasCdcSink"));
+
+    const cdcSinkOverviewDocsLink = useRavenLink({ hash: "36RFXH" });
 
     const featureAvailability = useLimitedFeatureAvailability({
         defaultFeatureAvailability,
@@ -132,6 +136,11 @@ export default function EditCdcSinkTaskInfoHub() {
                     Once the task is active, every committed change in the source tables is captured and applied to
                     RavenDB. Progress is tracked using the last processed checkpoint.
                 </p>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href={cdcSinkOverviewDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - CDC Sink Overview
+                </a>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper isUnlimited={hasCdcSink} data={featureAvailability} />
         </AboutViewFloating>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskEmbeddedTableEditor.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskEmbeddedTableEditor.tsx
@@ -142,7 +142,18 @@ export default function EditCdcSinkTaskEmbeddedTableEditor({ path }: { path: Emb
             <EditCdcSinkTaskAdvancedSettings hasAdvancedValues={hasAdvancedValues}>
                 <FormGroup>
                     <FormSwitch control={control} name={`${path}.caseSensitiveKeys`}>
-                        Case sensitive keys
+                        Case-sensitive keys
+                        <PopoverWithHoverWrapper
+                            message={
+                                <>
+                                    When enabled, string values in primary key columns are compared case-sensitively
+                                    when matching embedded items. Applies only to <strong>Array</strong> and{" "}
+                                    <strong>Map</strong> embedded tables.
+                                </>
+                            }
+                        >
+                            <Icon icon="info-new" margin="ms-1" />
+                        </PopoverWithHoverWrapper>
                     </FormSwitch>
                 </FormGroup>
                 <EditCdcSinkTaskPatchAdvancedField path={path} />

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskOnDeleteFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskOnDeleteFields.tsx
@@ -35,8 +35,8 @@ export default function EditCdcSinkTaskOnDeleteFields({ path }: { path: RootTabl
                                     embedded item, or <code>Value</code>-type property is kept.
                                 </p>
                                 <p>
-                                    If a delete patch is configured, it still runs BEFORE the delete decision, even when{" "}
-                                    <em>Skip deletion</em> is on.
+                                    If a delete patch is configured, it still runs even when <em>Skip deletion</em> is
+                                    on.
                                     <br />
                                     You can use it to mark the document as archived,
                                     <br />
@@ -56,13 +56,28 @@ export default function EditCdcSinkTaskOnDeleteFields({ path }: { path: RootTabl
                         message={
                             <>
                                 <p>
-                                    A delete patch is a JavaScript snippet that runs on <strong>DELETE</strong> events
-                                    from the source, BEFORE the delete is applied or ignored.
+                                    A delete patch is a JavaScript snippet that runs when RavenDB processes a{" "}
+                                    <strong>DELETE</strong> event from the source.
+                                </p>
+                                <ul>
+                                    <li>
+                                        <strong>Root tables:</strong> <code>this</code> is the existing document.
+                                        <br />
+                                        When deletion is not skipped, RavenDB deletes the document after the patch runs.
+                                    </li>
+                                    <li>
+                                        <strong>Embedded tables:</strong> <code>this</code> is the parent document. When
+                                        deletion is not skipped, the embedded item is removed before the patch runs; use{" "}
+                                        <code>$old</code> to access the removed item.
+                                    </li>
+                                </ul>
+                                <p>
+                                    When <em>Skip deletion</em> is enabled, the automatic deletion or removal is not
+                                    applied, but the patch still runs.
                                 </p>
                                 <p>
-                                    Use it when a delete should trigger additional changes, such as marking documents as
-                                    archived (combined with <em>Skip deletion</em>), writing an audit record with{" "}
-                                    <code>put()</code>, or reversing parent-level aggregates when an embedded item is
+                                    Use it to mark retained documents as archived, write audit records with{" "}
+                                    <code>put()</code>, or update parent-level aggregates after an embedded item is
                                     removed.
                                 </p>
                             </>
@@ -184,6 +199,6 @@ const deletePatchSyntaxHelp = (
     </div>
 );
 
-const deletePatchPlaceholder = `// Optional. Runs on DELETE events from the source BEFORE the delete is applied or ignored.
+const deletePatchPlaceholder = `// Optional. Runs when a DELETE event is processed, even when "Skip deletion" is enabled.
 // e.g.  this.Archived = true;   // combine with "Skip deletion" for soft-delete
 // Click the (?) icon below for syntax and more examples.`;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-27034/CDC-Sink-Fix-tooltips-add-link-to-docs

### Additional description
- Add a link to the CDC Sink documentation in "About this view"
- Add a tooltip to the "Case sensitive keys" toggle
- Fix text in tooltip for "Delete patch"

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
