### PR TITLE
[Custom-6.2.17] RavenDB-26721 & RavenDB-26903 &  RavenDB-27109 & RavenDB-27119 & RavenDB-27138

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
@@ -54,7 +54,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
 
         RavenAwsS3Client.FillMetadata(multipartRequest.Metadata, _metadata);
 
-        var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken);
+        var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken).ConfigureAwait(false);
         _uploadId = initiateResponse.UploadId;
         _partNumber = 1;
         _partEtags = new List<PartETag>();
@@ -67,7 +67,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
 
     public async Task UploadPartAsync(Stream stream)
     {
-        await UploadPartAsync(stream, stream.Length);
+        await UploadPartAsync(stream, stream.Length).ConfigureAwait(false);
     }
 
     public async Task UploadPartAsync(Stream stream, long size)
@@ -90,7 +90,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
                     _progress?.UploadProgress.UpdateUploaded(args.IncrementTransferred);
                     _progress?.OnUploadProgress?.Invoke();
                 }
-            }, _cancellationToken);
+            }, _cancellationToken).ConfigureAwait(false);
 
         _partEtags.Add(new PartETag(uploadResponse.PartNumber.GetValueOrDefault(), uploadResponse.ETag));
     }
@@ -110,6 +110,6 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
                 Key = _key,
                 PartETags = _partEtags
             },
-            _cancellationToken);
+            _cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AzureMultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AzureMultiPartUploader.cs
@@ -60,7 +60,7 @@ public class AzureMultiPartUploader : IMultiPartUploader
                 _progress.UploadProgress.SetUploaded(uploadedSoFar + value);
                 _progress.OnUploadProgress?.Invoke();
             })
-        }, _cancellationToken);
+        }, _cancellationToken).ConfigureAwait(false);
     }
 
     public void CompleteUpload()
@@ -73,6 +73,6 @@ public class AzureMultiPartUploader : IMultiPartUploader
         await _blockBlobClient.CommitBlockListAsync(_base64BlockIds, new CommitBlockListOptions
         {
             Metadata = _metadata
-        }, _cancellationToken);
+        }, _cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -46,6 +46,16 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             _extension = extension;
         }
 
