### PR TITLE
RavenDB-27095 CDC - Added support for table dual-mapping

### DIFF
--- a/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
@@ -456,43 +456,61 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
     /// <param name="defaultSchema">Default schema when SourceTableSchema is null (e.g., "public" for PostgreSQL, "dbo" for SQL Server).</param>
     public List<TableInfo> CollectAllTablesFlat(string defaultSchema)
     {
+        // A source table can be mapped several times at once (a root collection and/or embedded arrays -
+        // RavenDB-27095), but the physical table must be read/captured exactly ONCE and then fanned out to
+        // all its processors. Dedup by (schema, table), preferring the root mapping's PrimaryKeyColumns for
+        // keyset pagination: two passes so a standalone root that appears after the parent embedding it
+        // still wins over the embedded entry.
         var tables = new List<TableInfo>();
+        var seen = new HashSet<TableInfo>();
+
+        void AddUnique(string schema, string tableName, List<string> primaryKeyColumns)
+        {
+            var info = new TableInfo
+            {
+                Schema = string.IsNullOrEmpty(schema) ? defaultSchema : schema,
+                TableName = tableName,
+                PrimaryKeyColumns = primaryKeyColumns,
+            };
+            if (seen.Add(info))
+                tables.Add(info);
+        }
+
+        // Pass 1: root tables (their PrimaryKeyColumns take precedence).
         foreach (var table in Tables)
         {
             if (table.Disabled)
                 continue;
 
-            tables.Add(new TableInfo
-            {
-                Schema = string.IsNullOrEmpty(table.SourceTableSchema) ? defaultSchema : table.SourceTableSchema,
-                TableName = table.SourceTableName,
-                PrimaryKeyColumns = table.PrimaryKeyColumns,
-            });
+            AddUnique(table.SourceTableSchema, table.SourceTableName, table.PrimaryKeyColumns);
+        }
+
+        // Pass 2: embedded tables, added only when not already covered by a root mapping.
+        foreach (var table in Tables)
+        {
+            if (table.Disabled)
+                continue;
 
             if (table.EmbeddedTables != null)
             {
                 foreach (var embedded in table.EmbeddedTables)
-                    CollectEmbeddedTablesFlat(embedded, defaultSchema, tables);
+                    CollectEmbeddedTablesFlat(embedded, defaultSchema, AddUnique);
             }
         }
+
         return tables;
     }
 
-    private static void CollectEmbeddedTablesFlat(CdcSinkEmbeddedTableConfig embedded, string defaultSchema, List<TableInfo> tables)
+    private static void CollectEmbeddedTablesFlat(CdcSinkEmbeddedTableConfig embedded, string defaultSchema, Action<string, string, List<string>> addUnique)
     {
         RuntimeHelpers.EnsureSufficientExecutionStack();
 
-        tables.Add(new TableInfo
-        {
-            Schema = string.IsNullOrEmpty(embedded.SourceTableSchema) ? defaultSchema : embedded.SourceTableSchema,
-            TableName = embedded.SourceTableName,
-            PrimaryKeyColumns = embedded.PrimaryKeyColumns,
-        });
+        addUnique(embedded.SourceTableSchema, embedded.SourceTableName, embedded.PrimaryKeyColumns);
 
         if (embedded.EmbeddedTables != null)
         {
             foreach (var child in embedded.EmbeddedTables)
-                CollectEmbeddedTablesFlat(child, defaultSchema, tables);
+                CollectEmbeddedTablesFlat(child, defaultSchema, addUnique);
         }
     }
 

--- a/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
@@ -449,69 +449,39 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
     }
 
     /// <summary>
-    /// Collects the active configured tables (including embedded tables recursively) as a flat list
-    /// of TableInfo instances with schema, name, and primary key columns. Disabled root tables - and
-    /// their embedded tables - are excluded, so they are neither initial-loaded nor change-captured.
+    /// Collects the active configured tables (including embedded tables recursively) as a flat,
+    /// deduplicated list of physical (schema, table) identities. A source table can be mapped several
+    /// times at once (a root collection and/or embedded arrays), but must be read/captured exactly ONCE
+    /// and then fanned out to all its processors. Disabled root tables - and their embedded tables -
+    /// are excluded, so they are neither initial-loaded nor change-captured.
     /// </summary>
     /// <param name="defaultSchema">Default schema when SourceTableSchema is null (e.g., "public" for PostgreSQL, "dbo" for SQL Server).</param>
     public List<TableInfo> CollectAllTablesFlat(string defaultSchema)
     {
-        // A source table can be mapped several times at once (a root collection and/or embedded arrays),
-        // but the physical table must be read/captured exactly ONCE and then fanned out to all its
-        // processors. Dedup by (schema, table), preferring the root mapping's PrimaryKeyColumns for
-        // keyset pagination: two passes so a standalone root that appears after the parent embedding it
-        // still wins over the embedded entry.
         var tables = new List<TableInfo>();
         var seen = new HashSet<TableInfo>();
 
-        void AddUnique(string schema, string tableName, List<string> primaryKeyColumns)
+        void AddUnique(string schema, string tableName)
         {
             var info = new TableInfo
             {
                 Schema = string.IsNullOrEmpty(schema) ? defaultSchema : schema,
                 TableName = tableName,
-                PrimaryKeyColumns = primaryKeyColumns,
             };
             if (seen.Add(info))
                 tables.Add(info);
         }
 
-        // Pass 1: root tables (their PrimaryKeyColumns take precedence).
         foreach (var table in Tables)
         {
             if (table.Disabled)
                 continue;
 
-            AddUnique(table.SourceTableSchema, table.SourceTableName, table.PrimaryKeyColumns);
-        }
-
-        // Pass 2: embedded tables, added only when not already covered by a root mapping.
-        foreach (var table in Tables)
-        {
-            if (table.Disabled)
-                continue;
-
-            if (table.EmbeddedTables != null)
-            {
-                foreach (var embedded in table.EmbeddedTables)
-                    CollectEmbeddedTablesFlat(embedded, defaultSchema, AddUnique);
-            }
+            AddUnique(table.SourceTableSchema, table.SourceTableName);
+            ForEachEmbeddedTable(table.EmbeddedTables, e => AddUnique(e.SourceTableSchema, e.SourceTableName));
         }
 
         return tables;
-    }
-
-    private static void CollectEmbeddedTablesFlat(CdcSinkEmbeddedTableConfig embedded, string defaultSchema, Action<string, string, List<string>> addUnique)
-    {
-        RuntimeHelpers.EnsureSufficientExecutionStack();
-
-        addUnique(embedded.SourceTableSchema, embedded.SourceTableName, embedded.PrimaryKeyColumns);
-
-        if (embedded.EmbeddedTables != null)
-        {
-            foreach (var child in embedded.EmbeddedTables)
-                CollectEmbeddedTablesFlat(child, defaultSchema, addUnique);
-        }
     }
 
     /// <summary>
