### PR TITLE
RavenDB-26965 Create quill-config database with PreventDeletesError lock mode

### DIFF
--- a/src/Raven.Quill/Endpoints/WizardEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/WizardEndpoints.cs
@@ -299,7 +299,7 @@ public static class WizardEndpoints
         try
         {
             // cluster-wide-atomic: this call IS the slug-uniqueness gate
-            created = await RavenStoreFactory.EnsureDatabaseAsync(store, slug, ct);
+            created = await RavenStoreFactory.EnsureDatabaseAsync(store, slug, ct: ct);
         }
         catch (ConcurrencyException)
         {

--- a/src/Raven.Quill/Hosting/RavenReadinessService.cs
+++ b/src/Raven.Quill/Hosting/RavenReadinessService.cs
@@ -4,6 +4,7 @@ using Polly.Registry;
 using Polly.Retry;
 using Polly.Timeout;
 using Raven.Client.Documents;
+using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Quill.Infrastructure;
 
@@ -61,7 +62,7 @@ public sealed class RavenReadinessService(
                         await store.Maintenance.Server.SendAsync(new GetBuildNumberOperation(), ct);
                     }, stoppingToken);
 
-                    var created = await RavenStoreFactory.EnsureDatabaseAsync(store, opts.ConfigDatabase, stoppingToken);
+                    var created = await RavenStoreFactory.EnsureDatabaseAsync(store, opts.ConfigDatabase, DatabaseLockMode.PreventDeletesError, stoppingToken);
                     logger.LogInformation(
                         "RavenDB ready at {Url}; config database {Database} {Action}.",
                         opts.RavenUrl, opts.ConfigDatabase, created ? "created" : "already present");

--- a/src/Raven.Quill/Infrastructure/RavenStoreFactory.cs
+++ b/src/Raven.Quill/Infrastructure/RavenStoreFactory.cs
@@ -30,13 +30,13 @@ public static class RavenStoreFactory
     public static IDocumentStore Create(IOptions<ApplianceOptions> options) =>
         Create(options.Value);
 
-    public static async Task<bool> EnsureDatabaseAsync(IDocumentStore store, string database, CancellationToken ct = default)
+    public static async Task<bool> EnsureDatabaseAsync(IDocumentStore store, string database, DatabaseLockMode lockMode = DatabaseLockMode.Unlock, CancellationToken ct = default)
     {
         var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database), ct);
         if (record is not null)
             return false;
 
-        await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(database)), ct);
+        await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord(database) { LockMode = lockMode }), ct);
         return true;
     }
 

--- a/test/QuillTests/RavenStoreFactoryTests.cs
+++ b/test/QuillTests/RavenStoreFactoryTests.cs
@@ -1,0 +1,58 @@
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Quill.Infrastructure;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace QuillTests;
+
+public class RavenStoreFactoryTests(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task EnsureDatabase_creates_config_database_with_prevent_deletes_lock()
+    {
+        var store = GetDocumentStore();
+        var name = "quill-config-" + Guid.NewGuid().ToString("N");
+
+        try
+        {
+            var created = await RavenStoreFactory.EnsureDatabaseAsync(store, name, DatabaseLockMode.PreventDeletesError);
+
+            Assert.True(created);
+            Assert.Equal(DatabaseLockMode.PreventDeletesError, await GetLockModeAsync(store, name));
+        }
+        finally
+        {
+            await UnlockAndDeleteAsync(store, name);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task EnsureDatabase_leaves_per_app_database_unlocked_by_default()
+    {
+        var store = GetDocumentStore();
+        var name = "per-app-" + Guid.NewGuid().ToString("N");
+        using var _ = Databases.EnsureDatabaseDeletion(name, store);
+
+        var created = await RavenStoreFactory.EnsureDatabaseAsync(store, name);
+
+        Assert.True(created);
+        Assert.Equal(DatabaseLockMode.Unlock, await GetLockModeAsync(store, name));
+    }
+
+    private static async Task<DatabaseLockMode> GetLockModeAsync(IDocumentStore store, string database)
+    {
+        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database));
+        Assert.NotNull(record);
+        return record.LockMode;
+    }
+
+    private static async Task UnlockAndDeleteAsync(IDocumentStore store, string database)
+    {
+        // teardown can't delete a PreventDeletes database, so release the lock first
+        await store.Maintenance.Server.SendAsync(new SetDatabasesLockOperation(database, DatabaseLockMode.Unlock));
+        await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(database, hardDelete: true));
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26965/Quill-make-the-quill-config-database-undeletable

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