+        protected override Task<IDisposable> OnBeforeRestoreAsync()
+        {
+            // the per-database cluster transaction command counter is rebuilt from the restored compare-exchange
+            // (atomic guard) values on the fresh cluster. A snapshot backup carries over the source's
+            // TruncatedClusterTransactionCommandsCount, which can be higher than that rebuilt counter and would then
+            // block cleanup of the new commands. Reset it so cleanup is driven purely by the rebuilt counter.
+            RestoreSettings.DatabaseRecord.TruncatedClusterTransactionCommandsCount = 0;
+            return base.OnBeforeRestoreAsync();
+        }
+
         protected override async Task RestoreAsync()
         {
             Database.DocumentsStorage.ResetLastCompletedClusterTransactionIndex();

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -11,28 +11,35 @@ namespace Raven.Server.Indexing;
 
 public sealed class LuceneVoronStream : VoronStream
 {
-    // A single, reusable handler shared across every transaction this stream is bound to.
-    // It captures only 'this' (so it can write the Llt field) and crucially does NOT capture any
-    // LowLevelTransaction - otherwise it would pin the disposed transaction and reintroduce the
-    // retention that RavenDB-26186 set out to remove. The transaction to compare against comes from
-    // the OnDispose argument instead.
+    // A single, reusable handler shared across every transaction this stream is bound to (used for both
+    // += and -=, so detaching removes the exact same delegate instance). It is bound to the
+    // CleanupTransaction method rather than a lambda on purpose: a method cannot capture enclosing locals,
+    // so it is impossible to accidentally capture - and thereby pin - a LowLevelTransaction here and
+    // reintroduce the retention that RavenDB-26186 set out to remove.
     private readonly Action<IPagerLevelTransactionState> _cleanupHandler;
 
     public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt) : base(name, chunksDetails, llt)
     {
-        // LowLevelTransaction.Dispose() invokes OnDispose with itself as the argument, so the handler
-        // receives the exact transaction being disposed. The compare-exchange nulls Llt only when it still
-        // points to that transaction, which makes a stale handler (one whose transaction was already replaced
-        // by UpdateCurrentTransaction) a safe no-op, and is race-safe against a concurrent in-flight read.
-        //
-        // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive the
-        // transaction that created them. Nulling Llt on dispose lets the GC collect the disposed
-        // LowLevelTransaction and its associated structures (page positions, journal references, etc.),
-        // which can be substantial depending on the indexing batch size.
-        // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
-        _cleanupHandler = txBeingDisposed => Interlocked.CompareExchange(ref Llt, null, (LowLevelTransaction)txBeingDisposed);
+        _cleanupHandler = CleanupTransaction;
 
         Llt.Transaction.LowLevelTransaction.OnDispose += _cleanupHandler;
+    }
+
+    // Nulls Llt when the transaction it currently points at is disposed. LowLevelTransaction.Dispose() invokes
+    // OnDispose with itself as the argument, so we receive the exact transaction being disposed; the compare-exchange
+    // nulls Llt only when it still points to that transaction. That makes a stale handler (one whose transaction was
+    // already replaced by UpdateCurrentTransaction) a safe no-op, and is race-safe against a concurrent in-flight read.
+    //
+    // Why null Llt at all: Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive the
+    // transaction that created them. Nulling Llt on dispose lets the GC collect the disposed LowLevelTransaction and its
+    // associated structures (page positions, journal references, etc.), which can be substantial depending on the
+    // indexing batch size. When the stream is reused, UpdateCurrentTransaction sets a fresh transaction.
+    //
+    // This is a method, not a lambda, so it cannot capture (and thereby pin) a LowLevelTransaction. The transaction to
+    // compare against always comes from the argument, never a captured variable.
+    private void CleanupTransaction(IPagerLevelTransactionState txBeingDisposed)
+    {
+        Interlocked.CompareExchange(ref Llt, null, (LowLevelTransaction)txBeingDisposed);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Voron;
 using Voron.Data;
 using Voron.Data.BTrees;
@@ -10,22 +11,28 @@ namespace Raven.Server.Indexing;
 
 public sealed class LuceneVoronStream : VoronStream
 {
+    // A single, reusable handler shared across every transaction this stream is bound to.
+    // It captures only 'this' (so it can write the Llt field) and crucially does NOT capture any
+    // LowLevelTransaction - otherwise it would pin the disposed transaction and reintroduce the
+    // retention that RavenDB-26186 set out to remove. The transaction to compare against comes from
+    // the OnDispose argument instead.
+    private readonly Action<IPagerLevelTransactionState> _cleanupHandler;
+
     public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt) : base(name, chunksDetails, llt)
     {
-        RegisterTransactionCleanup();
-    }
+        // LowLevelTransaction.Dispose() invokes OnDispose with itself as the argument, so the handler
+        // receives the exact transaction being disposed. The compare-exchange nulls Llt only when it still
+        // points to that transaction, which makes a stale handler (one whose transaction was already replaced
+        // by UpdateCurrentTransaction) a safe no-op, and is race-safe against a concurrent in-flight read.
+        //
+        // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive the
+        // transaction that created them. Nulling Llt on dispose lets the GC collect the disposed
+        // LowLevelTransaction and its associated structures (page positions, journal references, etc.),
+        // which can be substantial depending on the indexing batch size.
+        // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
+        _cleanupHandler = txBeingDisposed => Interlocked.CompareExchange(ref Llt, null, (LowLevelTransaction)txBeingDisposed);
 
-    private void RegisterTransactionCleanup()
-    {
-        Llt.Transaction.LowLevelTransaction.OnDispose += _ =>
-        {
-            // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive
-            // the transaction that created them. Nulling _llt here allows the GC to collect the
-            // disposed LowLevelTransaction and its associated structures (page positions, journal
-            // references, etc.), which can be substantial depending on the indexing batch size.
-            // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
-            Llt = null;
-        };
+        Llt.Transaction.LowLevelTransaction.OnDispose += _cleanupHandler;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -33,11 +40,24 @@ public sealed class LuceneVoronStream : VoronStream
     {
         if (tx != null)
         {
-            if (Llt == tx.LowLevelTransaction)
+            var newLlt = tx.LowLevelTransaction;
+            if (Llt == newLlt)
                 return;
 
-            Llt = tx.LowLevelTransaction;
-            RegisterTransactionCleanup();
+            // Detach the handler from the old transaction. This is NOT required for correctness - the
+            // compare-exchange in _cleanupHandler already makes a leftover handler a safe no-op (it only nulls
+            // Llt when Llt still points to the transaction being disposed), and since the handler captures only 'this'
+            // (never a LowLevelTransaction) a leftover handler does not pin the old transaction either.
+            // We detach anyway to keep things tidy: handlers don't pile up on a still-live transaction's
+            // OnDispose list, and a disposed transaction's list doesn't carry a dead no-op handler.
+            // (If the old transaction was already disposed, Llt is null here and there is nothing to detach -
+            // the handler already ran and nulled Llt.)
+            var oldLlt = Llt;
+            if (oldLlt != null)
+                oldLlt.Transaction.LowLevelTransaction.OnDispose -= _cleanupHandler;
+
+            Llt = newLlt;
+            newLlt.Transaction.LowLevelTransaction.OnDispose += _cleanupHandler;
             LastPage = default(Page);
             return;
         }

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -884,8 +884,6 @@ namespace Raven.Server.ServerWide.Commands
             var lowerDb = database.ToLowerInvariant();
             var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
 
-            // The required prefix is the database only, so the iterator stops at the database boundary
-            // and doesn't read (and deserialize) commands that belong to other databases.
             using (GetPrefix(context, database, out Slice databasePrefix))
             {
                 // 'startAfter' is exclusive, so we seek after (fromCount - 1) in order to include the command at

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -757,6 +757,19 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
+        public static unsafe long? ReadFirstClusterTransactionPreviousCount(ClusterOperationContext context, string database)
+        {
+            var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
+            using (GetPrefix(context, database, out var prefixSlice))
+            {
+                if (items.SeekOnePrimaryKeyPrefix(prefixSlice, out var reader) == false)
+                    return null;
+
+                var keyPtr = reader.Read((int)TransactionCommandsColumn.Key, out var size);
+                return Bits.SwapBytes(*(long*)(keyPtr + size - sizeof(long)));
+            }
+        }
+
         public const byte Separator = 30;
 
         public static unsafe bool DeleteCommands<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long upToCommandCount)

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -817,6 +817,18 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
+        // 'startAfter' is exclusive, so we seek after (fromCount - 1) to include the command at exactly 'fromCount' (counts are discrete).
+        // For fromCount null/0 there is nothing to skip: return an empty slice (seek from the database start) and a no-op scope.
+        private static ByteStringContext.InternalScope GetStartAfterPrefix<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, out Slice startAfter)
+            where TTransaction : RavenTransaction
+        {
+            if (fromCount is > 0)
+                return GetPrefix(context, database, out startAfter, fromCount.Value - 1);
+
+            startAfter = Slices.Empty;
+            return default;
+        }
+
         public sealed class SingleClusterDatabaseCommand : IDynamicJson, IDisposable
         {
             public ClusterTransactionOptions Options;
@@ -885,57 +897,48 @@ namespace Raven.Server.ServerWide.Commands
             var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
 
             using (GetPrefix(context, database, out Slice databasePrefix))
+            using (GetStartAfterPrefix(context, database, fromCount, out var startAfter))
             {
-                // 'startAfter' is exclusive, so we seek after (fromCount - 1) in order to include the command at
-                // exactly 'fromCount'. Counts are discrete, so excluding (fromCount - 1) starts inclusively at 'fromCount'.
-                var startAfter = Slices.Empty;
-                IDisposable startAfterScope = null;
-                if (fromCount is > 0)
-                    startAfterScope = GetPrefix(context, database, out startAfter, fromCount.Value - 1);
-
-                using (startAfterScope)
+                var readSize = 0;
+                var commandsBulk = items.SeekByPrimaryKeyPrefix(databasePrefix, startAfter, 0);
+                foreach (var command in commandsBulk)
                 {
-                    var readSize = 0;
-                    var commandsBulk = items.SeekByPrimaryKeyPrefix(databasePrefix, startAfter, 0);
-                    foreach (var command in commandsBulk)
+                    if (take <= 0)
+                        yield break;
+
+                    var reader = command.Value.Reader;
+                    var result = ReadCommand(context, reader);
+                    if (result == null)
+                        yield break;
+
+                    Debug.Assert(result.Database == lowerDb);
+                    Debug.Assert(result.PreviousCount >= fromCount);
+
+                    if (result.Database != lowerDb)
                     {
-                        if (take <= 0)
-                            yield break;
-
-                        var reader = command.Value.Reader;
-                        var result = ReadCommand(context, reader);
-                        if (result == null)
-                            yield break;
-
-                        Debug.Assert(result.Database == lowerDb);
-                        Debug.Assert(result.PreviousCount >= fromCount);
-
-                        if (result.Database != lowerDb)
-                        {
-                            // beware of reading commands of other databases.
-                            result.Dispose();
-                            continue;
-                        }
-
-                        if (result.PreviousCount < fromCount)
-                        {
-                            result.Dispose();
-                            continue;
-                        }
-
-                        if (lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
-                        {
-                            result.Dispose();
-                            continue;
-                        }
-
-                        take--;
-                        yield return result;
-
-                        readSize += reader.Size;
-                        if (readSize > maxBytesToRead)
-                            yield break;
+                        // beware of reading commands of other databases.
+                        result.Dispose();
+                        continue;
                     }
+
+                    if (result.PreviousCount < fromCount)
+                    {
+                        result.Dispose();
+                        continue;
+                    }
+
+                    if (lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
+                    {
+                        result.Dispose();
+                        continue;
+                    }
+
+                    take--;
+                    yield return result;
+
+                    readSize += reader.Size;
+                    if (readSize > maxBytesToRead)
+                        yield break;
                 }
             }
         }

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -883,45 +883,58 @@ namespace Raven.Server.ServerWide.Commands
         {
             var lowerDb = database.ToLowerInvariant();
             var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
-            using (GetPrefix(context, database, out Slice prefixSlice, fromCount))
+
+            // The required prefix is the database only, so the iterator stops at the database boundary
+            // and doesn't read (and deserialize) commands that belong to other databases.
+            using (GetPrefix(context, database, out Slice databasePrefix))
             {
-                var readSize = 0;
-                var commandsBulk = items.SeekByPrimaryKey(prefixSlice, 0);
-                foreach (var command in commandsBulk)
+                // 'startAfter' is exclusive, so we seek after (fromCount - 1) in order to include the command at
+                // exactly 'fromCount'. Counts are discrete, so excluding (fromCount - 1) starts inclusively at 'fromCount'.
+                var startAfter = Slices.Empty;
+                IDisposable startAfterScope = null;
+                if (fromCount is > 0)
+                    startAfterScope = GetPrefix(context, database, out startAfter, fromCount.Value - 1);
+
+                using (startAfterScope)
                 {
-                    if (take <= 0)
-                        yield break;
-
-                    var reader = command.Reader;
-                    var result = ReadCommand(context, reader);
-                    if (result == null)
-                        yield break;
-
-                    if (result.Database != lowerDb)
+                    var readSize = 0;
+                    var commandsBulk = items.SeekByPrimaryKeyPrefix(databasePrefix, startAfter, 0);
+                    foreach (var command in commandsBulk)
                     {
-                        // beware of reading commands of other databases.
-                        result.Dispose();
-                        continue;
+                        if (take <= 0)
+                            yield break;
+
+                        var reader = command.Value.Reader;
+                        var result = ReadCommand(context, reader);
+                        if (result == null)
+                            yield break;
+
+                        if (result.Database != lowerDb)
+                        {
+                            // beware of reading commands of other databases.
+                            result.Dispose();
+                            continue;
+                        }
+
+                        if (result.PreviousCount < fromCount)
+                        {
+                            result.Dispose();
+                            continue;
+                        }
+
+                        if (lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
+                        {
+                            result.Dispose();
+                            continue;
+                        }
+
+                        take--;
+                        yield return result;
+
+                        readSize += reader.Size;
+                        if (readSize > maxBytesToRead)
+                            yield break;
                     }
-
-                    if (result.PreviousCount < fromCount)
-                    {
-                        result.Dispose();
-                        continue;
-                    }
-
-                    if (lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
-                    {
-                        result.Dispose();
-                        continue;
-                    }
-
-                    take--;
-                    yield return result;
-
-                    readSize += reader.Size;
-                    if(readSize > maxBytesToRead)
-                        yield break;
                 }
             }
         }

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -907,6 +907,9 @@ namespace Raven.Server.ServerWide.Commands
                         if (result == null)
                             yield break;
 
+                        Debug.Assert(result.Database == lowerDb);
+                        Debug.Assert(result.PreviousCount >= fromCount);
+
                         if (result.Database != lowerDb)
                         {
                             // beware of reading commands of other databases.

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -912,7 +912,7 @@ namespace Raven.Server.ServerWide.Commands
                         yield break;
 
                     Debug.Assert(result.Database == lowerDb);
-                    Debug.Assert(result.PreviousCount >= fromCount);
+                    Debug.Assert(fromCount == null || result.PreviousCount >= fromCount);
 
                     if (result.Database != lowerDb)
                     {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -26,6 +26,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.ServerWide.Maintenance.Sharding;
 using Raven.Server.Utils;
 using Sparrow;
+using Sparrow.Platform;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
 
@@ -832,10 +833,16 @@ namespace Raven.Server.ServerWide.Maintenance
                 commandCount = Math.Min(commandCount, report.LastCompletedClusterTransaction);
             }
 
-            if (commandCount <= state.ReadTruncatedClusterTransactionCommandsCount())
+            var truncatedCount = state.ReadTruncatedClusterTransactionCommandsCount();
+            if (commandCount <= truncatedCount)
                 return null;
 
-            return commandCount;
+            // Delete the cluster transaction commands in bounded batches instead of removing a potentially huge
+            // backlog (e.g. millions of entries) in a single transaction. Capping the target also advances the
+            // cleanup command id each round (it is derived from this value), so the observer keeps re-issuing the
+            // cleanup until 'commandCount' is reached.
+            var batchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
+            return Math.Min(commandCount, truncatedCount + batchSize);
         }
 
         private static bool AllDatabaseNodesHasReport(DatabaseObservationState state)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -839,10 +839,6 @@ namespace Raven.Server.ServerWide.Maintenance
             if (commandCount <= truncatedCount)
                 return null;
 
-            // Delete the cluster transaction commands in bounded batches instead of removing a potentially huge
-            // backlog (e.g. millions of entries) in a single transaction. Capping the target also advances the
-            // cleanup command id each round (it is derived from this value), so the observer keeps re-issuing the
-            // cleanup until 'commandCount' is reached.
             return Math.Min(commandCount, truncatedCount + ClusterTransactionsCleanupBatchSize);
         }
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -839,7 +839,7 @@ namespace Raven.Server.ServerWide.Maintenance
             if (commandCount <= truncatedCount)
                 return null;
 
-            var firstCommandsCount = ClusterTransactionCommand.ReadFirstClusterTransactionPreviousCount(context, state.Name);
+            var firstCommandsCount = ClusterTransactionCommand.ReadFirstClusterTransactionPreviousCount(context, state.RawDatabase.DatabaseName);
             if (firstCommandsCount == null || firstCommandsCount >= commandCount)
                 return null;
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -94,7 +94,7 @@ namespace Raven.Server.ServerWide.Maintenance
             }, null, ThreadNames.ForClusterObserver($"Cluster observer for term {_term}", _term));
         }
 
-        internal static readonly int ClusterTransactionsCleanupBatchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
+        internal int _clusterTransactionsCleanupBatchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
 
         public bool Suspended = false; // don't really care about concurrency here
         internal long _iteration;
@@ -843,7 +843,7 @@ namespace Raven.Server.ServerWide.Maintenance
             if (firstCommandsCount == null || firstCommandsCount >= commandCount)
                 return null;
 
-            return Math.Min(commandCount, Math.Max(truncatedCount + ClusterTransactionsCleanupBatchSize, firstCommandsCount.Value + 1));
+            return Math.Min(commandCount, Math.Max(truncatedCount + _clusterTransactionsCleanupBatchSize, firstCommandsCount.Value + 1));
         }
 
         private static bool AllDatabaseNodesHasReport(DatabaseObservationState state)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -94,7 +94,7 @@ namespace Raven.Server.ServerWide.Maintenance
             }, null, ThreadNames.ForClusterObserver($"Cluster observer for term {_term}", _term));
         }
 
-        private static readonly int ClusterTransactionsCleanupBatchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
+        internal static readonly int ClusterTransactionsCleanupBatchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
 
         public bool Suspended = false; // don't really care about concurrency here
         internal long _iteration;
@@ -270,7 +270,7 @@ namespace Raven.Server.ServerWide.Maintenance
                             }
                         }
 
-                        var cleanUp = mergedState.States.Min(s => CleanUpDatabaseValues(s.Value) ?? -1);
+                        var cleanUp = mergedState.States.Min(s => CleanUpDatabaseValues(context, s.Value) ?? -1);
                         if (cleanUp > 0)
                         {
                             cleanUpState ??= new Dictionary<string, long>();
@@ -812,7 +812,7 @@ namespace Raven.Server.ServerWide.Maintenance
             return (bool)result.Result;
         }
 
-        private long? CleanUpDatabaseValues(DatabaseObservationState state)
+        private long? CleanUpDatabaseValues(ClusterOperationContext context, DatabaseObservationState state)
         {
             if (_server.Engine.CommandsVersionManager.CurrentClusterMinimalVersion <
                 ClusterCommandsVersionManager.ClusterCommandsVersions[nameof(CleanUpClusterStateCommand)])
@@ -839,7 +839,11 @@ namespace Raven.Server.ServerWide.Maintenance
             if (commandCount <= truncatedCount)
                 return null;
 
-            return Math.Min(commandCount, truncatedCount + ClusterTransactionsCleanupBatchSize);
+            var firstCommandsCount = ClusterTransactionCommand.ReadFirstClusterTransactionPreviousCount(context, state.Name);
+            if (firstCommandsCount == null || firstCommandsCount >= commandCount)
+                return null;
+
+            return Math.Min(commandCount, Math.Max(truncatedCount + ClusterTransactionsCleanupBatchSize, firstCommandsCount.Value + 1));
         }
 
         private static bool AllDatabaseNodesHasReport(DatabaseObservationState state)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -94,6 +94,8 @@ namespace Raven.Server.ServerWide.Maintenance
             }, null, ThreadNames.ForClusterObserver($"Cluster observer for term {_term}", _term));
         }
 
+        private static readonly int ClusterTransactionsCleanupBatchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
+
         public bool Suspended = false; // don't really care about concurrency here
         internal long _iteration;
         private readonly long _term;
@@ -841,8 +843,7 @@ namespace Raven.Server.ServerWide.Maintenance
             // backlog (e.g. millions of entries) in a single transaction. Capping the target also advances the
             // cleanup command id each round (it is derived from this value), so the observer keeps re-issuing the
             // cleanup until 'commandCount' is reached.
-            var batchSize = PlatformDetails.Is32Bits ? 1 * 1024 : 10 * 1024;
-            return Math.Min(commandCount, truncatedCount + batchSize);
+            return Math.Min(commandCount, truncatedCount + ClusterTransactionsCleanupBatchSize);
         }
 
         private static bool AllDatabaseNodesHasReport(DatabaseObservationState state)

--- a/test/FastTests/Issues/RavenDB-26903.cs
+++ b/test/FastTests/Issues/RavenDB-26903.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Raven.Server.Documents.PeriodicBackup.DirectUpload;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_26903 : NoDisposalNeeded
+    {
+        public RavenDB_26903(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // Backups run the smuggler under AsyncHelpers.RunSyncWithSynchronization, which installs a
+        // single-threaded ExclusiveSynchronizationContext on the dedicated backup thread and pumps it
+        // only while the smuggler is executing. A multipart upload part is started (fire-and-forget)
+        // during that run, and the final in-flight part is awaited later in DirectUploadStream.Dispose.
+        //
+        // If the cloud upload awaits capture that synchronization context (the default ConfigureAwait(true)),
+        // the part's completion continuation is posted back to the context after its message loop has already
+        // ended, so it can never run. DirectUploadStream.Dispose then blocks forever on that task, hanging the
+        // dedicated backup thread.
+        //
+        // This test reproduces the exact lifecycle with the real AwsS3MultiPartUploader and a fake S3 client
+        // (no network): a context that captures continuations but never runs them, an upload started under it,
+        // and a blocking wait afterwards. It times out (fails) unless the uploader uses ConfigureAwait(false).
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public void DirectUpload_multipart_upload_must_not_capture_the_backup_synchronization_context()
+        {
+            var client = new AsyncCompletingS3Client();
+            var uploader = new AwsS3MultiPartUploader(client, bucketName: "bucket", storageClass: S3StorageClass.Standard,
+                progress: null, key: "key", metadata: new Dictionary<string, string>(), cancellationToken: default);
+
+            // Initialize() runs without a synchronization context (fast path), exactly like during backup setup.
+            uploader.Initialize();
+
+            using var stream = new MemoryStream(new byte[1024]);
+
+            var context = new NonPumpingSynchronizationContext();
+            var previous = SynchronizationContext.Current;
+
+            Task uploadTask;
+            SynchronizationContext.SetSynchronizationContext(context);
+            try
+            {
+                // Mirrors StartUploadTask() running on the backup thread while the ExclusiveSynchronizationContext
+                // is current: the upload is kicked off here but not awaited.
+                uploadTask = uploader.UploadPartAsync(stream);
+            }
+            finally
+            {
+                // The smuggler finishes and the message loop ends -> the context is no longer pumped,
+                // just like when RunSyncWithSynchronization returns.
+                SynchronizationContext.SetSynchronizationContext(previous);
+            }
+
+            // Mirrors DirectUploadStream.Dispose blocking on the last in-flight part. If the part's continuation
+            // was captured by 'context' (which is no longer pumped), the task never completes and this times out.
+            var completed = uploadTask.Wait(TimeSpan.FromSeconds(10));
+
+            Assert.True(completed,
+                "The multipart upload task never completed: its continuation was captured by the backup " +
+                "synchronization context and orphaned once the message loop ended. The cloud upload awaits " +
+                "must use ConfigureAwait(false).");
+        }
+
+        // A synchronization context that captures posted continuations but never executes them - modeling the
+        // backup's ExclusiveSynchronizationContext after its message loop has stopped pumping.
+        private sealed class NonPumpingSynchronizationContext : SynchronizationContext
+        {
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                // Intentionally drop the continuation: nothing pumps this context anymore.
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override SynchronizationContext CreateCopy() => this;
+        }
+
+        // Fake S3 client whose async operations complete asynchronously on the thread pool (no network).
+        // It uses ConfigureAwait(false) internally so that its OWN completion does not depend on the test's
+        // non-pumping context - only the production uploader's ConfigureAwait behavior is under test.
+        private sealed class AsyncCompletingS3Client : AmazonS3Client
+        {
+            public AsyncCompletingS3Client()
+                : base(new BasicAWSCredentials("test", "test"), new AmazonS3Config { ServiceURL = "https://localhost:1" })
+            {
+            }
+
+            public override async Task<InitiateMultipartUploadResponse> InitiateMultipartUploadAsync(InitiateMultipartUploadRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                return new InitiateMultipartUploadResponse { UploadId = "test-upload-id" };
+            }
+
+            public override async Task<UploadPartResponse> UploadPartAsync(UploadPartRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+                return new UploadPartResponse { PartNumber = 1, ETag = "\"test-etag\"" };
+            }
+
+            public override async Task<CompleteMultipartUploadResponse> CompleteMultipartUploadAsync(CompleteMultipartUploadRequest request, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                return new CompleteMultipartUploadResponse();
+            }
+        }
+    }
+}

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2602,6 +2602,7 @@ select incl(c)"
                 return ClusterTransactionCommand.ReadCommandsBatch(ctx, database, fromCount: 0, take: long.MaxValue).Count();
         }
 
