### PR TITLE
RavenDB-27062 Unify Quill license credential naming on "License Key"

### DIFF
--- a/docker/quill/README.md
+++ b/docker/quill/README.md
@@ -112,7 +112,7 @@ docker pull ravendb/quill:latest             # or a pinned tag: ravendb/quill:0.
 ```bash
 cd docker/quill/compose
 cp .env.example .env
-# Fill in QUILL_API_KEY (operator login) and QUILL_LICENSE_KEY (activation token).
+# Fill in QUILL_API_KEY (operator login) and QUILL_LICENSE_KEY (license key).
 ```
 
 The image **activates itself at startup** using `QUILL_LICENSE_KEY` — no operator action. Status walks
@@ -264,7 +264,7 @@ docker rm -f nw-postgres            # if you used the throwaway Postgres
 
 | Symptom | Cause / fix |
 |---|---|
-| Bootstrap stuck at `NeedsActivation` | Startup activation had nothing to redeem. Set `QUILL_LICENSE_KEY` in `.env` to a real token issued by the Quill sign-up flow and confirm the appliance can reach `api.ravendb.net`. Check `docker compose logs` for the activation line. |
+| Bootstrap stuck at `NeedsActivation` | Startup activation had nothing to redeem. Set `QUILL_LICENSE_KEY` in `.env` to a real license key issued by the Quill sign-up flow and confirm the appliance can reach `api.ravendb.net`. Check `docker compose logs` for the activation line. |
 | `401 Unauthorized` on `/api/*` (or bounced to `/login`) | Missing/wrong API key or an expired session. Pass `-H "X-Api-Key: <key>"` (the `QUILL_API_KEY` from `.env`) or sign in again. `QUILL_API_KEY` is **required** — auth fails closed when it's unset. |
 | `https://…:443` connection refused | nginx only starts after activation extracts the wildcard cert. During pre-activation, check status via `docker exec quill curl -s http://127.0.0.1:5000/api/bootstrap/status` or watch `docker compose logs quill`. If `:443` never comes up after activation reports `Ready`, check the `03-proxy` service in the logs. |
 | Wizard **Connect** fails | The connection-string host isn't reachable **from the container**. Use a LAN IP or `host.docker.internal`, not `localhost`. |

--- a/docker/quill/compose/.env.example
+++ b/docker/quill/compose/.env.example
@@ -1,7 +1,7 @@
 # Required. Operator login key for the Quill dashboard/API.
 QUILL_API_KEY=
 
-# Required. License activation token. On first boot, the appliance uses this
+# Required. License key. On first boot, the appliance uses this
 # to fetch its setup package from api.ravendb.net and switch to secure mode.
 QUILL_LICENSE_KEY=
 

--- a/docker/quill/compose/docker-compose.yml
+++ b/docker/quill/compose/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - quill-data:/var/lib/quill
     environment:
       QUILL_API_KEY: ${QUILL_API_KEY:?QUILL_API_KEY is required (operator login key)}
-      QUILL_LICENSE_KEY: ${QUILL_LICENSE_KEY:?QUILL_LICENSE_KEY is required (activation token)}
+      QUILL_LICENSE_KEY: ${QUILL_LICENSE_KEY:?QUILL_LICENSE_KEY is required (license key)}
 
 volumes:
   quill-data:

--- a/src/Raven.Quill/AiHelper/ILicenseClient.cs
+++ b/src/Raven.Quill/AiHelper/ILicenseClient.cs
@@ -2,7 +2,7 @@ namespace Raven.Quill.AiHelper;
 
 public interface ILicenseClient
 {
-    Task DownloadSetupPackageToAsync(string token, Stream destination, CancellationToken ct);
+    Task DownloadSetupPackageToAsync(string licenseKey, Stream destination, CancellationToken ct);
 }
 
 public sealed class LicenseRetrievalException(string message) : Exception(message);

