### PR TITLE
RavenDB-27138 - Delete cluster transaction commands in bounded batches

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -763,6 +763,19 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
+        public static unsafe long? ReadFirstClusterTransactionPreviousCount(ClusterOperationContext context, string database)
+        {
+            var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
+            using (GetPrefix(context, database, out var prefixSlice))
+            {
+                if (items.SeekOnePrimaryKeyPrefix(prefixSlice, out var reader) == false)
+                    return null;
+
+                var keyPtr = reader.Read((int)TransactionCommandsColumn.Key, out var size);
+                return Bits.SwapBytes(*(long*)(keyPtr + size - sizeof(long)));
+            }
+        }
+
         public const byte Separator = 30;
 
         public static unsafe bool DeleteCommands<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long upToCommandCount)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -26,6 +26,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.ServerWide.Maintenance.Sharding;
 using Raven.Server.Utils;
 using Sparrow;
+using Sparrow.Platform;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
 
@@ -832,10 +833,16 @@ namespace Raven.Server.ServerWide.Maintenance
                 commandCount = Math.Min(commandCount, report.LastCompletedClusterTransaction);
             }
 
-            if (commandCount <= state.ReadTruncatedClusterTransactionCommandsCount())
+            var truncatedCount = state.ReadTruncatedClusterTransactionCommandsCount();
+            if (commandCount <= truncatedCount)
                 return null;
 
-            return commandCount;
+            // Delete the cluster transaction commands in bounded batches instead of removing a potentially huge
+            // backlog (e.g. millions of entries) in a single transaction. Capping the target also advances the
+            // cleanup command id each round (it is derived from this value), so the observer keeps re-issuing the
+            // cleanup until 'commandCount' is reached.
+            var batchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
+            return Math.Min(commandCount, truncatedCount + batchSize);
         }
 
         private static bool AllDatabaseNodesHasReport(DatabaseObservationState state)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -839,10 +839,6 @@ namespace Raven.Server.ServerWide.Maintenance
             if (commandCount <= truncatedCount)
                 return null;
 
-            // Delete the cluster transaction commands in bounded batches instead of removing a potentially huge
-            // backlog (e.g. millions of entries) in a single transaction. Capping the target also advances the
-            // cleanup command id each round (it is derived from this value), so the observer keeps re-issuing the
-            // cleanup until 'commandCount' is reached.
             return Math.Min(commandCount, truncatedCount + ClusterTransactionsCleanupBatchSize);
         }
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -839,7 +839,7 @@ namespace Raven.Server.ServerWide.Maintenance
             if (commandCount <= truncatedCount)
                 return null;
 
-            var firstCommandsCount = ClusterTransactionCommand.ReadFirstClusterTransactionPreviousCount(context, state.Name);
+            var firstCommandsCount = ClusterTransactionCommand.ReadFirstClusterTransactionPreviousCount(context, state.RawDatabase.DatabaseName);
             if (firstCommandsCount == null || firstCommandsCount >= commandCount)
                 return null;
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -94,7 +94,7 @@ namespace Raven.Server.ServerWide.Maintenance
             }, null, ThreadNames.ForClusterObserver($"Cluster observer for term {_term}", _term));
         }
 
-        internal static readonly int ClusterTransactionsCleanupBatchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
+        internal int _clusterTransactionsCleanupBatchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
 
         public bool Suspended = false; // don't really care about concurrency here
         internal long _iteration;
@@ -843,7 +843,7 @@ namespace Raven.Server.ServerWide.Maintenance
             if (firstCommandsCount == null || firstCommandsCount >= commandCount)
                 return null;
 
-            return Math.Min(commandCount, Math.Max(truncatedCount + ClusterTransactionsCleanupBatchSize, firstCommandsCount.Value + 1));
+            return Math.Min(commandCount, Math.Max(truncatedCount + _clusterTransactionsCleanupBatchSize, firstCommandsCount.Value + 1));
         }
 
         private static bool AllDatabaseNodesHasReport(DatabaseObservationState state)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -94,7 +94,7 @@ namespace Raven.Server.ServerWide.Maintenance
             }, null, ThreadNames.ForClusterObserver($"Cluster observer for term {_term}", _term));
         }
 
-        private static readonly int ClusterTransactionsCleanupBatchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
+        internal static readonly int ClusterTransactionsCleanupBatchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
 
         public bool Suspended = false; // don't really care about concurrency here
         internal long _iteration;