+        [RavenMultiplatformFact(RavenTestCategory.ClusterTransactions, RavenArchitecture.AllX64)]
         public async Task ClusterTransactionCommandsCleanup_ShouldDrainLargeBacklog_WhenObserverResumes()
         {
             const int count = 50_000;
@@ -2723,6 +2724,57 @@ select incl(c)"
                         return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() <= 1);
                 }, timeout: 120_000);
             }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.Sharding)]
+        public async Task ClusterTransactionCommandsCleanup_ShouldCleanupCommands_ForShardedDatabase()
+        {
+            const int count = 100;
+
+            using var server = GetNewServer();
+            using var store = Sharding.GetDocumentStore(new Options { Server = server });
+
+            // make sure the (single-node) cluster observer exists, then suspend it so a backlog can build up
+            await AssertWaitForTrueAsync(() => Task.FromResult(server.ServerStore.Observer != null));
+            var observer = server.ServerStore.Observer;
+            observer.Suspended = true;
+
+            for (var i = 0; i < count; i++)
+            {
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                await session.SaveChangesAsync();
+            }
+
+            // The cleanup point is the minimum over the shards of the last *executed own-command* position, so a
+            // shard whose last own command sits early in the stream would hold the whole tail back. Append one
+            // command per shard so every shard's completed position reaches the end of the backlog, which makes
+            // the drained state deterministic: at most one retained marker row per shard.
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var shardCount = record.Sharding.Shards.Count;
+            var remainingShards = new HashSet<int>(record.Sharding.Shards.Keys);
+            for (var i = 0; remainingShards.Count > 0; i++)
+            {
+                var id = $"TestObjs/tail/{i}";
+                var shardNumber = await Sharding.GetShardNumberForAsync(store, id);
+                if (remainingShards.Remove(shardNumber) == false)
+                    continue;
+
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), id);
+                await session.SaveChangesAsync();
+            }
+
+            // the commands are stored under the sharded (parent) database name, one row per shard batch
+            Assert.Equal(count + shardCount, CountClusterTransactionCommands(server, store.Database));
+
+            // Resume cleanup. The observer computes the cleanup point from the shard states, but must read the
+            // first command row under the sharded database name - if it used the shard name ('db$0') the lookup
+            // would find nothing and no cleanup would ever be issued for a sharded database.
+            observer.Suspended = false;
+
+            await AssertWaitForTrueAsync(() =>
+                Task.FromResult(CountClusterTransactionCommands(server, store.Database) <= shardCount), timeout: 60_000);
         }
 
         [RavenFact(RavenTestCategory.ClusterTransactions)]

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -29,13 +29,17 @@ using Raven.Server.Config.Settings;
 using Raven.Server.Documents;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Rachis;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Tables;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -2393,7 +2397,142 @@ select incl(c)"
                 Assert.Equal(count, await session.Query<TestObj>().CountAsync());
             }
         }
