### PR TITLE
RavenDB-27038 test cdc dry run

### DIFF
--- a/src/Raven.Client/Documents/Operations/CdcSink/Test/CdcTestRequest.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/Test/CdcTestRequest.cs
@@ -1,0 +1,17 @@
+using Raven.Client.Documents.Operations.ETL.SQL;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Documents.Operations.CdcSink.Test;
+
+internal class CdcTestRequest : IDynamicJson
+{
+    public CdcSinkConfiguration Configuration { get; set; }
+
+    public SqlConnectionString Connection { get; set; }
+
+    public DynamicJsonValue ToJson() => new()
+    {
+        [nameof(Configuration)] = Configuration?.ToJson(),
+        [nameof(Connection)] = Connection?.ToJson(),
+    };
+}

--- a/src/Raven.Client/Documents/Operations/CdcSink/Test/CdcTestResult.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/Test/CdcTestResult.cs
@@ -6,15 +6,15 @@ namespace Raven.Client.Documents.Operations.CdcSink.Test;
 internal class CdcTestResult : IDynamicJson
 {
     public bool Success { get; set; }
-   
     public string Error { get; set; }
-
-    public Dictionary<string, string> Sampled { get; set; } = new();
+    public List<string> CompletedTables { get; set; } = new();
+    public List<string> Warnings { get; set; } = new();
 
     public DynamicJsonValue ToJson() => new()
     {
         [nameof(Success)] = Success,
         [nameof(Error)] = Error,
-        [nameof(Sampled)] = DynamicJsonValue.Convert(Sampled)
+        [nameof(CompletedTables)] = CompletedTables,
+        [nameof(Warnings)] = new DynamicJsonArray(Warnings)
     };
 }

--- a/src/Raven.Client/Documents/Operations/CdcSink/Test/CdcTestResult.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/Test/CdcTestResult.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Documents.Operations.CdcSink.Test;
+
+internal class CdcTestResult : IDynamicJson
+{
+    public bool Success { get; set; }
+   
+    public string Error { get; set; }
+
+    public Dictionary<string, string> Sampled { get; set; } = new();
+
+    public DynamicJsonValue ToJson() => new()
+    {
+        [nameof(Success)] = Success,
+        [nameof(Error)] = Error,
+        [nameof(Sampled)] = DynamicJsonValue.Convert(Sampled)
+    };
+}

--- a/src/Raven.Client/Documents/Operations/CdcSink/Test/VerifyCdcSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/Test/VerifyCdcSinkOperation.cs
@@ -9,10 +9,10 @@ using Sparrow.Json;
 namespace Raven.Client.Documents.Operations.CdcSink.Test;
 
 /// <summary>
-/// Runs the real CDC pull flow once against the configured source and samples one row per table to verify
-/// CDC is set up correctly — without persisting anything (no task, documents, checkpoint or state) and
-/// undoing any CDC setup it provisions on the source. Calls <c>POST /admin/cdc-sink/cdc-test</c>.
-/// Requires <c>DatabaseAdmin</c>.
+/// Runs the real CDC pull flow once against the configured source to verify CDC is set up correctly —
+/// reading one row from each configured table and reporting which tables were reached, without persisting
+/// anything (no task, documents, checkpoint or state) and undoing any CDC setup it provisions on the source.
+/// Calls <c>POST /admin/cdc-sink/dry-run</c>. Requires <c>DatabaseAdmin</c>.
 /// </summary>
 internal class VerifyCdcSinkOperation : IMaintenanceOperation<CdcTestResult>
 {
@@ -45,7 +45,7 @@ internal class VerifyCdcSinkOperation : IMaintenanceOperation<CdcTestResult>
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            url = $"{node.Url}/databases/{node.Database}/admin/cdc-sink/cdc-test";
+            url = $"{node.Url}/databases/{node.Database}/admin/cdc-sink/dry-run";
 
             return new HttpRequestMessage
             {

--- a/src/Raven.Client/Documents/Operations/CdcSink/Test/VerifyCdcSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/Test/VerifyCdcSinkOperation.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.CdcSink.Test;
+
+/// <summary>
+/// Runs the real CDC pull flow once against the configured source and samples one row per table to verify
+/// CDC is set up correctly — without persisting anything (no task, documents, checkpoint or state) and
+/// undoing any CDC setup it provisions on the source. Calls <c>POST /admin/cdc-sink/cdc-test</c>.
+/// Requires <c>DatabaseAdmin</c>.
+/// </summary>
+internal class VerifyCdcSinkOperation : IMaintenanceOperation<CdcTestResult>
+{
+    private readonly CdcTestRequest _request;
+
+    public VerifyCdcSinkOperation(CdcTestRequest request)
+    {
+        _request = request ?? throw new ArgumentNullException(nameof(request));
+    }
+
+    public RavenCommand<CdcTestResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
+    {
+        return new VerifyCdcSinkCommand(conventions, _request);
+    }
+
+    private sealed class VerifyCdcSinkCommand : RavenCommand<CdcTestResult>
+    {
+        private readonly CdcTestRequest _request;
+        private readonly DocumentConventions _conventions;
+
+        public VerifyCdcSinkCommand(DocumentConventions conventions, CdcTestRequest request)
+        {
+            _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
+            _request = request ?? throw new ArgumentNullException(nameof(request));
+        }
+
+        // The run provisions (and undoes) CDC on the source, so it is not a pure read - don't allow
+        // FastestNode failover.
+        public override bool IsReadRequest => false;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/admin/cdc-sink/cdc-test";
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new BlittableJsonContent(
+                    async stream => await ctx.WriteAsync(stream, ctx.ReadObject(_request.ToJson(), "CdcTestRequest")).ConfigureAwait(false),
+                    _conventions),
+            };
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = JsonDeserializationClient.CdcTestResult(response);
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -263,6 +263,10 @@ namespace Raven.Client.Json.Serialization
 
         internal static readonly Func<BlittableJsonReaderObject, TestCdcSinkMappingRequest> TestCdcSinkMappingRequest = GenerateJsonDeserializationRoutine<TestCdcSinkMappingRequest>();
 
+        internal static readonly Func<BlittableJsonReaderObject, CdcTestRequest> CdcTestRequest = GenerateJsonDeserializationRoutine<CdcTestRequest>();
+
+        internal static readonly Func<BlittableJsonReaderObject, CdcTestResult> CdcTestResult = GenerateJsonDeserializationRoutine<CdcTestResult>();
+
         internal static readonly Func<BlittableJsonReaderObject, CdcSinkSourceSchema> CdcSinkSourceSchema = GenerateJsonDeserializationRoutine<CdcSinkSourceSchema>();
 
         internal static readonly Func<BlittableJsonReaderObject, CdcSinkSchemaRequest> CdcSinkSchemaRequest = GenerateJsonDeserializationRoutine<CdcSinkSchemaRequest>();

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -68,6 +68,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler, IAsyncDis
         Name = Configuration.Name;
         Statistics = new CdcSinkProcessStatistics(Name, database.Configuration.CdcSink);
         DocumentProcessor = new CdcSinkDocumentProcessor(configuration, defaultSchema) { Logger = Logger };
+        ExceptionAggregator = new ExceptionAggregator(Logger, $"Could not dispose {GetType().Name}: '{Name}'");
     }
 
     protected CancellationToken CancellationToken => _cts.Token;
@@ -1256,24 +1257,26 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler, IAsyncDis
         return JsonDeserializationServer.CdcSinkTaskState(doc.Data);
     }
 
-    public virtual void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+    protected readonly ExceptionAggregator ExceptionAggregator;
 
-    public virtual ValueTask DisposeAsync()
+    private void DisposeCore()
     {
         // Mark disposed up front so a concurrent GetConnectionStatus() bails out before touching _cts,
         // even on the never-started path where Stop() returns early but _cts is still disposed below.
         _disposed.Raise();
 
-        var exceptionAggregator = new ExceptionAggregator(Logger, $"Could not dispose {GetType().Name}: '{Name}'");
+        ExceptionAggregator.Execute(() => Stop("Dispose"));
+        ExceptionAggregator.Execute(() => _cts.Dispose());
+        ExceptionAggregator.Execute(() => CommandBuilder.Dispose());
 
-        exceptionAggregator.Execute(() => Stop("Dispose"));
+        ExceptionAggregator.ThrowIfNeeded();
+    }
 
-        exceptionAggregator.Execute(() => _cts.Dispose());
+    public virtual void Dispose() => DisposeCore();
 
-        exceptionAggregator.Execute(() => CommandBuilder.Dispose());
-
-        exceptionAggregator.ThrowIfNeeded();
-
+    public virtual ValueTask DisposeAsync()
+    {
+        DisposeCore();
         return ValueTask.CompletedTask;
     }
 

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -34,7 +34,7 @@ using Raven.Server.Documents.TasksErrors;
 
 namespace Raven.Server.Documents.CdcSink;
 
-public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
+public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler, IAsyncDisposable
 {
     internal const string Tag = "CDC Sink";
 
@@ -433,7 +433,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         }
     }
 