--- a/src/Raven.Quill/AiHelper/LicenseHttpClient.cs
+++ b/src/Raven.Quill/AiHelper/LicenseHttpClient.cs
@@ -4,9 +4,9 @@ public sealed class LicenseHttpClient(HttpClient httpClient) : ILicenseClient
 {
     private const string LicensePathPrefix = "/api/v1/quill/licenses";
 
-    public async Task DownloadSetupPackageToAsync(string token, Stream destination, CancellationToken ct)
+    public async Task DownloadSetupPackageToAsync(string licenseKey, Stream destination, CancellationToken ct)
     {
-        var url = $"{LicensePathPrefix}/{Uri.EscapeDataString(token)}";
+        var url = $"{LicensePathPrefix}/{Uri.EscapeDataString(licenseKey)}";
 
         HttpResponseMessage response;
         try

--- a/src/Raven.Quill/Hosting/ApplianceActivationService.cs
+++ b/src/Raven.Quill/Hosting/ApplianceActivationService.cs
@@ -17,7 +17,7 @@ public sealed class ApplianceActivationService(
     {
         var opts = options.Value;
 
-        if (string.IsNullOrWhiteSpace(opts.LicenseToken))
+        if (string.IsNullOrWhiteSpace(opts.LicenseKey))
         {
             logger.LogInformation(
                 "No QUILL_LICENSE_KEY; skipping startup activation (appliance stays in NeedsActivation).");
@@ -38,7 +38,7 @@ public sealed class ApplianceActivationService(
             try
             {
                 await using (var tempFile = File.Create(tempZipPath))
-                    await licenseClient.DownloadSetupPackageToAsync(opts.LicenseToken ?? string.Empty, tempFile, stoppingToken);
+                    await licenseClient.DownloadSetupPackageToAsync(opts.LicenseKey ?? string.Empty, tempFile, stoppingToken);
 
                 Directory.CreateDirectory(opts.SetupPackagePath);
                 // zip-slip guard: ExtractToDirectory rejects ../ and absolute entries

--- a/src/Raven.Quill/Hosting/ApplianceOptions.cs
+++ b/src/Raven.Quill/Hosting/ApplianceOptions.cs
@@ -17,7 +17,7 @@ public sealed class ApplianceOptions
 
     public string SetupPackagePath { get; set; } = "/setup";
 
-    public string? LicenseToken { get; set; }
+    public string? LicenseKey { get; set; }
 
     public string? ApiKey { get; set; }
 

--- a/src/Raven.Quill/Program.cs
+++ b/src/Raven.Quill/Program.cs
@@ -73,7 +73,7 @@ builder.Services.AddOptions<ApplianceOptions>()
         ReadEnv("RAVEN_QUILL_RAVENDB_S6_SERVICE", v => options.RavenDbS6Service = v);
         ReadEnv("RAVEN_QUILL_LICENSE_API_URL", v => options.LicenseApiUrl = v);
         ReadEnv("RAVEN_QUILL_API_URL", v => options.AiApiUrl = v);
-        ReadEnv("QUILL_LICENSE_KEY", v => options.LicenseToken = v);
+        ReadEnv("QUILL_LICENSE_KEY", v => options.LicenseKey = v);
         ReadEnv("QUILL_API_KEY", v => options.ApiKey = v);
         ReadEnv("RAVEN_QUILL_RAVENDB_INTERNAL_PORT", v =>
         {

--- a/test/QuillTests/E2E/ApplianceFullFlowTests.cs
+++ b/test/QuillTests/E2E/ApplianceFullFlowTests.cs
@@ -69,17 +69,17 @@ public class ApplianceFullFlowTests(ITestOutputHelper output) : CdcSinkIntegrati
         // — so no `using` here. (RavenTestBase tracks the store separately for
         // class teardown; that's a second touch but DocumentStore.Dispose is
         // idempotent, so it's a no-op when the WAF got there first.)
-        // The license token (QUILL_LICENSE_KEY) drives startup activation; the WAF seeds the operator
+        // The license key (QUILL_LICENSE_KEY) drives startup activation; the WAF seeds the operator
         // API key and authenticates every client by default, so the now-gated admin calls below pass.
         var store = GetDocumentStore();
         using var factory = new ApplianceWebApplicationFactory(
             licenseApiUrl: licenseApi.BaseAddress,
             setupPackagePath: setupRoot,
             applianceStore: store,
-            configureOptions: opts => opts.LicenseToken = HardcodedLicenseKey);
+            configureOptions: opts => opts.LicenseKey = HardcodedLicenseKey);
         var client = factory.CreateClient();
 
-        // ---------- T3. Startup activation pulls the package by token; wait for READY ----------
+        // ---------- T3. Startup activation pulls the package by license key; wait for READY ----------
         // No operator redeem call anymore: ApplianceActivationService runs at startup, fetches the
         // setup-package zip from the (mock) license API by QUILL_LICENSE_KEY, unpacks it, and — with no
         // s6 in the test host — flips bootstrap to Ready inline.

--- a/test/QuillTests/E2E/Fixtures/ApplianceWebApplicationFactory.cs
+++ b/test/QuillTests/E2E/Fixtures/ApplianceWebApplicationFactory.cs
@@ -15,7 +15,7 @@ namespace QuillTests.E2E.Fixtures;
 ///     RavenDB code paths without launching a second instance.
 ///   - Removes RavenReadinessService and flips IServerReady ready (the test store is already ready).
 ///   - Every CreateClient() carries the TestApiKey header by default; tests that exercise the
-///     unauthenticated path remove it. Startup activation is inert unless a license token / mock zip is
+///     unauthenticated path remove it. Startup activation is inert unless a license key / mock zip is
 ///     configured (see ApplianceActivationService), so it stays out of the way of non-activation tests.
 internal sealed class ApplianceWebApplicationFactory : WebApplicationFactory<Program>
 {

--- a/test/QuillTests/E2E/Fixtures/MockLicenseApi.cs
+++ b/test/QuillTests/E2E/Fixtures/MockLicenseApi.cs
@@ -9,8 +9,8 @@ using Microsoft.Extensions.Logging;
 namespace QuillTests.E2E.Fixtures;
 
 /// In-process stand-in for api.ravendb.net. Hosts the RavenDB-26783 endpoint
-/// GET /api/v1/quill/licenses/{token} returning the embedded setup-package zip
-/// bytes when {token} matches the configured key, 404 otherwise. Caller disposes;
+/// GET /api/v1/quill/licenses/{licenseKey} returning the embedded setup-package zip
+/// bytes when the license key matches the configured one, 404 otherwise. Caller disposes;
 /// the bound base URL is exposed for the appliance to dial.
 public sealed class MockLicenseApi : IAsyncDisposable
 {
@@ -32,9 +32,9 @@ public sealed class MockLicenseApi : IAsyncDisposable
 
         var app = builder.Build();
 
-        app.MapGet("/api/v1/quill/licenses/{token}", (string token, HttpContext ctx) =>
+        app.MapGet("/api/v1/quill/licenses/{presentedKey}", (string presentedKey, HttpContext ctx) =>
         {
-            if (!string.Equals(token, licenseKey, StringComparison.Ordinal))
+            if (!string.Equals(presentedKey, licenseKey, StringComparison.Ordinal))
                 return Results.NotFound();
 
             return Results.File(setupPackageZipBytes,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27062/Unify-Quill-License-naming

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