-        
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task ReadCommandsBatch_ShouldReturnAllDatabaseCommands_RespectingFromCountAndTake()
+        {
+            const int count = 20;
+
+            using var store = GetDocumentStore();
+
+            var database = await GetDatabase(store.Database);
+
+            // Block the database tx-merger so the cluster-transaction executor cannot drain (and clean up)
+            // the commands. This keeps them in the cluster-storage table while we read them back.
+            using var mre = new ManualResetEvent(false);
+            var blockerTask = database.TxMerger.Enqueue(new TestCommand(mre, TimeSpan.FromSeconds(30)));
+
+            // The rows are written to the cluster-storage table when the raft command is applied, but the
+            // client-side await of a cluster-wide tx only completes once the (blocked) database applies it -
+            // so we fire the transactions here and await them only after releasing the merger.
+            var tasks = Task.WhenAll(Enumerable.Range(0, count).Select(async i =>
+            {
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                await session.SaveChangesAsync();
+            }));
+
+            try
+            {
+                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                {
+                    // wait until all the commands were persisted to the cluster-storage table
+                    await AssertWaitForTrueAsync(() =>
+                    {
+                        using (context.OpenReadTransaction())
+                            return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() == count);
+                    });
+
+                    using (context.OpenReadTransaction())
+                    {
+                        // reading from the beginning must return every command of the database, in ascending order
+                        var all = ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).ToList();
+                        Assert.Equal(count, all.Count);
+                        Assert.All(all, c => Assert.Equal(store.Database.ToLowerInvariant(), c.Database));
+                        Assert.Equal(all.Select(c => c.PreviousCount).OrderBy(x => x), all.Select(c => c.PreviousCount));
+
+                        // 'take' must bound the number of commands returned
+                        var firstFive = ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: 5).ToList();
+                        Assert.Equal(5, firstFive.Count);
+                        Assert.Equal(all.Take(5).Select(c => c.PreviousCount), firstFive.Select(c => c.PreviousCount));
+
+                        // 'fromCount' must return the tail starting at the requested count (inclusive)
+                        var from = all[12].PreviousCount;
+                        var tail = ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: from, take: long.MaxValue).ToList();
+                        Assert.Equal(count - 12, tail.Count);
+                        Assert.Equal(from, tail[0].PreviousCount);
+                        Assert.Equal(all.Skip(12).Select(c => c.PreviousCount), tail.Select(c => c.PreviousCount));
+                    }
+                }
+            }
+            finally
+            {
+                mre.Set();
+            }
+
+            await blockerTask;
+            await tasks;
+
+            using (var session = store.OpenAsyncSession())
+                Assert.Equal(count, await session.Query<TestObj>().CountAsync());
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public void ReadCommandsBatch_ShouldSeekCorrectly_WithLargePreviousCount()
+        {
+            // Bootstrap the single-node cluster so the cluster-storage schema (the TransactionCommands table) exists.
+            using var store = GetDocumentStore();
+            const string database = "read-commands-batch-large-count";
+
+            // PreviousCount values chosen to exercise the big-endian key ordering, including values above
+            // int.MaxValue and around the 2^32 byte-carry boundary (where 'fromCount - 1' borrows across bytes).
+            var counts = new[]
+            {
+                0L,
+                1L,
+                int.MaxValue,            // 2^31 - 1
+                (long)int.MaxValue + 1,  // 2^31
+                (1L << 32) - 1,          // 2^32 - 1  (the lower 4 bytes are all 0xFF)
+                1L << 32,                // 2^32      (carry into the 5th byte)
+                1_000_000_000_000L       // 10^12
+            };
+
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
+                    foreach (var previousCount in counts)
+                        InsertTransactionCommand(context, items, database, previousCount);
+
+                    tx.Commit();
+                }
+
+                using (context.OpenReadTransaction())
+                {
+                    // reading from 0 must return every row in ascending order - validates big-endian key ordering at large values
+                    var all = ClusterTransactionCommand.ReadCommandsBatch(context, database, fromCount: 0, take: long.MaxValue).ToList();
+                    Assert.Equal(counts.OrderBy(x => x).ToArray(), all.Select(c => c.PreviousCount).ToArray());
+
+                    // a 'fromCount' that exactly matches a large row must include that row.
+                    // Here fromCount - 1 == (2^32 - 1), which is itself a present row and borrows across a byte boundary.
+                    const long fromExact = 1L << 32; // 2^32
+                    var tailExact = ClusterTransactionCommand.ReadCommandsBatch(context, database, fromCount: fromExact, take: long.MaxValue).ToList();
+                    Assert.Equal(counts.Where(c => c >= fromExact).OrderBy(x => x).ToArray(), tailExact.Select(c => c.PreviousCount).ToArray());
+                    Assert.Equal(fromExact, tailExact[0].PreviousCount);
+
+                    // a 'fromCount' that falls between two large rows (no exact match) must return only the next-higher rows
+                    const long fromBetween = 4_000_000_000L; // between 2^31 and (2^32 - 1)
+                    var tailBetween = ClusterTransactionCommand.ReadCommandsBatch(context, database, fromCount: fromBetween, take: long.MaxValue).ToList();
+                    Assert.Equal(counts.Where(c => c >= fromBetween).OrderBy(x => x).ToArray(), tailBetween.Select(c => c.PreviousCount).ToArray());
+                }
+            }
+        }
+
+        private static unsafe void InsertTransactionCommand(TransactionOperationContext context, Table items, string database, long previousCount)
+        {
+            // mirrors ClusterTransactionCommand.SaveCommandBatch: Key = db <sep> big-endian(previousCount), then the commands blittable and the raft index.
+            using (ClusterTransactionCommand.GetPrefix(context, database, out Slice keySlice, previousCount))
+            using (var commands = context.ReadObject(new DynamicJsonValue { ["DatabaseCommands"] = new DynamicJsonArray() }, "cmd"))
+            using (items.Allocate(out TableValueBuilder tvb))
+            {
+                tvb.Add(keySlice.Content.Ptr, keySlice.Size);
+                tvb.Add(commands.BasePointer, commands.Size);
+                tvb.Add(previousCount); // RaftIndex - unique per row, not asserted on
+                items.Insert(tvb);
+            }
+        }
+
         [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task TestCase()
         {

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -33,6 +33,7 @@ using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.ServerWide.Maintenance;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
 using Sparrow.Json;
@@ -2643,6 +2644,77 @@ select incl(c)"
                 // Resume cleanup. The observer must drain the whole backlog - in bounded batches, over several
                 // cleanup commands - leaving at most the single retained marker. If batching were broken (e.g. the
                 // cleanup command id didn't advance) rows would be orphaned and this would time out.
+                observer.Suspended = false;
+
+                await AssertWaitForTrueAsync(() =>
+                {
+                    using (context.OpenReadTransaction())
+                        return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() <= 1);
+                }, timeout: 120_000);
+            }
+        }
+
+        [RavenMultiplatformFact(RavenTestCategory.ClusterTransactions, RavenArchitecture.AllX64)]
+        public async Task ClusterTransactionCommandsCleanup_ShouldDrainBacklog_WhenSingleTransactionExceedsTwoCleanupBatches()
+        {
+            // A single cluster-wide transaction is stored as one row in the cluster's TransactionCommands table, and
+            // cleanup deletes whole rows. When such a row spans more than 2x ClusterTransactionsCleanupBatchSize
+            // commands, the first cleanup round deletes it but advances TruncatedClusterTransactionCommandsCount only
+            // to truncatedCount + batchSize, which lands more than a batch below the next row. Every following round
+            // then computes the same capped target (truncatedCount never moves because nothing gets deleted), so the
+            // cleanup command id never changes, ContainsCommandId blocks the re-issue and the remaining rows are
+            // orphaned forever.
+            var hugeCount = 2 * ClusterObserver.ClusterTransactionsCleanupBatchSize + 100;
+            const int tailCount = 512;
+
+            using var server = GetNewServer();
+            using var store = GetDocumentStore(new Options { Server = server });
+
+            // make sure the (single-node) cluster observer exists, then suspend it so a backlog can build up
+            await AssertWaitForTrueAsync(() => Task.FromResult(server.ServerStore.Observer != null));
+            var observer = server.ServerStore.Observer;
+            observer.Suspended = true;
+
+            // one oversized cluster-wide transaction -> a single commands row spanning 'hugeCount' commands
+            // (atomic guards are disabled only to keep the raft command lean, they don't affect the commands count)
+            using (var session = store.OpenAsyncSession(new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide,
+                DisableAtomicDocumentWritesInClusterWideTransaction = true
+            }))
+            {
+                for (var i = 0; i < hugeCount; i++)
+                    await session.StoreAsync(new TestObj(), $"TestObjs/huge/{i}");
+
+                await session.SaveChangesAsync();
+            }
+
+            // followed by regular single-command transactions - the rows a stalled cleanup would orphan
+            const int concurrency = 128;
+            for (var start = 0; start < tailCount; start += concurrency)
+            {
+                var end = Math.Min(start + concurrency, tailCount);
+                await Task.WhenAll(Enumerable.Range(start, end - start).Select(async i =>
+                {
+                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                    await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                    await session.SaveChangesAsync();
+                }));
+            }
+
+            using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                // sanity: the backlog is one oversized row followed by 'tailCount' single-command rows
+                using (context.OpenReadTransaction())
+                {
+                    var rows = ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).ToList();
+                    Assert.Equal(1 + tailCount, rows.Count);
+                    Assert.Equal(0L, rows[0].PreviousCount);
+                    Assert.Equal((long)hugeCount, rows[1].PreviousCount);
+                }
+
+                // Resume cleanup. The observer must keep advancing the truncated commands count past the oversized
+                // row until the tail drains, leaving at most the single retained marker.
                 observer.Suspended = false;
 
                 await AssertWaitForTrueAsync(() =>

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2602,11 +2602,9 @@ select incl(c)"
                 return ClusterTransactionCommand.ReadCommandsBatch(ctx, database, fromCount: 0, take: long.MaxValue).Count();
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.ClusterTransactions, RavenArchitecture.AllX64)]
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task ClusterTransactionCommandsCleanup_ShouldDrainLargeBacklog_WhenObserverResumes()
         {
-            const int count = 50_000;
-
             using var server = GetNewServer();
             using var store = GetDocumentStore(new Options { Server = server });
 
@@ -2615,29 +2613,23 @@ select incl(c)"
             var observer = server.ServerStore.Observer;
             observer.Suspended = true;
 
-            // Write 'count' cluster-wide transactions. The database executor processes them, but with the observer
-            // suspended none of the transaction commands are cleaned up, so they accumulate in the cluster storage.
-            const int concurrency = 128;
-            for (var start = 0; start < count; start += concurrency)
+            // shrink this observer's cleanup batch size so a backlog spanning several cleanup batches
+            // can be built with a small number of transactions
+            observer._clusterTransactionsCleanupBatchSize = 64;
+            var count = 2 * observer._clusterTransactionsCleanupBatchSize + 5;
+
+            // Write 'count' cluster-wide transactions. The database executor processes them, but with the
+            // observer suspended none of the transaction commands are cleaned up, so they accumulate in the
+            // cluster storage.
+            for (var i = 0; i < count; i++)
             {
-                var end = Math.Min(start + concurrency, count);
-                await Task.WhenAll(Enumerable.Range(start, end - start).Select(async i =>
-                {
-                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
-                    await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
-                    await session.SaveChangesAsync();
-                }));
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                await session.SaveChangesAsync();
             }
 
             using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                // wait until every transaction command was persisted to the cluster storage
-                await AssertWaitForTrueAsync(() =>
-                {
-                    using (context.OpenReadTransaction())
-                        return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() == count);
-                }, timeout: 60_000);
-
                 // verify the full backlog is present before enabling the observer
                 using (context.OpenReadTransaction())
                     Assert.Equal(count, ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count());