@@ -270,7 +270,7 @@ namespace Raven.Server.ServerWide.Maintenance
                             }
                         }
 
-                        var cleanUp = mergedState.States.Min(s => CleanUpDatabaseValues(s.Value) ?? -1);
+                        var cleanUp = mergedState.States.Min(s => CleanUpDatabaseValues(context, s.Value) ?? -1);
                         if (cleanUp > 0)
                         {
                             cleanUpState ??= new Dictionary<string, long>();
@@ -812,7 +812,7 @@ namespace Raven.Server.ServerWide.Maintenance
             return (bool)result.Result;
         }
 
-        private long? CleanUpDatabaseValues(DatabaseObservationState state)
+        private long? CleanUpDatabaseValues(ClusterOperationContext context, DatabaseObservationState state)
         {
             if (_server.Engine.CommandsVersionManager.CurrentClusterMinimalVersion <
                 ClusterCommandsVersionManager.ClusterCommandsVersions[nameof(CleanUpClusterStateCommand)])
@@ -839,7 +839,11 @@ namespace Raven.Server.ServerWide.Maintenance
             if (commandCount <= truncatedCount)
                 return null;
 
-            return Math.Min(commandCount, truncatedCount + ClusterTransactionsCleanupBatchSize);
+            var firstCommandsCount = ClusterTransactionCommand.ReadFirstClusterTransactionPreviousCount(context, state.Name);
+            if (firstCommandsCount == null || firstCommandsCount >= commandCount)
+                return null;
+
+            return Math.Min(commandCount, Math.Max(truncatedCount + ClusterTransactionsCleanupBatchSize, firstCommandsCount.Value + 1));
         }
 
         private static bool AllDatabaseNodesHasReport(DatabaseObservationState state)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -94,6 +94,8 @@ namespace Raven.Server.ServerWide.Maintenance
             }, null, ThreadNames.ForClusterObserver($"Cluster observer for term {_term}", _term));
         }
 
+        private static readonly int ClusterTransactionsCleanupBatchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
+
         public bool Suspended = false; // don't really care about concurrency here
         internal long _iteration;
         private readonly long _term;
@@ -841,8 +843,7 @@ namespace Raven.Server.ServerWide.Maintenance
             // backlog (e.g. millions of entries) in a single transaction. Capping the target also advances the
             // cleanup command id each round (it is derived from this value), so the observer keeps re-issuing the
             // cleanup until 'commandCount' is reached.
-            var batchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
-            return Math.Min(commandCount, truncatedCount + batchSize);
+            return Math.Min(commandCount, truncatedCount + ClusterTransactionsCleanupBatchSize);
         }
 
         private static bool AllDatabaseNodesHasReport(DatabaseObservationState state)

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2602,6 +2602,7 @@ select incl(c)"
                 return ClusterTransactionCommand.ReadCommandsBatch(ctx, database, fromCount: 0, take: long.MaxValue).Count();
         }
 
+        [RavenMultiplatformFact(RavenTestCategory.ClusterTransactions, RavenArchitecture.AllX64)]
         public async Task ClusterTransactionCommandsCleanup_ShouldDrainLargeBacklog_WhenObserverResumes()
         {
             const int count = 50_000;
@@ -2723,6 +2724,57 @@ select incl(c)"
                         return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() <= 1);
                 }, timeout: 120_000);
             }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.Sharding)]
