### PR TITLE
RavenDB-27155 Probe function-tool support when testing an AI chat connection

### DIFF
--- a/src/Raven.Quill.Web/src/api/generated/server-api.ts
+++ b/src/Raven.Quill.Web/src/api/generated/server-api.ts
@@ -462,6 +462,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/ai/connection-strings/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["aiConnectionStrings.test"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/ai/connection-strings/{name}": {
         parameters: {
             query?: never;
@@ -971,6 +987,10 @@ export interface components {
         AiConnectionStringDeleteConflictResponse: {
             error: string;
             referencingAgentIds: string[];
+        };
+        AiConnectionStringTestResponse: {
+            success: boolean;
+            error?: null | string;
         };
         /** @enum {unknown} */
         AiConnectorType: "None" | "OpenAi" | "AzureOpenAi" | "Ollama" | "Embedded" | "Google" | "HuggingFace" | "MistralAi" | "Vertex";
@@ -2851,6 +2871,39 @@ export interface operations {
             };
         };
     };
+    "aiConnectionStrings.test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AiConnectionString"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AiConnectionStringTestResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
     "aiConnectionStrings.detail": {
         parameters: {
             query?: never;
@@ -3789,6 +3842,7 @@ export type AiAgentToolSubAgent = components["schemas"]["AiAgentToolSubAgent"];
 export type AiConnectionString = components["schemas"]["AiConnectionString"];
 export type AiConnectionStringCreatedResponse = components["schemas"]["AiConnectionStringCreatedResponse"];
 export type AiConnectionStringDeleteConflictResponse = components["schemas"]["AiConnectionStringDeleteConflictResponse"];
+export type AiConnectionStringTestResponse = components["schemas"]["AiConnectionStringTestResponse"];
 export type AiConnectorType = components["schemas"]["AiConnectorType"];
 export type AiConversationMessage = components["schemas"]["AiConversationMessage"];
 export type AiMessageRole = components["schemas"]["AiMessageRole"];
@@ -3909,6 +3963,7 @@ export const API_ENDPOINTS = {
         delete: (name: string) => `/ai/connection-strings/${encodeURIComponent(name)}`,
         detail: (name: string) => `/ai/connection-strings/${encodeURIComponent(name)}`,
         list: "/ai/connection-strings",
+        test: "/ai/connection-strings/test",
     },
     aiModels: {
         list: "/ai/models",
@@ -4000,6 +4055,7 @@ export function createServerApi(client: ApiClient) {
             delete: (name: string) => client.delete<void, ApiErrorResponse | AiConnectionStringDeleteConflictResponse>(API_ENDPOINTS.aiConnectionStrings.delete(name)),
             detail: (name: string) => client.get<AiConnectionString, ApiErrorResponse>(API_ENDPOINTS.aiConnectionStrings.detail(name)),
             list: () => client.get<AiConnectionString[], ApiErrorResponse>(API_ENDPOINTS.aiConnectionStrings.list),
+            test: (request: AiConnectionString) => client.post<AiConnectionStringTestResponse, ApiErrorResponse>(API_ENDPOINTS.aiConnectionStrings.test, request),
         },
         aiModels: {
             list: (request: AiModelsRequest) => client.post<AiModelsResponse, ApiErrorResponse>(API_ENDPOINTS.aiModels.list, request),

--- a/src/Raven.Quill.Web/src/components/ai-connection-string/ai-connection-string-form.tsx
+++ b/src/Raven.Quill.Web/src/components/ai-connection-string/ai-connection-string-form.tsx
@@ -82,6 +82,10 @@ export function AiConnectionStringForm({
     const saveMutation = useMutation({
         mutationFn: async (values: ConnectionStringFormData) => {
             const dto = mapFormDataToDto(values, modelType);
+            const test = await api.services.aiConnectionStrings.test(dto);
+            if (!test.success) {
+                throw new Error(test.error ?? "The selected model can't be used by an agent.");
+            }
             const result = await api.services.aiConnectionStrings.create(
                 existingIdentifier ? { ...dto, identifier: existingIdentifier } : dto,
             );

--- a/src/Raven.Quill.Web/src/mocks/ai-connection-strings-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/ai-connection-strings-mocks.ts
@@ -1,4 +1,4 @@
-import type { AiConnectionString } from "@/api/generated/server-api";
+import type { AiConnectionString, AiConnectionStringTestResponse } from "@/api/generated/server-api";
 import { getServerConnectionStringName } from "@/components/ai-connection-string/ai-connection-string-utils";
 import { apiHttp } from "./api-http";
 
@@ -14,6 +14,8 @@ export const aiConnectionStringsMocks = {
             const connectionString = await request.json();
             return response(200).json({ name: connectionString.name ?? "connection-string" });
         }),
+    test: (result: AiConnectionStringTestResponse = { success: true }) =>
+        apiHttp.post("/api/ai/connection-strings/test", ({ response }) => response(200).json(result)),
     delete: () => apiHttp.delete("/api/ai/connection-strings/{name}", ({ response }) => response(204).empty()),
 };
 

--- a/src/Raven.Quill.Web/src/mocks/default-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/default-mocks.ts
@@ -29,6 +29,7 @@ export const defaultApiMocks = {
         aiConnectionStringsMocks.list(),
         aiConnectionStringsMocks.detail(),
         aiConnectionStringsMocks.create(),
+        aiConnectionStringsMocks.test(),
         aiConnectionStringsMocks.delete(),
     ],
     aiModels: [aiModelsMocks.list()],

--- a/src/Raven.Quill/Contracts/AiConnectionStringTestResponse.cs
+++ b/src/Raven.Quill/Contracts/AiConnectionStringTestResponse.cs
@@ -1,0 +1,3 @@
+namespace Raven.Quill.Contracts;
+
+public sealed record AiConnectionStringTestResponse(bool Success, string? Error = null);

--- a/src/Raven.Quill/Endpoints/AiConnectionStringsEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/AiConnectionStringsEndpoints.cs
@@ -41,52 +41,6 @@ public static class AiConnectionStringsEndpoints
             .Produces<AiConnectionStringDeleteConflictResponse>(StatusCodes.Status409Conflict);
     }
 
-    public sealed class AiModelsRequest
-    {
-        public static AiModelsRequest From(AiConnectionString connection)
-        {
-            switch (connection.GetActiveProvider())
-            {
-                case AiConnectorType.OpenAi:
-                    return new AiModelsRequest
-                    {
-                        ConnectorType = AiConnectorType.OpenAi,
-                        OpenAiSettings = connection.OpenAiSettings
-                    };
-                case AiConnectorType.AzureOpenAi:
-                    return new AiModelsRequest
-                    {
-                        ConnectorType = AiConnectorType.AzureOpenAi,
-                        AzureOpenAiSettings = connection.AzureOpenAiSettings
-                    };
-                case AiConnectorType.Ollama:
-                    return new AiModelsRequest
-                    {
-                        ConnectorType = AiConnectorType.Ollama,
-                        OllamaSettings = connection.OllamaSettings
-                    };
-                case AiConnectorType.Google:
-                    return new AiModelsRequest
-                    {
-                        ConnectorType = AiConnectorType.Google,
-                        GoogleSettings = connection.GoogleSettings
-                    };
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        public AiConnectorType ConnectorType { get; set; }
-
-        public OllamaSettings? OllamaSettings { get; set; }
-
-        public OpenAiSettings? OpenAiSettings { get; set; }
-
-        public AzureOpenAiSettings? AzureOpenAiSettings { get; set; }
-
-        public GoogleSettings? GoogleSettings { get; set; }
-    }
-
     private static async Task<IResult> DeleteAsync(
         string name,
         IDocumentStore store,

--- a/src/Raven.Quill/Endpoints/AiConnectionStringsEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/AiConnectionStringsEndpoints.cs
@@ -21,6 +21,11 @@ public static class AiConnectionStringsEndpoints
             .Produces<AiConnectionStringCreatedResponse>()
             .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest)
             .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
+        group.MapPost("/test", TestAsync)
+            .WithName("aiConnectionStrings.test")
+            .Accepts<AiConnectionString>("application/json")
+            .Produces<AiConnectionStringTestResponse>()
+            .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest);
         group.MapGet("/", ListAsync)
             .WithName("aiConnectionStrings.list")
             .Produces<List<AiConnectionString>>()
@@ -164,16 +169,8 @@ public static class AiConnectionStringsEndpoints
             return Results.BadRequest(new ApiErrorResponse($"AI agent connection strings require ModelType=Chat; got '{connectionString.ModelType}'"));
 
         var provider = connectionString.GetActiveProvider();
-        switch (provider)
-        {
-            case AiConnectorType.OpenAi:
-            case AiConnectorType.AzureOpenAi:
-            case AiConnectorType.Ollama:
-                // supported providers
-                break;
-            default:
-                return Results.BadRequest(new ApiErrorResponse($"unsupported provider '{provider}'"));
-        }
+        if (IsSupportedProvider(provider) == false)
+            return Results.BadRequest(new ApiErrorResponse($"unsupported provider '{provider}'"));
 
         var serverWideConnection = new ServerWideConnectionString
         {
@@ -190,5 +187,76 @@ public static class AiConnectionStringsEndpoints
         return Results.Ok(new AiConnectionStringCreatedResponse(connectionString.Name));
     }
 
-    internal sealed class AiConnectionStringsLogger;
+    private static async Task<IResult> TestAsync(
+        AiConnectionString body,
+        IAiHelperClient aiClient,
+        ILogger<AiConnectionStringsLogger> logger,
+        CancellationToken ct)
+    {
+        var errors = new List<string>();
+        if (body.Validate(errors) == false)
+            return Results.BadRequest(new ApiErrorResponse(string.Join("; ", errors)));
+
+        if (body.ModelType != AiModelType.Chat)
+            return Results.BadRequest(new ApiErrorResponse($"AI agent connection strings require ModelType=Chat; got '{body.ModelType}'"));
+
+        var provider = body.GetActiveProvider();
+        if (IsSupportedProvider(provider) == false)
+            return Results.BadRequest(new ApiErrorResponse($"unsupported provider '{provider}'"));
+
+        var path = $"{TestConnectionPath}?type={provider}&modelType={AiModelType.Chat}";
+        var (transport, content) = await aiClient.SendAsync(path, "POST", GetProviderSettings(body, provider), ct);
+        if (transport != AiHelperStatus.Success)
+        {
+            logger.LogWarning(
+                "Could not run the AI model test for connection string name={Name}: transport {Transport}.",
+                body.Name, transport);
+            return Results.Ok(new AiConnectionStringTestResponse(Success: false, Error: "Could not reach the provider to verify the model."));
+        }
+
+        var result = await aiClient.DeserializeAsync<AiTestConnectionResult>(content, ct);
+        if (result is null)
+            return Results.Ok(new AiConnectionStringTestResponse(Success: false, Error: "Could not read the model test result."));
+
+        if (result.Success == false)
+            return Results.Ok(new AiConnectionStringTestResponse(Success: false, Error: result.Error));
+
+        return result.SupportsTools
+            ? Results.Ok(new AiConnectionStringTestResponse(Success: true))
+            : Results.Ok(new AiConnectionStringTestResponse(
+                Success: false,
+                Error: $"Model '{GetModelName(body, provider)}' does not support function tools, so it can't be used by an agent. Pick a different model."));
+    }
+
+    private static object GetProviderSettings(AiConnectionString connection, AiConnectorType provider) =>
+        provider switch
+        {
+            AiConnectorType.OpenAi => connection.OpenAiSettings,
+            AiConnectorType.AzureOpenAi => connection.AzureOpenAiSettings,
+            AiConnectorType.Ollama => connection.OllamaSettings,
+            _ => throw new ArgumentOutOfRangeException(nameof(provider), provider, "unsupported provider"),
+        };
+
+    private static string? GetModelName(AiConnectionString connection, AiConnectorType provider) =>
+        provider switch
+        {
+            AiConnectorType.OpenAi => connection.OpenAiSettings?.Model,
+            AiConnectorType.AzureOpenAi => connection.AzureOpenAiSettings?.DeploymentName,
+            AiConnectorType.Ollama => connection.OllamaSettings?.Model,
+            _ => null,
+        };
+
+    private static bool IsSupportedProvider(AiConnectorType provider) =>
+        provider is AiConnectorType.OpenAi or AiConnectorType.AzureOpenAi or AiConnectorType.Ollama;
+
+    private const string TestConnectionPath = "/admin/ai/test-connection";
+
+    private sealed class AiTestConnectionResult
+    {
+        public bool Success { get; set; }
+        public string? Error { get; set; }
+        public bool SupportsTools { get; set; }
+    }
+
+    private sealed class AiConnectionStringsLogger;
 }

--- a/src/Raven.Server/Documents/AI/AiConnectionTestResult.cs
+++ b/src/Raven.Server/Documents/AI/AiConnectionTestResult.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Raven.Server.Documents.ETL.Providers.AI;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.AI;
+
+public sealed class AiConnectionTestResult : IDynamicJson
+{
+    public bool Success;
+
+    public string Error;
+
+    public List<LogEntry> Log;
+
+    public bool AcceptsImageInput;
+
+    public bool SupportsTools;
+
+    public DynamicJsonValue ToJson()
+    {
+        var djv = new DynamicJsonValue
+        {
+            [nameof(Success)] = Success,
+            [nameof(Error)] = Error,
+            [nameof(AcceptsImageInput)] = AcceptsImageInput,
+            [nameof(SupportsTools)] = SupportsTools
+        };
+
+        if (Log != null)
+            djv[nameof(Log)] = new DynamicJsonArray(collection: Log);
+
+        return djv;
+    }
+}

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -352,6 +352,31 @@ public class ChatCompletionClient : IDisposable
         return (r.Result.ToString(), r.Message.ToString());
     }
 
+    public async Task<bool> TestSupportsToolsAsync(CancellationToken token)
+    {
+        try
+        {
+            using var _ = _contextPool.AllocateOperationContext(out JsonOperationContext context);
+
+            var userMessage = context.ReadObject(new DynamicJsonValue
+            {
+                [Constants.RequestFields.Role] = Constants.RequestFields.RoleUserValue,
+                [Constants.RequestFields.Content] = "hi"
+            }, "probe/user");
+
+            var paramsSchema = GetSchemaForTool(schema: null, sampleObject: "{\"reason\":\"why the tool is being called\"}");
+            var tool = GetTool(context, "connection_test_probe", "A probe so the request matches an agent call. Do not call it.", paramsSchema);
+
+            var request = CreateCompletionRequest(context, messages: [userMessage], attachments: null, tools: [context.ReadObject(tool, "probe/tool")], useTools: true, streaming: false, EmptySchema);
+            await CompleteAsync(context, request, new AiUsage(), schema: null, trace: null, token);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
     private const string AcceptsImageInputProbePngBase64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
@@ -1,18 +1,7 @@
-﻿using System;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.Extensions.AI;
-using Microsoft.SemanticKernel.Embeddings;
-using Raven.Client.Documents.Operations.AI;
-using Raven.Server.Documents.AI;
-using Raven.Server.Documents.AI.Embeddings;
 using Raven.Server.Documents.Handlers.Processors;
-using Raven.Server.Json;
-using Raven.Server.Web.System;
 using Sparrow.Json;
-using Sparrow.Json.Parsing;
-
-#pragma warning disable SKEXP0001
 
 namespace Raven.Server.Documents.ETL.Providers.AI.Handlers.Processors;
 
@@ -26,128 +15,7 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
 
     public override async ValueTask ExecuteAsync()
     {
-        var aiConnectorType = RequestHandler.GetEnumQueryString<AiConnectorType>("type");
-        if (aiConnectorType == AiConnectorType.None)
-            throw new ArgumentException($"AI connector type cannot be '{AiConnectorType.None}'");
-
-        var modelType = RequestHandler.GetEnumQueryString<AiModelType>("modelType");
-
-        InMemoryLoggerProvider logger = null;
-        bool acceptsImageInput = false;
-        try
-        {
-            using (var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken())
-            using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            {
-                var json = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "etl/test/script");
-
-                var aiConnectionString = new AiConnectionString { ModelType = modelType };
-
-                switch (aiConnectorType)
-                {
-                    case AiConnectorType.OpenAi:
-                        var openAiSettings = JsonDeserializationServer.OpenAiSettings(json);
-                        aiConnectionString.OpenAiSettings = openAiSettings;
-                        break;
-
-                    case AiConnectorType.AzureOpenAi:
-                        var azureOpenAiSettings = JsonDeserializationServer.AzureOpenAiSettings(json);
-                        aiConnectionString.AzureOpenAiSettings = azureOpenAiSettings;
-                        break;
-
-                    case AiConnectorType.Ollama:
-                        var ollamaSettings = JsonDeserializationServer.OllamaSettings(json);
-                        aiConnectionString.OllamaSettings = ollamaSettings;
-                        break;
-
-                    case AiConnectorType.Embedded:
-                        var embeddedSettings = JsonDeserializationServer.EmbeddedSettings(json);
-                        aiConnectionString.EmbeddedSettings = embeddedSettings;
-                        break;
-
-                    case AiConnectorType.Google:
-                        var googleSettings = JsonDeserializationServer.GoogleSettings(json);
-                        aiConnectionString.GoogleSettings = googleSettings;
-                        break;
-
-                    case AiConnectorType.Vertex:
-                        var vertexSettings = JsonDeserializationServer.VertexSettings(json);
-                        aiConnectionString.VertexSettings = vertexSettings;
-                        break;
-
-                    case AiConnectorType.HuggingFace:
-                        var huggingFace = JsonDeserializationServer.HuggingFaceSettings(json);
-                        aiConnectionString.HuggingFaceSettings = huggingFace;
-                        break;
-
-                    case AiConnectorType.MistralAi:
-                        var mistralAiSettings = JsonDeserializationServer.MistralAiSettings(json);
-                        aiConnectionString.MistralAiSettings = mistralAiSettings;
-                        break;
-
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-
-                switch (aiConnectionString.ModelType)
-                {
-                    case AiModelType.TextEmbeddings:
-                        var aiEtlConfiguration = new EmbeddingsGenerationConfiguration { Connection = aiConnectionString };
-                        (IEmbeddingGenerator<string, Embedding<float>> service, logger) = AiHelper.CreateEmbeddingServicesForTest(aiEtlConfiguration);
-                        var embeddings = await service.GenerateAsync(EmbeddingsHelper.ValuesListToVerifyConnection, cancellationToken: token.Token);
-
-                        if (embeddings.Count != EmbeddingsHelper.ValuesListToVerifyConnection.Count)
-                            throw new EmbeddingsMismatchException(
-                                $"Failed to generate embeddings for test values. Expected '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' result, but got '{embeddings.Count}'.");
-                        break;
-                    case AiModelType.Chat:
-                        using (var client = ChatCompletionClient.CreateChatCompletionClient( ServerStore.ContextPool, aiConnectionString))
-                        {
-                            var schema = ChatCompletionClient.GetSchemaFromSampleObject("{\"answer\":\"the answer to the user's prompt\"}");
-                            await client.TestCompleteAsync("Reply with exact word only: raven", "hi", schema, token.Token);
-                            acceptsImageInput = await client.TestAcceptsImageInputAsync(token.Token);
-                        }
-
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException("Invalid model type: " + aiConnectionString.ModelType);
-                    }
-
-                var result = new DynamicJsonValue
-                {
-                    [nameof(NodeConnectionTestResult.Success)] = true,
-                    [nameof(NodeConnectionTestResult.AcceptsImageInput)] = acceptsImageInput
-                };
-
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
-                {
-                    context.Write(writer, result);
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            var result = new DynamicJsonValue
-            {
-                [nameof(NodeConnectionTestResult.Success)] = false,
-                [nameof(NodeConnectionTestResult.Error)] = e.ToString()
-            };
-
-            if (logger != null)
-            {
-                var logsArray = new DynamicJsonArray(collection: logger.GetLogs());
-                result[nameof(NodeConnectionTestResult.Log)] = logsArray;
-            }
-
-            using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
-            {
-                context.Write(writer, result);
-            }
-        }
-        finally
-        {
-            logger?.Dispose();
-        }
+        using (var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken())
+            await AiIntegrationTestConnectionHelper.ExecuteAsync(RequestHandler, token.Token);
     }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiIntegrationTestConnectionHelper.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiIntegrationTestConnectionHelper.cs
@@ -7,9 +7,7 @@ using Raven.Server.Documents.AI;
 using Raven.Server.Documents.AI.Embeddings;
 using Raven.Server.Json;
 using Raven.Server.Web;
-using Raven.Server.Web.System;
 using Sparrow.Json;
-using Sparrow.Json.Parsing;
 
 #pragma warning disable SKEXP0001
 
@@ -107,37 +105,34 @@ internal static class AiIntegrationTestConnectionHelper
                         throw new ArgumentOutOfRangeException("Invalid model type: " + aiConnectionString.ModelType);
                 }
 
-                var result = new DynamicJsonValue
+                var result = new AiConnectionTestResult
                 {
-                    [nameof(NodeConnectionTestResult.Success)] = true,
-                    [nameof(NodeConnectionTestResult.AcceptsImageInput)] = acceptsImageInput,
-                    [nameof(NodeConnectionTestResult.SupportsTools)] = supportsTools
+                    Success = true,
+                    AcceptsImageInput = acceptsImageInput,
+                    SupportsTools = supportsTools
                 };
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, requestHandler.ResponseBodyStream()))
                 {
-                    context.Write(writer, result);
+                    context.Write(writer, result.ToJson());
                 }
             }
         }
         catch (Exception e)
         {
-            var result = new DynamicJsonValue
+            var result = new AiConnectionTestResult
             {
-                [nameof(NodeConnectionTestResult.Success)] = false,
-                [nameof(NodeConnectionTestResult.Error)] = e.ToString()
+                Success = false,
+                Error = e.ToString()
             };
 
             if (logger != null)
-            {
-                var logsArray = new DynamicJsonArray(collection: logger.GetLogs());
-                result[nameof(NodeConnectionTestResult.Log)] = logsArray;
-            }
+                result.Log = [..logger.GetLogs()];
 
             using (requestHandler.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriter(context, requestHandler.ResponseBodyStream()))
             {
-                context.Write(writer, result);
+                context.Write(writer, result.ToJson());
             }
         }
         finally

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiIntegrationTestConnectionHelper.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiIntegrationTestConnectionHelper.cs
@@ -27,6 +27,7 @@ internal static class AiIntegrationTestConnectionHelper
 
         InMemoryLoggerProvider logger = null;
         var acceptsImageInput = false;
+        var supportsTools = false;
         try
         {
             using (requestHandler.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -98,6 +99,7 @@ internal static class AiIntegrationTestConnectionHelper
                             var schema = ChatCompletionClient.GetSchemaFromSampleObject("{\"answer\":\"the answer to the user's prompt\"}");
                             await client.TestCompleteAsync("Reply with exact word only: raven", "hi", schema, cancellationToken);
                             acceptsImageInput = await client.TestAcceptsImageInputAsync(cancellationToken);
+                            supportsTools = await client.TestSupportsToolsAsync(cancellationToken);
                         }
 
                         break;
@@ -108,7 +110,8 @@ internal static class AiIntegrationTestConnectionHelper
                 var result = new DynamicJsonValue
                 {
                     [nameof(NodeConnectionTestResult.Success)] = true,
-                    [nameof(NodeConnectionTestResult.AcceptsImageInput)] = acceptsImageInput
+                    [nameof(NodeConnectionTestResult.AcceptsImageInput)] = acceptsImageInput,
+                    [nameof(NodeConnectionTestResult.SupportsTools)] = supportsTools
                 };
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, requestHandler.ResponseBodyStream()))

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiIntegrationTestConnectionHelper.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiIntegrationTestConnectionHelper.cs
@@ -26,6 +26,7 @@ internal static class AiIntegrationTestConnectionHelper
         var modelType = requestHandler.GetEnumQueryString<AiModelType>("modelType");
 
         InMemoryLoggerProvider logger = null;
+        var acceptsImageInput = false;
         try
         {
             using (requestHandler.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -95,7 +96,8 @@ internal static class AiIntegrationTestConnectionHelper
                         using (var client = ChatCompletionClient.CreateChatCompletionClient(requestHandler.ServerStore.ContextPool, aiConnectionString))
                         {
                             var schema = ChatCompletionClient.GetSchemaFromSampleObject("{\"answer\":\"the answer to the user's prompt\"}");
-                            await client.TestCompleteAsync("Reply with exact word only: raven", "hi", schema, requestHandler.HttpContext.RequestAborted);
+                            await client.TestCompleteAsync("Reply with exact word only: raven", "hi", schema, cancellationToken);
+                            acceptsImageInput = await client.TestAcceptsImageInputAsync(cancellationToken);
                         }
 
                         break;
@@ -103,7 +105,11 @@ internal static class AiIntegrationTestConnectionHelper
                         throw new ArgumentOutOfRangeException("Invalid model type: " + aiConnectionString.ModelType);
                 }
 
-                var result = new DynamicJsonValue { [nameof(NodeConnectionTestResult.Success)] = true };
+                var result = new DynamicJsonValue
+                {
+                    [nameof(NodeConnectionTestResult.Success)] = true,
+                    [nameof(NodeConnectionTestResult.AcceptsImageInput)] = acceptsImageInput
+                };
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, requestHandler.ResponseBodyStream()))
                 {

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -137,6 +137,8 @@ namespace Raven.Server.Web.System
 
         public bool AcceptsImageInput;
 
+        public bool SupportsTools;
+
         public DynamicJsonValue ToJson()
         {
             var djv = new DynamicJsonValue

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -135,10 +135,6 @@ namespace Raven.Server.Web.System
         public string Error;
         public List<string> Log;
 
-        public bool AcceptsImageInput;
-
-        public bool SupportsTools;
-
         public DynamicJsonValue ToJson()
         {
             var djv = new DynamicJsonValue

--- a/src/Raven.Studio/typescript/commands/database/cluster/testAiConnectionStringCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/cluster/testAiConnectionStringCommand.ts
@@ -12,7 +12,7 @@ class testAiConnectionStringCommand extends commandBase {
         super();
     }
 
-    execute(): JQueryPromise<Raven.Server.Web.System.NodeConnectionTestResult> {
+    execute(): JQueryPromise<Raven.Server.Documents.AI.AiConnectionTestResult> {
         const args = {
             type: this.type,
             modelType: this.modelType,
@@ -24,7 +24,7 @@ class testAiConnectionStringCommand extends commandBase {
             .fail((response: JQueryXHR) =>
                 this.reportError(`Failed to test AI connection`, response.responseText, response.statusText)
             )
-            .done((result: Raven.Server.Web.System.NodeConnectionTestResult) => {
+            .done((result: Raven.Server.Documents.AI.AiConnectionTestResult) => {
                 if (!result.Success) {
                     this.reportError(`Failed to test AI connection`, result.Error);
                 }

--- a/src/Raven.Studio/typescript/commands/serverWide/connectionStrings/testServerWideAiConnectionStringCommand.ts
+++ b/src/Raven.Studio/typescript/commands/serverWide/connectionStrings/testServerWideAiConnectionStringCommand.ts
@@ -10,7 +10,7 @@ export default class testServerWideAiConnectionStringCommand extends commandBase
         super();
     }
 
-    execute(): JQueryPromise<Raven.Server.Web.System.NodeConnectionTestResult> {
+    execute(): JQueryPromise<Raven.Server.Documents.AI.AiConnectionTestResult> {
         const args = {
             type: this.type,
             modelType: this.modelType,
@@ -23,7 +23,7 @@ export default class testServerWideAiConnectionStringCommand extends commandBase
             .fail((response: JQueryXHR) =>
                 this.reportError(`Failed to test AI connection`, response.responseText, response.statusText)
             )
-            .done((result: Raven.Server.Web.System.NodeConnectionTestResult) => {
+            .done((result: Raven.Server.Documents.AI.AiConnectionTestResult) => {
                 if (!result.Success) {
                     this.reportError(`Failed to test AI connection`, result.Error);
                 }

--- a/src/Raven.Studio/typescript/components/common/connectionTests/ConnectionTestResult.tsx
+++ b/src/Raven.Studio/typescript/components/common/connectionTests/ConnectionTestResult.tsx
@@ -3,7 +3,7 @@ import ConnectionStringError from "./ConnectionTestError";
 import RichAlert from "components/common/RichAlert";
 
 interface ConnectionTestResultProps {
-    testResult: Raven.Server.Web.System.NodeConnectionTestResult;
+    testResult: Pick<Raven.Server.Web.System.NodeConnectionTestResult, "Success" | "Error">;
 }
 
 export default function ConnectionTestResult({ testResult }: ConnectionTestResultProps) {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/store/editGenAiTaskSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/store/editGenAiTaskSlice.ts
@@ -17,7 +17,7 @@ interface EditGenAiTaskState {
     taskId: number;
     sourceView: EditAiTaskSourceView;
     currentStep: EditGenAiTaskStepId;
-    connectionStringTest: loadableData<Raven.Server.Web.System.NodeConnectionTestResult>;
+    connectionStringTest: loadableData<Raven.Server.Documents.AI.AiConnectionTestResult>;
     contextTest: loadableData<
         { value: string; attachments?: Raven.Server.Documents.ETL.Providers.AI.AiAttachment[] }[]
     >;
@@ -249,7 +249,7 @@ const testConnectionString = createAsyncThunk(
         connectorType: Raven.Client.Documents.Operations.AI.AiConnectorType;
         modelType: Raven.Client.Documents.Operations.AI.AiModelType;
         settings: AiConnectionStringsSettings;
-    }): Promise<Raven.Server.Web.System.NodeConnectionTestResult> => {
+    }): Promise<Raven.Server.Documents.AI.AiConnectionTestResult> => {
         return services.tasksService.testAiConnectionString(
             payload.databaseName,
             payload.connectorType,

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideConnectionStrings/ServerWideConnectionStrings.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideConnectionStrings/ServerWideConnectionStrings.stories.tsx
@@ -97,7 +97,7 @@ function mockTestResults(isSuccess: boolean) {
     tasksService.withTestElasticSearchNodeConnection(
         isSuccess ? undefined : SharedStubs.nodeConnectionTestErrorResult()
     );
-    tasksService.withTestAiConnectionString(isSuccess ? undefined : SharedStubs.nodeConnectionTestErrorResult());
+    tasksService.withTestAiConnectionString(isSuccess ? undefined : SharedStubs.aiConnectionTestErrorResult());
     manageServerService.withTestPeriodicBackupCredentials(
         isSuccess ? undefined : SharedStubs.nodeConnectionTestErrorResult()
     );

--- a/src/Raven.Studio/typescript/test/mocks/services/MockTasksService.ts
+++ b/src/Raven.Studio/typescript/test/mocks/services/MockTasksService.ts
@@ -187,11 +187,11 @@ export default class MockTasksService extends AutoMockService<TasksService> {
         return this.mockResolvedValue(this.mocks.getLocalFolderPathOptions, dto, TasksStubs.localFolderPathOptions());
     }
 
-    withTestAiConnectionString(dto?: Raven.Server.Web.System.NodeConnectionTestResult) {
+    withTestAiConnectionString(dto?: Raven.Server.Documents.AI.AiConnectionTestResult) {
         return this.mockResolvedValue(
             this.mocks.testAiConnectionString,
             dto,
-            SharedStubs.nodeConnectionTestSuccessResult()
+            SharedStubs.aiConnectionTestSuccessResult()
         );
     }
 

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -790,7 +790,6 @@ export class DatabasesStubs {
             TcpServerUrl: null,
             Log: [],
             Error: "System.UriFormatException: Invalid URI: The format of the URI could not be determined.\n   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)\n   at System.Uri..ctor(String uriString)\n   at Raven.Server.Documents.ETL.Providers.Queue.QueueBrokerConnectionHelper.CreateRabbitMqConnection(RabbitMqConnectionSettings settings) in D:\\Builds\\RavenDB-6.0-Nightly\\20231123-0200\\src\\Raven.Server\\Documents\\ETL\\Providers\\Queue\\QueueBrokerConnectionHelper.cs:line 80",
-            AcceptsImageInput: false,
         };
     }
 
@@ -801,7 +800,6 @@ export class DatabasesStubs {
             TcpServerUrl: null,
             Log: [],
             Error: null,
-            AcceptsImageInput: false,
         };
     }
 

--- a/src/Raven.Studio/typescript/test/stubs/SharedStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/SharedStubs.ts
@@ -6,7 +6,6 @@ export class SharedStubs {
             TcpServerUrl: null,
             Log: [],
             Error: "System.UriFormatException: Invalid URI: The format of the URI could not be determined.\n   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)\n   at System.Uri..ctor(String uriString)\n   at Raven.Server.Documents.ETL.Providers.Queue.QueueBrokerConnectionHelper.CreateRabbitMqConnection(RabbitMqConnectionSettings settings) in D:\\Builds\\RavenDB-6.0-Nightly\\20231123-0200\\src\\Raven.Server\\Documents\\ETL\\Providers\\Queue\\QueueBrokerConnectionHelper.cs:line 80",
-            AcceptsImageInput: false,
         };
     }
 
@@ -17,7 +16,26 @@ export class SharedStubs {
             TcpServerUrl: null,
             Log: [],
             Error: null,
+        };
+    }
+
+    static aiConnectionTestErrorResult(): Raven.Server.Documents.AI.AiConnectionTestResult {
+        return {
+            Success: false,
+            Log: [],
+            Error: "System.Net.Http.HttpRequestException: No connection could be made because the target machine actively refused it.",
             AcceptsImageInput: false,
+            SupportsTools: false,
+        };
+    }
+
+    static aiConnectionTestSuccessResult(): Raven.Server.Documents.AI.AiConnectionTestResult {
+        return {
+            Success: true,
+            Log: [],
+            Error: null,
+            AcceptsImageInput: true,
+            SupportsTools: true,
         };
     }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
@@ -74,7 +74,7 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
     enableDocumentExpiration = ko.observable<boolean>(false);
     isCommunityLicense = licenseModel.getStatusValue("Type") === "Community";
 
-    testConnectionResult = ko.observable<Raven.Server.Web.System.NodeConnectionTestResult>();
+    testConnectionResult = ko.observable<Raven.Server.Documents.AI.AiConnectionTestResult>();
 
     constructor(db: database) {
         super(db);

--- a/test/QuillTests/AiConnectionStringsEndpointsTests.cs
+++ b/test/QuillTests/AiConnectionStringsEndpointsTests.cs
@@ -154,6 +154,59 @@ public class AiConnectionStringsEndpointsTests(ITestOutputHelper output, QuillCo
     }
 
     [RavenFact(RavenTestCategory.Quill)]
+    public async Task Test_reports_failure_when_the_provider_is_unreachable()
+    {
+        var result = await Host.TestConnectionStringAsync(new AiConnectionString
+        {
+            Name = "probe-ollama-cs",
+            ModelType = AiModelType.Chat,
+            OllamaSettings = new OllamaSettings { Uri = "http://localhost:11434/", Model = "llama3.1" },
+        });
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrWhiteSpace(result.Error));
+
+        Assert.DoesNotContain("Could not reach the provider", result.Error);
+        Assert.DoesNotContain("Could not read the model test result", result.Error);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Test_rejects_provider_outside_the_supported_set()
+    {
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => Host.TestConnectionStringAsync(new AiConnectionString
+        {
+            Name = "probe-google-cs",
+            ModelType = AiModelType.Chat,
+            GoogleSettings = new GoogleSettings { ApiKey = "g-key", Endpoint = "https://generativelanguage.googleapis.com/v1/", Model = "gemini-1.5-flash" },
+        }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        Assert.Contains("unsupported provider", ex.Body);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Test_rejects_non_chat_model_type()
+    {
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => Host.TestConnectionStringAsync(new AiConnectionString
+        {
+            Name = "probe-embed-cs",
+            ModelType = AiModelType.TextEmbeddings,
+            OpenAiSettings = new OpenAiSettings { ApiKey = "sk-test", Endpoint = "https://api.openai.com/v1/", Model = "text-embedding-3-small" },
+        }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Test_returns_400_for_null_body()
+    {
+        var resp = await Host.Client.PostAsync(
+            QuillRoutes.ConnectionStringsTest, new StringContent("null", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
     public async Task List_returns_created_connection_strings()
     {
         await Host.PostConnectionStringAsync(OpenAiCs("list-demo-llm"));

--- a/test/QuillTests/E2E/Fixtures/QuillHost.cs
+++ b/test/QuillTests/E2E/Fixtures/QuillHost.cs
@@ -95,6 +95,9 @@ public sealed class QuillHost : IAsyncDisposable
     public Task<IReadOnlyList<AiConnectionString>> GetConnectionStringsAsync() =>
         QuillHttp.GetAsync<IReadOnlyList<AiConnectionString>>(Client, QuillRoutes.ConnectionStrings);
 
+    public Task<AiConnectionStringTestResponse> TestConnectionStringAsync(AiConnectionString body) =>
+        QuillHttp.PostAsync<AiConnectionStringTestResponse>(Client, QuillRoutes.ConnectionStringsTest, body);
+
     public Task<AiConnectionString> GetConnectionStringAsync(string name) =>
         QuillHttp.GetAsync<AiConnectionString>(Client, QuillRoutes.ConnectionString(name));
 

--- a/test/QuillTests/E2E/Fixtures/QuillHttpExtensions.cs
+++ b/test/QuillTests/E2E/Fixtures/QuillHttpExtensions.cs
@@ -105,6 +105,7 @@ internal static class QuillRoutes
     public const string AuthLogin = "/api/auth/login";
     public const string AuthStatus = "/api/auth/status";
     public const string ConnectionStrings = "/api/ai/connection-strings";
+    public const string ConnectionStringsTest = $"{ConnectionStrings}/test";
     public static string ConnectionString(string name) => $"{ConnectionStrings}/{name}";
     public const string AiModels = "/api/ai/models";
     public const string SettingsLicense = "/api/settings/license";

--- a/test/SlowTests/Server/Documents/AI/AiConnectionTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiConnectionTests.cs
@@ -11,7 +11,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Http;
 using Raven.Client.Json;
-using Raven.Server.Web.System;
+using Raven.Server.Documents.AI;
 using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
@@ -115,7 +115,7 @@ namespace SlowTests.Server.Documents.AI
         {
         }
 
-        internal class TestAiConnectionStringOperation : IMaintenanceOperation<NodeConnectionTestResult>
+        internal class TestAiConnectionStringOperation : IMaintenanceOperation<AiConnectionTestResult>
         {
             private readonly AiConnectionString _connectionString;
 
@@ -124,12 +124,12 @@ namespace SlowTests.Server.Documents.AI
                 _connectionString = connectionString;
             }
 
-            public RavenCommand<NodeConnectionTestResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            public RavenCommand<AiConnectionTestResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
             {
                 return new TestAiConnectionStringCommand(_connectionString);
             }
 
-            private class TestAiConnectionStringCommand : RavenCommand<NodeConnectionTestResult>
+            private class TestAiConnectionStringCommand : RavenCommand<AiConnectionTestResult>
             {
                 private readonly AiConnectionString _connectionString;
 
@@ -155,14 +155,14 @@ namespace SlowTests.Server.Documents.AI
                 }
 
 
-                private static Func<BlittableJsonReaderObject, NodeConnectionTestResult> NodeConnectionTestResult = JsonDeserializationBase.GenerateJsonDeserializationRoutine<NodeConnectionTestResult>();
+                private static Func<BlittableJsonReaderObject, AiConnectionTestResult> AiConnectionTestResult = JsonDeserializationBase.GenerateJsonDeserializationRoutine<AiConnectionTestResult>();
 
                 public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
                 {
                     if (response == null)
                         throw new InvalidOperationException("Response is null");
 
-                    Result = NodeConnectionTestResult(response);
+                    Result = AiConnectionTestResult(response);
                 }
             }
         }

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -67,6 +67,7 @@ using Raven.Server.Dashboard.Cluster;
 using Raven.Server.Dashboard.Cluster.Notifications;
 using Raven.Server.Dashboard.Cluster.Notifications.DatabaseNotifications;
 using Raven.Server.Documents;
+using Raven.Server.Documents.AI;
 using Raven.Server.Documents.Commands.Replication;
 using Raven.Server.Documents.ETL;
 using Raven.Server.Documents.ETL.Providers.AI.Embeddings.Stats;
@@ -698,6 +699,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(TrafficWatchTcpChange));
 
             scripter.AddType(typeof(NodeConnectionTestResult));
+            scripter.AddType(typeof(AiConnectionTestResult));
             scripter.AddType(typeof(ClientCertificateGenerationResult));
 
             // request with POST parameters


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27155/Quill-dashboard-you-can-select-a-model-that-does-not-work

### Additional description

Probe tool support when testing AI chat connection and return more meaningful error message when the model doesn't support tool calls.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