@@ -2655,7 +2647,7 @@ select incl(c)"
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.ClusterTransactions, RavenArchitecture.AllX64)]
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task ClusterTransactionCommandsCleanup_ShouldDrainBacklog_WhenSingleTransactionExceedsTwoCleanupBatches()
         {
             // A single cluster-wide transaction is stored as one row in the cluster's TransactionCommands table, and
@@ -2665,9 +2657,6 @@ select incl(c)"
             // then computes the same capped target (truncatedCount never moves because nothing gets deleted), so the
             // cleanup command id never changes, ContainsCommandId blocks the re-issue and the remaining rows are
             // orphaned forever.
-            var hugeCount = 2 * ClusterObserver.ClusterTransactionsCleanupBatchSize + 100;
-            const int tailCount = 512;
-
             using var server = GetNewServer();
             using var store = GetDocumentStore(new Options { Server = server });
 
@@ -2675,6 +2664,11 @@ select incl(c)"
             await AssertWaitForTrueAsync(() => Task.FromResult(server.ServerStore.Observer != null));
             var observer = server.ServerStore.Observer;
             observer.Suspended = true;
+
+            // shrink this observer's cleanup batch size so the oversized transaction stays small
+            observer._clusterTransactionsCleanupBatchSize = 64;
+            var hugeCount = 2 * observer._clusterTransactionsCleanupBatchSize + 100;
+            const int tailCount = 128;
 
             // one oversized cluster-wide transaction -> a single commands row spanning 'hugeCount' commands
             // (atomic guards are disabled only to keep the raft command lean, they don't affect the commands count)
@@ -2691,16 +2685,11 @@ select incl(c)"
             }
 
             // followed by regular single-command transactions - the rows a stalled cleanup would orphan
-            const int concurrency = 128;
-            for (var start = 0; start < tailCount; start += concurrency)
+            for (var i = 0; i < tailCount; i++)
             {
-                var end = Math.Min(start + concurrency, tailCount);
-                await Task.WhenAll(Enumerable.Range(start, end - start).Select(async i =>
-                {
-                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
-                    await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
-                    await session.SaveChangesAsync();
-                }));
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                await session.SaveChangesAsync();
             }
 
             using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2471,7 +2471,6 @@ select incl(c)"
         public void ReadCommandsBatch_ShouldSeekCorrectly_WithLargePreviousCount()
         {
             // Bootstrap the single-node cluster so the cluster-storage schema (the TransactionCommands table) exists.
-            using var store = GetDocumentStore();
             const string database = "read-commands-batch-large-count";
 
             // PreviousCount values chosen to exercise the big-endian key ordering, including values above
@@ -2487,7 +2486,8 @@ select incl(c)"
                 1_000_000_000_000L       // 10^12
             };
 
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using var server = GetNewServer();
+            using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 using (var tx = context.OpenWriteTransaction())
                 {

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -13,6 +13,7 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
@@ -2531,6 +2532,73 @@ select incl(c)"
                 tvb.Add(previousCount); // RaftIndex - unique per row, not asserted on
                 items.Insert(tvb);
             }
+        }
+
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task RestoredDatabase_ShouldCleanUpClusterTransactionCommands_EvenWhenTruncatedCountFromBackupIsHigh()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+
+            using (var source = GetDocumentStore())
+            {
+                const int originalCount = 64;
+                for (int i = 0; i < originalCount; i++)
+                {
+                    using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                    {
+                        await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                        await session.SaveChangesAsync();
+                    }
+
+                    using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                    {
+                        session.Delete($"TestObjs/{i}");
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                await AssertWaitForTrueAsync(async () =>
+                {
+                    var r = (await source.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(source.Database)));
+                    return r.TruncatedClusterTransactionCommandsCount >= originalCount;
+                }, timeout: 60_000);
+
+                var config = Backup.CreateBackupConfiguration(backupPath, BackupType.Snapshot);
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, source);
+            }
+
+            using var newServer = GetNewServer();
+            var restoredDatabase = GetDatabaseName();
+            using var store = new DocumentStore { Urls = new[] { newServer.WebUrl }, Database = restoredDatabase }.Initialize();
+
+            var restore = new RestoreBackupOperation(new RestoreBackupConfiguration
+            {
+                BackupLocation = Directory.GetDirectories(backupPath).First(),
+                DatabaseName = restoredDatabase
+            });
+            var operation = await store.Maintenance.Server.SendAsync(restore);
+            await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+            var restoredRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(restoredDatabase));
+            Assert.True(restoredRecord.TruncatedClusterTransactionCommandsCount == 0);
+
+            const int newCount = 5;
+            for (int i = 0; i < newCount; i++)
+            {
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), $"NewObjs/{i}");
+                await session.SaveChangesAsync();
+            }
+
+            await AssertWaitForTrueAsync(() =>
+                Task.FromResult(CountClusterTransactionCommands(newServer, restoredDatabase) <= 1), timeout: 30_000);
+        }
+
+        private static long CountClusterTransactionCommands(RavenServer server, string database)
+        {
+            using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+                return ClusterTransactionCommand.ReadCommandsBatch(ctx, database, fromCount: 0, take: long.MaxValue).Count();
         }
 
         [RavenFact(RavenTestCategory.ClusterTransactions)]

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2601,6 +2601,58 @@ select incl(c)"
                 return ClusterTransactionCommand.ReadCommandsBatch(ctx, database, fromCount: 0, take: long.MaxValue).Count();
         }
 