+        public async Task ClusterTransactionCommandsCleanup_ShouldCleanupCommands_ForShardedDatabase()
+        {
+            const int count = 100;
+
+            using var server = GetNewServer();
+            using var store = Sharding.GetDocumentStore(new Options { Server = server });
+
+            // make sure the (single-node) cluster observer exists, then suspend it so a backlog can build up
+            await AssertWaitForTrueAsync(() => Task.FromResult(server.ServerStore.Observer != null));
+            var observer = server.ServerStore.Observer;
+            observer.Suspended = true;
+
+            for (var i = 0; i < count; i++)
+            {
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                await session.SaveChangesAsync();
+            }
+
+            // The cleanup point is the minimum over the shards of the last *executed own-command* position, so a
+            // shard whose last own command sits early in the stream would hold the whole tail back. Append one
+            // command per shard so every shard's completed position reaches the end of the backlog, which makes
+            // the drained state deterministic: at most one retained marker row per shard.
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var shardCount = record.Sharding.Shards.Count;
+            var remainingShards = new HashSet<int>(record.Sharding.Shards.Keys);
+            for (var i = 0; remainingShards.Count > 0; i++)
+            {
+                var id = $"TestObjs/tail/{i}";
+                var shardNumber = await Sharding.GetShardNumberForAsync(store, id);
+                if (remainingShards.Remove(shardNumber) == false)
+                    continue;
+
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), id);
+                await session.SaveChangesAsync();
+            }
+
+            // the commands are stored under the sharded (parent) database name, one row per shard batch
+            Assert.Equal(count + shardCount, CountClusterTransactionCommands(server, store.Database));
+
+            // Resume cleanup. The observer computes the cleanup point from the shard states, but must read the
+            // first command row under the sharded database name - if it used the shard name ('db$0') the lookup
+            // would find nothing and no cleanup would ever be issued for a sharded database.
+            observer.Suspended = false;
+
+            await AssertWaitForTrueAsync(() =>
+                Task.FromResult(CountClusterTransactionCommands(server, store.Database) <= shardCount), timeout: 60_000);
         }
 
         [RavenFact(RavenTestCategory.ClusterTransactions)]

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -33,6 +33,7 @@ using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.ServerWide.Maintenance;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
 using Sparrow.Json;
@@ -2643,6 +2644,77 @@ select incl(c)"
                 // Resume cleanup. The observer must drain the whole backlog - in bounded batches, over several
                 // cleanup commands - leaving at most the single retained marker. If batching were broken (e.g. the
                 // cleanup command id didn't advance) rows would be orphaned and this would time out.
+                observer.Suspended = false;
+
+                await AssertWaitForTrueAsync(() =>
+                {
+                    using (context.OpenReadTransaction())
+                        return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() <= 1);
+                }, timeout: 120_000);
+            }
+        }
+
+        [RavenMultiplatformFact(RavenTestCategory.ClusterTransactions, RavenArchitecture.AllX64)]
+        public async Task ClusterTransactionCommandsCleanup_ShouldDrainBacklog_WhenSingleTransactionExceedsTwoCleanupBatches()
+        {
+            // A single cluster-wide transaction is stored as one row in the cluster's TransactionCommands table, and
+            // cleanup deletes whole rows. When such a row spans more than 2x ClusterTransactionsCleanupBatchSize
+            // commands, the first cleanup round deletes it but advances TruncatedClusterTransactionCommandsCount only
+            // to truncatedCount + batchSize, which lands more than a batch below the next row. Every following round
+            // then computes the same capped target (truncatedCount never moves because nothing gets deleted), so the
+            // cleanup command id never changes, ContainsCommandId blocks the re-issue and the remaining rows are
+            // orphaned forever.
+            var hugeCount = 2 * ClusterObserver.ClusterTransactionsCleanupBatchSize + 100;
+            const int tailCount = 512;
+
+            using var server = GetNewServer();
+            using var store = GetDocumentStore(new Options { Server = server });
+
+            // make sure the (single-node) cluster observer exists, then suspend it so a backlog can build up
+            await AssertWaitForTrueAsync(() => Task.FromResult(server.ServerStore.Observer != null));
+            var observer = server.ServerStore.Observer;
+            observer.Suspended = true;
+
+            // one oversized cluster-wide transaction -> a single commands row spanning 'hugeCount' commands
+            // (atomic guards are disabled only to keep the raft command lean, they don't affect the commands count)
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide,
+                DisableAtomicDocumentWritesInClusterWideTransaction = true
+            }))
+            {
+                for (var i = 0; i < hugeCount; i++)
+                    await session.StoreAsync(new TestObj(), $"TestObjs/huge/{i}");
+
+                await session.SaveChangesAsync();
+            }
+
+            // followed by regular single-command transactions - the rows a stalled cleanup would orphan
+            const int concurrency = 128;
+            for (var start = 0; start < tailCount; start += concurrency)
+            {
+                var end = Math.Min(start + concurrency, tailCount);
+                await Task.WhenAll(Enumerable.Range(start, end - start).Select(async i =>
+                {
+                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                    await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                    await session.SaveChangesAsync();
+                }));
+            }
+
+            using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                // sanity: the backlog is one oversized row followed by 'tailCount' single-command rows
+                using (context.OpenReadTransaction())
+                {
+                    var rows = ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).ToList();
+                    Assert.Equal(1 + tailCount, rows.Count);
+                    Assert.Equal(0L, rows[0].PreviousCount);
+                    Assert.Equal((long)hugeCount, rows[1].PreviousCount);
+                }
+
+                // Resume cleanup. The observer must keep advancing the truncated commands count past the oversized
+                // row until the tail drains, leaving at most the single retained marker.
                 observer.Suspended = false;
 
                 await AssertWaitForTrueAsync(() =>

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2602,11 +2602,9 @@ select incl(c)"
                 return ClusterTransactionCommand.ReadCommandsBatch(ctx, database, fromCount: 0, take: long.MaxValue).Count();
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.ClusterTransactions, RavenArchitecture.AllX64)]
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task ClusterTransactionCommandsCleanup_ShouldDrainLargeBacklog_WhenObserverResumes()
         {
-            const int count = 50_000;
-
             using var server = GetNewServer();
             using var store = GetDocumentStore(new Options { Server = server });
 
@@ -2615,29 +2613,23 @@ select incl(c)"
             var observer = server.ServerStore.Observer;
             observer.Suspended = true;
 
-            // Write 'count' cluster-wide transactions. The database executor processes them, but with the observer
-            // suspended none of the transaction commands are cleaned up, so they accumulate in the cluster storage.
-            const int concurrency = 128;
-            for (var start = 0; start < count; start += concurrency)
+            // shrink this observer's cleanup batch size so a backlog spanning several cleanup batches
+            // can be built with a small number of transactions
+            observer._clusterTransactionsCleanupBatchSize = 64;
+            var count = 2 * observer._clusterTransactionsCleanupBatchSize + 5;
+
+            // Write 'count' cluster-wide transactions. The database executor processes them, but with the
+            // observer suspended none of the transaction commands are cleaned up, so they accumulate in the
+            // cluster storage.
+            for (var i = 0; i < count; i++)
             {
-                var end = Math.Min(start + concurrency, count);
-                await Task.WhenAll(Enumerable.Range(start, end - start).Select(async i =>
-                {
-                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
-                    await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
-                    await session.SaveChangesAsync();
-                }));
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                await session.SaveChangesAsync();
             }
 
             using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                // wait until every transaction command was persisted to the cluster storage
-                await AssertWaitForTrueAsync(() =>
-                {
-                    using (context.OpenReadTransaction())
-                        return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() == count);
-                }, timeout: 60_000);
-
                 // verify the full backlog is present before enabling the observer
                 using (context.OpenReadTransaction())
                     Assert.Equal(count, ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count());