@@ -537,12 +507,18 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
     {
         public string Schema { get; set; }
         public string TableName { get; set; }
-        public List<string> PrimaryKeyColumns { get; set; }
 
         public string FullName => $"{Schema}.{TableName}";
 
-        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(FullName);
-        public override bool Equals(object obj) => obj is TableInfo other && string.Equals(FullName, other.FullName, StringComparison.OrdinalIgnoreCase);
+        // Component-wise so dotted identifiers can't fold two tables into one
+        // (schema "a" + table "b.c" vs schema "a.b" + table "c").
+        public override int GetHashCode() => HashCode.Combine(
+            StringComparer.OrdinalIgnoreCase.GetHashCode(Schema ?? string.Empty),
+            StringComparer.OrdinalIgnoreCase.GetHashCode(TableName ?? string.Empty));
+
+        public override bool Equals(object obj) => obj is TableInfo other
+            && string.Equals(Schema, other.Schema, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(TableName, other.TableName, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool HaveColumnsChanged(List<CdcColumnMapping> local, List<CdcColumnMapping> remote)

--- a/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
@@ -456,9 +456,9 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
     /// <param name="defaultSchema">Default schema when SourceTableSchema is null (e.g., "public" for PostgreSQL, "dbo" for SQL Server).</param>
     public List<TableInfo> CollectAllTablesFlat(string defaultSchema)
     {
-        // A source table can be mapped several times at once (a root collection and/or embedded arrays -
-        // RavenDB-27095), but the physical table must be read/captured exactly ONCE and then fanned out to
-        // all its processors. Dedup by (schema, table), preferring the root mapping's PrimaryKeyColumns for
+        // A source table can be mapped several times at once (a root collection and/or embedded arrays),
+        // but the physical table must be read/captured exactly ONCE and then fanned out to all its
+        // processors. Dedup by (schema, table), preferring the root mapping's PrimaryKeyColumns for
         // keyset pagination: two passes so a standalone root that appears after the parent embedding it
         // still wins over the embedded entry.
         var tables = new List<TableInfo>();

--- a/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
@@ -510,8 +510,6 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
 
         public string FullName => $"{Schema}.{TableName}";
 
-        // Component-wise so dotted identifiers can't fold two tables into one
-        // (schema "a" + table "b.c" vs schema "a.b" + table "c").
         public override int GetHashCode() => HashCode.Combine(
             StringComparer.OrdinalIgnoreCase.GetHashCode(Schema ?? string.Empty),
             StringComparer.OrdinalIgnoreCase.GetHashCode(TableName ?? string.Empty));

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
@@ -37,10 +37,6 @@ public class CdcSinkDocumentProcessor
         _includeDisabledTables = includeDisabledTables;
         _tableIndex = new Dictionary<(string, string), List<CdcSinkTableProcessor>>(TableKeyComparer.Instance);
 
-        // Two passes: all root mappings register before any embedded one, so processors[0] of every
-        // table's list is the root whenever the table has one. Index 0 is the table's PRIMARY
-        // processor - it owns the decode-buffer pool and represents the table in the
-        // single-representative accessors.
         foreach (var table in config.Tables)
         {
             // A disabled table is excluded from the runtime mapping: no processor is registered, so its rows
@@ -56,7 +52,7 @@ public class CdcSinkDocumentProcessor
             var schema = string.IsNullOrEmpty(table.SourceTableSchema) ? defaultSchema : table.SourceTableSchema;
 
             var discriminator = BuildDiscriminator(table.CollectionName, path: null);
-            var dispatchKey = MakeKey(schema, table.SourceTableName) + "|" + discriminator;
+            var dispatchKey = MakeKey(schema, table.SourceTableName) + DispatchKeySeparator + discriminator;
             var rootPropertyLookup = BuildPropertyLookup(table.Columns);
             var rootProcessor = new CdcSinkTableProcessor
             {
@@ -125,7 +121,6 @@ public class CdcSinkDocumentProcessor
         for (int i = 0; i < tableScripts.Count; i++)
         {
             var (key, script) = tableScripts[i];
-            // The counter keeps function names unique when distinct keys sanitize to the same string.
             var funcName = $"__cdc_{i}_{SanitizeForJs(key)}";
 
             functions[funcName] = new DeclaredFunction
@@ -232,7 +227,7 @@ public class CdcSinkDocumentProcessor
 
             var embeddedSchema = string.IsNullOrEmpty(embedded.SourceTableSchema) ? defaultSchema : embedded.SourceTableSchema;
             var discriminator = BuildDiscriminator(rootConfig.CollectionName, path);
-            var dispatchKey = MakeKey(embeddedSchema, embedded.SourceTableName) + "|" + discriminator;
+            var dispatchKey = MakeKey(embeddedSchema, embedded.SourceTableName) + DispatchKeySeparator + discriminator;
             var embeddedPropertyLookup = BuildPropertyLookup(embedded.Columns);
             var processor = new CdcSinkTableProcessor
             {
@@ -289,10 +284,6 @@ public class CdcSinkDocumentProcessor
         return false;
     }
 
-    /// <summary>
-    /// True when the source table is configured in this task. Existence-only check for streaming
-    /// providers that must skip rows of published-but-unconfigured tables.
-    /// </summary>
     public bool HasProcessors(string schema, string table)
     {
         return _tableIndex.ContainsKey((schema ?? string.Empty, table));
@@ -475,6 +466,8 @@ public class CdcSinkDocumentProcessor
         };
     }
 
+    private const string DispatchKeySeparator = "|";
+
     private static string MakeKey(string schema, string tableName)
     {
         if (string.IsNullOrEmpty(schema))
@@ -490,11 +483,6 @@ public class CdcSinkDocumentProcessor
         list.Add(processor);
     }
 
-    /// <summary>
-    /// Builds the mapping identity described on <see cref="CdcSinkTableProcessor.Discriminator"/>:
-    /// the root collection name, followed by the embedded property path when <paramref name="path"/>
-    /// is non-null. Escaping keeps segment boundaries unambiguous for any collection/property name.
-    /// </summary>
     private static string BuildDiscriminator(string collectionName, List<EmbeddedPathSegment> path)
     {
         var sb = new StringBuilder();

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
@@ -17,8 +17,6 @@ namespace Raven.Server.Documents.CdcSink;
 /// </summary>
 public class CdcSinkDocumentProcessor
 {
-    private readonly CdcSinkConfiguration _config;
-    private readonly string _defaultSchema;
     private readonly bool _includeDisabledTables;
     private readonly Dictionary<(string Schema, string Table), List<CdcSinkTableProcessor>> _tableIndex;
 
@@ -36,11 +34,13 @@ public class CdcSinkDocumentProcessor
     /// </param>
     public CdcSinkDocumentProcessor(CdcSinkConfiguration config, string defaultSchema = "", bool includeDisabledTables = false)
     {
-        _config = config;
-        _defaultSchema = defaultSchema;
         _includeDisabledTables = includeDisabledTables;
         _tableIndex = new Dictionary<(string, string), List<CdcSinkTableProcessor>>(TableKeyComparer.Instance);
 
+        // Two passes: all root mappings register before any embedded one, so processors[0] of every
+        // table's list is the root whenever the table has one. Index 0 is the table's PRIMARY
+        // processor - it owns the decode-buffer pool and represents the table in the
+        // single-representative accessors.
         foreach (var table in config.Tables)
         {
             // A disabled table is excluded from the runtime mapping: no processor is registered, so its rows
@@ -55,19 +55,20 @@ public class CdcSinkDocumentProcessor
             // now indexes consistently.
             var schema = string.IsNullOrEmpty(table.SourceTableSchema) ? defaultSchema : table.SourceTableSchema;
 
-            // Register the root table
-            var rootKey = MakeKey(schema, table.SourceTableName);
+            var discriminator = BuildDiscriminator(table.CollectionName, path: null);
+            var dispatchKey = MakeKey(schema, table.SourceTableName) + "|" + discriminator;
             var rootPropertyLookup = BuildPropertyLookup(table.Columns);
             var rootProcessor = new CdcSinkTableProcessor
             {
-                Key = rootKey,
-                KeyOnDelete = rootKey + "__on_delete",
+                Key = dispatchKey,
+                KeyOnDelete = dispatchKey + "__on_delete",
                 Schema = schema,
                 Table = table.SourceTableName,
-                Discriminator = string.Empty,
+                Discriminator = discriminator,
                 RootConfig = table,
                 CollectionName = table.CollectionName,
                 IsRoot = true,
+                IgnoresDeletes = table.OnDelete?.IgnoreDeletes == true && table.OnDelete.Patch == null,
                 Columns = table.Columns,
                 AttachmentColumns = FilterAttachmentColumns(table.Columns),
                 PropertyLookup = rootPropertyLookup,
@@ -76,48 +77,43 @@ public class CdcSinkDocumentProcessor
             };
 
             AddProcessor(schema, table.SourceTableName, rootProcessor);
+        }
 
-            // Register all embedded tables recursively
+        foreach (var table in config.Tables)
+        {
+            if (table.Disabled && _includeDisabledTables == false)
+                continue;
+
             if (table.EmbeddedTables != null)
-            {
-                RegisterEmbeddedTables(table, table.EmbeddedTables, table.PrimaryKeyColumns, rootPropertyLookup, new List<EmbeddedPathSegment>(), defaultSchema);
-            }
+                RegisterEmbeddedTables(table, table.EmbeddedTables, table.PrimaryKeyColumns, new List<EmbeddedPathSegment>(), defaultSchema);
         }
 
         CombinedPatchRequest = BuildCombinedPatchRequest();
     }
 
     /// <summary>
-    /// Builds a single combined script that dispatches per-table patches by table name.
-     /// Each per-table function receives $row as a parameter — so user scripts
+    /// Builds a single combined script that dispatches per-mapping patches by processor Key.
+    /// Each per-mapping function receives $row as a parameter — so user scripts
     /// can reference $row.column_name naturally, with `this` bound to the document.
+    /// Built from the registered processors so registration uses the same per-mapping keys the
+    /// dispatch path emits — a source table mapped several ways runs each mapping's own script.
     /// </summary>
     private PatchRequest BuildCombinedPatchRequest()
     {
-        var tableScripts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var tableScripts = new List<(string Key, string Script)>();
 
-        foreach (var table in _config.Tables)
+        foreach (var (_, processors) in _tableIndex)
         {
-            // Skip patches for disabled tables that weren't registered above - no op will reference them.
-            if (table.Disabled && _includeDisabledTables == false)
-                continue;
-
-            var schema = string.IsNullOrEmpty(table.SourceTableSchema) ? _defaultSchema : table.SourceTableSchema;
-
-            if (table.Patch != null)
-                tableScripts.TryAdd(MakeKey(schema, table.SourceTableName), table.Patch);
-
-            if (table.OnDelete?.Patch != null)
-                tableScripts.TryAdd(OnDeleteKey(schema, table.SourceTableName), table.OnDelete.Patch);
-
-            CdcSinkConfiguration.ForEachEmbeddedTable(table.EmbeddedTables, e =>
+            foreach (var processor in processors)
             {
-                var embeddedSchema = string.IsNullOrEmpty(e.SourceTableSchema) ? _defaultSchema : e.SourceTableSchema;
-                if (e.Patch != null)
-                    tableScripts.TryAdd(MakeKey(embeddedSchema, e.SourceTableName), e.Patch);
-                if (e.OnDelete?.Patch != null)
-                    tableScripts.TryAdd(OnDeleteKey(embeddedSchema, e.SourceTableName), e.OnDelete.Patch);
-            });
+                var patch = processor.IsRoot ? processor.RootConfig.Patch : processor.EmbeddedConfig.Patch;
+                if (patch != null)
+                    tableScripts.Add((processor.Key, patch));
+
+                var onDelete = processor.IsRoot ? processor.RootConfig.OnDelete : processor.EmbeddedConfig.OnDelete;
+                if (onDelete?.Patch != null)
+                    tableScripts.Add((processor.KeyOnDelete, onDelete.Patch));
+            }
         }
 
         if (tableScripts.Count == 0)
@@ -126,9 +122,11 @@ public class CdcSinkDocumentProcessor
         var functions = new Dictionary<string, DeclaredFunction>(StringComparer.OrdinalIgnoreCase);
         var switchCases = new StringBuilder();
 
-        foreach (var (tableName, script) in tableScripts)
+        for (int i = 0; i < tableScripts.Count; i++)
         {
-            var funcName = $"__cdc_{SanitizeForJs(tableName)}";
+            var (key, script) = tableScripts[i];
+            // The counter keeps function names unique when distinct keys sanitize to the same string.
+            var funcName = $"__cdc_{i}_{SanitizeForJs(key)}";
 
             functions[funcName] = new DeclaredFunction
             {
@@ -137,7 +135,7 @@ public class CdcSinkDocumentProcessor
                 Type = DeclaredFunction.FunctionType.JavaScript,
             };
 
-            switchCases.Append("    case \"").Append(EscapeJsString(tableName))
+            switchCases.Append("    case \"").Append(EscapeJsString(key))
                 .Append("\": ").Append(funcName).Append(".call(this, $row, $old); break;\n");
         }
 
@@ -176,7 +174,6 @@ public class CdcSinkDocumentProcessor
         CdcSinkTableConfig rootConfig,
         List<CdcSinkEmbeddedTableConfig> embeddedTables,
         List<string> parentPkColumns,
-        Dictionary<string, string> parentPropertyLookup,
         List<EmbeddedPathSegment> currentPath,
         string defaultSchema)
     {
@@ -234,18 +231,20 @@ public class CdcSinkDocumentProcessor
             var rootJoinColumns = path[0].Config.JoinColumns;
 
             var embeddedSchema = string.IsNullOrEmpty(embedded.SourceTableSchema) ? defaultSchema : embedded.SourceTableSchema;
-            var key = MakeKey(embeddedSchema, embedded.SourceTableName);
+            var discriminator = BuildDiscriminator(rootConfig.CollectionName, path);
+            var dispatchKey = MakeKey(embeddedSchema, embedded.SourceTableName) + "|" + discriminator;
             var embeddedPropertyLookup = BuildPropertyLookup(embedded.Columns);
             var processor = new CdcSinkTableProcessor
             {
-                Key = key,
-                KeyOnDelete = key + "__on_delete",
+                Key = dispatchKey,
+                KeyOnDelete = dispatchKey + "__on_delete",
                 Schema = embeddedSchema,
                 Table = embedded.SourceTableName,
-                Discriminator = BuildEmbeddedDiscriminator(path),
+                Discriminator = discriminator,
                 RootConfig = rootConfig,
                 CollectionName = rootConfig.CollectionName,
                 IsRoot = false,
+                IgnoresDeletes = embedded.OnDelete?.IgnoreDeletes == true && embedded.OnDelete.Patch == null,
                 EmbeddedConfig = embedded,
                 PathFromRoot = path,
                 RootJoinColumns = rootJoinColumns,
@@ -261,7 +260,7 @@ public class CdcSinkDocumentProcessor
             // Recurse for deep nesting
             if (embedded.EmbeddedTables != null && embedded.EmbeddedTables.Count > 0)
             {
-                RegisterEmbeddedTables(rootConfig, embedded.EmbeddedTables, embedded.PrimaryKeyColumns, embeddedPropertyLookup, path, defaultSchema);
+                RegisterEmbeddedTables(rootConfig, embedded.EmbeddedTables, embedded.PrimaryKeyColumns, path, defaultSchema);
             }
         }
     }
@@ -291,22 +290,32 @@ public class CdcSinkDocumentProcessor
     }
 
     /// <summary>
-    /// The primary processor for a source table: the root processor when the table is mapped as a
-    /// collection, otherwise the first embedded processor. NOT for row routing - anything that turns a
-    /// source row into document ops must use <see cref="GetProcessors"/> and fan out, or it silently drops
-    /// the table's other mappings. This single-representative accessor is only for operations about the
-    /// table itself where any one processor suffices: existence checks, the dry-run preview, and tests.
+    /// True when the source table is configured in this task. Existence-only check for streaming
+    /// providers that must skip rows of published-but-unconfigured tables.
+    /// </summary>
+    public bool HasProcessors(string schema, string table)
+    {
+        return _tableIndex.ContainsKey((schema ?? string.Empty, table));
+    }
+
+    /// <summary>
+    /// The primary processor for a source table: processors[0], which registration order guarantees is
+    /// the root processor when the table is mapped as a collection, otherwise the first embedded
+    /// processor. NOT for row routing - anything that turns a source row into document ops must use
+    /// <see cref="GetProcessors"/> and fan out, or it silently drops the table's other mappings. This
+    /// single-representative accessor is only for operations about the table itself where any one
+    /// processor suffices: existence checks, the dry-run preview, and tests.
     /// </summary>
     public CdcSinkTableProcessor GetPrimaryProcessor(string schema, string table)
     {
-        return SelectPrimary(GetProcessors(schema, table));
+        return GetProcessors(schema, table)[0];
     }
 
     public bool TryGetPrimaryProcessor(string schema, string table, out CdcSinkTableProcessor processor)
     {
         if (TryGetProcessors(schema, table, out var processors))
         {
-            processor = SelectPrimary(processors);
+            processor = processors[0];
             return true;
         }
 
@@ -315,16 +324,16 @@ public class CdcSinkDocumentProcessor
     }
 
     /// <summary>
-    /// Resolves the exact processor for a source table by its <see cref="CdcSinkTableProcessor.Discriminator"/>
-    /// (empty = root, otherwise the embedded property path). Used by tx-log replay to restore the specific
-    /// mapping an op belonged to. Falls back to the primary processor when the discriminator is empty or
-    /// matches no processor.
+    /// Resolves the exact processor for a source table by its <see cref="CdcSinkTableProcessor.Discriminator"/>.
+    /// Used by tx-log replay to restore the specific mapping an op belonged to. An op persisted without a
+    /// discriminator resolves to the primary processor; an unknown discriminator throws - the mapping
+    /// changed between persist and replay, and silently picking another processor would misroute the op.
     /// </summary>
     public CdcSinkTableProcessor GetProcessor(string schema, string table, string discriminator)
     {
         var processors = GetProcessors(schema, table);
         if (string.IsNullOrEmpty(discriminator))
-            return SelectPrimary(processors);
+            return processors[0];
 
         for (int i = 0; i < processors.Count; i++)
         {
@@ -332,18 +341,9 @@ public class CdcSinkDocumentProcessor
                 return processors[i];
         }
 
-        return SelectPrimary(processors);
-    }
-
-    private static CdcSinkTableProcessor SelectPrimary(IReadOnlyList<CdcSinkTableProcessor> processors)
-    {
-        for (int i = 0; i < processors.Count; i++)
-        {
-            if (processors[i].IsRoot)
-                return processors[i];
-        }
-
-        return processors[0];
+        throw new InvalidOperationException(
+            $"No processor with discriminator '{discriminator}' found for table '{schema}.{table}'. " +
+            "The table mapping changed between when the batch was persisted and this replay.");
     }
 
     public void SetSourceColumnNames(string schema, string table, string[] columnNames)
@@ -393,10 +393,10 @@ public class CdcSinkDocumentProcessor
 
     /// <summary>
     /// Processes a single row against the primary processor for its source table and returns one op.
-    /// Kept for callers (tests, previews) that map each table once; streaming and initial load fan a row
-    /// out to every processor via <see cref="GetProcessors"/> so all mappings are produced.
+    /// Kept internal for tests that map each table once; streaming and initial load fan a row out to
+    /// every processor via <see cref="GetProcessors"/> so all mappings are produced.
     /// </summary>
-    public CdcSinkDocumentOp ProcessRow(CdcSinkRow row, JsonOperationContext context)
+    internal CdcSinkDocumentOp ProcessRow(CdcSinkRow row, JsonOperationContext context)
     {
         if (_tableIndex.TryGetValue((row.TableSchema ?? string.Empty, row.TableName), out var processors) == false)
         {
@@ -405,7 +405,7 @@ public class CdcSinkDocumentProcessor
             return null;
         }
 
-        return ProcessRow(SelectPrimary(processors), row.Operation, row.Data, context);
+        return ProcessRow(processors[0], row.Operation, row.Data, context);
     }
 
     public CdcSinkDocumentOp ProcessRow(CdcSinkTableProcessor processor, CdcSinkOperation operation, object[] data, JsonOperationContext context)
@@ -423,9 +423,8 @@ public class CdcSinkDocumentProcessor
 
         if (operation == CdcSinkOperation.Delete)
         {
-            var onDelete = config.OnDelete;
-            if (onDelete?.IgnoreDeletes == true && onDelete.Patch == null)
-                return null; // silently ignore — no patch, no delete
+            if (processor.IgnoresDeletes)
+                return null;
 
             return new CdcSinkDocumentOp
             {
@@ -458,9 +457,8 @@ public class CdcSinkDocumentProcessor
 
     private CdcSinkDocumentOp ProcessEmbeddedRow(CdcSinkTableProcessor processor, CdcSinkOperation operation, object[] data, JsonOperationContext context)
     {
-        var onDelete = processor.EmbeddedConfig.OnDelete;
-        if (operation == CdcSinkOperation.Delete && onDelete?.IgnoreDeletes == true && onDelete.Patch == null)
-            return null; // silently ignore — no patch, no delete
+        if (operation == CdcSinkOperation.Delete && processor.IgnoresDeletes)
+            return null;
 
         var parentDocumentId = processor.GetParentDocumentId(data);
         var mappedData = processor.MapColumns(data, context);
@@ -477,12 +475,6 @@ public class CdcSinkDocumentProcessor
         };
     }
 
-    /// <summary>
-    /// Dispatch key for OnDelete.Patch scripts in the combined patch request,
-    /// distinct from the regular Patch key for the same table.
-    /// </summary>
-    internal static string OnDeleteKey(string schema, string tableName) => MakeKey(schema, tableName) + "__on_delete";
-
     private static string MakeKey(string schema, string tableName)
     {
         if (string.IsNullOrEmpty(schema))
@@ -498,19 +490,36 @@ public class CdcSinkDocumentProcessor
         list.Add(processor);
     }
 
-    private static string BuildEmbeddedDiscriminator(List<EmbeddedPathSegment> path)
+    /// <summary>
+    /// Builds the mapping identity described on <see cref="CdcSinkTableProcessor.Discriminator"/>:
+    /// the root collection name, followed by the embedded property path when <paramref name="path"/>
+    /// is non-null. Escaping keeps segment boundaries unambiguous for any collection/property name.
+    /// </summary>
+    private static string BuildDiscriminator(string collectionName, List<EmbeddedPathSegment> path)
     {
-        if (path.Count == 1)
-            return path[0].Config.PropertyName;
-
         var sb = new StringBuilder();
-        for (int i = 0; i < path.Count; i++)
+        AppendEscaped(sb, collectionName);
+
+        if (path != null)
         {
-            if (i > 0)
+            for (int i = 0; i < path.Count; i++)
+            {
                 sb.Append('/');
-            sb.Append(path[i].Config.PropertyName);
+                AppendEscaped(sb, path[i].Config.PropertyName);
+            }
         }
+
         return sb.ToString();
+
+        static void AppendEscaped(StringBuilder sb, string segment)
+        {
+            foreach (var c in segment)
+            {
+                if (c is '/' or '\\')
+                    sb.Append('\\');
+                sb.Append(c);
+            }
+        }
     }
 
     private static List<CdcColumnMapping> FilterAttachmentColumns(List<CdcColumnMapping> columns)

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
@@ -292,16 +292,17 @@ public class CdcSinkDocumentProcessor
 
     /// <summary>
     /// The primary processor for a source table: the root processor when the table is mapped as a
-    /// collection, otherwise the first embedded processor. Callers that need every mapping (streaming,
-    /// initial load, replay) use <see cref="GetProcessors"/>; this single-processor accessor is kept for
-    /// column-metadata setup, previews and tests where any one processor of the table is sufficient.
+    /// collection, otherwise the first embedded processor. NOT for row routing - anything that turns a
+    /// source row into document ops must use <see cref="GetProcessors"/> and fan out, or it silently drops
+    /// the table's other mappings. This single-representative accessor is only for operations about the
+    /// table itself where any one processor suffices: existence checks, the dry-run preview, and tests.
     /// </summary>
-    public CdcSinkTableProcessor GetProcessor(string schema, string table)
+    public CdcSinkTableProcessor GetPrimaryProcessor(string schema, string table)
     {
         return SelectPrimary(GetProcessors(schema, table));
     }
 
-    public bool TryGetProcessor(string schema, string table, out CdcSinkTableProcessor processor)
+    public bool TryGetPrimaryProcessor(string schema, string table, out CdcSinkTableProcessor processor)
     {
         if (TryGetProcessors(schema, table, out var processors))
         {

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
@@ -348,7 +348,7 @@ public class CdcSinkDocumentProcessor
 
     public void SetSourceColumnNames(string schema, string table, string[] columnNames)
     {
-        if (_tableIndex.TryGetValue((schema ?? "", table), out var processors) == false)
+        if (_tableIndex.TryGetValue((schema ?? string.Empty, table), out var processors) == false)
             throw new InvalidOperationException($"Cannot set source column names for unknown table '{schema}.{table}'.");
 
         // Every processor for this source table shares the same source columns - set them all so each
@@ -398,7 +398,7 @@ public class CdcSinkDocumentProcessor
     /// </summary>
     public CdcSinkDocumentOp ProcessRow(CdcSinkRow row, JsonOperationContext context)
     {
-        if (_tableIndex.TryGetValue((row.TableSchema ?? "", row.TableName), out var processors) == false)
+        if (_tableIndex.TryGetValue((row.TableSchema ?? string.Empty, row.TableName), out var processors) == false)
         {
             if (Logger?.IsDebugEnabled == true)
                 Logger.Debug($"Discarding CDC row for table '{row.TableSchema}.{row.TableName}' — not configured in the CDC Sink task.");

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkDocumentProcessor.cs
@@ -20,7 +20,7 @@ public class CdcSinkDocumentProcessor
     private readonly CdcSinkConfiguration _config;
     private readonly string _defaultSchema;
     private readonly bool _includeDisabledTables;
-    private readonly Dictionary<(string Schema, string Table), CdcSinkTableProcessor> _tableIndex;
+    private readonly Dictionary<(string Schema, string Table), List<CdcSinkTableProcessor>> _tableIndex;
 
     internal RavenLogger Logger { get; set; }
 
@@ -39,7 +39,7 @@ public class CdcSinkDocumentProcessor
         _config = config;
         _defaultSchema = defaultSchema;
         _includeDisabledTables = includeDisabledTables;
-        _tableIndex = new Dictionary<(string, string), CdcSinkTableProcessor>(TableKeyComparer.Instance);
+        _tableIndex = new Dictionary<(string, string), List<CdcSinkTableProcessor>>(TableKeyComparer.Instance);
 
         foreach (var table in config.Tables)
         {
@@ -64,6 +64,7 @@ public class CdcSinkDocumentProcessor
                 KeyOnDelete = rootKey + "__on_delete",
                 Schema = schema,
                 Table = table.SourceTableName,
+                Discriminator = string.Empty,
                 RootConfig = table,
                 CollectionName = table.CollectionName,
                 IsRoot = true,
@@ -74,7 +75,7 @@ public class CdcSinkDocumentProcessor
                 LinkedTables = table.LinkedTables,
             };
 
-            _tableIndex[(schema, table.SourceTableName)] = rootProcessor;
+            AddProcessor(schema, table.SourceTableName, rootProcessor);
 
             // Register all embedded tables recursively
             if (table.EmbeddedTables != null)
@@ -241,6 +242,7 @@ public class CdcSinkDocumentProcessor
                 KeyOnDelete = key + "__on_delete",
                 Schema = embeddedSchema,
                 Table = embedded.SourceTableName,
+                Discriminator = BuildEmbeddedDiscriminator(path),
                 RootConfig = rootConfig,
                 CollectionName = rootConfig.CollectionName,
                 IsRoot = false,
@@ -254,7 +256,7 @@ public class CdcSinkDocumentProcessor
                 LinkedTables = embedded.LinkedTables,
             };
 
-            _tableIndex[(embeddedSchema, embedded.SourceTableName)] = processor;
+            AddProcessor(embeddedSchema, embedded.SourceTableName, processor);
 
             // Recurse for deep nesting
             if (embedded.EmbeddedTables != null && embedded.EmbeddedTables.Count > 0)
@@ -264,29 +266,94 @@ public class CdcSinkDocumentProcessor
         }
     }
 
-    public CdcSinkTableProcessor GetProcessor(string schema, string table)
+    public IReadOnlyList<CdcSinkTableProcessor> GetProcessors(string schema, string table)
     {
-        if (_tableIndex.TryGetValue((schema ?? "", table), out var processor) == false)
+        if (_tableIndex.TryGetValue((schema ?? string.Empty, table), out var processors) == false)
             throw new InvalidOperationException($"No processor found for table '{schema}.{table}'.");
-        return processor;
+        return processors;
     }
 
     /// <summary>
-    /// Like <see cref="GetProcessor"/> but returns false instead of throwing when the table is not
-    /// configured in this CDC Sink task. Used by streaming providers (e.g. PostgreSQL) where the
-    /// source may publish rows for tables that are not part of the task configuration - those rows
-    /// must be skipped, not crash the process.
+    /// Like <see cref="GetProcessors"/> but returns false instead of throwing when the table is not
+    /// configured. Used by streaming providers (e.g. PostgreSQL) where the source may publish rows for
+    /// tables that are not part of the task configuration - those rows must be skipped, not crash.
     /// </summary>
+    private bool TryGetProcessors(string schema, string table, out IReadOnlyList<CdcSinkTableProcessor> processors)
+    {
+        if (_tableIndex.TryGetValue((schema ?? string.Empty, table), out var list))
+        {
+            processors = list;
+            return true;
+        }
+
+        processors = null;
+        return false;
+    }
+
+    /// <summary>
+    /// The primary processor for a source table: the root processor when the table is mapped as a
+    /// collection, otherwise the first embedded processor. Callers that need every mapping (streaming,
+    /// initial load, replay) use <see cref="GetProcessors"/>; this single-processor accessor is kept for
+    /// column-metadata setup, previews and tests where any one processor of the table is sufficient.
+    /// </summary>
+    public CdcSinkTableProcessor GetProcessor(string schema, string table)
+    {
+        return SelectPrimary(GetProcessors(schema, table));
+    }
+
     public bool TryGetProcessor(string schema, string table, out CdcSinkTableProcessor processor)
     {
-        return _tableIndex.TryGetValue((schema ?? "", table), out processor);
+        if (TryGetProcessors(schema, table, out var processors))
+        {
+            processor = SelectPrimary(processors);
+            return true;
+        }
+
+        processor = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves the exact processor for a source table by its <see cref="CdcSinkTableProcessor.Discriminator"/>
+    /// (empty = root, otherwise the embedded property path). Used by tx-log replay to restore the specific
+    /// mapping an op belonged to. Falls back to the primary processor when the discriminator is empty or
+    /// matches no processor.
+    /// </summary>
+    public CdcSinkTableProcessor GetProcessor(string schema, string table, string discriminator)
+    {
+        var processors = GetProcessors(schema, table);
+        if (string.IsNullOrEmpty(discriminator))
+            return SelectPrimary(processors);
+
+        for (int i = 0; i < processors.Count; i++)
+        {
+            if (string.Equals(processors[i].Discriminator, discriminator, StringComparison.Ordinal))
+                return processors[i];
+        }
+
+        return SelectPrimary(processors);
+    }
+
+    private static CdcSinkTableProcessor SelectPrimary(IReadOnlyList<CdcSinkTableProcessor> processors)
+    {
+        for (int i = 0; i < processors.Count; i++)
+        {
+            if (processors[i].IsRoot)
+                return processors[i];
+        }
+
+        return processors[0];
     }
 
     public void SetSourceColumnNames(string schema, string table, string[] columnNames)
     {
-        if (_tableIndex.TryGetValue((schema ?? "", table), out var processor) == false)
+        if (_tableIndex.TryGetValue((schema ?? "", table), out var processors) == false)
             throw new InvalidOperationException($"Cannot set source column names for unknown table '{schema}.{table}'.");
-        processor.SetSourceColumnNames(columnNames);
+
+        // Every processor for this source table shares the same source columns - set them all so each
+        // one recomputes its own index arrays (a doubly-mapped table has a root and embedded processor).
+        for (int i = 0; i < processors.Count; i++)
+            processors[i].SetSourceColumnNames(columnNames);
     }
 
     /// <summary>
@@ -307,8 +374,9 @@ public class CdcSinkDocumentProcessor
     /// </summary>
     public void ClearValuePools()
     {
-        foreach (var (_, processor) in _tableIndex)
-            processor.ClearPool();
+        foreach (var (_, processors) in _tableIndex)
+            for (int i = 0; i < processors.Count; i++)
+                processors[i].ClearPool();
     }
 
     /// <summary>
@@ -317,20 +385,26 @@ public class CdcSinkDocumentProcessor
     /// </summary>
     public void ResetSourceColumnNames()
     {
-        foreach (var (_, processor) in _tableIndex)
-            processor.ResetSourceColumnNames();
+        foreach (var (_, processors) in _tableIndex)
+            for (int i = 0; i < processors.Count; i++)
+                processors[i].ResetSourceColumnNames();
     }
 
+    /// <summary>
+    /// Processes a single row against the primary processor for its source table and returns one op.
+    /// Kept for callers (tests, previews) that map each table once; streaming and initial load fan a row
+    /// out to every processor via <see cref="GetProcessors"/> so all mappings are produced.
+    /// </summary>
     public CdcSinkDocumentOp ProcessRow(CdcSinkRow row, JsonOperationContext context)
     {
-        if (_tableIndex.TryGetValue((row.TableSchema ?? "", row.TableName), out var processor) == false)
+        if (_tableIndex.TryGetValue((row.TableSchema ?? "", row.TableName), out var processors) == false)
         {
             if (Logger?.IsDebugEnabled == true)
                 Logger.Debug($"Discarding CDC row for table '{row.TableSchema}.{row.TableName}' — not configured in the CDC Sink task.");
             return null;
         }
 
-        return ProcessRow(processor, row.Operation, row.Data, context);
+        return ProcessRow(SelectPrimary(processors), row.Operation, row.Data, context);
     }
 
     public CdcSinkDocumentOp ProcessRow(CdcSinkTableProcessor processor, CdcSinkOperation operation, object[] data, JsonOperationContext context)
@@ -413,6 +487,29 @@ public class CdcSinkDocumentProcessor
         if (string.IsNullOrEmpty(schema))
             return tableName;
         return schema + "." + tableName;
+    }
+
+    private void AddProcessor(string schema, string table, CdcSinkTableProcessor processor)
+    {
+        var key = (schema ?? string.Empty, table);
+        if (_tableIndex.TryGetValue(key, out var list) == false)
+            _tableIndex[key] = list = new List<CdcSinkTableProcessor>(1);
+        list.Add(processor);
+    }
+
+    private static string BuildEmbeddedDiscriminator(List<EmbeddedPathSegment> path)
+    {
+        if (path.Count == 1)
+            return path[0].Config.PropertyName;
+
+        var sb = new StringBuilder();
+        for (int i = 0; i < path.Count; i++)
+        {
+            if (i > 0)
+                sb.Append('/');
+            sb.Append(path[i].Config.PropertyName);
+        }
+        return sb.ToString();
     }
 
     private static List<CdcColumnMapping> FilterAttachmentColumns(List<CdcColumnMapping> columns)

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -595,11 +595,6 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         }
     }
 
-    /// <summary>
-    /// Fans an initial-load row out to every processor of a source table, appending the ops directly.
-    /// Same as <see cref="AddUpsertEvents"/> without the <see cref="CdcEvent"/> wrapper the
-    /// upsert-only initial load would immediately discard. Takes ownership of <paramref name="values"/>.
-    /// </summary>
     protected void AddUpsertOps(IReadOnlyList<CdcSinkTableProcessor> processors, object[] values, JsonOperationContext context, List<CdcSinkDocumentOp> output)
     {
         for (int i = 0; i < processors.Count; i++)
@@ -657,7 +652,6 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             object[] oldForProc;
             if (processors.Count == 1)
             {
-                // Sole processor == processors[0]: it owns the caller's array, zero-clone hot path.
                 oldForProc = oldValues;
                 oldValues = null;
             }

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -571,14 +571,18 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     // ---------------------------------------------------------------------------------------------
     // Fan-out. A single source table can feed several destinations at once - a root collection and/or
     // one or more embedded arrays. A decoded row must therefore produce an op for EVERY
-    // processor registered for that table, not just one. These helpers decode-once/emit-many: the first
-    // processor reuses the caller's decoded array, each additional processor gets a clone rented from its
-    // own pool so ReturnBatchValues returns each array to the right pool with no cross-processor sharing.
+    // processor registered for that table, not just one. These helpers decode-once/emit-many.
+    //
+    // Pool ownership: the caller's decoded arrays are rented from processors[0]'s pool, and each helper
+    // either hands such an array to a processors[0]-owned op or returns it to processors[0]'s pool once
+    // the loop is done. Every other processor works on a clone rented from its own pool. Two invariants
+    // follow: an array is never returned (which clears it in place) while a later processor still reads
+    // it, and every array goes back to the pool it was rented from.
     // ---------------------------------------------------------------------------------------------
 
     /// <summary>
-    /// Emits an Upsert event for every processor of a source table (INSERT, or the post-image of an
-    /// initial-load row). Takes ownership of <paramref name="values"/>.
+    /// Emits an Upsert event for every processor of a source table (INSERT, or an UPDATE post-image
+    /// without reparent detection). Takes ownership of <paramref name="values"/>.
     /// </summary>
     protected void AddUpsertEvents(IReadOnlyList<CdcSinkTableProcessor> processors, object[] values, JsonOperationContext context, List<CdcEvent> output)
     {
@@ -592,23 +596,41 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     }
 
     /// <summary>
-    /// Emits a Delete event for every processor of a source table. Takes ownership of
-    /// <paramref name="values"/>; a processor that ignores deletes releases its array back to its pool.
+    /// Fans an initial-load row out to every processor of a source table, appending the ops directly.
+    /// Same as <see cref="AddUpsertEvents"/> without the <see cref="CdcEvent"/> wrapper the
+    /// upsert-only initial load would immediately discard. Takes ownership of <paramref name="values"/>.
     /// </summary>
-    protected void AddDeleteEvents(IReadOnlyList<CdcSinkTableProcessor> processors, object[] values, JsonOperationContext context, List<CdcEvent> output)
+    protected void AddUpsertOps(IReadOnlyList<CdcSinkTableProcessor> processors, object[] values, JsonOperationContext context, List<CdcSinkDocumentOp> output)
     {
         for (int i = 0; i < processors.Count; i++)
         {
             var proc = processors[i];
             var rowValues = i == 0 ? values : CloneValues(proc, values);
-            var op = DocumentProcessor.ProcessRow(proc, CdcSinkOperation.Delete, rowValues, context);
-            if (op == null)
-            {
-                proc.ReturnValues(rowValues); // delete ignored by config - release the unused array
-                continue;
-            }
-            output.Add(new CdcEvent(CdcEventType.Delete, op, null));
+            output.Add(DocumentProcessor.ProcessRow(proc, CdcSinkOperation.Upsert, rowValues, context));
         }
+    }
+
+    /// <summary>
+    /// Emits a Delete event for every processor of a source table that doesn't ignore deletes.
+    /// Takes ownership of <paramref name="values"/>.
+    /// </summary>
+    protected void AddDeleteEvents(IReadOnlyList<CdcSinkTableProcessor> processors, object[] values, JsonOperationContext context, List<CdcEvent> output)
+    {
+        var valuesConsumed = false;
+        for (int i = 0; i < processors.Count; i++)
+        {
+            var proc = processors[i];
+            if (proc.IgnoresDeletes)
+                continue;
+
+            var rowValues = i == 0 ? values : CloneValues(proc, values);
+            var op = DocumentProcessor.ProcessRow(proc, CdcSinkOperation.Delete, rowValues, context);
+            output.Add(new CdcEvent(CdcEventType.Delete, op, null));
+            valuesConsumed |= i == 0;
+        }
+
+        if (valuesConsumed == false)
+            processors[0].ReturnValues(values);
     }
 
     /// <summary>
@@ -620,7 +642,6 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     /// </summary>
     protected void AddUpdateEvents(IReadOnlyList<CdcSinkTableProcessor> processors, object[] newValues, object[] oldValues, List<CdcEvent> output)
     {
-        var oldValuesAvailable = oldValues != null; // becomes false once an embedded processor takes ownership
         for (int i = 0; i < processors.Count; i++)
         {
             var proc = processors[i];
@@ -633,13 +654,12 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
                 continue;
             }
 
-            // Embedded processor: it needs an old-row array from its own pool. The first embedded
-            // consumer reuses the caller's array; any later one gets a clone.
             object[] oldForProc;
-            if (oldValuesAvailable)
+            if (processors.Count == 1)
             {
+                // Sole processor == processors[0]: it owns the caller's array, zero-clone hot path.
                 oldForProc = oldValues;
-                oldValuesAvailable = false;
+                oldValues = null;
             }
             else
             {
@@ -650,11 +670,11 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             if (delete.HasValue)
                 output.Add(delete.Value);
             else
-                proc.ReturnValues(oldForProc); // no reparent - release the unused old-values array
+                proc.ReturnValues(oldForProc); // no reparent - release the unused old-values clone
             output.Add(upsert);
         }
 
-        if (oldValuesAvailable)
+        if (oldValues != null)
             processors[0].ReturnValues(oldValues);
     }
 
@@ -663,6 +683,17 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         var dst = proc.RentValues();
         Array.Copy(src, dst, src.Length);
         return dst;
+    }
+
+    protected static bool HasEmbeddedProcessor(IReadOnlyList<CdcSinkTableProcessor> processors)
+    {
+        for (int i = 0; i < processors.Count; i++)
+        {
+            if (processors[i].IsRoot == false)
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -1083,7 +1114,6 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
 
             // On first batch for this table, set source column names from the reader if not already set
             bool columnNamesSet = primary.SourceColumnNames != null;
-            var fanOut = new List<CdcEvent>(processors.Count);
 
             while (await reader.ReadAsync(ct))
             {
@@ -1115,10 +1145,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
                 }
 
                 // Initial load only produces inserts; fan the row out to every processor.
-                fanOut.Clear();
-                AddUpsertEvents(processors, values, jsonParsingCtx, fanOut);
-                for (int i = 0; i < fanOut.Count; i++)
-                    ops.Add(fanOut[i].Op);
+                AddUpsertOps(processors, values, jsonParsingCtx, ops);
             }
 
             // Extract last keys from the last non-null op's RawValues for keyset pagination resume.

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -574,9 +574,6 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
     // processor registered for that table, not just one. These helpers decode-once/emit-many: the first
     // processor reuses the caller's decoded array, each additional processor gets a clone rented from its
     // own pool so ReturnBatchValues returns each array to the right pool with no cross-processor sharing.
-    //
-    // The single-processor case (the overwhelmingly common one) takes the exact same path as before -
-    // no clone, no extra allocation.
     // ---------------------------------------------------------------------------------------------
 
     /// <summary>
@@ -657,8 +654,6 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             output.Add(upsert);
         }
 
-        // Defensive: if the old-row array was decoded but never consumed (no embedded processor),
-        // return it to the decode processor's pool. In practice callers pass null when there is none.
         if (oldValuesAvailable)
             processors[0].ReturnValues(oldValues);
     }

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -568,6 +568,108 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         return (new CdcEvent(CdcEventType.Delete, deleteOp, null), upsert);
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // Fan-out. A single source table can feed several destinations at once - a root collection and/or
+    // one or more embedded arrays (RavenDB-27095). A decoded row must therefore produce an op for EVERY
+    // processor registered for that table, not just one. These helpers decode-once/emit-many: the first
+    // processor reuses the caller's decoded array, each additional processor gets a clone rented from its
+    // own pool so ReturnBatchValues returns each array to the right pool with no cross-processor sharing.
+    //
+    // The single-processor case (the overwhelmingly common one) takes the exact same path as before -
+    // no clone, no extra allocation.
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Emits an Upsert event for every processor of a source table (INSERT, or the post-image of an
+    /// initial-load row). Takes ownership of <paramref name="values"/>.
+    /// </summary>
+    protected void AddUpsertEvents(IReadOnlyList<CdcSinkTableProcessor> processors, object[] values, JsonOperationContext context, List<CdcEvent> output)
+    {
+        for (int i = 0; i < processors.Count; i++)
+        {
+            var proc = processors[i];
+            var rowValues = i == 0 ? values : CloneValues(proc, values);
+            var op = DocumentProcessor.ProcessRow(proc, CdcSinkOperation.Upsert, rowValues, context);
+            output.Add(new CdcEvent(CdcEventType.Upsert, op, null));
+        }
+    }
+
+    /// <summary>
+    /// Emits a Delete event for every processor of a source table. Takes ownership of
+    /// <paramref name="values"/>; a processor that ignores deletes releases its array back to its pool.
+    /// </summary>
+    protected void AddDeleteEvents(IReadOnlyList<CdcSinkTableProcessor> processors, object[] values, JsonOperationContext context, List<CdcEvent> output)
+    {
+        for (int i = 0; i < processors.Count; i++)
+        {
+            var proc = processors[i];
+            var rowValues = i == 0 ? values : CloneValues(proc, values);
+            var op = DocumentProcessor.ProcessRow(proc, CdcSinkOperation.Delete, rowValues, context);
+            if (op == null)
+            {
+                proc.ReturnValues(rowValues); // delete ignored by config - release the unused array
+                continue;
+            }
+            output.Add(new CdcEvent(CdcEventType.Delete, op, null));
+        }
+    }
+
+    /// <summary>
+    /// Emits update events for every processor of a source table. Root processors produce a single
+    /// Upsert; embedded processors run reparent detection (via <see cref="CreateEmbeddedUpdateEvents"/>)
+    /// which may add a Delete against the old parent plus an Upsert against the new one.
+    /// Takes ownership of <paramref name="newValues"/> and (when non-null) <paramref name="oldValues"/>.
+    /// <paramref name="oldValues"/> may be null only when the table has no embedded processor.
+    /// </summary>
+    protected void AddUpdateEvents(IReadOnlyList<CdcSinkTableProcessor> processors, object[] newValues, object[] oldValues, List<CdcEvent> output)
+    {
+        var oldValuesAvailable = oldValues != null; // becomes false once an embedded processor takes ownership
+        for (int i = 0; i < processors.Count; i++)
+        {
+            var proc = processors[i];
+            var rowValues = i == 0 ? newValues : CloneValues(proc, newValues);
+            var newOp = DocumentProcessor.ProcessRow(proc, CdcSinkOperation.Upsert, rowValues, StreamingJsonContext);
+
+            if (proc.IsRoot)
+            {
+                output.Add(new CdcEvent(CdcEventType.Upsert, newOp, null));
+                continue;
+            }
+
+            // Embedded processor: it needs an old-row array from its own pool. The first embedded
+            // consumer reuses the caller's array; any later one gets a clone.
+            object[] oldForProc;
+            if (oldValuesAvailable)
+            {
+                oldForProc = oldValues;
+                oldValuesAvailable = false;
+            }
+            else
+            {
+                oldForProc = CloneValues(proc, oldValues);
+            }
+
+            var (delete, upsert) = CreateEmbeddedUpdateEvents(newOp, oldForProc);
+            if (delete.HasValue)
+                output.Add(delete.Value);
+            else
+                proc.ReturnValues(oldForProc); // no reparent - release the unused old-values array
+            output.Add(upsert);
+        }
+
+        // Defensive: if the old-row array was decoded but never consumed (no embedded processor),
+        // return it to the decode processor's pool. In practice callers pass null when there is none.
+        if (oldValuesAvailable)
+            processors[0].ReturnValues(oldValues);
+    }
+
+    private static object[] CloneValues(CdcSinkTableProcessor proc, object[] src)
+    {
+        var dst = proc.RentValues();
+        Array.Copy(src, dst, src.Length);
+        return dst;
+    }
+
     /// <summary>
     /// Returns an async stream of CDC events from the source database.
     /// Each subclass converts provider-specific events into <see cref="CdcEvent"/>:
@@ -965,10 +1067,12 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
         try
         {
             var ops = new List<CdcSinkDocumentOp>();
-            CdcSinkTableProcessor processor;
+            IReadOnlyList<CdcSinkTableProcessor> processors;
             try
             {
-                processor = DocumentProcessor.GetProcessor(tableInfo.Schema, tableInfo.TableName);
+                // Every processor this source table feeds - a root collection and/or embedded arrays.
+                // A row is read once and fanned out to all of them (RavenDB-27095).
+                processors = DocumentProcessor.GetProcessors(tableInfo.Schema, tableInfo.TableName);
             }
             catch (InvalidOperationException e)
             {
@@ -980,8 +1084,11 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
                     "in the task's table mapping. Fix the table configuration; the task will restart.", e);
             }
 
+            var primary = processors[0];
+
             // On first batch for this table, set source column names from the reader if not already set
-            bool columnNamesSet = processor.SourceColumnNames != null;
+            bool columnNamesSet = primary.SourceColumnNames != null;
+            var fanOut = new List<CdcEvent>(processors.Count);
 
             while (await reader.ReadAsync(ct))
             {
@@ -990,12 +1097,13 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
                     var columnNames = new string[reader.FieldCount];
                     for (int i = 0; i < reader.FieldCount; i++)
                         columnNames[i] = reader.GetName(i);
-                    processor.SetSourceColumnNames(columnNames);
+                    // Sets column names on every processor of this table so each recomputes its indices.
+                    DocumentProcessor.SetSourceColumnNames(tableInfo.Schema, tableInfo.TableName, columnNames);
                     columnNamesSet = true;
                 }
                 else
                 {
-                    string[] sourceColumnNames = processor.SourceColumnNames;
+                    string[] sourceColumnNames = primary.SourceColumnNames;
                     if (sourceColumnNames != null && reader.FieldCount != sourceColumnNames.Length)
                     {
                         throw new InvalidOperationException(
@@ -1005,13 +1113,17 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
                     }
                 }
 
-                var values = processor.RentValues();
+                var values = primary.RentValues();
                 for (int i = 0; i < reader.FieldCount; i++)
                 {
                     values[i] = reader.IsDBNull(i) ? null : ConvertInitialLoadValue(reader, i, tableInfo);
                 }
 
-                ops.Add(DocumentProcessor.ProcessRow(processor, CdcSinkOperation.Upsert, values, jsonParsingCtx));
+                // Initial load only produces inserts; fan the row out to every processor.
+                fanOut.Clear();
+                AddUpsertEvents(processors, values, jsonParsingCtx, fanOut);
+                for (int i = 0; i < fanOut.Count; i++)
+                    ops.Add(fanOut[i].Op);
             }
 
             // Extract last keys from the last non-null op's RawValues for keyset pagination resume.

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -570,7 +570,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
 
     // ---------------------------------------------------------------------------------------------
     // Fan-out. A single source table can feed several destinations at once - a root collection and/or
-    // one or more embedded arrays (RavenDB-27095). A decoded row must therefore produce an op for EVERY
+    // one or more embedded arrays. A decoded row must therefore produce an op for EVERY
     // processor registered for that table, not just one. These helpers decode-once/emit-many: the first
     // processor reuses the caller's decoded array, each additional processor gets a clone rented from its
     // own pool so ReturnBatchValues returns each array to the right pool with no cross-processor sharing.
@@ -1071,7 +1071,7 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler
             try
             {
                 // Every processor this source table feeds - a root collection and/or embedded arrays.
-                // A row is read once and fanned out to all of them (RavenDB-27095).
+                // A row is read once and fanned out to all of them.
                 processors = DocumentProcessor.GetProcessors(tableInfo.Schema, tableInfo.TableName);
             }
             catch (InvalidOperationException e)

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
@@ -19,15 +19,17 @@ public class CdcSinkTableProcessor
     private readonly StringBuilder _sb = new();
 
     /// <summary>
-    /// The key used to look up this processor in the table index (schema.table or just table).
+    /// Patch dispatch key for this mapping: "schema.table|discriminator". Unique per processor, so a
+    /// source table mapped several ways dispatches each mapping's patch script separately.
     /// </summary>
     public string Key { get; init; }
 
     /// <summary>
-    /// Stable identity for this processor WITHIN its source table, used to disambiguate when the
-    /// same source table feeds multiple destinations (a root collection plus one or more embedded
-    /// arrays). Empty for the root processor; for an embedded processor it is the slash-joined path
-    /// of embedded property names from the root (e.g. "OrderDetails" or "Departments/Employees").
+    /// Identity of this mapping, unique across the whole configuration: the root collection name,
+    /// extended for an embedded processor with the slash-joined path of embedded property names
+    /// (e.g. "Orders" or "Orders/Departments/Employees"). '/' and '\' inside a segment are escaped
+    /// with '\' so segment boundaries stay unambiguous. Uniqueness follows from config validation:
+    /// root collection names are unique config-wide and embedded property names are unique per parent.
     /// Persisted with each op so tx-log replay can restore the exact processor.
     /// </summary>
     public string Discriminator { get; init; } = string.Empty;
@@ -40,6 +42,9 @@ public class CdcSinkTableProcessor
 
     /// <summary>Pre-computed Key + "__on_delete" for the OnDelete dispatch path.</summary>
     public string KeyOnDelete { get; init; }
+
+    /// <summary>True when this mapping ignores deletes (IgnoreDeletes with no OnDelete patch), so a DELETE row produces no op.</summary>
+    public bool IgnoresDeletes { get; init; }
 
     /// <summary>
     /// The root table configuration this processor belongs to.

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
@@ -43,7 +43,6 @@ public class CdcSinkTableProcessor
     /// <summary>Pre-computed Key + "__on_delete" for the OnDelete dispatch path.</summary>
     public string KeyOnDelete { get; init; }
 
-    /// <summary>True when this mapping ignores deletes (IgnoreDeletes with no OnDelete patch), so a DELETE row produces no op.</summary>
     public bool IgnoresDeletes { get; init; }
 
     /// <summary>

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
@@ -23,6 +23,15 @@ public class CdcSinkTableProcessor
     /// </summary>
     public string Key { get; init; }
 
+    /// <summary>
+    /// Stable identity for this processor WITHIN its source table, used to disambiguate when the
+    /// same source table feeds multiple destinations (a root collection plus one or more embedded
+    /// arrays). Empty for the root processor; for an embedded processor it is the slash-joined path
+    /// of embedded property names from the root (e.g. "OrderDetails" or "Departments/Employees").
+    /// Persisted with each op so tx-log replay can restore the exact processor.
+    /// </summary>
+    public string Discriminator { get; init; } = string.Empty;
+
     /// <summary>Source table schema (e.g. "public", "dbo"). Empty string when not specified.</summary>
     public string Schema { get; init; }
 

--- a/src/Raven.Server/Documents/CdcSink/Commands/CdcSinkBatchCommand.cs
+++ b/src/Raven.Server/Documents/CdcSink/Commands/CdcSinkBatchCommand.cs
@@ -1624,8 +1624,8 @@ public sealed class CdcSinkBatchCommand : DocumentMergedTransactionCommand
         public string ProcessorTable { get; set; }
         /// <summary>
         /// Which mapping of the source table this op belonged to, so replay restores the exact processor
-        /// when a table feeds several destinations. Empty for the root mapping; the
-        /// slash-joined embedded property path otherwise.
+        /// when a table feeds several destinations. See <see cref="CdcSinkTableProcessor.Discriminator"/>
+        /// for the format; replay throws when it no longer matches a registered mapping.
         /// </summary>
         public string ProcessorDiscriminator { get; set; }
         public BlittableJsonReaderObject MappedData { get; set; }

--- a/src/Raven.Server/Documents/CdcSink/Commands/CdcSinkBatchCommand.cs
+++ b/src/Raven.Server/Documents/CdcSink/Commands/CdcSinkBatchCommand.cs
@@ -1597,6 +1597,7 @@ public sealed class CdcSinkBatchCommand : DocumentMergedTransactionCommand
                 Operation = op.Operation,
                 ProcessorSchema = op.Processor?.Schema,
                 ProcessorTable = op.Processor?.Table,
+                ProcessorDiscriminator = op.Processor?.Discriminator,
                 MappedData = mappedBlittable,
                 RawData = rawBlittable,
                 BinaryData = binaryBlittable,
@@ -1621,6 +1622,12 @@ public sealed class CdcSinkBatchCommand : DocumentMergedTransactionCommand
         public CdcSinkOperation Operation { get; set; }
         public string ProcessorSchema { get; set; }
         public string ProcessorTable { get; set; }
+        /// <summary>
+        /// Which mapping of the source table this op belonged to, so replay restores the exact processor
+        /// when a table feeds several destinations. Empty for the root mapping; the
+        /// slash-joined embedded property path otherwise.
+        /// </summary>
+        public string ProcessorDiscriminator { get; set; }
         public BlittableJsonReaderObject MappedData { get; set; }
         public BlittableJsonReaderObject RawData { get; set; }
         /// <summary>
@@ -1668,7 +1675,7 @@ public sealed class CdcSinkBatchCommand : DocumentMergedTransactionCommand
             {
                 var serialized = Ops[i];
                 var mappedDjv = serialized.MappedData != null ? new DynamicJsonValue(serialized.MappedData) : null;
-                var processor = docProcessor.GetProcessor(serialized.ProcessorSchema, serialized.ProcessorTable);
+                var processor = docProcessor.GetProcessor(serialized.ProcessorSchema, serialized.ProcessorTable, serialized.ProcessorDiscriminator);
 
                 // Rebuild object[] from the serialized blittable using processor's column name order
                 object[] rawValues = null;

--- a/src/Raven.Server/Documents/CdcSink/Commands/CdcSinkBatchCommand.cs
+++ b/src/Raven.Server/Documents/CdcSink/Commands/CdcSinkBatchCommand.cs
@@ -793,7 +793,7 @@ public sealed class CdcSinkBatchCommand : DocumentMergedTransactionCommand
 
     /// <summary>
     /// Builds the cache key for arrayStates, including parent FK values for nested paths.
-    /// For depth-1 embedded tables (e.g., Order → Lines[]), the key is just "schema.table:PropertyName".
+    /// For depth-1 embedded tables (e.g., Order → Lines[]), the key is just "{processor.Key}:PropertyName".
     /// For deeper nesting (e.g., Company → Departments[] → Employees[]), the key includes
     /// the FK values that identify which parent element the array belongs to, so that
     /// employees in different departments get separate working arrays.

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -60,7 +60,7 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
         /// <summary>
         /// Every processor this source table feeds - a root collection and/or embedded arrays. All share
         /// the same source columns; index 0 is the primary (used to rent the decode buffer). A row is
-        /// decoded once and fanned out to all of them (RavenDB-27095).
+        /// decoded once and fanned out to all of them.
         /// </summary>
         public required IReadOnlyList<CdcSinkTableProcessor> Processors { get; init; }
 

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -622,7 +622,6 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
             // _resolvedTables, so tables on a non-default schema stream too. Row events for uncached
             // table IDs are skipped automatically by the TryGetValue check.
             var tableMapCache = new Dictionary<long, TableInfo>();
-            // Reused across rows; CdcEvent is a struct the consumer copies out between yields.
             var events = new List<CdcEvent>();
 
             await foreach (var (header, binlogEvent) in client.Replicate(ct))

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -67,9 +67,6 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
         /// <summary>True when at least one processor is embedded - only then do UPDATEs need the pre-image.</summary>
         public required bool HasEmbedded { get; init; }
 
-        /// <summary>The primary processor (index 0); owns the pool the decode buffer is rented from.</summary>
-        public CdcSinkTableProcessor Processor => Processors[0];
-
         /// <summary>
         /// Expected binlog type bytes for column positions 0..RequiredPrefixLength-1,
         /// computed from INFORMATION_SCHEMA DATA_TYPE at resolve time. Used for prefix
@@ -333,13 +330,10 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
             // With several processors we must cover the widest one so a schema change in any
             // mapped position is detected.
             var requiredLen = 0;
-            var hasEmbedded = false;
             for (int p = 0; p < processors.Count; p++)
             {
                 if (processors[p].RequiredPrefixLength > requiredLen)
                     requiredLen = processors[p].RequiredPrefixLength;
-                if (processors[p].IsRoot == false)
-                    hasEmbedded = true;
             }
             var expectedPrefix = new byte[requiredLen];
             for (int i = 0; i < requiredLen && i < columnsArray.Length; i++)
@@ -350,7 +344,7 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
             {
                 Columns = columnsArray,
                 Processors = processors,
-                HasEmbedded = hasEmbedded,
+                HasEmbedded = HasEmbeddedProcessor(processors),
                 ExpectedTypesPrefix = expectedPrefix,
             };
         }
@@ -628,6 +622,8 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
             // _resolvedTables, so tables on a non-default schema stream too. Row events for uncached
             // table IDs are skipped automatically by the TryGetValue check.
             var tableMapCache = new Dictionary<long, TableInfo>();
+            // Reused across rows; CdcEvent is a struct the consumer copies out between yields.
+            var events = new List<CdcEvent>();
 
             await foreach (var (header, binlogEvent) in client.Replicate(ct))
             {
@@ -705,7 +701,7 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
                         foreach (var row in writeRows.Rows)
                         {
                             var values = DecodeRowInternal(wTable, row.Cells);
-                            var events = new List<CdcEvent>(wTable.Processors.Count);
+                            events.Clear();
                             AddUpsertEvents(wTable.Processors, values, StreamingJsonContext, events);
                             foreach (var e in events)
                                 yield return e;
@@ -719,7 +715,7 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
                         {
                             var newValues = DecodeRowInternal(uTable, row.AfterUpdate.Cells);
                             var oldValues = uTable.HasEmbedded ? DecodeRowInternal(uTable, row.BeforeUpdate.Cells) : null;
-                            var events = new List<CdcEvent>(uTable.Processors.Count + 1);
+                            events.Clear();
                             AddUpdateEvents(uTable.Processors, newValues, oldValues, events);
                             foreach (var e in events)
                                 yield return e;
@@ -732,7 +728,7 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
                         foreach (var row in deleteRows.Rows)
                         {
                             var values = DecodeRowInternal(dTable, row.Cells);
-                            var events = new List<CdcEvent>(dTable.Processors.Count);
+                            events.Clear();
                             AddDeleteEvents(dTable.Processors, values, StreamingJsonContext, events);
                             foreach (var e in events)
                                 yield return e;
@@ -757,7 +753,7 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
         TableInfo tableInfo, IReadOnlyList<object> cells)
     {
         var columns = tableInfo.Columns;
-        var processor = tableInfo.Processor;
+        var processor = tableInfo.Processors[0];
         var values = processor.RentValues();
         for (int i = 0; i < columns.Length && i < cells.Count; i++)
         {

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -56,7 +56,19 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
     private sealed class TableInfo
     {
         public required ColumnInfo[] Columns { get; init; }
-        public required CdcSinkTableProcessor Processor { get; init; }
+
+        /// <summary>
+        /// Every processor this source table feeds - a root collection and/or embedded arrays. All share
+        /// the same source columns; index 0 is the primary (used to rent the decode buffer). A row is
+        /// decoded once and fanned out to all of them (RavenDB-27095).
+        /// </summary>
+        public required IReadOnlyList<CdcSinkTableProcessor> Processors { get; init; }
+
+        /// <summary>True when at least one processor is embedded - only then do UPDATEs need the pre-image.</summary>
+        public required bool HasEmbedded { get; init; }
+
+        /// <summary>The primary processor (index 0); owns the pool the decode buffer is rented from.</summary>
+        public CdcSinkTableProcessor Processor => Processors[0];
 
         /// <summary>
         /// Expected binlog type bytes for column positions 0..RequiredPrefixLength-1,
@@ -310,13 +322,25 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
             for (int i = 0; i < columnsArray.Length; i++)
                 columnNames[i] = columnsArray[i].Name;
 
-            var processor = DocumentProcessor.GetProcessor(tableInfo.Schema, tableInfo.TableName);
-            processor.SetSourceColumnNames(columnNames);
+            // Set column names on every processor for this source table (root + embedded), then fan a
+            // row out to all of them. SetSourceColumnNames on the document processor updates them all.
+            DocumentProcessor.SetSourceColumnNames(tableInfo.Schema, tableInfo.TableName, columnNames);
+            var processors = DocumentProcessor.GetProcessors(tableInfo.Schema, tableInfo.TableName);
 
             // Build the expected type prefix covering all mapped column positions.
             // RequiredPrefixLength is computed by SetSourceColumnNames — it's the max
             // ordinal of any column we actually read (PK, mapped, join, attachment) + 1.
-            var requiredLen = processor.RequiredPrefixLength;
+            // With several processors we must cover the widest one so a schema change in any
+            // mapped position is detected.
+            var requiredLen = 0;
+            var hasEmbedded = false;
+            for (int p = 0; p < processors.Count; p++)
+            {
+                if (processors[p].RequiredPrefixLength > requiredLen)
+                    requiredLen = processors[p].RequiredPrefixLength;
+                if (processors[p].IsRoot == false)
+                    hasEmbedded = true;
+            }
             var expectedPrefix = new byte[requiredLen];
             for (int i = 0; i < requiredLen && i < columnsArray.Length; i++)
                 expectedPrefix[i] = MapDataTypeToBinlogType(columnsArray[i].DataType);
@@ -325,7 +349,8 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
             _resolvedTables[tableKey] = new TableInfo
             {
                 Columns = columnsArray,
-                Processor = processor,
+                Processors = processors,
+                HasEmbedded = hasEmbedded,
                 ExpectedTypesPrefix = expectedPrefix,
             };
         }
@@ -678,7 +703,13 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
                         if (tableMapCache.TryGetValue(writeRows.TableId, out var wTable) == false)
                             break;
                         foreach (var row in writeRows.Rows)
-                            yield return new CdcEvent(CdcEventType.Upsert, DecodeRow(wTable, row.Cells, CdcSinkOperation.Upsert, StreamingJsonContext), null);
+                        {
+                            var values = DecodeRowInternal(wTable, row.Cells);
+                            var events = new List<CdcEvent>(wTable.Processors.Count);
+                            AddUpsertEvents(wTable.Processors, values, StreamingJsonContext, events);
+                            foreach (var e in events)
+                                yield return e;
+                        }
                         break;
 
                     case UpdateRowsEvent updateRows:
@@ -686,21 +717,12 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
                             break;
                         foreach (var row in updateRows.Rows)
                         {
-                            var newOp = DecodeRow(uTable, row.AfterUpdate.Cells, CdcSinkOperation.Upsert, StreamingJsonContext);
-                            if (newOp?.Processor is { IsRoot: false })
-                            {
-                                var oldValues = DecodeRowInternal(uTable, row.BeforeUpdate.Cells);
-                                var (delete, upsert) = CreateEmbeddedUpdateEvents(newOp, oldValues);
-                                if (delete.HasValue)
-                                    yield return delete.Value;
-                                else
-                                    uTable.Processor.ReturnValues(oldValues); // no reparent — release the unused old-values array
-                                yield return upsert;
-                            }
-                            else
-                            {
-                                yield return new CdcEvent(CdcEventType.Upsert, newOp, null);
-                            }
+                            var newValues = DecodeRowInternal(uTable, row.AfterUpdate.Cells);
+                            var oldValues = uTable.HasEmbedded ? DecodeRowInternal(uTable, row.BeforeUpdate.Cells) : null;
+                            var events = new List<CdcEvent>(uTable.Processors.Count + 1);
+                            AddUpdateEvents(uTable.Processors, newValues, oldValues, events);
+                            foreach (var e in events)
+                                yield return e;
                         }
                         break;
 
@@ -708,7 +730,13 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
                         if (tableMapCache.TryGetValue(deleteRows.TableId, out var dTable) == false)
                             break;
                         foreach (var row in deleteRows.Rows)
-                            yield return new CdcEvent(CdcEventType.Delete, DecodeRow(dTable, row.Cells, CdcSinkOperation.Delete, StreamingJsonContext), null);
+                        {
+                            var values = DecodeRowInternal(dTable, row.Cells);
+                            var events = new List<CdcEvent>(dTable.Processors.Count);
+                            AddDeleteEvents(dTable.Processors, values, StreamingJsonContext, events);
+                            foreach (var e in events)
+                                yield return e;
+                        }
                         break;
 
                     case XidEvent:
@@ -720,18 +748,10 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
             }
     }
 
-    private CdcSinkDocumentOp DecodeRow(
-        TableInfo tableInfo, IReadOnlyList<object> cells,
-        CdcSinkOperation operation, DocumentsOperationContext jsonParsingContext)
-    {
-        var values = DecodeRowInternal(tableInfo, cells);
-        return DocumentProcessor.ProcessRow(tableInfo.Processor, operation, values, jsonParsingContext);
-    }
-
     /// <summary>
-    /// Decodes binlog cells into raw column values and returns the decoded values array.
-    /// Used by <see cref="DecodeRow"/> and by the reparent detection path
-    /// (which needs the raw values without calling ProcessRow); the processor is available via <paramref name="tableInfo"/>.
+    /// Decodes binlog cells into raw column values and returns the decoded values array, rented from the
+    /// primary processor's pool. The caller fans the array out to every processor of the table via the
+    /// AddUpsert/AddDelete/AddUpdate helpers.
     /// </summary>
     private object[] DecodeRowInternal(
         TableInfo tableInfo, IReadOnlyList<object> cells)

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -67,7 +67,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
     /// </summary>
     // Processors: every mapping the relation feeds - a root collection and/or embedded arrays. All share
     // the same source columns; index 0 is the primary (used to rent the decode buffer). A row is decoded
-    // once and fanned out to all of them (RavenDB-27095).
+    // once and fanned out to all of them.
     private readonly Dictionary<uint, (PostgresTypeCategory[] Types, IReadOnlyList<CdcSinkTableProcessor> Processors)> _relationProcessors = new();
 
     // PostgreSQL SQLSTATE for insufficient_privilege (e.g. the connection user lacks the

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -582,7 +582,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
     /// </summary>
     private bool IsConfiguredRelation(RelationMessage relation)
     {
-        if (DocumentProcessor.TryGetProcessor(relation.Namespace, relation.RelationName, out _))
+        if (DocumentProcessor.TryGetPrimaryProcessor(relation.Namespace, relation.RelationName, out _))
             return true;
 
         if (_unconfiguredRelations.Add(relation.RelationId) && Logger.IsInfoEnabled)

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -466,6 +466,9 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
             ct,
             _lastLsn);
 
+        // Reused across messages; CdcEvent is a struct the consumer copies out between yields.
+        var events = new List<CdcEvent>();
+
         await foreach (var message in replicationStream.WithCancellation(ct))
         {
             LastActivityTime = Database.Time.GetUtcNow();
@@ -487,7 +490,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                     }
                     {
                         var (procs, values) = await DecodeRowInternal(insert.Relation, insert.NewRow, ct);
-                        var events = new List<CdcEvent>(procs.Count);
+                        events.Clear();
                         AddUpsertEvents(procs, values, StreamingJsonContext, events);
                         foreach (var e in events)
                             yield return e;
@@ -515,9 +518,9 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                         oldValues = null;
                     }
 
-                    var updateEvents = new List<CdcEvent>(procs.Count + 1);
-                    AddUpdateEvents(procs, newValues, oldValues, updateEvents);
-                    foreach (var e in updateEvents)
+                    events.Clear();
+                    AddUpdateEvents(procs, newValues, oldValues, events);
+                    foreach (var e in events)
                         yield return e;
                     break;
                 }
@@ -531,7 +534,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                         // No pre-image available (REPLICA IDENTITY DEFAULT), so we can't detect reparenting -
                         // upsert into the current parent, matching the single-processor behavior.
                         var (procs, values) = await DecodeRowInternal(update.Relation, update.NewRow, ct);
-                        var events = new List<CdcEvent>(procs.Count);
+                        events.Clear();
                         AddUpsertEvents(procs, values, StreamingJsonContext, events);
                         foreach (var e in events)
                             yield return e;
@@ -545,7 +548,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                     }
                     {
                         var (procs, values) = await DecodeRowInternal(keyDel.Relation, keyDel.Key, ct);
-                        var events = new List<CdcEvent>(procs.Count);
+                        events.Clear();
                         AddDeleteEvents(procs, values, StreamingJsonContext, events);
                         foreach (var e in events)
                             yield return e;
@@ -559,7 +562,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                     }
                     {
                         var (procs, values) = await DecodeRowInternal(fullDel.Relation, fullDel.OldRow, ct);
-                        var events = new List<CdcEvent>(procs.Count);
+                        events.Clear();
                         AddDeleteEvents(procs, values, StreamingJsonContext, events);
                         foreach (var e in events)
                             yield return e;
@@ -582,7 +585,7 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
     /// </summary>
     private bool IsConfiguredRelation(RelationMessage relation)
     {
-        if (DocumentProcessor.TryGetPrimaryProcessor(relation.Namespace, relation.RelationName, out _))
+        if (DocumentProcessor.HasProcessors(relation.Namespace, relation.RelationName))
             return true;
 
         if (_unconfiguredRelations.Add(relation.RelationId) && Logger.IsInfoEnabled)
@@ -713,14 +716,6 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
         }
 
         return (processors, values);
-    }
-
-    private static bool HasEmbeddedProcessor(IReadOnlyList<CdcSinkTableProcessor> processors)
-    {
-        for (int i = 0; i < processors.Count; i++)
-            if (processors[i].IsRoot == false)
-                return true;
-        return false;
     }
 
     private string QuoteTableList(List<CdcSinkConfiguration.TableInfo> tables)

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -65,7 +65,10 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
     /// mapping, keyed by the relation's real OID. (Re)built from the RelationMessage that pgoutput sends
     /// before a relation's rows and again on a schema change (see the RelationMessage case in GetCdcEvents).
     /// </summary>
-    private readonly Dictionary<uint, (PostgresTypeCategory[] Types, CdcSinkTableProcessor Processor)> _relationProcessors = new();
+    // Processors: every mapping the relation feeds - a root collection and/or embedded arrays. All share
+    // the same source columns; index 0 is the primary (used to rent the decode buffer). A row is decoded
+    // once and fanned out to all of them (RavenDB-27095).
+    private readonly Dictionary<uint, (PostgresTypeCategory[] Types, IReadOnlyList<CdcSinkTableProcessor> Processors)> _relationProcessors = new();
 
     // PostgreSQL SQLSTATE for insufficient_privilege (e.g. the connection user lacks the
     // REPLICATION role attribute needed to create/read a publication or replication slot).
@@ -482,8 +485,13 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                         await DrainTuple(insert.NewRow, ct);
                         break;
                     }
-                    yield return new CdcEvent(CdcEventType.Upsert,
-                        await DecodeRow(insert.Relation, insert.NewRow, CdcSinkOperation.Upsert, StreamingJsonContext, ct), null);
+                    {
+                        var (procs, values) = await DecodeRowInternal(insert.Relation, insert.NewRow, ct);
+                        var events = new List<CdcEvent>(procs.Count);
+                        AddUpsertEvents(procs, values, StreamingJsonContext, events);
+                        foreach (var e in events)
+                            yield return e;
+                    }
                     break;
                 case FullUpdateMessage fullUpdate:
                 {
@@ -496,24 +504,21 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                         break;
                     }
 
-                    var (proc, oldValues) = await DecodeRowInternal(fullUpdate.Relation, fullUpdate.OldRow, ct);
-                    var newOp = await DecodeRow(fullUpdate.Relation, fullUpdate.NewRow, CdcSinkOperation.Upsert, StreamingJsonContext, ct);
+                    // OldRow must be consumed before NewRow. Decode both in order; the pre-image is only
+                    // needed when an embedded processor is present (reparent detection).
+                    var (procs, oldValues) = await DecodeRowInternal(fullUpdate.Relation, fullUpdate.OldRow, ct);
+                    var (_, newValues) = await DecodeRowInternal(fullUpdate.Relation, fullUpdate.NewRow, ct);
 
-                    if (newOp?.Processor is { IsRoot: false })
+                    if (HasEmbeddedProcessor(procs) == false)
                     {
-                        var (delete, upsert) = CreateEmbeddedUpdateEvents(newOp, oldValues);
-                        if (delete.HasValue)
-                            yield return delete.Value;
-                        else
-                            proc.ReturnValues(oldValues); // no reparent — release the unused old-values array
-                        yield return upsert;
+                        procs[0].ReturnValues(oldValues); // root-only update - pre-image unused
+                        oldValues = null;
                     }
-                    else
-                    {
-                        // Root table FullUpdateMessage — old values unused, return to pool.
-                        proc.ReturnValues(oldValues);
-                        yield return new CdcEvent(CdcEventType.Upsert, newOp, null);
-                    }
+
+                    var updateEvents = new List<CdcEvent>(procs.Count + 1);
+                    AddUpdateEvents(procs, newValues, oldValues, updateEvents);
+                    foreach (var e in updateEvents)
+                        yield return e;
                     break;
                 }
                 case UpdateMessage update:
@@ -522,8 +527,15 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                         await DrainTuple(update.NewRow, ct);
                         break;
                     }
-                    yield return new CdcEvent(CdcEventType.Upsert,
-                        await DecodeRow(update.Relation, update.NewRow, CdcSinkOperation.Upsert, StreamingJsonContext, ct), null);
+                    {
+                        // No pre-image available (REPLICA IDENTITY DEFAULT), so we can't detect reparenting -
+                        // upsert into the current parent, matching the single-processor behavior.
+                        var (procs, values) = await DecodeRowInternal(update.Relation, update.NewRow, ct);
+                        var events = new List<CdcEvent>(procs.Count);
+                        AddUpsertEvents(procs, values, StreamingJsonContext, events);
+                        foreach (var e in events)
+                            yield return e;
+                    }
                     break;
                 case KeyDeleteMessage keyDel:
                     if (IsConfiguredRelation(keyDel.Relation) == false)
@@ -531,8 +543,13 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                         await DrainTuple(keyDel.Key, ct);
                         break;
                     }
-                    yield return new CdcEvent(CdcEventType.Delete,
-                        await DecodeRow(keyDel.Relation, keyDel.Key, CdcSinkOperation.Delete, StreamingJsonContext, ct), null);
+                    {
+                        var (procs, values) = await DecodeRowInternal(keyDel.Relation, keyDel.Key, ct);
+                        var events = new List<CdcEvent>(procs.Count);
+                        AddDeleteEvents(procs, values, StreamingJsonContext, events);
+                        foreach (var e in events)
+                            yield return e;
+                    }
                     break;
                 case FullDeleteMessage fullDel:
                     if (IsConfiguredRelation(fullDel.Relation) == false)
@@ -540,8 +557,13 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
                         await DrainTuple(fullDel.OldRow, ct);
                         break;
                     }
-                    yield return new CdcEvent(CdcEventType.Delete,
-                        await DecodeRow(fullDel.Relation, fullDel.OldRow, CdcSinkOperation.Delete, StreamingJsonContext, ct), null);
+                    {
+                        var (procs, values) = await DecodeRowInternal(fullDel.Relation, fullDel.OldRow, ct);
+                        var events = new List<CdcEvent>(procs.Count);
+                        AddDeleteEvents(procs, values, StreamingJsonContext, events);
+                        foreach (var e in events)
+                            yield return e;
+                    }
                     break;
                 case CommitMessage commit:
                     _lastLsn = commit.CommitLsn;
@@ -642,19 +664,12 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
         }
     }
 
-    private async Task<CdcSinkDocumentOp> DecodeRow(
-        RelationMessage relation, ReplicationTuple row, CdcSinkOperation operation, JsonOperationContext jsonParsingContext, CancellationToken ct = default)
-    {
-        var (proc, values) = await DecodeRowInternal(relation, row, ct);
-        return DocumentProcessor.ProcessRow(proc, operation, values, jsonParsingContext);
-    }
-
     /// <summary>
-    /// (Re)builds the per-relation decode state (type categories + processor + source column names) from a
+    /// (Re)builds the per-relation decode state (type categories + processors + source column names) from a
     /// RelationMessage and caches it keyed by the relation's real OID. Called when a RelationMessage arrives
     /// (first encounter or schema change) and as a lazy fallback from DecodeRowInternal.
     /// </summary>
-    private (PostgresTypeCategory[] Types, CdcSinkTableProcessor Processor) BuildRelationMapping(RelationMessage relation)
+    private (PostgresTypeCategory[] Types, IReadOnlyList<CdcSinkTableProcessor> Processors) BuildRelationMapping(RelationMessage relation)
     {
         var typeCategories = PostgresColumnTypeMapping.BuildTypeCategoriesFromRelation(relation, _vectorOid);
 
@@ -662,20 +677,21 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
         for (int i = 0; i < relation.Columns.Count; i++)
             columnNames[i] = relation.Columns[i].ColumnName;
 
-        var processor = DocumentProcessor.GetProcessor(relation.Namespace, relation.RelationName);
-        processor.SetSourceColumnNames(columnNames);
+        // Set column names on every processor for this relation (root + embedded), then fan rows out to all.
+        DocumentProcessor.SetSourceColumnNames(relation.Namespace, relation.RelationName, columnNames);
+        var processors = DocumentProcessor.GetProcessors(relation.Namespace, relation.RelationName);
 
-        var entry = (typeCategories, processor);
+        var entry = (typeCategories, processors);
         _relationProcessors[relation.RelationId] = entry;
         return entry;
     }
 
     /// <summary>
-    /// Resolves the processor for a relation, decodes a replication tuple into raw column values,
-    /// and returns both. Used by <see cref="DecodeRow"/> and by the reparent detection path
-    /// (which needs the raw values without calling ProcessRow).
+    /// Resolves the processors for a relation, decodes a replication tuple into raw column values (rented
+    /// from the primary processor's pool), and returns both. The caller fans the array out to every
+    /// processor via the AddUpsert/AddDelete/AddUpdate helpers.
     /// </summary>
-    private async Task<(CdcSinkTableProcessor Processor, object[] Values)> DecodeRowInternal(
+    private async Task<(IReadOnlyList<CdcSinkTableProcessor> Processors, object[] Values)> DecodeRowInternal(
         RelationMessage relation, ReplicationTuple row, CancellationToken ct)
     {
         // The RelationMessage that precedes a relation's rows (and is re-sent on schema change) builds the
@@ -683,9 +699,9 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
         if (_relationProcessors.TryGetValue(relation.RelationId, out var entry) == false)
             entry = BuildRelationMapping(relation);
 
-        var (types, proc) = entry;
+        var (types, processors) = entry;
 
-        var values = proc.RentValues();
+        var values = processors[0].RentValues();
         int columnIndex = 0;
         var relationKey = $"{relation.Namespace}.{relation.RelationName}";
 
@@ -696,7 +712,15 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
             columnIndex++;
         }
 
-        return (proc, values);
+        return (processors, values);
+    }
+
+    private static bool HasEmbeddedProcessor(IReadOnlyList<CdcSinkTableProcessor> processors)
+    {
+        for (int i = 0; i < processors.Count; i++)
+            if (processors[i].IsRoot == false)
+                return true;
+        return false;
     }
 
     private string QuoteTableList(List<CdcSinkConfiguration.TableInfo> tables)

--- a/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/PostgresCdcSinkProcess.cs
@@ -466,7 +466,6 @@ public class PostgresCdcSinkProcess : CdcSinkProcess
             ct,
             _lastLsn);
 