+        public async Task ClusterTransactionCommandsCleanup_ShouldDrainLargeBacklog_WhenObserverResumes()
+        {
+            const int count = 50_000;
+
+            using var server = GetNewServer();
+            using var store = GetDocumentStore(new Options { Server = server });
+
+            // make sure the (single-node) cluster observer exists, then suspend it so a backlog can build up
+            await AssertWaitForTrueAsync(() => Task.FromResult(server.ServerStore.Observer != null));
+            var observer = server.ServerStore.Observer;
+            observer.Suspended = true;
+
+            // Write 'count' cluster-wide transactions. The database executor processes them, but with the observer
+            // suspended none of the transaction commands are cleaned up, so they accumulate in the cluster storage.
+            const int concurrency = 128;
+            for (var start = 0; start < count; start += concurrency)
+            {
+                var end = Math.Min(start + concurrency, count);
+                await Task.WhenAll(Enumerable.Range(start, end - start).Select(async i =>
+                {
+                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                    await session.StoreAsync(new TestObj(), $"TestObjs/{i}");
+                    await session.SaveChangesAsync();
+                }));
+            }
+
+            using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                // wait until every transaction command was persisted to the cluster storage
+                await AssertWaitForTrueAsync(() =>
+                {
+                    using (context.OpenReadTransaction())
+                        return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() == count);
+                }, timeout: 60_000);
+
+                // verify the full backlog is present before enabling the observer
+                using (context.OpenReadTransaction())
+                    Assert.Equal(count, ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count());
+
+                // Resume cleanup. The observer must drain the whole backlog - in bounded batches, over several
+                // cleanup commands - leaving at most the single retained marker. If batching were broken (e.g. the
+                // cleanup command id didn't advance) rows would be orphaned and this would time out.
+                observer.Suspended = false;
+
+                await AssertWaitForTrueAsync(() =>
+                {
+                    using (context.OpenReadTransaction())
+                        return Task.FromResult(ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, fromCount: 0, take: long.MaxValue).Count() <= 1);
+                }, timeout: 120_000);
+            }
+        }
+
         [RavenFact(RavenTestCategory.ClusterTransactions)]
         public async Task TestCase()
         {

--- a/test/StressTests/Issues/RavenDB-26721.cs
+++ b/test/StressTests/Issues/RavenDB-26721.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Issues;
+
+public class RavenDB_26721 : RavenTestBase
+{
+    public RavenDB_26721(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Doc
+    {
+        public string Id { get; set; }
+        public string Body { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<Doc>
+    {
+        public Index()
+        {
+            Map = docs => from d in docs select new { d.Body };
+            Index(x => x.Body, FieldIndexing.Search);
+            Store(x => x.Body, FieldStorage.Yes);
+        }
+    }
+
+    private class Projection
+    {
+        public string Body { get; set; }
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Encryption | RavenTestCategory.Indexes)]
+    public async Task Streaming_Projection_Query_On_Encrypted_Db_Aborted_MidStream_Does_Not_Throw()
+    {
+        // Repro for RavenDB-26721: during a streaming projection query over an encrypted database, the index read
+        // transaction could be disposed on one thread while a VoronStream read was still in flight on another thread
+        // (Lucene caches VoronStream instances per-thread via SegmentReader, and the streaming loop can resume its
+        // async continuation on a different thread). The transaction's OnDispose handler nulled LuceneVoronStream.Llt,
+        // and the in-flight read then dereferenced the now-null Llt in VoronStream.UpdateLastPageIfNeeded -> NRE,
+        // which surfaced to the client as a confusing "Invalid JSON" error.
+        //
+        // It only manifests on encrypted databases because the encrypted read path calls Llt.GetPageWithoutCache at
+        // every page boundary (decrypting each page) - that is ~100-1000x slower than the memory-mapped non-encrypted
+        // path, widening the race window enough for the concurrent dispose to land inside an in-flight read.
+
+        var enc = await Encryption.EncryptedServerAsync();
+        var cert = enc.Certificates.ServerCertificateForCommunication.Value;
+
+        using var store = GetDocumentStore(new Options
+        {
+            AdminCertificate = cert,
+            ClientCertificate = cert,
+            ModifyDatabaseName = _ => enc.DatabaseName,
+            ModifyDatabaseRecord = r => r.Encrypted = true,
+            Path = NewDataPath()
+        });
+
+        await new Index().ExecuteAsync(store);
+
+        const int docCount = 50_000;
+        var filler = new string('x', 300);
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < docCount; i++)
+                await bulk.StoreAsync(new Doc { Body = "common " + filler + " " + i });
+        }
+
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(20));
+
+        Exception failure = null;
+        var deadline = DateTime.UtcNow.AddMinutes(3);
+
+        var workers = Enumerable.Range(0, 32).Select(_ => Task.Run(async () =>
+        {
+            while (DateTime.UtcNow < deadline && Volatile.Read(ref failure) == null)
+            {
+                try
+                {
+                    using var session = store.OpenAsyncSession();
+                    var q = session.Advanced.AsyncDocumentQuery<Doc, Index>()
+                        .Search(x => x.Body, "common")
+                        .SelectFields<Projection>();
+
+                    await using var stream = await session.Advanced.StreamAsync(q);
+
+                    int c = 0;
+                    while (await stream.MoveNextAsync())
+                    {
+                        if (++c >= 2000)
+                            break; // read many, then abort (dispose) -> abort the request mid-stream
+                    }
+                }
+                catch (Exception e)
+                {
+                    var msg = e.GetType().Name + ": " + e.Message;
+                    if (msg.Contains("Invalid JSON") || msg.Contains("NullReference"))
+                        Interlocked.CompareExchange(ref failure, e, null);
+
+                    // any other exception (e.g. an expected cancellation/abort of the stream) is ignored on purpose
+                }
+            }
+        })).ToArray();
+
+        await Task.WhenAll(workers);
+
+        Assert.True(failure == null,
+            "Streaming an encrypted projection query and aborting mid-stream must not surface a NullReferenceException " +
+            "(seen by the client as 'Invalid JSON'). Got: " + failure);
+    }
+}


### PR DESCRIPTION
This fix is on top of 6.2.17 version.

- **RavenDB-26721:** Fix `NullReferenceException` in encrypted streaming queries when the read transaction is disposed during an in-flight `VoronStream` read. https://github.com/ravendb/ravendb/pull/23038.
- **RavenDB-26903:** Fix backup hang on cloud direct upload (S3/Azure) after `RunSyncWithSynchronization` change. https://github.com/ravendb/ravendb/pull/23071.
- **RavenDB-27109:** Cluster transaction executor reads and deserializes other databases' commands, causing high CPU. https://github.com/ravendb/ravendb/pull/23215.
- **RavenDB-27119:** Cluster transaction commands are never cleaned up after restoring a snapshot to a new cluster. https://github.com/ravendb/ravendb/pull/23234.
- **RavenDB-27138:** Cluster transaction commands cleanup deletes the entire backlog in a single transaction. https://github.com/ravendb/ravendb/pull/23236.