### PR TITLE
RavenDB-27131 “About this view” popover doesn’t scroll vertically

### DIFF
--- a/src/Raven.Studio/typescript/components/common/AboutView.scss
+++ b/src/Raven.Studio/typescript/components/common/AboutView.scss
@@ -60,9 +60,43 @@
         color: bs5variables.$text-color-var;
         border-radius: bs5variables.$border-radius-lg;
     }
-    .popover-inner {
-        max-height: calc(100vh - 240px);
-        overflow: auto;
+    .popover-body {
+        max-height: calc(100vh - 120px);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+
+        > div {
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
+        }
+    }
+
+    .about-view-accordion {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+
+        .accordion-item {
+            display: flex;
+            flex-direction: column;
+            flex-shrink: 0;
+
+            &:has(.accordion-collapse.show) {
+                flex-shrink: 1;
+                min-height: 0;
+            }
+        }
+
+        .accordion-header {
+            flex-shrink: 0;
+        }
+
+        .accordion-collapse.show {
+            min-height: 0;
+            overflow-y: auto;
+        }
     }
     .popover-arrow {
         &:before {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27131

### Additional description

<img width="2540" height="1254" alt="image" src="https://github.com/user-attachments/assets/91124072-142b-483a-93c9-eab3e6f6f2df" />

<img width="2545" height="1252" alt="image" src="https://github.com/user-attachments/assets/e1e1712c-fde5-4e3d-a9d9-16f045a42078" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