-        // Reused across messages; CdcEvent is a struct the consumer copies out between yields.
         var events = new List<CdcEvent>();
 
         await foreach (var message in replicationStream.WithCancellation(ct))

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -544,7 +544,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
         /// <summary>
         /// Every processor this source table feeds - a root collection and/or embedded arrays. All share
         /// the same source columns; index 0 is the primary (used to rent the decode buffer). A change row
-        /// is decoded once and fanned out to all of them (RavenDB-27095).
+        /// is decoded once and fanned out to all of them.
         /// </summary>
         public IReadOnlyList<CdcSinkTableProcessor> Processors;
 

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -591,15 +591,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
             var quotedFn = CommandBuilder.QuoteIdentifier($"fn_cdc_get_all_changes_{captureInstance}");
             // GetProcessors throws if the table isn't registered; every configured table is, so this is non-empty.
             var processors = DocumentProcessor.GetProcessors(tableInfo.Schema, tableInfo.TableName);
-            var hasEmbedded = false;
-            for (int p = 0; p < processors.Count; p++)
-            {
-                if (processors[p].IsRoot == false)
-                {
-                    hasEmbedded = true;
-                    break;
-                }
-            }
+            var hasEmbedded = HasEmbeddedProcessor(processors);
 
             // If ANY processor is embedded we need the pre-image to detect reparenting, so use
             // 'all update old'. A table mapped only as a root collection uses 'all' and skips it.

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -317,7 +317,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 {
                     var rowLsn = reader[0] as byte[];
                     var rowSeq = reader[1] as byte[];
-                    var operation = reader.GetInt32(2);
+                    var operation = (SqlServerCdcOperation)reader.GetInt32(2);
 
                     var values = processors[0].RentValues();
                     for (int i = 0; i < columns.Length; i++)
@@ -326,7 +326,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                         values[i] = reader.IsDBNull(ordinal) ? null : ConvertSqlServerValue(reader.GetValue(ordinal));
                     }
 
