### PR TITLE
RavenDB-27076 Raise clean ReferenceError for undefined identifiers in server-side JS (Jint 4.6+ reference change)

### DIFF
--- a/src/Raven.Server/Documents/Patch/JintNullPropagationReferenceResolver.cs
+++ b/src/Raven.Server/Documents/Patch/JintNullPropagationReferenceResolver.cs
@@ -29,10 +29,17 @@ namespace Raven.Server.Documents.Patch
             if (_args == null || name.StartsWith('$') == false)
             {
                 if (name == "length")
+                {
                     value = _numberPositiveZero;
-                else
-                    value = reference.IsPropertyReference ? JsValue.Undefined : JsValue.Null;
-                return true;
+                    return true;
+                }
+
+                value = JsValue.Undefined;
+
+                if (reference.IsPropertyReference)
+                    return true;
+
+                return false; // bare undefined name: let Jint throw a clean ReferenceError, not InvalidCastException (RavenDB-27076)
             }
 
             value = _args.Get(name.Substring(1));

--- a/test/FastTests/Client/Indexing/JavaScriptIndexTests.cs
+++ b/test/FastTests/Client/Indexing/JavaScriptIndexTests.cs
@@ -1046,7 +1046,7 @@ map('Products', prod => {
                     result.Duration = 6;
                 }
 
-                if (prod.Mode == Refurbished)
+                if (prod.Mode == 'Refurbished')
                     result.Duration /= 2;
 
                 return result;

--- a/test/FastTests/Issues/RavenDB_27076.cs
+++ b/test/FastTests/Issues/RavenDB_27076.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_27076 : RavenTestBase
+    {
+        public RavenDB_27076(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public async Task CallingUndefinedFunctionInPatch_ShouldThrowCleanReferenceError()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Joe" }, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(() =>
+                store.Operations.SendAsync(new PatchOperation("users/1", null,
+                    new PatchRequest { Script = "this.Name = someUndefinedFn123(this.Name);" })));
+
+            Assert.Contains("someUndefinedFn123 is not defined", ex.Message);
+        }
+
+        private sealed class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
@@ -798,17 +798,11 @@ output(result);
                         }, database, database.ServerStore, context);
                     
                     var result = (RelationalDatabaseEtlTestScriptResult)testResult;
-                    Assert.Equal(0, result.TransformationErrors.Count);
+                    Assert.Equal(1, result.TransformationErrors.Count);
+                    Assert.Contains("varchar is not defined", result.TransformationErrors[0].Error);
                     Assert.Equal(0, result.ItemLoadErrors.Count);
                     Assert.Equal(0, result.SlowSqlWarnings.Count);
-
-                    Assert.Equal(1, result.Summary.Count);
-
-                    var users = result.Summary.First(x => x.TableName == "Users");
-
-                    Assert.Equal(2, users.Commands.Length);  // insert & delete
-
-                    Assert.Equal("{\"varcharExists\":false,\"nvarcharExists\":false}", result.DebugOutput[0]);
+                    Assert.Equal(0, result.Summary.Count);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27076

### Additional description

#### Context
`SnowflakeEtlTests.VarcharAndNVarcharFunctionsArentAvailable` started failing after the Jint upgrade (#22507). This is not a Snowflake problem - the change came from Jint itself.

Jint 4.6.0 (sebastienros/jint#2266) changed how it treats a name that does not exist, to follow the ECMAScript spec. Before, an undefined name had the base `Undefined`; now it has a special `Reference.Unresolvable` marker (a `JsString`).

Our resolver relied on the old behavior. When a script called an undefined name, Jint used to route it through our `TryGetCallable` fallback, which quietly returned `undefined`. After the bump, `JintCallExpression` instead casts that marker to an `Environment` and throws `InvalidCastException` before our fallback runs. So on current `v7.2`, calling any undefined name in a server-side script (patch / ETL / index / subscription) already fails, just with a confusing `InvalidCastException`.

#### What this PR does
The fix is a small change in JintNullPropagationReferenceResolver.TryUnresolvableReference. When a script uses a name that does not exist anywhere (a typo, or a function that is not available in that script, and not a document field like doc.field), we now let Jint raise the normal ReferenceError: <name> is not defined, just like any JavaScript engine, instead of the confusing InvalidCastException. This holds whether the name is called (foo()) or only read (var x = foo).

#### Backward compatibility and behavior change
Calling an undefined name already fails after the bump; we only make the error clear instead of confusing. Everything that legitimately used the resolver (null-propagation over missing fields, array helpers on absent fields, .length === 0, $-args) still works. 

The one thing this PR may surface is that existing typos in already-deployed JS scripts/indexes will now show an error. Affected surfaces: any server-side JS script (patch / ETL / index / subscription).

#### Tests
- SnowflakeEtlTests.VarcharAndNVarcharFunctionsArentAvailable: assertions inverted; the call now yields a transformation error containing varchar is not defined.
- FastTests/Issues/RavenDB_27076: new Snowflake-free regression that patches a document with an undefined function call.
- JavaScriptIndexTests.CanIndexSwitchCases: fixed a pre-existing typo (Refurbished to 'Refurbished'). It was a bare name that used to resolve to null silently; with this change, it would throw, so it is corrected to the intended string literal.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed