### PR TITLE
RavenDB-27119 - Fix cluster transaction commands never cleaned up after snapshot restore

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -46,6 +46,16 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             _extension = extension;
         }
 
+        protected override Task<IDisposable> OnBeforeRestoreAsync()
+        {
+            // the per-database cluster transaction command counter is rebuilt from the restored compare-exchange
+            // (atomic guard) values on the fresh cluster. A snapshot backup carries over the source's
+            // TruncatedClusterTransactionCommandsCount, which can be higher than that rebuilt counter and would then
+            // block cleanup of the new commands. Reset it so cleanup is driven purely by the rebuilt counter.
+            RestoreSettings.DatabaseRecord.TruncatedClusterTransactionCommandsCount = 0;
+            return base.OnBeforeRestoreAsync();
+        }
+
         protected override async Task RestoreAsync()
         {
             Database.DocumentsStorage.ResetLastCompletedClusterTransactionIndex();

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -13,6 +13,7 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
@@ -2394,6 +2395,73 @@ select incl(c)"
             }
         }
         
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task RestoredDatabase_ShouldCleanUpClusterTransactionCommands_EvenWhenTruncatedCountFromBackupIsHigh()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+
+            using (var source = GetDocumentStore())
+            {
+                const int originalCount = 64;
+                for (int i = 0; i < originalCount; i++)
+                {
+                    using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                    {
+                        await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                        await session.SaveChangesAsync();
+                    }
+
+                    using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                    {
+                        session.Delete($"TestObjs/{i}");
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                await AssertWaitForTrueAsync(async () =>
+                {
+                    var r = (await source.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(source.Database)));
+                    return r.TruncatedClusterTransactionCommandsCount >= originalCount;
+                }, timeout: 60_000);
+
+                var config = Backup.CreateBackupConfiguration(backupPath, BackupType.Snapshot);
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, source);
+            }
+
+            using var newServer = GetNewServer();
+            var restoredDatabase = GetDatabaseName();
+            using var store = new DocumentStore { Urls = new[] { newServer.WebUrl }, Database = restoredDatabase }.Initialize();
+
+            var restore = new RestoreBackupOperation(new RestoreBackupConfiguration
+            {
+                BackupLocation = Directory.GetDirectories(backupPath).First(),
+                DatabaseName = restoredDatabase
+            });
+            var operation = await store.Maintenance.Server.SendAsync(restore);
+            await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+            var restoredRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(restoredDatabase));
+            Assert.True(restoredRecord.TruncatedClusterTransactionCommandsCount == 0);
+
+            const int newCount = 5;
+            for (int i = 0; i < newCount; i++)
+            {
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), $"NewObjs/{i}");
+                await session.SaveChangesAsync();
+            }
+
+            await AssertWaitForTrueAsync(() =>
+                Task.FromResult(CountClusterTransactionCommands(newServer, restoredDatabase) <= 1), timeout: 30_000);
+        }
+
+        private static long CountClusterTransactionCommands(RavenServer server, string database)
+        {
+            using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+                return ClusterTransactionCommand.ReadCommandsBatch(ctx, database, fromCount: 0, take: long.MaxValue).Count();
+        }
+
         [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task TestCase()
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27119/Cluster-transaction-commands-are-never-cleaned-up-after-restoring-a-snapshot-to-a-new-cluster

### Additional description

#### Problem
After restoring a **snapshot** backup to a fresh cluster, newly created cluster
transaction commands are never deleted and accumulate indefinitely in the
`TransactionCommands` cluster storage table - leading to a large backlog and high
CPU in the per-database cluster-transaction executor.

#### Root cause
On a snapshot restore, two values end up out of sync:

- **`TruncatedClusterTransactionCommandsCount`** lives in the database record. A
  snapshot backup writes the full raw record (`DocumentDatabase.FullBackupTo`), so
  the source's (high) value is carried over to the new cluster unchanged. (A logical
  backup strips this field, so it is not affected.)
- The **per-database command counter** (`TransactionCommandsCountPerDatabase`) is
  not part of the backup. On restore it is rebuilt by re-playing each restored
  **atomic-guard** compare-exchange as a cluster transaction command
  (`DatabaseCompareExchangeActions.TryHandleAtomicGuard`), so the counter equals the
  number of *live* atomic guards on the fresh cluster.

When documents were deleted before the backup, each delete added a command (raising
the source's truncated count) but removed the document's atomic guard. So the rebuilt
counter can be far lower than the carried-over truncated count. New commands then get
low indexes, all below `TruncatedClusterTransactionCommandsCount`. The observer only
cleans up when `commandCount > TruncatedClusterTransactionCommandsCount`
(`ClusterObserver.CleanUpDatabaseValues`), so cleanup is skipped permanently.

#### Fix
Reset `TruncatedClusterTransactionCommandsCount` to `0` on snapshot restore, in
`RestoreSnapshotTask.OnBeforeRestoreAsync`, before the restored database record is
saved. The per-database counter is rebuilt from scratch on the new cluster, so
nothing is truncated yet; cleanup is then driven purely by that rebuilt counter and
the observer re-advances the truncated value as it cleans. The reset is only needed
in the snapshot path - logical restores never carry the field over.

#### Test
Added `SlowTests.Cluster.ClusterTransactionTests.RestoredDatabase_ShouldCleanUpClusterTransactionCommands_EvenWhenTruncatedCountFromBackupIsHigh`:

- Source: cluster-wide **store + delete** of N documents, so the truncated count
  climbs (two commands per document) while the live compare-exchange count returns to 0.
- **Snapshot** backup → restore to a fresh server (asserts the high truncated count is
  carried over and then reset to 0, and that the rebuilt count-per-database is 0).
- A few new cluster-wide transactions, then asserts the commands are cleaned up.

Fails deterministically without the fix (the new commands are never deleted); passes with it.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