-                    if (operation == 3) // pre-update image for embedded table
+                    if (operation == SqlServerCdcOperation.UpdateBefore) // pre-update image for embedded table
                     {
                         pendingPreUpdate ??= new Dictionary<LsnSeqKey, object[]>();
                         pendingPreUpdate[new LsnSeqKey(rowLsn, rowSeq)] = values;
@@ -335,22 +335,29 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
 
                     events.Clear();
 
-                    if (operation == 1) // delete
+                    if (operation == SqlServerCdcOperation.Delete)
                     {
                         AddDeleteEvents(processors, values, StreamingJsonContext, events);
                     }
-                    else if (operation == 4 && ci.HasEmbedded && pendingPreUpdate != null &&
+                    else if (operation == SqlServerCdcOperation.UpdateAfter && ci.HasEmbedded && pendingPreUpdate != null &&
                              pendingPreUpdate.Remove(new LsnSeqKey(rowLsn, rowSeq), out var oldValues))
                     {
                         // Post-update image paired with its stashed pre-update: fan out with reparent
                         // detection for embedded processors.
                         AddUpdateEvents(processors, values, oldValues, events);
                     }
+                    else if (operation is SqlServerCdcOperation.Insert or SqlServerCdcOperation.UpdateAfter)
+                    {
+                        // Insert, or a post-update on a root-only table / without a paired pre-image:
+                        // upsert into the current location for every processor.
+                        AddUpsertEvents(processors, values, StreamingJsonContext, events);
+                    }
                     else
                     {
-                        // Insert (op=2), or a post-update (op=4) on a root-only table / without a paired
-                        // pre-image: upsert into the current location for every processor.
-                        AddUpsertEvents(processors, values, StreamingJsonContext, events);
+                        throw new InvalidOperationException(
+                            $"Unexpected SQL Server CDC __$operation value {(int)operation} for capture instance " +
+                            $"'{ci.CaptureInstance}' (table {ci.TableInfo.FullName}). Expected 1 (delete), 2 (insert), " +
+                            "3 (pre-update image), or 4 (post-update image).");
                     }
 
                     foreach (var evt in events)
@@ -513,6 +520,18 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
     }
 
 
+    /// <summary>
+    /// Values of the <c>__$operation</c> column returned by <c>fn_cdc_get_all_changes_*</c>.
+    /// UpdateBefore (the pre-image) is only delivered under the 'all update old' row-filter option.
+    /// </summary>
+    private enum SqlServerCdcOperation
+    {
+        Delete = 1,
+        Insert = 2,
+        UpdateBefore = 3,
+        UpdateAfter = 4
+    }
+
     private sealed class CaptureInstanceInfo
     {
         public CdcSinkConfiguration.TableInfo TableInfo;
@@ -565,12 +584,10 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 quotedColumns[i] = CommandBuilder.QuoteIdentifier(columns[i]);
             var columnList = string.Join(", ", quotedColumns);
 
-            // __$operation values: 1=delete, 2=insert, 3=pre-update image, 4=post-update image.
-            // Embedded tables need pre-update images to detect join-column changes (reparenting),
-            // so we use the 'all update old' row-filter option which delivers op=3 alongside op=4.
-            // (The default 'all' option drops op=3 and only returns the post-image — which means
-            // the previous code path here never actually saw a pre-image.) For root tables we
-            // don't need pre-images, so we still use 'all' and skip the extra row.
+            // Embedded tables need the pre-image (see SqlServerCdcOperation.UpdateBefore) to detect
+            // join-column changes (reparenting), so we use the 'all update old' row-filter option which
+            // delivers it alongside the post-image. The default 'all' option drops the pre-image and
+            // returns only the post-image, so for root-only tables we use 'all' and skip the extra row.
             var quotedFn = CommandBuilder.QuoteIdentifier($"fn_cdc_get_all_changes_{captureInstance}");
             // GetProcessors throws if the table isn't registered; every configured table is, so this is non-empty.
             var processors = DocumentProcessor.GetProcessors(tableInfo.Schema, tableInfo.TableName);

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -601,8 +601,8 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 }
             }
 
