### PR TITLE
RavenDB-27154 Show agent system prompt instead of tool list on AI suggestion cards

### DIFF
--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/suggestion-picker.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/suggestion-picker.tsx
@@ -1,7 +1,6 @@
 import { useFormContext, useWatch } from "react-hook-form";
 import { cn } from "@/lib/utils";
 import { SELECTED_CARD_CLASSES } from "@/components/form/form-radio-cards";
-import type { AiAgentConfiguration } from "@/api/generated/server-api";
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
 import { applySuggestionToForm } from "@/pages/setup/add-capability-wizard/agent-config-form";
 import { useCapabilityWizardStore } from "@/pages/setup/add-capability-wizard/capability-wizard-store";
@@ -38,18 +37,12 @@ export function SuggestionPicker() {
                         )}
                     >
                         <span className="block text-sm font-semibold">{config.name}</span>
-                        <span className="mt-2 block text-xs leading-5 text-muted-foreground">
-                            {describeTools(config)}
+                        <span className="mt-2 line-clamp-4 block text-xs leading-5 text-muted-foreground">
+                            {config.systemPrompt}
                         </span>
                     </button>
                 );
             })}
         </div>
     );
-}
-
-function describeTools(config: AiAgentConfiguration) {
-    const toolNames = (config.queries ?? []).map((query) => query.name).filter(Boolean);
-
-    return toolNames.length > 0 ? `Tools: ${toolNames.join(", ")}` : "No query tools.";
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27154/Quill-dashboard-create-your-agent-with-AI-provides-no-description

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