@@ -2655,7 +2647,7 @@ select incl(c)"
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.ClusterTransactions, RavenArchitecture.AllX64)]
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task ClusterTransactionCommandsCleanup_ShouldDrainBacklog_WhenSingleTransactionExceedsTwoCleanupBatches()
         {
             // A single cluster-wide transaction is stored as one row in the cluster's TransactionCommands table, and
@@ -2665,9 +2657,6 @@ select incl(c)"
             // then computes the same capped target (truncatedCount never moves because nothing gets deleted), so the
             // cleanup command id never changes, ContainsCommandId blocks the re-issue and the remaining rows are
             // orphaned forever.
-            var hugeCount = 2 * ClusterObserver.ClusterTransactionsCleanupBatchSize + 100;
-            const int tailCount = 512;
-
             using var server = GetNewServer();
             using var store = GetDocumentStore(new Options { Server = server });
 
@@ -2675,6 +2664,11 @@ select incl(c)"
             await AssertWaitForTrueAsync(() => Task.FromResult(server.ServerStore.Observer != null));
             var observer = server.ServerStore.Observer;
             observer.Suspended = true;
+
+            // shrink this observer's cleanup batch size so the oversized transaction stays small
+            observer._clusterTransactionsCleanupBatchSize = 64;
+            var hugeCount = 2 * observer._clusterTransactionsCleanupBatchSize + 100;
+            const int tailCount = 128;
 
             // one oversized cluster-wide transaction -> a single commands row spanning 'hugeCount' commands
             // (atomic guards are disabled only to keep the raft command lean, they don't affect the commands count)
@@ -2691,16 +2685,11 @@ select incl(c)"
             }
 
             // followed by regular single-command transactions - the rows a stalled cleanup would orphan
-            const int concurrency = 128;
-            for (var start = 0; start < tailCount; start += concurrency)
+            for (var i = 0; i < tailCount; i++)
             {
-                var end = Math.Min(start + concurrency, tailCount);
-                await Task.WhenAll(Enumerable.Range(start, end - start).Select(async i =>
-                {
-                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
-                    await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
-                    await session.SaveChangesAsync();
-                }));
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                await session.SaveChangesAsync();
             }
 
             using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2601,6 +2601,58 @@ select incl(c)"
                 return ClusterTransactionCommand.ReadCommandsBatch(ctx, database, fromCount: 0, take: long.MaxValue).Count();
         }
 
+        public async Task ClusterTransactionCommandsCleanup_ShouldDrainLargeBacklog_WhenObserverResumes()
+        {
+            const int count = 50_000;
+
+            using var server = GetNewServer();
+            using var store = GetDocumentStore(new Options { Server = server });
+
+            // make sure the (single-node) cluster observer exists, then suspend it so a backlog can build up
+            await AssertWaitForTrueAsync(() => Task.FromResult(server.ServerStore.Observer != null));
+            var observer = server.ServerStore.Observer;
+            observer.Suspended = true;
+
+            // Write 'count' cluster-wide transactions. The database executor processes them, but with the observer
+            // suspended none of the transaction commands are cleaned up, so they accumulate in the cluster storage.
+            const int concurrency = 128;
+            for (var start = 0; start < count; start += concurrency)
+            {
+                var end = Math.Min(start + concurrency, count);
+                await Task.WhenAll(Enumerable.Range(start, end - start).Select(async i =>
+                {
+                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                    await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                    await session.SaveChangesAsync();
+                }));
+            }
+
+            using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                // wait until every transaction command was persisted to the cluster storage
+                await AssertWaitForTrueAsync(() =>
+                {
+                    using (context.OpenReadTransaction())
+                        return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() == count);
+                }, timeout: 60_000);
+
+                // verify the full backlog is present before enabling the observer
+                using (context.OpenReadTransaction())
+                    Assert.Equal(count, ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count());
+
+                // Resume cleanup. The observer must drain the whole backlog - in bounded batches, over several
+                // cleanup commands - leaving at most the single retained marker. If batching were broken (e.g. the
+                // cleanup command id didn't advance) rows would be orphaned and this would time out.
+                observer.Suspended = false;
+
+                await AssertWaitForTrueAsync(() =>
+                {
+                    using (context.OpenReadTransaction())
+                        return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() <= 1);
+                }, timeout: 120_000);
+            }
+        }
+
         [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task TestCase()
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27138/Cluster-transaction-commands-cleanup-deletes-the-entire-backlog-in-a-single-transaction

### Additional description

#### Problem
When the cluster observer cleans up processed cluster transaction commands, it removes the entire backlog (up to the target count) in a single raft state-machine transaction. With a large backlog - e.g. millions of entries, which can accumulate after a restore - this is one huge Voron transaction and a significant memory/time spike.

#### Root cause
`ClusterObserver.CleanUpDatabaseValues` returns the full target `commandCount` (the minimum `LastCompletedClusterTransaction` across the database's nodes). `CleanUpClusterStateCommand` is applied as a single transaction, and `ClusterTransactionCommand.DeleteCommands` -> `Table.DeleteByPrimaryKeyPrefix` deletes all matching rows within it, so the whole backlog is deleted at once.

Note: this can't be fixed by capping inside `DeleteCommands` alone. The observer dedups cleanup commands by an id derived from `hash(dbName ^ commandCount)`. If the delete were capped but the observer kept computing the same full `commandCount`, the id would be identical, `ContainsCommandId` would block the re-issue, and the remaining rows would be orphaned.

#### Fix
Cap the observer's cleanup target to `truncatedCount + batchSize` in `CleanUpDatabaseValues`, with `batchSize = 10 * 1024` on 64-bit and `1 * 1024` on 32-bit. This:
- bounds each delete transaction to at most `batchSize`, and
- advances the cleanup command id each round (it's derived from the target), so the observer re-issues the cleanup until `commandCount` is reached - draining the backlog batch by batch.

`DeleteCommands` needs no change: `upToCommandCount` already bounds what it deletes.

A single cluster-wide transaction is stored as one whole row, so a transaction with more than `batchSize` commands can leave the watermark more than a batch below the next row. A capped target could then land in that gap, delete nothing, freeze the watermark - and with it the command id - and stall the cleanup forever. To prevent that, the target is clamped up to at least the first remaining transaction's count + 1 (via the new `ClusterTransactionCommand.ReadFirstClusterTransactionPreviousCount`), so every round deletes at least the first row and makes progress. An oversized transaction is deleted as a single row in one go - it cannot be split anyway.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