-            // If ANY processor is embedded we need op=3 (pre-image) to detect reparenting, so use
-            // 'all update old'. A table mapped only as a root collection uses 'all' and skips op=3.
+            // If ANY processor is embedded we need the pre-image to detect reparenting, so use
+            // 'all update old'. A table mapped only as a root collection uses 'all' and skips it.
             var rowFilterOption = hasEmbedded ? "all update old" : "all";
             var query = $@"
                 SELECT __$start_lsn, __$seqval, __$operation, {columnList}

--- a/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/SqlServerCdcSinkProcess.cs
@@ -301,7 +301,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
 
                 await using var reader = await cmd.ExecuteReaderAsync(ct);
                 var columns = ci.Columns;
-                var processor = DocumentProcessor.GetProcessor(ci.TableInfo.Schema, ci.TableInfo.TableName);
+                var processors = ci.Processors;
                 // Query shape: __$start_lsn (0), __$seqval (1), __$operation (2), user columns (3+)
 
                 // For embedded tables, op 3 (pre-update image) is kept so we can detect
@@ -310,6 +310,8 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 // is found regardless of whether the UPDATE changed any PK column (a PK-derived
                 // key would miss when the embedded PK includes the join column).
                 Dictionary<LsnSeqKey, object[]> pendingPreUpdate = null;