-    protected async Task<(string Checkpoint, int Rows)> SubmitBatch(List<CdcSinkDocumentOp> ops, string checkpoint = null,
+    protected virtual async Task<(string Checkpoint, int Rows)> SubmitBatch(List<CdcSinkDocumentOp> ops, string checkpoint = null,
         Dictionary<string, CdcSinkTableLoadState> tableLoadUpdates = null,
         Commands.CdcSinkBatchCommand.DocumentGrouper grouper = null)
     {
@@ -599,7 +599,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     /// while we're waiting for the next event, we immediately flush any accumulated ops
     /// without waiting for another event to arrive.
     /// </summary>
-    protected async Task ProcessCdcStream(CancellationToken ct)
+    protected virtual async Task ProcessCdcStream(CancellationToken ct)
     {
         var batch = new List<CdcSinkDocumentOp>();
         var pending = new List<CdcSinkDocumentOp>();
@@ -928,7 +928,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     /// keys, and the context whose memory the ops' blittables reference (the caller disposes it once
     /// the batch has been written).
     /// </summary>
-    private readonly record struct InitialLoadBatch(List<CdcSinkDocumentOp> Ops, string[] LastKeys, IDisposable Context);
+    protected readonly record struct InitialLoadBatch(List<CdcSinkDocumentOp> Ops, string[] LastKeys, IDisposable Context);
 
     /// <summary>
     /// Returns a completed batch's values to their per-table pools and clears the reference, so a
@@ -943,7 +943,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         ops = null;
     }
 
-    private async Task<InitialLoadBatch> ReadOneBatch(
+    protected virtual async Task<InitialLoadBatch> ReadOneBatch(
         DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
         string[] lastKeys, int maxBatchSize, CancellationToken ct)
     {
@@ -1245,7 +1245,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     }
 
 
-    protected CdcSinkTaskState LoadState(DocumentsOperationContext context)
+    protected virtual CdcSinkTaskState LoadState(DocumentsOperationContext context)
     {
         var stateDocId = CdcSinkTaskState.GetDocumentId(Configuration.Name);
         var doc = Database.DocumentsStorage.Get(context, stateDocId);
@@ -1256,7 +1256,9 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         return JsonDeserializationServer.CdcSinkTaskState(doc.Data);
     }
 
-    public virtual void Dispose()
+    public virtual void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+    public virtual ValueTask DisposeAsync()
     {
         // Mark disposed up front so a concurrent GetConnectionStatus() bails out before touching _cts,
         // even on the never-started path where Stop() returns early but _cts is still disposed below.
@@ -1271,6 +1273,8 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         exceptionAggregator.Execute(() => CommandBuilder.Dispose());
 
         exceptionAggregator.ThrowIfNeeded();
+
+        return ValueTask.CompletedTask;
     }
 
     public void LowMemory(LowMemorySeverity lowMemorySeverity)

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
@@ -28,6 +28,8 @@ public class CdcSinkTableProcessor
 
     /// <summary>Source table name.</summary>
     public string Table { get; init; }
+    
+    public string FullName => $"{Schema}.{Table}";
 
     /// <summary>Pre-computed Key + "__on_delete" for the OnDelete dispatch path.</summary>
     public string KeyOnDelete { get; init; }

--- a/src/Raven.Server/Documents/CdcSink/Handlers/CdcSinkHandler.cs
+++ b/src/Raven.Server/Documents/CdcSink/Handlers/CdcSinkHandler.cs
@@ -27,8 +27,8 @@ public class CdcSinkHandler : DatabaseRequestHandler
             await processor.ExecuteAsync();
     }
 
-    [RavenAction("/databases/*/admin/cdc-sink/cdc-test", "POST", AuthorizationStatus.DatabaseAdmin)]
-    public async Task CdcTest()
+    [RavenAction("/databases/*/admin/cdc-sink/dry-run", "POST", AuthorizationStatus.DatabaseAdmin)]
+    public async Task DryRun()
     {
         using (var processor = new CdcSinkHandlerProcessorForCdcTest(this))
             await processor.ExecuteAsync();

--- a/src/Raven.Server/Documents/CdcSink/Handlers/CdcSinkHandler.cs
+++ b/src/Raven.Server/Documents/CdcSink/Handlers/CdcSinkHandler.cs
@@ -27,6 +27,13 @@ public class CdcSinkHandler : DatabaseRequestHandler
             await processor.ExecuteAsync();
     }
 
+    [RavenAction("/databases/*/admin/cdc-sink/cdc-test", "POST", AuthorizationStatus.DatabaseAdmin)]
+    public async Task CdcTest()
+    {
+        using (var processor = new CdcSinkHandlerProcessorForCdcTest(this))
+            await processor.ExecuteAsync();
+    }
+
     [RavenAction("/databases/*/cdc-sink/errors", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
     public async Task GetErrors()
     {

--- a/src/Raven.Server/Documents/CdcSink/Handlers/Processors/CdcSinkHandlerProcessorForCdcTest.cs
+++ b/src/Raven.Server/Documents/CdcSink/Handlers/Processors/CdcSinkHandlerProcessorForCdcTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.CdcSink.Test;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.CdcSink.Test;
 using Raven.Server.ServerWide.Context;
@@ -22,9 +23,16 @@ internal sealed class CdcSinkHandlerProcessorForCdcTest : AbstractCdcSinkHandler
             var bodyJson = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "CdcTestRequest");
             var request = JsonDeserializationClient.CdcTestRequest(bodyJson);
 
-            request.Configuration.Initialize(request.Connection);
-
-            var result = await CdcSinkTestProcess.VerifyAsync(RequestHandler.Database, request.Configuration, cts.Token);
+            CdcTestResult result;
+            if (request.Configuration == null)
+            {
+                result = new CdcTestResult { Success = false, Error = $"'{nameof(CdcTestRequest.Configuration)}' is required." };
+            }
+            else
+            {
+                request.Configuration.Initialize(request.Connection);
+                result = await CdcSinkTestProcess.VerifyAsync(RequestHandler.Database, request.Configuration, cts);
+            }
 
             await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
             {

--- a/src/Raven.Server/Documents/CdcSink/Handlers/Processors/CdcSinkHandlerProcessorForCdcTest.cs
+++ b/src/Raven.Server/Documents/CdcSink/Handlers/Processors/CdcSinkHandlerProcessorForCdcTest.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Json.Serialization;
+using Raven.Server.Documents.CdcSink.Test;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.CdcSink.Handlers.Processors;
+
+internal sealed class CdcSinkHandlerProcessorForCdcTest : AbstractCdcSinkHandlerProcessorForTest<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    public CdcSinkHandlerProcessorForCdcTest([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        using (var cts = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationToken(TimeSpan.FromMinutes(2)))
+        using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        {
+            var bodyJson = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "CdcTestRequest");
+            var request = JsonDeserializationClient.CdcTestRequest(bodyJson);
+
+            request.Configuration.Initialize(request.Connection);
+
+            var result = await CdcSinkTestProcess.VerifyAsync(RequestHandler.Database, request.Configuration, cts.Token);
+
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                context.Write(writer, result.ToJson());
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -54,9 +54,12 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
     private readonly string _connectionString;
     private readonly string _replicationConnectionString;
     private readonly TimeSpan _replicationTimeout;
-    private readonly NpgsqlDataSource _dataSource;
-    private string _publicationName;
-    private string _slotName;
+    protected readonly NpgsqlDataSource _dataSource;
+    protected string _publicationName;
+    protected string _slotName;
+
+    protected bool _createdPublication;
+    protected bool _createdSlot;
 
     private uint _vectorOid = uint.MaxValue; // pgvector extension OID, resolved at setup time. MaxValue = not installed.
 
@@ -96,25 +99,26 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
         _dataSource = dataSourceBuilder.Build();
     }
 
-    public override void Dispose()
+    public override async ValueTask DisposeAsync()
     {
-        base.Dispose();
+        await base.DisposeAsync();
 
-        // Ensure the replication connection is closed even if the async iterator
-        // didn't dispose cleanly (e.g., due to sync-over-async in Stop()).
-        // Without this, the WAL sender may keep the slot active, preventing
-        // database drops in test scenarios.
         try
         {
-            _replicationConn?.DisposeAsync().AsTask().Wait(TimeSpan.FromSeconds(5));
+            if (_replicationConn != null)
+            {
+                // _replicationConn has token attached which should unblock the connection
+                await _replicationConn.DisposeAsync();
+            }
         }
         catch
         {
             // best effort — the connection may already be disposed by the iterator
         }
 
-        _dataSource.Dispose();
+        await _dataSource.DisposeAsync();
     }
+
 
     protected override async Task RunInternalAsync(CancellationToken ct)
     {
@@ -173,6 +177,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                 await using var createCmd = new NpgsqlCommand(
                     $"CREATE PUBLICATION {quotedPubName} FOR TABLE {quotedTableList}", conn);
                 await createCmd.ExecuteNonQueryAsync(ct);
+                _createdPublication = true;
             }
             catch (PostgresException ex) when (ex.SqlState == InsufficientPrivilegeSqlState)
             {
@@ -218,6 +223,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                         $"SELECT pg_create_logical_replication_slot(@slotName, 'pgoutput')", conn);
                     createCmd.Parameters.AddWithValue("slotName", _slotName);
                     await createCmd.ExecuteNonQueryAsync(ct);
+                    _createdSlot = true;
                 }
                 catch (PostgresException ex) when (ex.SqlState == "42710")
                 {

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Runtime.CompilerServices;
-using System.Data.Common;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
@@ -12,11 +12,11 @@ using Npgsql.Replication.PgOutput;
 using Npgsql.Replication.PgOutput.Messages;
 using Raven.Client.Documents.Operations.CdcSink;
 using Raven.Server.Documents.CdcSink.Schema;
+using Raven.Server.Documents.TasksErrors;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.SqlMigration.NpgSQL;
 using Sparrow.Json;
-using Raven.Server.Documents.TasksErrors;
 
 namespace Raven.Server.Documents.CdcSink;
 
@@ -99,26 +99,30 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
         _dataSource = dataSourceBuilder.Build();
     }
 
-    public override async ValueTask DisposeAsync()
+    private async ValueTask DisposeCoreAsync()
     {
-        await base.DisposeAsync();
-
         try
         {
-            if (_replicationConn != null)
-            {
-                // _replicationConn has token attached which should unblock the connection
-                await _replicationConn.DisposeAsync();
-            }
+            await base.DisposeAsync();
         }
         catch
         {
-            // best effort — the connection may already be disposed by the iterator
+            // don't throw yet
         }
 
-        await _dataSource.DisposeAsync();
+        if (_replicationConn != null)
+        {
+            await ExceptionAggregator.ExecuteAsync(_replicationConn.DisposeAsync());
+        }
+
+        await ExceptionAggregator.ExecuteAsync(_dataSource.DisposeAsync());
+
+        ExceptionAggregator.ThrowIfNeeded();
     }
 
+    public override ValueTask DisposeAsync() => DisposeCoreAsync();
+
+    public override void Dispose() => DisposeCoreAsync().AsTask().Wait(TimeSpan.FromSeconds(5));
 
     protected override async Task RunInternalAsync(CancellationToken ct)
     {
@@ -356,7 +360,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
     ///   JoinColumns = ["order_id"]  — order_id IS in the PK
     ///   → Default REPLICA IDENTITY is sufficient, no action needed
     /// </summary>
-    private async Task EnsureReplicaIdentityForEmbeddedTables(CancellationToken ct)
+    protected virtual async Task EnsureReplicaIdentityForEmbeddedTables(CancellationToken ct)
     {
         var embeddedTables = CollectEmbeddedTablesNeedingReplicaIdentity(Configuration.Tables);
 
@@ -381,6 +385,10 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
 
             // Replica identity is insufficient — set to FULL so DELETE events include join columns
             var quotedTable = $"{CommandBuilder.QuoteIdentifier(schema)}.{CommandBuilder.QuoteIdentifier(table)}";
+
+            if (Configuration.TestMode)
+                throw new InvalidOperationException(CreateReplicaIdentityFullRequiredMessage(schema, table, embedded, quotedTable));
+
             try
             {
                 await using var alterCmd = new NpgsqlCommand(
@@ -394,20 +402,23 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
             catch (PostgresException ex) when (ex.SqlState == InsufficientPrivilegeSqlState)
             {
                 throw new InvalidOperationException(
-                    $"""
-                    Insufficient permissions to set REPLICA IDENTITY FULL on '{schema}.{table}'. 
-                    The embedded table's join column(s) ({string.Join(", ", embedded.JoinColumns)}) are not part of the primary key.
-                    DELETE events need REPLICA IDENTITY FULL to include the join columns for routing to the parent document. 
-                    An administrator can run:
-
-                      ALTER TABLE {quotedTable} REPLICA IDENTITY FULL;
-
-                    Alternatively, set OnDelete.IgnoreDeletes = true on this embedded table to skip delete processing.
-
-                    PostgreSQL error: {ex.MessageText}
-                    """, ex);
+                    CreateReplicaIdentityFullRequiredMessage(schema, table, embedded, quotedTable), ex);
             }
         }
+    }
+
+    private static string CreateReplicaIdentityFullRequiredMessage(string schema, string table, CdcSinkEmbeddedTableConfig embedded, string quotedTable)
+    {
+        return $"""
+                Insufficient permissions to set REPLICA IDENTITY FULL on '{schema}.{table}'. 
+                The embedded table's join column(s) ({string.Join(", ", embedded.JoinColumns)}) are not part of the primary key.
+                DELETE events need REPLICA IDENTITY FULL to include the join columns for routing to the parent document. 
+                An administrator can run:
+
+                  ALTER TABLE {quotedTable} REPLICA IDENTITY FULL;
+
+                Alternatively, set OnDelete.IgnoreDeletes = true on this embedded table to skip delete processing.
+                """;
     }
 
     private static List<CdcSinkEmbeddedTableConfig> CollectEmbeddedTablesNeedingReplicaIdentity(

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -51,6 +51,9 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
     // every reconnect; reset when the Agent becomes visible so a later regression re-reports.
     private bool _agentAdvisoryRecorded;
 
+    protected bool _enabledDatabaseCdc;
+    protected readonly List<CdcSinkConfiguration.TableInfo> _enabledCaptureTables = new();
+
     public SqlServerCdcSinkProcess(CdcSinkConfiguration configuration, DocumentDatabase database)
         : base(configuration, database, "dbo")
     {
@@ -113,6 +116,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 await using var cmd = conn.CreateCommand();
                 cmd.CommandText = "EXEC sys.sp_cdc_enable_db";
                 await cmd.ExecuteNonQueryAsync(ct);
+                _enabledDatabaseCdc = true;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -165,6 +169,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 AddParameter(cmd, "@schema", tableInfo.Schema);
                 AddParameter(cmd, "@table", tableInfo.TableName);
                 await cmd.ExecuteNonQueryAsync(ct);
+                _enabledCaptureTables.Add(tableInfo);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -741,7 +746,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
         return ConvertSqlServerValue(reader.GetValue(ordinal));
     }
 
-    private async Task<DbConnection> OpenConnectionAsync(CancellationToken ct)
+    protected async Task<DbConnection> OpenConnectionAsync(CancellationToken ct)
     {
         var factory = DbProviderFactories.GetFactory(_factoryName);
         var conn = factory.CreateConnection();

--- a/src/Raven.Server/Documents/CdcSink/Test/CdcSinkTestProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/Test/CdcSinkTestProcess.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
 using Raven.Client.Documents.Operations.CdcSink;
 using Raven.Client.Documents.Operations.CdcSink.Test;
 using Raven.Server.Documents.CdcSink.Commands;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands.CdcSink;
 using Raven.Server.ServerWide.Context;
 
@@ -14,7 +16,7 @@ namespace Raven.Server.Documents.CdcSink.Test;
 
 internal static class CdcSinkTestProcess
 {
-    public static async Task<CdcTestResult> VerifyAsync(DocumentDatabase database, CdcSinkConfiguration configuration, CancellationToken ct)
+    public static async Task<CdcTestResult> VerifyAsync(DocumentDatabase database, CdcSinkConfiguration configuration, OperationCancelToken token)
     {
         configuration.SkipInitialLoad = false;
         configuration.TestMode = true;
@@ -32,21 +34,28 @@ internal static class CdcSinkTestProcess
             return capture.Result;
         }
 
-        await using (var process = Create(database, configuration, capture))
+        try
         {
-            await process.RunCdcTestAsync(ct);
+            await using (var process = Create(database, configuration, capture, token))
+            {
+                await process.RunCdcTestAsync();
+            }
+        }
+        catch (Exception e)
+        {
+            capture.SetError(e);
         }
 
         return capture.Result;
     }
 
-    private static ICdcSinkTestProcess Create(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture)
+    private static ICdcSinkTestProcess Create(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture, OperationCancelToken token)
     {
         return configuration.Connection?.FactoryName switch
         {
-            "Npgsql" => new TestPostgresCdcSinkProcess(database, configuration, capture),
-            "Microsoft.Data.SqlClient" => new TestSqlServerCdcSinkProcess(database, configuration, capture),
-            "MySql.Data.MySqlClient" or "MySqlConnector.MySqlConnectorFactory" => new TestMySqlCdcSinkProcess(database, configuration, capture),
+            "Npgsql" => new TestPostgresCdcSinkProcess(database, configuration, capture, token),
+            "Microsoft.Data.SqlClient" => new TestSqlServerCdcSinkProcess(database, configuration, capture, token),
+            "MySql.Data.MySqlClient" or "MySqlConnector.MySqlConnectorFactory" => new TestMySqlCdcSinkProcess(database, configuration, capture, token),
             _ => throw new NotSupportedException($"CDC is not supported for provider '{configuration.Connection?.FactoryName}'")
         };
     }
@@ -54,15 +63,23 @@ internal static class CdcSinkTestProcess
     private sealed class TestSqlServerCdcSinkProcess : SqlServerCdcSinkProcess, ICdcSinkTestProcess
     {
         private readonly CdcSinkTestCapture _capture;
+        private readonly OperationCancelToken _token;
 
-        public TestSqlServerCdcSinkProcess(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture)
-            : base(configuration, database) => _capture = capture;
+        public TestSqlServerCdcSinkProcess(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture, OperationCancelToken token)
+            : base(configuration, database)
+        {
+            _capture = capture;
+            _token = token;
+        }
 
         protected override Task<(string Checkpoint, int Rows)> SubmitBatch(
             List<CdcSinkDocumentOp> ops, string checkpoint,
             Dictionary<string, CdcSinkTableLoadState> tableLoadUpdates,
             CdcSinkBatchCommand.DocumentGrouper grouper)
-            => _capture.Handle(ops, checkpoint);
+        {
+            _capture.Handle(tableLoadUpdates, checkpoint);
+            return Task.FromResult((checkpoint, ops.Count));
+        }
 
         protected override CdcSinkTaskState LoadState(DocumentsOperationContext context)
             => new() { ConfigurationName = Configuration.Name };
@@ -73,6 +90,8 @@ internal static class CdcSinkTestProcess
             DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
             string[] lastKeys, int maxBatchSize, CancellationToken ct)
         {
+            _token.Delay();
+
             if (_capture.TrySample(tableInfo.FullName) == false)
             {
                 return new InitialLoadBatch(new List<CdcSinkDocumentOp>(), lastKeys, null);
@@ -81,12 +100,20 @@ internal static class CdcSinkTestProcess
             return await base.ReadOneBatch(conn, tableInfo, keyColumns, lastKeys, 1, ct);
         }
 
-        public Task RunCdcTestAsync(CancellationToken ct) => _capture.RunCdcAsync(RunInternalAsync, ct);
+        public Task RunCdcTestAsync() => _capture.RunCdcAsync(RunInternalAsync, _token.Token);
 
         public override async ValueTask DisposeAsync()
         {
-            try { await UndoSourceSetupAsync(CancellationToken.None); }
-            catch { /* best effort */ }
+            using (var undoCts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+            {
+                try { await UndoSourceSetupAsync(undoCts.Token); }
+                catch (Exception e)
+                {
+                    _capture.AddWarning($"source cleanup failed: {e.Message}");
+                    if (Logger.IsWarnEnabled)
+                        Logger.Warn($"[{Name}] CDC dry-run source cleanup failed", e);
+                }
+            }
             await base.DisposeAsync();
         }
 
@@ -122,15 +149,34 @@ internal static class CdcSinkTestProcess
     private sealed class TestPostgresCdcSinkProcess : PostgresCdcSinkProcess, ICdcSinkTestProcess
     {
         private readonly CdcSinkTestCapture _capture;
+        private readonly OperationCancelToken _token;
+        public TestPostgresCdcSinkProcess(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture, OperationCancelToken token)
+            : base(configuration, database)
+        {
+            _capture = capture;
+            _token = token;
+        }
 
-        public TestPostgresCdcSinkProcess(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture)
-            : base(configuration, database) => _capture = capture;
+        protected override async Task EnsureReplicaIdentityForEmbeddedTables(CancellationToken ct)
+        {
+            try
+            {
+                await base.EnsureReplicaIdentityForEmbeddedTables(ct);
+            }
+            catch (Exception e)
+            {
+                _capture.AddWarning(e.Message);
+            }
+        }
 
         protected override Task<(string Checkpoint, int Rows)> SubmitBatch(
             List<CdcSinkDocumentOp> ops, string checkpoint,
             Dictionary<string, CdcSinkTableLoadState> tableLoadUpdates,
             CdcSinkBatchCommand.DocumentGrouper grouper)
-            => _capture.Handle(ops, checkpoint);
+        {
+            _capture.Handle(tableLoadUpdates, checkpoint);
+            return Task.FromResult((checkpoint, ops.Count));
+        }
 
         protected override CdcSinkTaskState LoadState(DocumentsOperationContext context)
             => new() { ConfigurationName = Configuration.Name };
@@ -141,6 +187,8 @@ internal static class CdcSinkTestProcess
             DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
             string[] lastKeys, int maxBatchSize, CancellationToken ct)
         {
+            _token.Delay();
+
             if (_capture.TrySample(tableInfo.FullName) == false)
             {
                 return new InitialLoadBatch(new List<CdcSinkDocumentOp>(), lastKeys, null);
@@ -149,12 +197,20 @@ internal static class CdcSinkTestProcess
             return await base.ReadOneBatch(conn, tableInfo, keyColumns, lastKeys, 1, ct);
         }
 
-        public Task RunCdcTestAsync(CancellationToken ct) => _capture.RunCdcAsync(RunInternalAsync, ct);
+        public Task RunCdcTestAsync() => _capture.RunCdcAsync(RunInternalAsync, _token.Token);
 
         public override async ValueTask DisposeAsync()
         {
-            try { await UndoSourceSetupAsync(CancellationToken.None); }
-            catch { /* best effort */ }
+            using (var undoCts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+            {
+                try { await UndoSourceSetupAsync(undoCts.Token); }
+                catch (Exception e)
+                {
+                    _capture.AddWarning($"source cleanup failed: {e.Message}");
+                    if (Logger.IsWarnEnabled)
+                        Logger.Warn($"[{Name}] CDC dry-run source cleanup failed", e);
+                }
+            }
             await base.DisposeAsync();
         }
 
@@ -193,15 +249,23 @@ internal static class CdcSinkTestProcess
     private sealed class TestMySqlCdcSinkProcess : MySqlCdcSinkProcess, ICdcSinkTestProcess
     {
         private readonly CdcSinkTestCapture _capture;
+        private readonly OperationCancelToken _token;
 
-        public TestMySqlCdcSinkProcess(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture)
-            : base(configuration, database) => _capture = capture;
+        public TestMySqlCdcSinkProcess(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture, OperationCancelToken token)
+            : base(configuration, database)
+        {
+            _capture = capture;
+            _token = token;
+        }
 
         protected override Task<(string Checkpoint, int Rows)> SubmitBatch(
             List<CdcSinkDocumentOp> ops, string checkpoint,
             Dictionary<string, CdcSinkTableLoadState> tableLoadUpdates,
             CdcSinkBatchCommand.DocumentGrouper grouper)
-            => _capture.Handle(ops, checkpoint);
+        {
+            _capture.Handle(tableLoadUpdates, checkpoint);
+            return Task.FromResult((checkpoint, ops.Count));
+        }
 
         protected override CdcSinkTaskState LoadState(DocumentsOperationContext context)
             => new() { ConfigurationName = Configuration.Name };
@@ -212,6 +276,8 @@ internal static class CdcSinkTestProcess
             DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
             string[] lastKeys, int maxBatchSize, CancellationToken ct)
         {
+            _token.Delay();
+
             if (_capture.TrySample(tableInfo.FullName) == false)
             {
                 return new InitialLoadBatch(new List<CdcSinkDocumentOp>(), lastKeys, null);
@@ -220,31 +286,31 @@ internal static class CdcSinkTestProcess
             return await base.ReadOneBatch(conn, tableInfo, keyColumns, lastKeys, 1, ct);
         }
 
-        public Task RunCdcTestAsync(CancellationToken ct) => _capture.RunCdcAsync(RunInternalAsync, ct);
+        public Task RunCdcTestAsync() => _capture.RunCdcAsync(RunInternalAsync, _token.Token);
     }
 }
 
 internal interface ICdcSinkTestProcess : IAsyncDisposable
 {
-    Task RunCdcTestAsync(CancellationToken ct);
+    Task RunCdcTestAsync();
 }
 
 internal sealed class CdcSinkTestCapture
 {
     private Exception _error;
-    private readonly Dictionary<string, string> _sampled = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _sampled = new(StringComparer.Ordinal);
+    private readonly List<string> _warnings = new();
 
-    public bool TrySample(string table) => _sampled.ContainsKey(table) == false;
+    public bool TrySample(string table) => _sampled.Contains(table) == false;
 
-    public Task<(string Checkpoint, int Rows)> Handle(List<CdcSinkDocumentOp> ops, string checkpoint)
+    public void AddWarning(string warning) => _warnings.Add(warning);
+
+    public void Handle(Dictionary<string, CdcSinkTableLoadState> tables, string checkpoint)
     {
-        foreach (var op in ops)
+        foreach (var table in tables ?? [])
         {
-            if (op != null)
-                _sampled.Add(op.Processor.FullName, op.DocumentId);
+            _sampled.Add(table.Key);
         }
-
-        return Task.FromResult((checkpoint, ops.Count));
     }
 
     public async Task RunCdcAsync(Func<CancellationToken, Task> runInternal, CancellationToken ct)
@@ -253,18 +319,23 @@ internal sealed class CdcSinkTestCapture
         {
             await runInternal(ct);
         }
+        catch (OperationCanceledException)
+        {
+            _error = new TimeoutException("CDC verification timed out.");
+        }
         catch (Exception e)
         {
             _error = e;
         }
     }
 
-    public void SetError(Exception e) => _error = e;
+    public void SetError(Exception e) => _error ??= e;
 
     public CdcTestResult Result => new()
     {
-        Success = _sampled.Count > 0 && _error is null,
-        Error = _error?.ToString() ?? (_sampled.Count > 0 ? null : "CDC is configured, but no rows were available to sample."),
-        Sampled = _sampled
+        Success = _error is null,
+        Error = _error?.ToString(),
+        CompletedTables = _sampled.ToList(),
+        Warnings = _warnings
     };
 }

--- a/src/Raven.Server/Documents/CdcSink/Test/CdcSinkTestProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/Test/CdcSinkTestProcess.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using Raven.Client.Documents.Operations.CdcSink;
+using Raven.Client.Documents.Operations.CdcSink.Test;
+using Raven.Server.Documents.CdcSink.Commands;
+using Raven.Server.ServerWide.Commands.CdcSink;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.CdcSink.Test;
+
+internal static class CdcSinkTestProcess
+{
+    public static async Task<CdcTestResult> VerifyAsync(DocumentDatabase database, CdcSinkConfiguration configuration, CancellationToken ct)
+    {
+        configuration.SkipInitialLoad = false;
+        configuration.TestMode = true;
+        
+        if (configuration.Connection?.FactoryName == "Npgsql")
+        {
+            AddCdcSinkCommand.AutoFillPostgresSettings(configuration, Guid.NewGuid().ToString("N"));
+        }
+
+        var capture = new CdcSinkTestCapture();
+
+        if (configuration.Validate(out var errors, validateName: false, validateConnection: false) == false)
+        {
+            capture.SetError(new InvalidOperationException(string.Join(Environment.NewLine, errors)));
+            return capture.Result;
+        }
+
+        await using (var process = Create(database, configuration, capture))
+        {
+            await process.RunCdcTestAsync(ct);
+        }
+
+        return capture.Result;
+    }
+
+    private static ICdcSinkTestProcess Create(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture)
+    {
+        return configuration.Connection?.FactoryName switch
+        {
+            "Npgsql" => new TestPostgresCdcSinkProcess(database, configuration, capture),
+            "Microsoft.Data.SqlClient" => new TestSqlServerCdcSinkProcess(database, configuration, capture),
+            "MySql.Data.MySqlClient" or "MySqlConnector.MySqlConnectorFactory" => new TestMySqlCdcSinkProcess(database, configuration, capture),
+            _ => throw new NotSupportedException($"CDC is not supported for provider '{configuration.Connection?.FactoryName}'")
+        };
+    }
+
+    private sealed class TestSqlServerCdcSinkProcess : SqlServerCdcSinkProcess, ICdcSinkTestProcess
+    {
+        private readonly CdcSinkTestCapture _capture;
+
+        public TestSqlServerCdcSinkProcess(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture)
+            : base(configuration, database) => _capture = capture;
+
+        protected override Task<(string Checkpoint, int Rows)> SubmitBatch(
+            List<CdcSinkDocumentOp> ops, string checkpoint,
+            Dictionary<string, CdcSinkTableLoadState> tableLoadUpdates,
+            CdcSinkBatchCommand.DocumentGrouper grouper)
+            => _capture.Handle(ops, checkpoint);
+
+        protected override CdcSinkTaskState LoadState(DocumentsOperationContext context)
+            => new() { ConfigurationName = Configuration.Name };
+
+        protected override Task ProcessCdcStream(CancellationToken ct) => Task.CompletedTask;
+
+        protected override async Task<InitialLoadBatch> ReadOneBatch(
+            DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
+            string[] lastKeys, int maxBatchSize, CancellationToken ct)
+        {
+            if (_capture.TrySample(tableInfo.FullName) == false)
+            {
+                return new InitialLoadBatch(new List<CdcSinkDocumentOp>(), lastKeys, null);
+            }
+
+            return await base.ReadOneBatch(conn, tableInfo, keyColumns, lastKeys, 1, ct);
+        }
+
+        public Task RunCdcTestAsync(CancellationToken ct) => _capture.RunCdcAsync(RunInternalAsync, ct);
+
+        public override async ValueTask DisposeAsync()
+        {
+            try { await UndoSourceSetupAsync(CancellationToken.None); }
+            catch { /* best effort */ }
+            await base.DisposeAsync();
+        }
+
+        private async Task UndoSourceSetupAsync(CancellationToken ct)
+        {
+            if (_enabledDatabaseCdc == false && _enabledCaptureTables.Count == 0)
+                return;
+
+            await using var conn = await OpenConnectionAsync(ct);
+
+            if (_enabledDatabaseCdc)
+            {
+                // We enabled CDC on the database, so it had none before us - disabling it reverts every
+                // capture instance we added in one step.
+                await using var cmd = conn.CreateCommand();
+                cmd.CommandText = "EXEC sys.sp_cdc_disable_db";
+                await cmd.ExecuteNonQueryAsync(ct);
+                return;
+            }
+
+            // The database already had CDC enabled (not by us) - disable only the capture instances we added.
+            foreach (var tableInfo in _enabledCaptureTables)
+            {
+                await using var cmd = conn.CreateCommand();
+                cmd.CommandText = "EXEC sys.sp_cdc_disable_table @source_schema = @schema, @source_name = @table, @capture_instance = N'all'";
+                AddParameter(cmd, "@schema", tableInfo.Schema);
+                AddParameter(cmd, "@table", tableInfo.TableName);
+                await cmd.ExecuteNonQueryAsync(ct);
+            }
+        }
+    }
+
+    private sealed class TestPostgresCdcSinkProcess : PostgresCdcSinkProcess, ICdcSinkTestProcess
+    {
+        private readonly CdcSinkTestCapture _capture;
+
+        public TestPostgresCdcSinkProcess(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture)
+            : base(configuration, database) => _capture = capture;
+
+        protected override Task<(string Checkpoint, int Rows)> SubmitBatch(
+            List<CdcSinkDocumentOp> ops, string checkpoint,
+            Dictionary<string, CdcSinkTableLoadState> tableLoadUpdates,
+            CdcSinkBatchCommand.DocumentGrouper grouper)
+            => _capture.Handle(ops, checkpoint);
+
+        protected override CdcSinkTaskState LoadState(DocumentsOperationContext context)
+            => new() { ConfigurationName = Configuration.Name };
+
+        protected override Task ProcessCdcStream(CancellationToken ct) => Task.CompletedTask;
+
+        protected override async Task<InitialLoadBatch> ReadOneBatch(
+            DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
+            string[] lastKeys, int maxBatchSize, CancellationToken ct)
+        {
+            if (_capture.TrySample(tableInfo.FullName) == false)
+            {
+                return new InitialLoadBatch(new List<CdcSinkDocumentOp>(), lastKeys, null);
+            }
+
+            return await base.ReadOneBatch(conn, tableInfo, keyColumns, lastKeys, 1, ct);
+        }
+
+        public Task RunCdcTestAsync(CancellationToken ct) => _capture.RunCdcAsync(RunInternalAsync, ct);
+
+        public override async ValueTask DisposeAsync()
+        {
+            try { await UndoSourceSetupAsync(CancellationToken.None); }
+            catch { /* best effort */ }
+            await base.DisposeAsync();
+        }
+
+        private async Task UndoSourceSetupAsync(CancellationToken ct)
+        {
+            if (_createdSlot == false && _createdPublication == false)
+                return;
+
+            await using var conn = _dataSource.CreateConnection();
+            await conn.OpenAsync(ct);
+
+            if (_createdSlot)
+            {
+                await using (var terminate = new NpgsqlCommand(
+                                 "SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE slot_name = @slot AND active_pid IS NOT NULL", conn))
+                {
+                    terminate.Parameters.AddWithValue("slot", _slotName);
+                    await terminate.ExecuteScalarAsync(ct);
+                }
+
+                await using var dropSlot = new NpgsqlCommand(
+                    "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name = @slot", conn);
+                dropSlot.Parameters.AddWithValue("slot", _slotName);
+                await dropSlot.ExecuteNonQueryAsync(ct);
+            }
+
+            if (_createdPublication)
+            {
+                await using var dropPub = new NpgsqlCommand(
+                    $"DROP PUBLICATION IF EXISTS {CommandBuilder.QuoteIdentifier(_publicationName)}", conn);
+                await dropPub.ExecuteNonQueryAsync(ct);
+            }
+        }
+    }
+
+    private sealed class TestMySqlCdcSinkProcess : MySqlCdcSinkProcess, ICdcSinkTestProcess
+    {
+        private readonly CdcSinkTestCapture _capture;
+
+        public TestMySqlCdcSinkProcess(DocumentDatabase database, CdcSinkConfiguration configuration, CdcSinkTestCapture capture)
+            : base(configuration, database) => _capture = capture;
+
+        protected override Task<(string Checkpoint, int Rows)> SubmitBatch(
+            List<CdcSinkDocumentOp> ops, string checkpoint,
+            Dictionary<string, CdcSinkTableLoadState> tableLoadUpdates,
+            CdcSinkBatchCommand.DocumentGrouper grouper)
+            => _capture.Handle(ops, checkpoint);
+
+        protected override CdcSinkTaskState LoadState(DocumentsOperationContext context)
+            => new() { ConfigurationName = Configuration.Name };
+
+        protected override Task ProcessCdcStream(CancellationToken ct) => Task.CompletedTask;
+
+        protected override async Task<InitialLoadBatch> ReadOneBatch(
+            DbConnection conn, CdcSinkConfiguration.TableInfo tableInfo, List<string> keyColumns,
+            string[] lastKeys, int maxBatchSize, CancellationToken ct)
+        {
+            if (_capture.TrySample(tableInfo.FullName) == false)
+            {
+                return new InitialLoadBatch(new List<CdcSinkDocumentOp>(), lastKeys, null);
+            }
+
+            return await base.ReadOneBatch(conn, tableInfo, keyColumns, lastKeys, 1, ct);
+        }
+
+        public Task RunCdcTestAsync(CancellationToken ct) => _capture.RunCdcAsync(RunInternalAsync, ct);
+    }
+}
+
+internal interface ICdcSinkTestProcess : IAsyncDisposable
+{
+    Task RunCdcTestAsync(CancellationToken ct);
+}
+
+internal sealed class CdcSinkTestCapture
+{
+    private Exception _error;
+    private readonly Dictionary<string, string> _sampled = new(StringComparer.Ordinal);
+
+    public bool TrySample(string table) => _sampled.ContainsKey(table) == false;
+
+    public Task<(string Checkpoint, int Rows)> Handle(List<CdcSinkDocumentOp> ops, string checkpoint)
+    {
+        foreach (var op in ops)
+        {
+            if (op != null)
+                _sampled.Add(op.Processor.FullName, op.DocumentId);
+        }
+
+        return Task.FromResult((checkpoint, ops.Count));
+    }
+
+    public async Task RunCdcAsync(Func<CancellationToken, Task> runInternal, CancellationToken ct)
+    {
+        try
+        {
+            await runInternal(ct);
+        }
+        catch (Exception e)
+        {
+            _error = e;
+        }
+    }
+
+    public void SetError(Exception e) => _error = e;
+
+    public CdcTestResult Result => new()
+    {
+        Success = _sampled.Count > 0 && _error is null,
+        Error = _error?.ToString() ?? (_sampled.Count > 0 ? null : "CDC is configured, but no rows were available to sample."),
+        Sampled = _sampled
+    };
+}

--- a/src/Raven.Server/ServerWide/Commands/CdcSink/AddCdcSinkCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/CdcSink/AddCdcSinkCommand.cs
@@ -55,15 +55,19 @@ namespace Raven.Server.ServerWide.Commands.CdcSink
 
             if (record.SqlConnectionStrings.TryGetValue(Configuration.ConnectionStringName, out var connectionString) == false)
                 return;
-
+            
             if (connectionString.FactoryName != "Npgsql")
                 return;
 
-            Configuration.Postgres ??= new CdcSinkPostgresSettings();
-
             // Same etag for both so they're clearly paired.
-            Configuration.Postgres.PublicationName ??= $"rvn_cdc_p_{etag}";
-            Configuration.Postgres.SlotName ??= $"rvn_cdc_s_{etag}";
+            AutoFillPostgresSettings(Configuration, etag.ToString());
+        }
+
+        public static void AutoFillPostgresSettings(CdcSinkConfiguration configuration, string guid)
+        {
+            configuration.Postgres ??= new CdcSinkPostgresSettings();
+            configuration.Postgres.PublicationName ??= $"rvn_cdc_p_{guid}";
+            configuration.Postgres.SlotName ??= $"rvn_cdc_s_{guid}";
         }
 
 

--- a/src/Raven.Server/ServerWide/Commands/CdcSink/AddCdcSinkCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/CdcSink/AddCdcSinkCommand.cs
@@ -59,12 +59,12 @@ namespace Raven.Server.ServerWide.Commands.CdcSink
             if (connectionString.FactoryName != "Npgsql")
                 return;
 
-            // Same etag for both so they're clearly paired.
             AutoFillPostgresSettings(Configuration, etag.ToString());
         }
 
         public static void AutoFillPostgresSettings(CdcSinkConfiguration configuration, string guid)
         {
+            // Same guid for both so they're clearly paired.
             configuration.Postgres ??= new CdcSinkPostgresSettings();
             configuration.Postgres.PublicationName ??= $"rvn_cdc_p_{guid}";
             configuration.Postgres.SlotName ??= $"rvn_cdc_s_{guid}";

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -84,6 +84,7 @@ namespace FastTests.Client
                 "AddCdcSinkCommand", "UpdateCdcSinkCommand",
                 "GetCdcSinkSchemaCommand", "TestCdcSinkMappingCommand",
                 "GetServerWideConnectionStringsCommand", "PutServerWideConnectionStringCommand", "RemoveServerWideConnectionStringCommand",
+                "VerifyCdcSinkCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27038

### Additional description

Adds a CDC Sink "verify" endpoint.

It works by inheriting the real CDC Sink process and overriding a few methods. 
It runs the actual CDC flow (connect, enable CDC, read) but samples one row per configured table to confirm
each table actually produces an item - without writing anything and undoing any CDC
it enabled on the source.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
