### PR TITLE
RavenDB-25106 Adjust server cert renewal date

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1493,30 +1493,26 @@ namespace Raven.Server
 
         public (bool ShouldRenew, DateTime RenewalDate) CalculateRenewalDate(CertificateUtils.CertificateHolder currentCertificate, bool forceRenew)
         {
-            // we want to setup all the renewals for Saturdays, 30 days before expiration. This is done to reduce the amount of cert renewals that are counted against our renewals
-            // but if we have less than 20 days or user asked to force-renew, we'll try anyway.
+            // we want to setup the renewal for the first possible date, AcmeRenewalThresholdPercentage (default: 30%) of the certificate lifetime before expiration
+            // but if we're already past that threshold or the user asked to force-renew, we'll try anyway.
 
             if (forceRenew)
                 return (true, DateTime.UtcNow.Date);
 
             var remainingDays = (currentCertificate.ServerCertificate.NotAfter - Time.GetUtcNow().ToLocalTime()).TotalDays;
             var daysToRenewBeforeExpiration = CalculateDaysToRenewBeforeExpiration(Certificate.ServerCertificate);
-            
+
             if (remainingDays <= daysToRenewBeforeExpiration)
             {
                 return (true, DateTime.UtcNow.Date);
             }
 
-            var firstPossibleDate = currentCertificate.ServerCertificate.NotAfter.ToUniversalTime().AddDays(-daysToRenewBeforeExpiration);
+            var firstPossibleDate = currentCertificate.ServerCertificate.NotAfter.ToUniversalTime().AddDays(-daysToRenewBeforeExpiration).Date;
 
-            // We can do this because saturday is last in the DayOfWeek enum
-            var daysUntilSaturday = DayOfWeek.Saturday - firstPossibleDate.DayOfWeek;
-            var firstPossibleSaturday = firstPossibleDate.AddDays(daysUntilSaturday);
+            if (firstPossibleDate == DateTime.UtcNow.Date)
+                return (true, firstPossibleDate);
 
-            if (firstPossibleSaturday.Date == DateTime.UtcNow.Date)
-                return (true, firstPossibleSaturday.Date);
-
-            return (false, firstPossibleSaturday.Date);
+            return (false, firstPossibleDate);
         }
 
         public async Task StartCertificateReplicationAsync(X509Certificate2 newCertificate, string password, bool replaceImmediately, string raftRequestId)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25106 

### Additional description

Adjusted server cert renewal date calculation to use the threshold date instead of closest next Saturday.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