+                
+                var events = new List<CdcEvent>(processors.Count + 1);
 
                 while (await reader.ReadAsync(ct))
                 {
@@ -317,7 +319,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                     var rowSeq = reader[1] as byte[];
                     var operation = reader.GetInt32(2);
 
-                    var values = processor.RentValues();
+                    var values = processors[0].RentValues();
                     for (int i = 0; i < columns.Length; i++)
                     {
                         int ordinal = i + 3;
@@ -331,26 +333,28 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                         continue;
                     }
 
-                    var cdcOperation = operation == 1 ? CdcSinkOperation.Delete : CdcSinkOperation.Upsert;
-                    var op = DocumentProcessor.ProcessRow(processor, cdcOperation, values, StreamingJsonContext);
+                    events.Clear();
 
-                    if (operation == 4 && !processor.IsRoot && pendingPreUpdate != null)
+                    if (operation == 1) // delete
                     {
-                        // Post-update image — pair with stashed pre-update for reparent detection
-                        if (pendingPreUpdate.Remove(new LsnSeqKey(rowLsn, rowSeq), out var oldValues))
-                        {
-                            var (delete, upsert) = CreateEmbeddedUpdateEvents(op, oldValues);
-                            if (delete.HasValue)
-                                buffer.Add((rowLsn, rowSeq, buffer.Count, delete.Value));
-                            else
-                                processor.ReturnValues(oldValues); // no reparent — release the unused old-values array
-                            buffer.Add((rowLsn, rowSeq, buffer.Count, upsert));
-                            continue;
-                        }
+                        AddDeleteEvents(processors, values, StreamingJsonContext, events);
+                    }
+                    else if (operation == 4 && ci.HasEmbedded && pendingPreUpdate != null &&
+                             pendingPreUpdate.Remove(new LsnSeqKey(rowLsn, rowSeq), out var oldValues))
+                    {
+                        // Post-update image paired with its stashed pre-update: fan out with reparent
+                        // detection for embedded processors.
+                        AddUpdateEvents(processors, values, oldValues, events);
+                    }
+                    else
+                    {
+                        // Insert (op=2), or a post-update (op=4) on a root-only table / without a paired
+                        // pre-image: upsert into the current location for every processor.
+                        AddUpsertEvents(processors, values, StreamingJsonContext, events);
                     }
 
-                    var eventType = cdcOperation == CdcSinkOperation.Delete ? CdcEventType.Delete : CdcEventType.Upsert;
-                    buffer.Add((rowLsn, rowSeq, buffer.Count, new CdcEvent(eventType, op, null)));
+                    foreach (var evt in events)
+                        buffer.Add((rowLsn, rowSeq, buffer.Count, evt));
                 }
 
                 // Defense-in-depth: under correct CDC semantics every op=3 is paired with an
@@ -359,7 +363,7 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 if (pendingPreUpdate is { Count: > 0 })
                 {
                     foreach (var arr in pendingPreUpdate.Values)
-                        processor.ReturnValues(arr);
+                        processors[0].ReturnValues(arr);
                     pendingPreUpdate.Clear();
                 }
             }
@@ -517,6 +521,16 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
         public string Query;
         /// <summary>Column names in the same order as the SELECT list (excludes CDC metadata columns).</summary>
         public string[] Columns;
+
+        /// <summary>
+        /// Every processor this source table feeds - a root collection and/or embedded arrays. All share
+        /// the same source columns; index 0 is the primary (used to rent the decode buffer). A change row
+        /// is decoded once and fanned out to all of them (RavenDB-27095).
+        /// </summary>
+        public IReadOnlyList<CdcSinkTableProcessor> Processors;
+
+        /// <summary>True when at least one processor is embedded - only then is the pre-image (op=3) needed.</summary>
+        public bool HasEmbedded;
     }
 
     private async Task<List<CaptureInstanceInfo>> ResolveCaptureInstances(CancellationToken ct)
@@ -558,9 +572,21 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
             // the previous code path here never actually saw a pre-image.) For root tables we
             // don't need pre-images, so we still use 'all' and skip the extra row.
             var quotedFn = CommandBuilder.QuoteIdentifier($"fn_cdc_get_all_changes_{captureInstance}");
-            // GetProcessor throws if the table isn't registered; every configured table is, so proc is always non-null.
-            var proc = DocumentProcessor.GetProcessor(tableInfo.Schema, tableInfo.TableName);
-            var rowFilterOption = proc.IsRoot ? "all" : "all update old";
+            // GetProcessors throws if the table isn't registered; every configured table is, so this is non-empty.
+            var processors = DocumentProcessor.GetProcessors(tableInfo.Schema, tableInfo.TableName);
+            var hasEmbedded = false;
+            for (int p = 0; p < processors.Count; p++)
+            {
+                if (processors[p].IsRoot == false)
+                {
+                    hasEmbedded = true;
+                    break;
+                }
+            }
+
+            // If ANY processor is embedded we need op=3 (pre-image) to detect reparenting, so use
+            // 'all update old'. A table mapped only as a root collection uses 'all' and skips op=3.
+            var rowFilterOption = hasEmbedded ? "all update old" : "all";
             var query = $@"
                 SELECT __$start_lsn, __$seqval, __$operation, {columnList}
                 FROM [cdc].{quotedFn}(@from_lsn, @to_lsn, N'{rowFilterOption}')
@@ -574,6 +600,8 @@ public class SqlServerCdcSinkProcess : CdcSinkProcess
                 CaptureInstance = captureInstance,
                 Query = query,
                 Columns = columnsArray,
+                Processors = processors,
+                HasEmbedded = hasEmbedded,
             });
 
             DocumentProcessor.SetSourceColumnNames(tableInfo.Schema, tableInfo.TableName, columnsArray);

--- a/src/Raven.Server/Documents/CdcSink/Test/CdcSinkTestRunner.cs
+++ b/src/Raven.Server/Documents/CdcSink/Test/CdcSinkTestRunner.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents.CdcSink.Test
             // whether the table is enabled for import, so a disabled table must still be resolvable here.
             var docProcessor = new CdcSinkDocumentProcessor(configuration, defaultSchema, includeDisabledTables: true);
             var tableSchema = string.IsNullOrEmpty(targetTable.SourceTableSchema) ? defaultSchema : targetTable.SourceTableSchema;
-            var processor = docProcessor.GetProcessor(tableSchema, targetTable.SourceTableName);
+            var processor = docProcessor.GetPrimaryProcessor(tableSchema, targetTable.SourceTableName);
             if (processor == null)
             {
                 result.Errors.Add($"Target table '{tableSchema}.{targetTable.SourceTableName}' is not registered in the document processor.");

--- a/test/SlowTests.Issues/Issues/RavenDB-26838.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26838.cs
@@ -223,7 +223,7 @@ public class RavenDB_26838 : RavenTestBase
             using var process = new TestCdcSinkProcess(config, database);
             var docProcessor = process.TestDocumentProcessor;
             docProcessor.SetSourceColumnNames("public", "orders", new[] { "order_id", "customer_name" });
-            var tableProcessor = docProcessor.GetProcessor("public", "orders");
+            var tableProcessor = docProcessor.GetPrimaryProcessor("public", "orders");
 
             var ops = new List<CdcSinkDocumentOp>();
             using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))

--- a/test/SlowTests.Issues/Issues/RavenDB-26955.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26955.cs
@@ -46,7 +46,7 @@ public class RavenDB_26955 : RavenTestBase
             Tables = new List<CdcSinkTableConfig> { config }
         };
         var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-        var processor = docProcessor.GetProcessor("public", "events");
+        var processor = docProcessor.GetPrimaryProcessor("public", "events");
 
         // Npgsql returns Postgres 'time without time zone' as a TimeOnly.
         var columnNames = new[] { "id", "start_time", "end_time", "precise_time" };

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
@@ -3073,6 +3073,137 @@ namespace SlowTests.Server.Documents.CdcSink
         }
 
         [RavenFact(RavenTestCategory.Sinks)]
+        public async Task SourceTableMappedBothEmbeddedAndStandalone_PopulatesBoth()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            // "order_lines" is mapped two ways at once: embedded under Orders as "Lines", and as its own
+            // "OrderLines" collection.
+            var ordersConfig = CreateRootTableConfig("Orders");
+            ordersConfig.EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+            {
+                new CdcSinkEmbeddedTableConfig
+                {
+                    SourceTableSchema = "public",
+                    SourceTableName = "order_lines",
+                    PropertyName = "Lines",
+                    PrimaryKeyColumns = new List<string> { "line_id" },
+                    JoinColumns = new List<string> { "order_id" },
+                    Type = CdcSinkRelationType.Array,
+                    Columns = new List<CdcColumnMapping>
+                    {
+                        new() { Column = "line_id", Name = "LineId" },
+                        new() { Column = "product", Name = "Product" },
+                        new() { Column = "qty", Name = "Qty" }
+                    }
+                }
+            };
+
+            var orderLinesConfig = new CdcSinkTableConfig
+            {
+                CollectionName = "OrderLines",
+                SourceTableSchema = "public",
+                SourceTableName = "order_lines",
+                PrimaryKeyColumns = new List<string> { "line_id" },
+                Columns = new List<CdcColumnMapping>
+                {
+                    new() { Column = "line_id", Name = "LineId" },
+                    new() { Column = "order_id", Name = "OrderId" },
+                    new() { Column = "product", Name = "Product" },
+                    new() { Column = "qty", Name = "Qty" }
+                }
+            };
+
+            var sinkConfig = new CdcSinkConfiguration
+            {
+                Name = "test-dual",
+                Tables = new List<CdcSinkTableConfig> { ordersConfig, orderLinesConfig }
+            };
+            var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
+
+            var lineProcessors = docProcessor.GetProcessors("public", "order_lines");
+            Assert.Equal(2, lineProcessors.Count);
+            Assert.Equal(1, lineProcessors.Count(p => p.IsRoot));
+            Assert.Equal(1, lineProcessors.Count(p => p.IsRoot == false));
+
+            var lineColumns = new[] { "line_id", "order_id", "product", "qty" };
+            docProcessor.SetSourceColumnNames("public", "order_lines", lineColumns);
+            SetSourceColumnNamesFromConfig(docProcessor.GetProcessor("public", "orders"), ordersConfig.Columns);
+
+            List<CdcSinkDocumentOp> FanOut(CdcSinkOperation operation, object[] data)
+            {
+                var ops = new List<CdcSinkDocumentOp>();
+                foreach (var proc in docProcessor.GetProcessors("public", "order_lines"))
+                    ops.Add(docProcessor.ProcessRow(proc, operation, (object[])data.Clone(), null));
+                return ops;
+            }
+
+            var orderOp = docProcessor.ProcessRow(new CdcSinkRow
+            {
+                TableSchema = "public", TableName = "orders",
+                Operation = CdcSinkOperation.Upsert,
+                Data = new object[] { 1, "Acme", 0 }
+            }, null);
+            await database.TxMerger.Enqueue(new CdcSinkBatchCommand(database,
+                new List<CdcSinkDocumentOp> { orderOp }, "test-dual", null, null, null, null, null, null));
+
+            await database.TxMerger.Enqueue(new CdcSinkBatchCommand(database,
+                FanOut(CdcSinkOperation.Upsert, new object[] { 1, 1, "Widget", 5 }),
+                "test-dual", null, null, null, null, null, null));
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var standalone = database.DocumentsStorage.Get(ctx, "OrderLines/1");
+                Assert.NotNull(standalone);
+                AssertDocumentMatches(ctx, standalone.Data, """
+                    { "LineId": 1, "OrderId": 1, "Product": "Widget", "Qty": 5 }
+                    """);
+
+                var order = database.DocumentsStorage.Get(ctx, "Orders/1");
+                Assert.NotNull(order);
+                Assert.True(order.Data.TryGet("Lines", out BlittableJsonReaderArray lines));
+                Assert.Equal(1, lines.Length);
+                AssertDocumentMatches(ctx, (BlittableJsonReaderObject)lines[0], """
+                    { "LineId": 1, "Product": "Widget", "Qty": 5 }
+                    """);
+            }
+
+            await database.TxMerger.Enqueue(new CdcSinkBatchCommand(database,
+                FanOut(CdcSinkOperation.Upsert, new object[] { 1, 1, "Widget", 10 }),
+                "test-dual", null, null, null, null, null, null));
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var standalone = database.DocumentsStorage.Get(ctx, "OrderLines/1");
+                Assert.True(standalone.Data.TryGet("Qty", out long standaloneQty));
+                Assert.Equal(10, standaloneQty);
+
+                var order = database.DocumentsStorage.Get(ctx, "Orders/1");
+                order.Data.TryGet("Lines", out BlittableJsonReaderArray lines);
+                Assert.Equal(1, lines.Length);
+                ((BlittableJsonReaderObject)lines[0]).TryGet("Qty", out long embeddedQty);
+                Assert.Equal(10, embeddedQty);
+            }
+
+            await database.TxMerger.Enqueue(new CdcSinkBatchCommand(database,
+                FanOut(CdcSinkOperation.Delete, new object[] { 1, 1, "Widget", 10 }),
+                "test-dual", null, null, null, null, null, null));
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                Assert.Null(database.DocumentsStorage.Get(ctx, "OrderLines/1"));
+
+                var order = database.DocumentsStorage.Get(ctx, "Orders/1");
+                order.Data.TryGet("Lines", out BlittableJsonReaderArray lines);
+                Assert.Equal(0, lines.Length);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
         public async Task EmbeddedOnDelete_Value_OldHasPreviousValue()
         {
             using var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
@@ -3235,17 +3235,12 @@ namespace SlowTests.Server.Documents.CdcSink
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
 
-            // Both roots embed the same source table under the same property name; the persisted
-            // identity must still tell the two mappings apart or replay reparents ops under the
-            // wrong root.
             var processors = docProcessor.GetProcessors("public", "order_lines");
             Assert.Equal(2, processors.Count);
             Assert.NotEqual(processors[0].Discriminator, processors[1].Discriminator);
             Assert.Same(processors[0], docProcessor.GetProcessor("public", "order_lines", processors[0].Discriminator));
             Assert.Same(processors[1], docProcessor.GetProcessor("public", "order_lines", processors[1].Discriminator));
 
-            // A discriminator that no longer matches any mapping must fail loudly instead of
-            // silently replaying against another mapping's processor.
             Assert.Throws<InvalidOperationException>(() => docProcessor.GetProcessor("public", "order_lines", "Removed/Mapping"));
         }
 
@@ -3316,8 +3311,6 @@ namespace SlowTests.Server.Documents.CdcSink
                 statsScope: null, statistics: null, logger: null);
             await database.TxMerger.Enqueue(command);
 
-            // Each mapping's patch runs against its own destination: registering or dispatching the
-            // scripts by source table alone would run one mapping's script for the other's ops.
             using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
@@ -3204,6 +3204,136 @@ namespace SlowTests.Server.Documents.CdcSink
         }
 
         [RavenFact(RavenTestCategory.Sinks)]
+        public void SameTableEmbeddedUnderTwoRoots_EachMappingResolvesByDiscriminator()
+        {
+            CdcSinkTableConfig CreateRoot(string collection, string sourceTable) => new CdcSinkTableConfig
+            {
+                CollectionName = collection,
+                SourceTableSchema = "public",
+                SourceTableName = sourceTable,
+                PrimaryKeyColumns = new List<string> { "id" },
+                Columns = new List<CdcColumnMapping> { new() { Column = "id", Name = "Id" } },
+                EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                {
+                    new()
+                    {
+                        SourceTableSchema = "public",
+                        SourceTableName = "order_lines",
+                        PropertyName = "Lines",
+                        PrimaryKeyColumns = new List<string> { "line_id" },
+                        JoinColumns = new List<string> { "id" },
+                        Type = CdcSinkRelationType.Array,
+                        Columns = new List<CdcColumnMapping> { new() { Column = "line_id", Name = "LineId" } }
+                    }
+                }
+            };
+
+            var sinkConfig = new CdcSinkConfiguration
+            {
+                Name = "test-discriminators",
+                Tables = new List<CdcSinkTableConfig> { CreateRoot("Orders", "orders"), CreateRoot("Invoices", "invoices") }
+            };
+            var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
+
+            // Both roots embed the same source table under the same property name; the persisted
+            // identity must still tell the two mappings apart or replay reparents ops under the
+            // wrong root.
+            var processors = docProcessor.GetProcessors("public", "order_lines");
+            Assert.Equal(2, processors.Count);
+            Assert.NotEqual(processors[0].Discriminator, processors[1].Discriminator);
+            Assert.Same(processors[0], docProcessor.GetProcessor("public", "order_lines", processors[0].Discriminator));
+            Assert.Same(processors[1], docProcessor.GetProcessor("public", "order_lines", processors[1].Discriminator));
+
+            // A discriminator that no longer matches any mapping must fail loudly instead of
+            // silently replaying against another mapping's processor.
+            Assert.Throws<InvalidOperationException>(() => docProcessor.GetProcessor("public", "order_lines", "Removed/Mapping"));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public async Task SourceTableMappedBothEmbeddedAndStandalone_EachMappingRunsItsOwnPatch()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var ordersConfig = CreateRootTableConfig("Orders");
+            ordersConfig.EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+            {
+                new CdcSinkEmbeddedTableConfig
+                {
+                    SourceTableSchema = "public",
+                    SourceTableName = "order_lines",
+                    PropertyName = "Lines",
+                    PrimaryKeyColumns = new List<string> { "line_id" },
+                    JoinColumns = new List<string> { "order_id" },
+                    Type = CdcSinkRelationType.Array,
+                    Patch = "this.EmbeddedPatchRan = true;",
+                    Columns = new List<CdcColumnMapping>
+                    {
+                        new() { Column = "line_id", Name = "LineId" },
+                        new() { Column = "product", Name = "Product" }
+                    }
+                }
+            };
+
+            var orderLinesConfig = new CdcSinkTableConfig
+            {
+                CollectionName = "OrderLines",
+                SourceTableSchema = "public",
+                SourceTableName = "order_lines",
+                PrimaryKeyColumns = new List<string> { "line_id" },
+                Patch = "this.RootPatchRan = true;",
+                Columns = new List<CdcColumnMapping>
+                {
+                    new() { Column = "line_id", Name = "LineId" },
+                    new() { Column = "order_id", Name = "OrderId" },
+                    new() { Column = "product", Name = "Product" }
+                }
+            };
+
+            var sinkConfig = new CdcSinkConfiguration
+            {
+                Name = "test-dual-patch",
+                Tables = new List<CdcSinkTableConfig> { ordersConfig, orderLinesConfig }
+            };
+            var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
+            docProcessor.SetSourceColumnNames("public", "order_lines", new[] { "line_id", "order_id", "product" });
+            SetSourceColumnNamesFromConfig(docProcessor.GetPrimaryProcessor("public", "orders"), ordersConfig.Columns);
+
+            var ops = new List<CdcSinkDocumentOp>
+            {
+                docProcessor.ProcessRow(new CdcSinkRow
+                {
+                    TableSchema = "public", TableName = "orders",
+                    Operation = CdcSinkOperation.Upsert,
+                    Data = new object[] { 1, "Acme", 0 }
+                }, null)
+            };
+            foreach (var proc in docProcessor.GetProcessors("public", "order_lines"))
+                ops.Add(docProcessor.ProcessRow(proc, CdcSinkOperation.Upsert, new object[] { 10, 1, "Widget" }, null));
+
+            var command = new CdcSinkBatchCommand(database, ops, "test-dual-patch", null,
+                tableLoadUpdates: null, patchRequest: docProcessor.CombinedPatchRequest,
+                statsScope: null, statistics: null, logger: null);
+            await database.TxMerger.Enqueue(command);
+
+            // Each mapping's patch runs against its own destination: registering or dispatching the
+            // scripts by source table alone would run one mapping's script for the other's ops.
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var order = database.DocumentsStorage.Get(ctx, "Orders/1");
+                Assert.NotNull(order);
+                Assert.True(order.Data.TryGet("EmbeddedPatchRan", out bool embeddedPatchRan) && embeddedPatchRan);
+                Assert.False(order.Data.TryGet("RootPatchRan", out bool _));
+
+                var line = database.DocumentsStorage.Get(ctx, "OrderLines/10");
+                Assert.NotNull(line);
+                Assert.True(line.Data.TryGet("RootPatchRan", out bool rootPatchRan) && rootPatchRan);
+                Assert.False(line.Data.TryGet("EmbeddedPatchRan", out bool _));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
         public async Task EmbeddedOnDelete_Value_OldHasPreviousValue()
         {
             using var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
@@ -100,7 +100,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { config }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var processor = docProcessor.GetProcessor(config.SourceTableSchema ?? "public", config.SourceTableName);
+            var processor = docProcessor.GetPrimaryProcessor(config.SourceTableSchema ?? "public", config.SourceTableName);
             SetSourceColumnNamesFromConfig(processor, config.Columns);
             return processor;
         }
@@ -120,10 +120,10 @@ namespace SlowTests.Server.Documents.CdcSink
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
 
             // Set column names on root processor too
-            var rootProcessor = docProcessor.GetProcessor(rootConfig.SourceTableSchema ?? "public", rootConfig.SourceTableName);
+            var rootProcessor = docProcessor.GetPrimaryProcessor(rootConfig.SourceTableSchema ?? "public", rootConfig.SourceTableName);
             SetSourceColumnNamesFromConfig(rootProcessor, rootConfig.Columns);
 
-            var processor = docProcessor.GetProcessor(embeddedConfig.SourceTableSchema ?? "", embeddedConfig.SourceTableName);
+            var processor = docProcessor.GetPrimaryProcessor(embeddedConfig.SourceTableSchema ?? "", embeddedConfig.SourceTableName);
             SetSourceColumnNamesFromConfig(processor, embeddedConfig.Columns);
             return processor;
         }
