### PR TITLE
RavenDB-24423 - Test fix: make AnalyzerOutputMatchesPreRavenDb24423 tolerant of OS Unicode/ICU version differences

### DIFF
--- a/test/SlowTests/Corax/RavenDB_24423BackwardCompatibility.cs
+++ b/test/SlowTests/Corax/RavenDB_24423BackwardCompatibility.cs
@@ -60,10 +60,11 @@ public class RavenDB_24423BackwardCompatibility(ITestOutputHelper output) : Rave
             if (currentToken.SequenceEqual(storedToken) == false && IsOsIcuCasingDrift(expectedRune, storedToken))
             {
                 // Rune.ToLowerInvariant is backed by the OS-shipped ICU, whose Unicode case tables vary by
-                // build (e.g. Windows 11 23H2 vs 25H2 / ICU 72 -> Unicode 15.0). The golden file was recorded
-                // on an older ICU that had no lowercase mapping for a few newly-cased code points, so it stored
-                // them un-folded; a newer ICU folds them. That is data drift across runtimes, not a Pre24423
-                // regression - skip just this code point. All other ~1.1M runes still assert the length/format.
+                // build (e.g. Windows 11 23H2 vs 25H2 / ICU 72 -> Unicode 15.0). When this runtime's ICU and
+                // the ICU that recorded the golden file disagree on a code point's case mapping, the bytes
+                // differ. That is data drift across runtimes, not a Pre24423 regression, and it can go either
+                // direction (this box newer or older than the recording box) - skip just this code point.
+                // All other ~1.1M runes still assert the length/format.
                 continue;
             }
 
@@ -71,16 +72,20 @@ public class RavenDB_24423BackwardCompatibility(ITestOutputHelper output) : Rave
         }
     }
 
-    // Detects the signature of an OS/ICU Unicode-version mismatch for a single code point: the golden file
-    // recorded it un-folded (the recording runtime's ICU had no lowercase mapping), but this runtime's ICU does
-    // fold it. This is deliberately narrow so a genuine transform/length regression is still caught.
+    // Detects an OS/ICU Unicode-version disagreement for a single code point: this runtime lowercases the rune
+    // to different bytes than the runtime that recorded the golden file. Bidirectional (this box may be newer or
+    // older). Scoped to the BMP: for a single BMP code point the golden token is exactly the recorded lowercased
+    // bytes, so the comparison is exact; Pre24423 truncates non-BMP tokens so a byte comparison isn't valid there
+    // (and those case mappings predate every ICU we run on, so no non-BMP drift is expected). Because it compares
+    // the directly-computed lowercasing - not the analyzer output - a genuine transform/length regression is still
+    // caught: when the casing agrees the assertion still runs.
     private static bool IsOsIcuCasingDrift(Rune rune, ReadOnlySpan<byte> storedToken)
     {
-        var raw = Encoding.UTF8.GetBytes(rune.ToString());
-        if (storedToken.SequenceEqual(raw) == false)
+        if (rune.IsBmp == false)
             return false;
 
-        return Rune.ToLowerInvariant(rune) != rune;
+        var localLower = Encoding.UTF8.GetBytes(Rune.ToLowerInvariant(rune).ToString());
+        return localLower.AsSpan().SequenceEqual(storedToken) == false;
     }
     
     [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Corax)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26887/SlowTests.Corax.RavenDB24423BackwardCompatibility.AnalyzerOutputMatchesPreRavenDb24423

### Additional description

#### Test fix only - no production code changes

`AnalyzerOutputMatchesPreRavenDb24423` compares analyzer output against a frozen golden file (`PreRavenDB_24423.gz`). Since .NET 5, lowercasing (`Rune.ToLowerInvariant`) is backed by the **OS-shipped ICU**, whose Unicode case tables vary by Windows build. So the same code produces slightly different bytes on different machines for a handful of code points whose case mappings were added in newer Unicode versions (e.g. U+2C2F Glagolitic - Unicode 9.0; U+A7C0/U+A7C7/U+A7D0/... Latin Extended-D - Unicode 14/15).

The golden file can only match one ICU version, so the test fails on any machine whose Unicode tables differ from the recording machine's - in **either direction**:

- newer machine (e.g. Win11 25H2 / ICU 72): folds characters the golden stored un-folded
- older machine (e.g. Jenkins agent): leaves un-folded characters the golden stored folded - `Expected: [234,159,136] (U+A7C8) / Actual: [234,159,135] (U+A7C7)`

Out of ~1.1M runes, only 5–6 code points are affected per machine.

**Fix:** before asserting, check whether this runtime's own `Rune.ToLowerInvariant` produces different bytes than the golden recorded for that code point. If so, the mismatch is ICU data drift, not an analyzer regression - skip just that code point. All other runes still assert the Pre24423 length/format logic in full, and a genuine analyzer regression is still caught (its output would also differ from the locally computed lowercase, where the assertion still runs).

The analyzer itself behaves correctly on every machine; only the frozen fixture can't represent two Unicode versions at once. Corax↔Lucene parity is unaffected - both engines lowercase through the same OS ICU, so they drift together.

### Type of change

- [ ] Bug fix
- [x] Test fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
