### PR TITLE
RavenDB-23797 query result IndexTimestamp and LastQueryTime must always be written as UTC 

### DIFF
--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1027,11 +1027,11 @@ namespace Raven.Server.Json
             writer.WriteComma();
             
             writer.WritePropertyName(nameof(result.IndexTimestamp));
-            writer.WriteString(result.IndexTimestamp.GetDefaultRavenFormat());
+            writer.WriteString(result.IndexTimestamp.GetDefaultRavenFormat(isUtc: true));
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(result.LastQueryTime));
-            writer.WriteString(result.LastQueryTime.GetDefaultRavenFormat());
+            writer.WriteString(result.LastQueryTime.GetDefaultRavenFormat(isUtc: true));
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(result.IsStale));

--- a/test/SlowTests/Issues/RavenDB_22750.cs
+++ b/test/SlowTests/Issues/RavenDB_22750.cs
@@ -2,6 +2,8 @@
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Session;
 using SlowTests.Core.Utils.Entities;
 using SlowTests.Core.Utils.Indexes;
 using Tests.Infrastructure;
@@ -33,6 +35,71 @@ public class RavenDB_22750 : RavenTestBase
 
                 Assert.Equal(DateTimeKind.Utc, stats.IndexTimestamp.Kind);
                 Assert.Equal(DateTimeKind.Utc, stats.LastQueryTime.Kind);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public async Task IndexTimestamp_And_LastQueryTime_Needs_To_Have_DateTimeKind_Specified_When_Index_Did_Not_Run_Any_Batch_Yet()
+    {
+        using (var store = GetDocumentStore())
+        {
+            // stopping indexing before index deployment guarantees LastIndexingTime stays null,
+            // pinning the race that makes IndexTimestamp fall back to DateTime.MinValue
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            await new Companies_ByEmployeeLastName().ExecuteAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.Query<Company, Companies_ByEmployeeLastName>()
+                    .Statistics(out var stats)
+                    .ToListAsync();
+
+                Assert.Equal(DateTimeKind.Utc, stats.IndexTimestamp.Kind);
+                Assert.Equal(DateTimeKind.Utc, stats.LastQueryTime.Kind);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public async Task IndexTimestamp_And_LastQueryTime_Needs_To_Have_DateTimeKind_Specified_For_Collection_Query()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.Query<Company>()
+                    .Statistics(out var stats)
+                    .ToListAsync();
+
+                Assert.Equal(DateTimeKind.Utc, stats.IndexTimestamp.Kind);
+                Assert.Equal(DateTimeKind.Utc, stats.LastQueryTime.Kind);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public async Task Streaming_IndexTimestamp_Needs_To_Have_DateTimeKind_Specified_When_Index_Did_Not_Run_Any_Batch_Yet()
+    {
+        using (var store = GetDocumentStore())
+        {
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            await new Companies_ByEmployeeLastName().ExecuteAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var query = session.Query<Company, Companies_ByEmployeeLastName>();
+
+                var reader = await session.Advanced.StreamAsync(query, out StreamQueryStatistics stats);
+
+                while (await reader.MoveNextAsync())
+                {
+                }
+
+                // StreamQueryStatistics carries only IndexTimestamp, no LastQueryTime
+                Assert.Equal(DateTimeKind.Utc, stats.IndexTimestamp.Kind);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23797 

### Additional description

When an index has not run any batch yet (or for collection queries) the value is `DateTime.MinValue` with `DateTimeKind.Unspecified`, so the kind-dependent `GetDefaultRavenFormat()` omitted the Z suffix and clients parsed it as Unspecified

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