@@ -1040,7 +1040,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { config }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var processor = docProcessor.GetProcessor("public", "documents");
+            var processor = docProcessor.GetPrimaryProcessor("public", "documents");
 
             var mappedData = new DynamicJsonValue
             {
@@ -1126,7 +1126,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { config }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var processor = docProcessor.GetProcessor("public", "products");
+            var processor = docProcessor.GetPrimaryProcessor("public", "products");
 
             var mappedData = new DynamicJsonValue
             {
@@ -1199,7 +1199,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { config }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var processor = docProcessor.GetProcessor("public", "articles");
+            var processor = docProcessor.GetPrimaryProcessor("public", "articles");
 
             var mappedData = new DynamicJsonValue
             {
@@ -1998,7 +1998,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { rootConfig }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var empProcessor = docProcessor.GetProcessor("public", "employees");
+            var empProcessor = docProcessor.GetPrimaryProcessor("public", "employees");
 
             return (rootConfig, deptConfig, empConfig, empProcessor);
         }
@@ -2350,7 +2350,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { tableConfig }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var processor = docProcessor.GetProcessor("public", "items");
+            var processor = docProcessor.GetPrimaryProcessor("public", "items");
 
             DynamicJsonValue MakeMapped(string name) => new DynamicJsonValue
             {
@@ -2458,7 +2458,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { tableConfig }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var processor = docProcessor.GetProcessor("public", "items");
+            var processor = docProcessor.GetPrimaryProcessor("public", "items");
 
             DynamicJsonValue MakeMapped(string name) => new DynamicJsonValue
             {
@@ -2551,7 +2551,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { tableConfig }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var processor = docProcessor.GetProcessor("public", "items");
+            var processor = docProcessor.GetPrimaryProcessor("public", "items");
 
             DynamicJsonValue MakeMapped(string name) => new DynamicJsonValue
             {
@@ -2639,7 +2639,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { tableConfig }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var processor = docProcessor.GetProcessor("public", "items");
+            var processor = docProcessor.GetPrimaryProcessor("public", "items");
 
             DynamicJsonValue MakeMapped(string name) => new DynamicJsonValue
             {
@@ -2711,8 +2711,8 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { badConfig, goodConfig }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var badProcessor = docProcessor.GetProcessor("public", "bad_orders");
-            var goodProcessor = docProcessor.GetProcessor("public", "good_orders");
+            var badProcessor = docProcessor.GetPrimaryProcessor("public", "bad_orders");
+            var goodProcessor = docProcessor.GetPrimaryProcessor("public", "good_orders");
 
             var badData = new DynamicJsonValue
             {
@@ -2806,7 +2806,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { config }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var processor = docProcessor.GetProcessor("public", "records");
+            var processor = docProcessor.GetPrimaryProcessor("public", "records");
 
             // Simulate Npgsql-returned types:
             // json/jsonb → string containing JSON
@@ -2916,7 +2916,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { tableConfig }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var processor = docProcessor.GetProcessor("public", "orders");
+            var processor = docProcessor.GetPrimaryProcessor("public", "orders");
 
             // Step 1: Create the document via a Put
             var putMapped = new DynamicJsonValue
@@ -3033,7 +3033,7 @@ namespace SlowTests.Server.Documents.CdcSink
 
             var sinkConfig = new CdcSinkConfiguration { Name = "test", Tables = new List<CdcSinkTableConfig> { rootConfig } };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var embProcessor = docProcessor.GetProcessor("public", "order_lines");
+            var embProcessor = docProcessor.GetPrimaryProcessor("public", "order_lines");
 
             // Step 1: Create parent
             var putCmd = new CdcSinkBatchCommand(database,
@@ -3129,7 +3129,7 @@ namespace SlowTests.Server.Documents.CdcSink
 
             var lineColumns = new[] { "line_id", "order_id", "product", "qty" };
             docProcessor.SetSourceColumnNames("public", "order_lines", lineColumns);
-            SetSourceColumnNamesFromConfig(docProcessor.GetProcessor("public", "orders"), ordersConfig.Columns);
+            SetSourceColumnNamesFromConfig(docProcessor.GetPrimaryProcessor("public", "orders"), ordersConfig.Columns);
 
             List<CdcSinkDocumentOp> FanOut(CdcSinkOperation operation, object[] data)
             {
@@ -3241,7 +3241,7 @@ namespace SlowTests.Server.Documents.CdcSink
 
             var sinkConfig = new CdcSinkConfiguration { Name = "test", Tables = new List<CdcSinkTableConfig> { rootConfig } };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var embProcessor = docProcessor.GetProcessor("public", "order_detail");
+            var embProcessor = docProcessor.GetPrimaryProcessor("public", "order_detail");
 
             // Step 1: Create parent
             var putCmd = new CdcSinkBatchCommand(database,
@@ -3318,7 +3318,7 @@ namespace SlowTests.Server.Documents.CdcSink
 
             var sinkConfig = new CdcSinkConfiguration { Name = "test", Tables = new List<CdcSinkTableConfig> { rootConfig } };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var embProcessor = docProcessor.GetProcessor("public", "order_tags");
+            var embProcessor = docProcessor.GetPrimaryProcessor("public", "order_tags");
 
             // Step 1: Create parent
             var putCmd = new CdcSinkBatchCommand(database,
@@ -3513,7 +3513,7 @@ namespace SlowTests.Server.Documents.CdcSink
                 Tables = new List<CdcSinkTableConfig> { rootConfig }
             };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var empProcessor = docProcessor.GetProcessor("public", "employees");
+            var empProcessor = docProcessor.GetPrimaryProcessor("public", "employees");
 
             // Delete employee Alice (emp_id=100) from dept_id=10
             var deleteData = new DynamicJsonValue { ["EmpId"] = 100 };
@@ -3593,7 +3593,7 @@ namespace SlowTests.Server.Documents.CdcSink
             rootConfig.EmbeddedTables = new List<CdcSinkEmbeddedTableConfig> { embeddedConfig };
             var sinkConfig = new CdcSinkConfiguration { Name = "test", Tables = new List<CdcSinkTableConfig> { rootConfig } };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var embProcessor = docProcessor.GetProcessor("public", "order_lines");
+            var embProcessor = docProcessor.GetPrimaryProcessor("public", "order_lines");
 
             // Seed with existing lines
             var putCmd = new CdcSinkBatchCommand(database,
@@ -3728,7 +3728,7 @@ namespace SlowTests.Server.Documents.CdcSink
             rootConfig.EmbeddedTables = new List<CdcSinkEmbeddedTableConfig> { embeddedConfig };
             var sinkConfig = new CdcSinkConfiguration { Name = "test", Tables = new List<CdcSinkTableConfig> { rootConfig } };
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
-            var embProcessor = docProcessor.GetProcessor("public", "order_lines");
+            var embProcessor = docProcessor.GetPrimaryProcessor("public", "order_lines");
 
             // Seed parent + one line with Amount=100
             var putCmd = new CdcSinkBatchCommand(database,
@@ -3839,10 +3839,10 @@ namespace SlowTests.Server.Documents.CdcSink
             var docProcessor = new CdcSinkDocumentProcessor(sinkConfig);
 
             // Set source column names (simulates what providers do from DB schema metadata)
-            var rootProcessor = docProcessor.GetProcessor("public", "groups");
+            var rootProcessor = docProcessor.GetPrimaryProcessor("public", "groups");
             SetSourceColumnNamesFromConfig(rootProcessor, rootConfig.Columns);
 
-            var embProcessor = docProcessor.GetProcessor("public", "group_members");
+            var embProcessor = docProcessor.GetPrimaryProcessor("public", "group_members");
             SetSourceColumnNamesFromConfig(embProcessor, rootConfig.EmbeddedTables[0].Columns);
 
             // --- Step 1: Create parent documents Groups/1 and Groups/2 ---

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkDisabledTableTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkDisabledTableTests.cs
@@ -110,12 +110,12 @@ namespace SlowTests.Server.Documents.CdcSink
         {
             var processor = new CdcSinkDocumentProcessor(BuildConfig(productsDisabled: true), "public");
 
-            Assert.True(processor.TryGetProcessor("public", "orders", out _));
-            Assert.True(processor.TryGetProcessor("public", "order_lines", out _));
+            Assert.True(processor.TryGetPrimaryProcessor("public", "orders", out _));
+            Assert.True(processor.TryGetPrimaryProcessor("public", "order_lines", out _));
 
-            Assert.False(processor.TryGetProcessor("public", "products", out _));
-            Assert.False(processor.TryGetProcessor("public", "product_tags", out _));
-            Assert.Throws<InvalidOperationException>(() => processor.GetProcessor("public", "products"));
+            Assert.False(processor.TryGetPrimaryProcessor("public", "products", out _));
+            Assert.False(processor.TryGetPrimaryProcessor("public", "product_tags", out _));
+            Assert.Throws<InvalidOperationException>(() => processor.GetPrimaryProcessor("public", "products"));
         }
 
         [RavenFact(RavenTestCategory.Sinks)]
@@ -125,9 +125,9 @@ namespace SlowTests.Server.Documents.CdcSink
             // table regardless of state, so they opt back in via includeDisabledTables.
             var processor = new CdcSinkDocumentProcessor(BuildConfig(productsDisabled: true), "public", includeDisabledTables: true);
 
-            Assert.True(processor.TryGetProcessor("public", "products", out _));
-            Assert.True(processor.TryGetProcessor("public", "product_tags", out _));
-            Assert.NotNull(processor.GetProcessor("public", "products"));
+            Assert.True(processor.TryGetPrimaryProcessor("public", "products", out _));
+            Assert.True(processor.TryGetPrimaryProcessor("public", "product_tags", out _));
+            Assert.NotNull(processor.GetPrimaryProcessor("public", "products"));
         }
 
         [RavenFact(RavenTestCategory.Sinks)]

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkFanOutTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkFanOutTests.cs
@@ -26,9 +26,6 @@ namespace SlowTests.Server.Documents.CdcSink
             using var store = GetDocumentStore();
             var database = await Databases.GetDocumentDatabaseInstanceFor(store);
 
-            // The standalone mapping ignores deletes; the embedded one doesn't. The embedding parent is
-            // listed first, yet the root must still register at index 0 (roots-first registration), so
-            // the ignoring processor is exactly the one that owns the shared decoded array.
             var config = new CdcSinkConfiguration
             {
                 Name = "fanout-delete",
@@ -75,13 +72,10 @@ namespace SlowTests.Server.Documents.CdcSink
                 var op = Assert.Single(deletes);
                 Assert.Equal(CdcSinkDocumentOpType.EmbeddedModify, op.Type);
                 Assert.Equal(CdcSinkOperation.Delete, op.Operation);
-                // The embedded processor must see the real row, not an array the ignoring processor
-                // already returned to its pool (which clears it in place).
                 Assert.Equal("Orders/1", op.DocumentId);
                 Assert.NotSame(values, op.RawValues);
                 Assert.Equal(10, (int)op.RawValues[0]);
 
-                // The unconsumed caller array went back to processors[0]'s pool, cleared.
                 Assert.All(values, Assert.Null);
             }
         }
@@ -110,14 +104,10 @@ namespace SlowTests.Server.Documents.CdcSink
 
             var (deletes, upserts) = process.RunAddUpdateEvents(processors, newValues, oldValues);
 
-            // The join column is unchanged: no mapping reparents. The second embedded processor must
-            // read the real pre-image, not an array the first one already returned (cleared) - a
-            // cleared pre-image fakes an old parent of "Orders/\0" and emits a spurious delete.
             Assert.Empty(deletes);
             Assert.Equal(2, upserts.Count);
             Assert.All(upserts, op => Assert.Equal("Orders/1", op.DocumentId));
 
-            // The caller's pre-image array went back to processors[0]'s pool, cleared.
             Assert.All(oldValues, Assert.Null);
         }
 

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkFanOutTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkFanOutTests.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.CdcSink;
+using Raven.Server.Documents;
+using Raven.Server.Documents.CdcSink;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.CdcSink
+{
+    public class CdcSinkFanOutTests : RavenTestBase
+    {
+        public CdcSinkFanOutTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public async Task DeleteFanOut_FirstProcessorIgnoresDeletes_LaterProcessorGetsIntactValues()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            // The standalone mapping ignores deletes; the embedded one doesn't. The embedding parent is
+            // listed first, yet the root must still register at index 0 (roots-first registration), so
+            // the ignoring processor is exactly the one that owns the shared decoded array.
+            var config = new CdcSinkConfiguration
+            {
+                Name = "fanout-delete",
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    CreateOrdersTableEmbeddingLines("Lines"),
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "OrderLines",
+                        SourceTableSchema = "public",
+                        SourceTableName = "order_lines",
+                        PrimaryKeyColumns = new List<string> { "line_id" },
+                        OnDelete = new CdcSinkOnDeleteConfig { IgnoreDeletes = true },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new() { Column = "line_id", Name = "LineId" },
+                            new() { Column = "order_id", Name = "OrderId" },
+                            new() { Column = "product", Name = "Product" }
+                        }
+                    }
+                }
+            };
+
+            using var process = new TestCdcSinkProcess(config, database);
+            var docProcessor = process.TestDocumentProcessor;
+            docProcessor.SetSourceColumnNames("public", "order_lines", new[] { "line_id", "order_id", "product" });
+
+            var processors = docProcessor.GetProcessors("public", "order_lines");
+            Assert.Equal(2, processors.Count);
+            Assert.True(processors[0].IsRoot);
+            Assert.True(processors[0].IgnoresDeletes);
+            Assert.False(processors[1].IgnoresDeletes);
+
+            var values = processors[0].RentValues();
+            values[0] = 10;
+            values[1] = 1;
+            values[2] = "Widget";
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var (deletes, upserts) = process.RunAddDeleteEvents(processors, values, context);
+
+                Assert.Empty(upserts);
+                var op = Assert.Single(deletes);
+                Assert.Equal(CdcSinkDocumentOpType.EmbeddedModify, op.Type);
+                Assert.Equal(CdcSinkOperation.Delete, op.Operation);
+                // The embedded processor must see the real row, not an array the ignoring processor
+                // already returned to its pool (which clears it in place).
+                Assert.Equal("Orders/1", op.DocumentId);
+                Assert.NotSame(values, op.RawValues);
+                Assert.Equal(10, (int)op.RawValues[0]);
+
+                // The unconsumed caller array went back to processors[0]'s pool, cleared.
+                Assert.All(values, Assert.Null);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public async Task UpdateFanOut_TwoEmbeddedMappings_NoReparent_EmitsOnlyUpserts()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            using var process = new TestCdcSinkProcess(CreateTwoEmbeddedMappingsConfig(), database);
+            var docProcessor = process.TestDocumentProcessor;
+            docProcessor.SetSourceColumnNames("public", "order_lines", new[] { "line_id", "order_id", "product" });
+
+            var processors = docProcessor.GetProcessors("public", "order_lines");
+            Assert.Equal(2, processors.Count);
+
+            var newValues = processors[0].RentValues();
+            newValues[0] = 10;
+            newValues[1] = 1;
+            newValues[2] = "Widget";
+            var oldValues = processors[0].RentValues();
+            oldValues[0] = 10;
+            oldValues[1] = 1;
+            oldValues[2] = "Gadget";
+
+            var (deletes, upserts) = process.RunAddUpdateEvents(processors, newValues, oldValues);
+
+            // The join column is unchanged: no mapping reparents. The second embedded processor must
+            // read the real pre-image, not an array the first one already returned (cleared) - a
+            // cleared pre-image fakes an old parent of "Orders/\0" and emits a spurious delete.
+            Assert.Empty(deletes);
+            Assert.Equal(2, upserts.Count);
+            Assert.All(upserts, op => Assert.Equal("Orders/1", op.DocumentId));
+
+            // The caller's pre-image array went back to processors[0]'s pool, cleared.
+            Assert.All(oldValues, Assert.Null);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public async Task UpdateFanOut_TwoEmbeddedMappings_Reparent_BothDeletesTargetOldParent()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            using var process = new TestCdcSinkProcess(CreateTwoEmbeddedMappingsConfig(), database);
+            var docProcessor = process.TestDocumentProcessor;
+            docProcessor.SetSourceColumnNames("public", "order_lines", new[] { "line_id", "order_id", "product" });
+
+            var processors = docProcessor.GetProcessors("public", "order_lines");
+
+            var newValues = processors[0].RentValues();
+            newValues[0] = 10;
+            newValues[1] = 1;
+            newValues[2] = "Widget";
+            var oldValues = processors[0].RentValues();
+            oldValues[0] = 10;
+            oldValues[1] = 2;
+            oldValues[2] = "Widget";
+
+            var (deletes, upserts) = process.RunAddUpdateEvents(processors, newValues, oldValues);
+
+            Assert.Equal(2, deletes.Count);
+            Assert.All(deletes, op => Assert.Equal("Orders/2", op.DocumentId));
+            Assert.NotSame(deletes[0].RawValues, deletes[1].RawValues);
+            Assert.Equal(2, upserts.Count);
+            Assert.All(upserts, op => Assert.Equal("Orders/1", op.DocumentId));
+        }
+
+        private static CdcSinkTableConfig CreateOrdersTableEmbeddingLines(params string[] propertyNames)
+        {
+            var embedded = new List<CdcSinkEmbeddedTableConfig>();
+            foreach (var propertyName in propertyNames)
+            {
+                embedded.Add(new CdcSinkEmbeddedTableConfig
+                {
+                    SourceTableSchema = "public",
+                    SourceTableName = "order_lines",
+                    PropertyName = propertyName,
+                    PrimaryKeyColumns = new List<string> { "line_id" },
+                    JoinColumns = new List<string> { "order_id" },
+                    Type = CdcSinkRelationType.Array,
+                    Columns = new List<CdcColumnMapping>
+                    {
+                        new() { Column = "line_id", Name = "LineId" },
+                        new() { Column = "product", Name = "Product" }
+                    }
+                });
+            }
+
+            return new CdcSinkTableConfig
+            {
+                CollectionName = "Orders",
+                SourceTableSchema = "public",
+                SourceTableName = "orders",
+                PrimaryKeyColumns = new List<string> { "order_id" },
+                Columns = new List<CdcColumnMapping> { new() { Column = "order_id", Name = "OrderId" } },
+                EmbeddedTables = embedded
+            };
+        }
+
+        private static CdcSinkConfiguration CreateTwoEmbeddedMappingsConfig()
+        {
+            return new CdcSinkConfiguration
+            {
+                Name = "fanout-update",
+                Tables = new List<CdcSinkTableConfig> { CreateOrdersTableEmbeddingLines("Lines", "Items") }
+            };
+        }
+
+        private sealed class TestCdcSinkProcess : CdcSinkProcess
+        {
+            public TestCdcSinkProcess(CdcSinkConfiguration configuration, DocumentDatabase database)
+                : base(configuration, database, defaultSchema: "public")
+            {
+            }
+
+            public CdcSinkDocumentProcessor TestDocumentProcessor => DocumentProcessor;
+
+            public (List<CdcSinkDocumentOp> Deletes, List<CdcSinkDocumentOp> Upserts) RunAddDeleteEvents(
+                IReadOnlyList<CdcSinkTableProcessor> processors, object[] values, JsonOperationContext context)
+            {
+                var events = new List<CdcEvent>();
+                AddDeleteEvents(processors, values, context, events);
+                return Split(events);
+            }
+
+            public (List<CdcSinkDocumentOp> Deletes, List<CdcSinkDocumentOp> Upserts) RunAddUpdateEvents(
+                IReadOnlyList<CdcSinkTableProcessor> processors, object[] newValues, object[] oldValues)
+            {
+                var events = new List<CdcEvent>();
+                AddUpdateEvents(processors, newValues, oldValues, events);
+                return Split(events);
+            }
+
+            private static (List<CdcSinkDocumentOp> Deletes, List<CdcSinkDocumentOp> Upserts) Split(List<CdcEvent> events)
+            {
+                var deletes = new List<CdcSinkDocumentOp>();
+                var upserts = new List<CdcSinkDocumentOp>();
+                foreach (var e in events)
+                {
+                    if (e.Type == CdcEventType.Delete)
+                        deletes.Add(e.Op);
+                    else
+                        upserts.Add(e.Op);
+                }
+                return (deletes, upserts);
+            }
+
+            public override bool IsHealthy(out string issue)
+            {
+                issue = null;
+                return true;
+            }
+
+            protected override Task RunInternalAsync(CancellationToken ct) => throw new NotSupportedException();
+
+            protected override IAsyncEnumerable<CdcEvent> GetCdcEvents(CancellationToken ct) => throw new NotSupportedException();
+
+            protected override string GetDefaultSchema() => "public";
+
+            protected override Task<DbConnection> OpenInitialLoadConnection(CancellationToken ct) => throw new NotSupportedException();
+
+            protected override Task<List<string>> ResolveInitialLoadKeyColumnsAsync(DbConnection conn, string schema, string table, CancellationToken ct) => throw new NotSupportedException();
+
+            protected override Task BindKeysetParameters(DbCommand cmd, CdcSinkConfiguration.TableInfo tableInfo, List<string> pkColumns, string[] lastKeys, CancellationToken ct) => throw new NotSupportedException();
+
+            protected override object ConvertInitialLoadValue(DbDataReader reader, int ordinal, CdcSinkConfiguration.TableInfo tableInfo) => throw new NotSupportedException();
+
+            protected override DbCommandBuilder CommandBuilder => null;
+
+            public override void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
@@ -673,6 +673,152 @@ namespace SlowTests.Server.Documents.CdcSink
         }
 
         [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
+        public async Task SourceTableMappedBothEmbeddedAndStandalone_PopulatesBoth()
+        {
+            // RavenDB-27095 (the exact reported scenario, MySQL/MariaDB): order_lines is mapped two ways at
+            // once - embedded under Orders as "Lines" AND as its own OrderLines collection. Both must
+            // populate through initial load AND streaming. Before the fix only the standalone collection
+            // filled and Orders.Lines came out null.
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE orders (
+                    id INT PRIMARY KEY,
+                    customer_name VARCHAR(200) NOT NULL
+                )");
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE order_lines (
+                    id INT PRIMARY KEY,
+                    order_id INT NOT NULL,
+                    product VARCHAR(200) NOT NULL,
+                    quantity INT NOT NULL,
+                    FOREIGN KEY (order_id) REFERENCES orders(id)
+                )");
+
+            ExecuteMySql(connectionString, "INSERT INTO orders (id, customer_name) VALUES (1, 'Alice')");
+            ExecuteMySql(connectionString, "INSERT INTO order_lines (id, order_id, product, quantity) VALUES (1, 1, 'Apples', 5)");
+            ExecuteMySql(connectionString, "INSERT INTO order_lines (id, order_id, product, quantity) VALUES (2, 1, 'Bananas', 3)");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-dual-mapping",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = schemaName,
+                        SourceTableName = "orders",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "customer_name", Name = "CustomerName" }
+                        },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = schemaName,
+                                SourceTableName = "order_lines",
+                                PropertyName = "Lines",
+                                Type = CdcSinkRelationType.Array,
+                                JoinColumns = new List<string> { "order_id" },
+                                PrimaryKeyColumns = new List<string> { "id" },
+                                Columns = new List<CdcColumnMapping>
+                                {
+                                    new CdcColumnMapping { Column = "id", Name = "LineId" },
+                                    new CdcColumnMapping { Column = "product", Name = "Product" },
+                                    new CdcColumnMapping { Column = "quantity", Name = "Quantity" }
+                                }
+                            }
+                        }
+                    },
+                    // Same source table, also mapped as its own standalone collection.
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "OrderLines",
+                        SourceTableSchema = schemaName,
+                        SourceTableName = "order_lines",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "LineId" },
+                            new CdcColumnMapping { Column = "order_id", Name = "OrderId" },
+                            new CdcColumnMapping { Column = "product", Name = "Product" },
+                            new CdcColumnMapping { Column = "quantity", Name = "Quantity" }
+                        }
+                    }
+                }
+            };
+
+            AddCdcSink(store, config);
+
+            // Initial load: standalone collection fully populated...
+            Assert.Equal(2, await WaitForDocumentCountAsync(store, "OrderLines", expectedCount: 2, timeoutMs: 60_000));
+
+            // ...AND the embedded array on the parent populated (the bug: this used to stay null).
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order = await session.LoadAsync<Order>("Orders/1");
+                return order?.Lines?.Count ?? 0;
+            }, 2, timeout: 60_000);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order = await session.LoadAsync<Order>("Orders/1");
+                Assert.Equal("Alice", order.CustomerName);
+                var products = order.Lines.Select(l => l.Product).OrderBy(p => p).ToList();
+                Assert.Equal(new[] { "Apples", "Bananas" }, products);
+
+                var standalone = await session.LoadAsync<StandaloneOrderLine>("OrderLines/1");
+                Assert.Equal("Apples", standalone.Product);
+                Assert.Equal(5, standalone.Quantity);
+                Assert.Equal(1, standalone.OrderId);
+            }
+
+            // Streaming INSERT: a 3rd line must appear in BOTH views.
+            ExecuteMySql(connectionString, "INSERT INTO order_lines (id, order_id, product, quantity) VALUES (3, 1, 'Cherries', 7)");
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order = await session.LoadAsync<Order>("Orders/1");
+                return order?.Lines?.Count ?? 0;
+            }, 3, timeout: 60_000);
+            Assert.Equal(3, await WaitForDocumentCountAsync(store, "OrderLines", expectedCount: 3, timeoutMs: 60_000));
+
+            // Streaming DELETE: the line must disappear from BOTH views.
+            ExecuteMySql(connectionString, "DELETE FROM order_lines WHERE id = 2");
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order = await session.LoadAsync<Order>("Orders/1");
+                return order?.Lines?.Count ?? 0;
+            }, 2, timeout: 60_000);
+            Assert.True(await WaitForDocumentDeletionAsync(store, "OrderLines/2", timeoutMs: 60_000));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order = await session.LoadAsync<Order>("Orders/1");
+                var products = order.Lines.Select(l => l.Product).OrderBy(p => p).ToList();
+                Assert.Equal(new[] { "Apples", "Cherries" }, products);
+            }
+        }
+
+        private class StandaloneOrderLine
+        {
+            public int OrderId { get; set; }
+            public string Product { get; set; }
+            public int Quantity { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
         public async Task PatchWithDollarRow()
         {
             using var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
@@ -675,10 +675,6 @@ namespace SlowTests.Server.Documents.CdcSink
         [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
         public async Task SourceTableMappedBothEmbeddedAndStandalone_PopulatesBoth()
         {
-            // RavenDB-27095 (the exact reported scenario, MySQL/MariaDB): order_lines is mapped two ways at
-            // once - embedded under Orders as "Lines" AND as its own OrderLines collection. Both must
-            // populate through initial load AND streaming. Before the fix only the standalone collection
-            // filled and Orders.Lines came out null.
             using var store = GetDocumentStore();
             using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out var schemaName, dataSet: null, includeData: false);
 
@@ -757,10 +753,8 @@ namespace SlowTests.Server.Documents.CdcSink
 
             AddCdcSink(store, config);
 
-            // Initial load: standalone collection fully populated...
             Assert.Equal(2, await WaitForDocumentCountAsync(store, "OrderLines", expectedCount: 2, timeoutMs: 60_000));
 
-            // ...AND the embedded array on the parent populated (the bug: this used to stay null).
             await AssertWaitForValueAsync(async () =>
             {
                 using var session = store.OpenAsyncSession();
@@ -781,7 +775,6 @@ namespace SlowTests.Server.Documents.CdcSink
                 Assert.Equal(1, standalone.OrderId);
             }
 
-            // Streaming INSERT: a 3rd line must appear in BOTH views.
             ExecuteMySql(connectionString, "INSERT INTO order_lines (id, order_id, product, quantity) VALUES (3, 1, 'Cherries', 7)");
 
             await AssertWaitForValueAsync(async () =>
@@ -792,7 +785,6 @@ namespace SlowTests.Server.Documents.CdcSink
             }, 3, timeout: 60_000);
             Assert.Equal(3, await WaitForDocumentCountAsync(store, "OrderLines", expectedCount: 3, timeoutMs: 60_000));
 
-            // Streaming DELETE: the line must disappear from BOTH views.
             ExecuteMySql(connectionString, "DELETE FROM order_lines WHERE id = 2");
 
             await AssertWaitForValueAsync(async () =>

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
@@ -892,9 +892,6 @@ namespace SlowTests.Server.Documents.CdcSink
         [RavenFact(RavenTestCategory.Sinks, MsSqlRequired = true, MsSqlCdcRequired = true)]
         public async Task SourceTableMappedBothEmbeddedAndStandalone_PopulatesBoth()
         {
-            // RavenDB-27095: order_lines is mapped two ways at once - embedded under Orders as "Lines" AND
-            // as its own OrderLines collection. Both must populate (initial load AND streaming). Before the
-            // fix only the standalone collection filled and Orders.Lines came out null.
             using var store = GetDocumentStore();
             var schema = CreateTestSchema();
 
@@ -912,7 +909,6 @@ namespace SlowTests.Server.Documents.CdcSink
 
             EnableCdcOnTables((schema, "orders"), (schema, "order_lines"));
 
-            // Two rows present at initial-load time.
             ExecuteMsSql($@"
                 INSERT INTO [{schema}].orders (id, customer_name) VALUES (1, 'Alice');
                 INSERT INTO [{schema}].order_lines (id, order_id, product, quantity) VALUES (1, 1, 'Apples', 5);
@@ -975,11 +971,9 @@ namespace SlowTests.Server.Documents.CdcSink
 
             AddCdcSink(store, config);
 
-            // Initial load: standalone collection fully populated...
             var standaloneCount = await WaitForDocumentCountAsync(store, "OrderLines", expectedCount: 2, timeoutMs: 60_000);
             Assert.Equal(2, standaloneCount);
 
-            // ...AND the embedded array on the parent populated (the bug: this used to stay null).
             await AssertWaitForValueAsync(async () =>
             {
                 using var session = store.OpenAsyncSession();
@@ -1000,7 +994,6 @@ namespace SlowTests.Server.Documents.CdcSink
                 Assert.Equal(1, standalone.OrderId);
             }
 
-            // Streaming INSERT: a 3rd line must appear in BOTH views.
             ExecuteMsSql($"INSERT INTO [{schema}].order_lines (id, order_id, product, quantity) VALUES (3, 1, 'Cherries', 7);");
 
             await AssertWaitForValueAsync(async () =>
@@ -1011,7 +1004,6 @@ namespace SlowTests.Server.Documents.CdcSink
             }, 3, timeout: 60_000);
             Assert.Equal(3, await WaitForDocumentCountAsync(store, "OrderLines", expectedCount: 3, timeoutMs: 60_000));
 
-            // Streaming DELETE: the line must disappear from BOTH views.
             ExecuteMsSql($"DELETE FROM [{schema}].order_lines WHERE id = 2;");
 
             await AssertWaitForValueAsync(async () =>

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkSqlServerIntegrationTests.cs
@@ -890,6 +890,154 @@ namespace SlowTests.Server.Documents.CdcSink
         }
 
         [RavenFact(RavenTestCategory.Sinks, MsSqlRequired = true, MsSqlCdcRequired = true)]
+        public async Task SourceTableMappedBothEmbeddedAndStandalone_PopulatesBoth()
+        {
+            // RavenDB-27095: order_lines is mapped two ways at once - embedded under Orders as "Lines" AND
+            // as its own OrderLines collection. Both must populate (initial load AND streaming). Before the
+            // fix only the standalone collection filled and Orders.Lines came out null.
+            using var store = GetDocumentStore();
+            var schema = CreateTestSchema();
+
+            ExecuteMsSql($@"
+                CREATE TABLE [{schema}].orders (
+                    id INT PRIMARY KEY,
+                    customer_name NVARCHAR(200) NOT NULL
+                );
+                CREATE TABLE [{schema}].order_lines (
+                    id INT PRIMARY KEY,
+                    order_id INT NOT NULL REFERENCES [{schema}].orders(id),
+                    product NVARCHAR(200) NOT NULL,
+                    quantity INT NOT NULL
+                )");
+
+            EnableCdcOnTables((schema, "orders"), (schema, "order_lines"));
+
+            // Two rows present at initial-load time.
+            ExecuteMsSql($@"
+                INSERT INTO [{schema}].orders (id, customer_name) VALUES (1, 'Alice');
+                INSERT INTO [{schema}].order_lines (id, order_id, product, quantity) VALUES (1, 1, 'Apples', 5);
+                INSERT INTO [{schema}].order_lines (id, order_id, product, quantity) VALUES (2, 1, 'Bananas', 3);");
+
+            var sqlCs = SetupSqlConnectionString(store);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-dual-mapping",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Orders",
+                        SourceTableSchema = schema,
+                        SourceTableName = "orders",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "customer_name", Name = "CustomerName" }
+                        },
+                        EmbeddedTables = new List<CdcSinkEmbeddedTableConfig>
+                        {
+                            new CdcSinkEmbeddedTableConfig
+                            {
+                                SourceTableSchema = schema,
+                                SourceTableName = "order_lines",
+                                PropertyName = "Lines",
+                                Type = CdcSinkRelationType.Array,
+                                JoinColumns = new List<string> { "order_id" },
+                                PrimaryKeyColumns = new List<string> { "id" },
+                                Columns = new List<CdcColumnMapping>
+                                {
+                                    new CdcColumnMapping { Column = "id", Name = "LineId" },
+                                    new CdcColumnMapping { Column = "product", Name = "Product" },
+                                    new CdcColumnMapping { Column = "quantity", Name = "Quantity" }
+                                }
+                            }
+                        }
+                    },
+                    // Same source table, also mapped as its own standalone collection.
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "OrderLines",
+                        SourceTableSchema = schema,
+                        SourceTableName = "order_lines",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "LineId" },
+                            new CdcColumnMapping { Column = "order_id", Name = "OrderId" },
+                            new CdcColumnMapping { Column = "product", Name = "Product" },
+                            new CdcColumnMapping { Column = "quantity", Name = "Quantity" }
+                        }
+                    }
+                }
+            };
+
+            AddCdcSink(store, config);
+
+            // Initial load: standalone collection fully populated...
+            var standaloneCount = await WaitForDocumentCountAsync(store, "OrderLines", expectedCount: 2, timeoutMs: 60_000);
+            Assert.Equal(2, standaloneCount);
+
+            // ...AND the embedded array on the parent populated (the bug: this used to stay null).
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order = await session.LoadAsync<Order>("Orders/1");
+                return order?.Lines?.Count ?? 0;
+            }, 2, timeout: 60_000);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order = await session.LoadAsync<Order>("Orders/1");
+                Assert.Equal("Alice", order.CustomerName);
+                var products = order.Lines.Select(l => l.Product).OrderBy(p => p).ToList();
+                Assert.Equal(new[] { "Apples", "Bananas" }, products);
+
+                var standalone = await session.LoadAsync<StandaloneOrderLine>("OrderLines/1");
+                Assert.Equal("Apples", standalone.Product);
+                Assert.Equal(5, standalone.Quantity);
+                Assert.Equal(1, standalone.OrderId);
+            }
+
+            // Streaming INSERT: a 3rd line must appear in BOTH views.
+            ExecuteMsSql($"INSERT INTO [{schema}].order_lines (id, order_id, product, quantity) VALUES (3, 1, 'Cherries', 7);");
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order = await session.LoadAsync<Order>("Orders/1");
+                return order?.Lines?.Count ?? 0;
+            }, 3, timeout: 60_000);
+            Assert.Equal(3, await WaitForDocumentCountAsync(store, "OrderLines", expectedCount: 3, timeoutMs: 60_000));
+
+            // Streaming DELETE: the line must disappear from BOTH views.
+            ExecuteMsSql($"DELETE FROM [{schema}].order_lines WHERE id = 2;");
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var order = await session.LoadAsync<Order>("Orders/1");
+                return order?.Lines?.Count ?? 0;
+            }, 2, timeout: 60_000);
+            Assert.True(await WaitForDocumentDeletionAsync(store, "OrderLines/2", timeoutMs: 60_000));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order = await session.LoadAsync<Order>("Orders/1");
+                var products = order.Lines.Select(l => l.Product).OrderBy(p => p).ToList();
+                Assert.Equal(new[] { "Apples", "Cherries" }, products);
+            }
+        }
+
+        private class StandaloneOrderLine
+        {
+            public int OrderId { get; set; }
+            public string Product { get; set; }
+            public int Quantity { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, MsSqlRequired = true, MsSqlCdcRequired = true)]
         public async Task EmbeddedArray_CdcStreaming_Insert()
         {
             using var store = GetDocumentStore();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27095/CDC-embedded-child-array-comes-out-null-when-the-same-source-table-is-also-mapped-as-its-own-collection

### Additional description

Added support for mapping table both as standalone and embedded (can be referenced this way multiple times)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
