### PR TITLE
RavenDB-27156 Shared-journal write failure corrupts branch indexes / crashes with AccessViolation

### DIFF
--- a/src/Voron/Impl/Journal/JournalWriter.cs
+++ b/src/Voron/Impl/Journal/JournalWriter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Sparrow;
 using Sparrow.Logging;
@@ -12,8 +13,6 @@ using Sparrow.Threading;
 using Voron.Global;
 using Voron.Impl.Paging;
 using Voron.Logging;
-using Voron.Platform.Posix;
-using Voron.Platform.Win32;
 using Voron.Util.Settings;
 
 namespace Voron.Impl.Journal
@@ -80,6 +79,12 @@ namespace Voron.Impl.Journal
         public void Write(long posBy4Kb, Span<Pal.journal_entry> entries, long totalNumberOf4Kbs)
         {
             Debug.Assert(_options.IoMetrics != null);
+
+            if (_options.ForTestingPurposes?.SimulatePartialJournalWriteFailure?.Invoke(totalNumberOf4Kbs) is { } failure)
+            {
+                SimulatePartialWriteAndThrow(posBy4Kb, entries, failure);
+                return;
+            }
 
             fixed (Pal.journal_entry* pEntries = entries)
             {
@@ -209,6 +214,33 @@ namespace Voron.Impl.Journal
                     exceptions.Add(e);
                 }
             }
+        }
+
+        private void SimulatePartialWriteAndThrow(long posBy4Kb, Span<Pal.journal_entry> entries, StorageEnvironmentOptions.TestingStuff.PartialJournalWriteFailure failure)
+        {
+            var remaining = failure.NumberOf4KbsToWrite;
+            if (remaining > 0)
+            {
+                var partial = new List<Pal.journal_entry>();
+                foreach (var entry in entries)
+                {
+                    if (remaining <= 0)
+                        break;
+                    var take = Math.Min(entry.NumberOf4Kbs, remaining);
+                    partial.Add(new Pal.journal_entry { Base = entry.Base, NumberOf4Kbs = take });
+                    remaining -= take;
+                }
+
+                var partialSpan = CollectionsMarshal.AsSpan(partial);
+                fixed (Pal.journal_entry* pEntries = partialSpan)
+                {
+                    var result = Pal.rvn_write_journal(_writeHandle, pEntries, partialSpan.Length, posBy4Kb * Constants.Storage.JournalPageSize, out var error);
+                    if (result != PalFlags.FailCodes.Success)
+                        PalHelper.ThrowLastError(result, error, $"Attempted to write (simulated partial write) to journal file - Path: {FileName.FullPath}");
+                }
+            }
+
+            throw failure.Error;
         }
 
         ~JournalWriter()

--- a/src/Voron/Impl/Journal/SharedJournalState.cs
+++ b/src/Voron/Impl/Journal/SharedJournalState.cs
@@ -47,14 +47,19 @@ public class SharedJournalState()
 
         while (_mergedCommitsQueue.TryDequeue(out var rec))
         {
-            rec.Transaction.Environment.Options.SetCatastrophicFailure(edi);
+            MarkCatastrophicFailure(rec.Transaction.Environment, edi);
             rec.Tcs.TrySetException(e);
         }
 
         foreach (var record in _mergedJournalJournalRecordsBuffer)
         {
-            record.Transaction.Environment.Options.SetCatastrophicFailure(edi);
+            MarkCatastrophicFailure(record.Transaction.Environment, edi);
             record.Tcs.TrySetException(e);
+        }
+
+        static void MarkCatastrophicFailure(StorageEnvironment env, ExceptionDispatchInfo edi)
+        {
+            try { env.Options.SetCatastrophicFailure(edi); } catch { /* best-effort */ }
         }
     }
 

--- a/src/Voron/Impl/Journal/SharedJournalState.cs
+++ b/src/Voron/Impl/Journal/SharedJournalState.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using Sparrow.Server.Platform;
 
@@ -42,13 +43,17 @@ public class SharedJournalState()
 
     public void SetException(Exception e)
     {
+        var edi = ExceptionDispatchInfo.Capture(e);
+
         while (_mergedCommitsQueue.TryDequeue(out var rec))
         {
+            rec.Transaction.Environment.Options.SetCatastrophicFailure(edi);
             rec.Tcs.TrySetException(e);
         }
 
         foreach (var record in _mergedJournalJournalRecordsBuffer)
         {
+            record.Transaction.Environment.Options.SetCatastrophicFailure(edi);
             record.Tcs.TrySetException(e);
         }
     }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -445,12 +445,17 @@ namespace Voron.Impl.Journal
                 }
                 catch (InvalidJournalException)
                 {
+                    // the journal may have grown the data pager (and the file) for transactions applied before
+                    // the error - the published state must reflect that even when we skip the journal
+                    _env.UpdateDataPagerState(dataPagerState);
+
                     if (_env.Options.IgnoreInvalidJournalErrors == true)
                     {
                         skippedInvalidJournals = true;
 
                         addToInitLog?.Invoke(LogLevel.Warn,
-                            $"Encountered invalid journal {journalNumber} @ {_env.Options}. Skipping this journal and keep going the recovery operation because '{nameof(_env.Options.IgnoreInvalidJournalErrors)}' options is set");
+                            $"Encountered invalid journal {journalNumber} @ {_env.Options}. Skipping this journal and keep going the recovery operation because '{nameof(_env.Options.IgnoreInvalidJournalErrors)}' options is set. " +
+                            $"Any transactions applied from it before the error remain in the data file (data pager: {dataPagerState.NumberOfAllocatedPages:#,#;;0} pages)");
                         continue;
                     }
 
@@ -465,7 +470,7 @@ namespace Voron.Impl.Journal
                 }
             }
 
-            Debug.Assert(skippedInvalidJournals || _env.CurrentStateRecord.DataPagerState.NumberOfAllocatedPages >= dataPagerState.NumberOfAllocatedPages,
+            Debug.Assert(_env.CurrentStateRecord.DataPagerState.NumberOfAllocatedPages >= dataPagerState.NumberOfAllocatedPages,
                 $"Published data pager state ({_env.CurrentStateRecord.DataPagerState.NumberOfAllocatedPages} pages) is behind the state recovery produced ({dataPagerState.NumberOfAllocatedPages} pages)");
 
             if (_env.Options.Encryption.IsEnabled == false) // for encryption, we already use AEAD, so no need

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -430,6 +430,11 @@ namespace Voron.Impl.Journal
 
                     lastProcessedJournal = journalNumber;
 
+                    // Must run before the RequireHeaderUpdate break: a journal that ends with an incomplete transaction
+                    // may still have grown the pager for its earlier valid transactions, and skipping the publish leaves
+                    // DataPagerState smaller than NextPageNumber
+                    _env.UpdateDataPagerState(dataPagerState);
+
                     if (journalReader.RequireHeaderUpdate) //this should prevent further load of transactions
                     {
                         requireHeaderUpdate = true;
@@ -437,8 +442,6 @@ namespace Voron.Impl.Journal
                     }
 
                     addToInitLog?.Invoke(LogLevel.Debug, $"Journal {journalNumber:#,#;;0} Recovered");
-
-                    _env.UpdateDataPagerState(dataPagerState);
                 }
                 catch (InvalidJournalException)
                 {

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -435,13 +435,13 @@ namespace Voron.Impl.Journal
                     // DataPagerState smaller than NextPageNumber
                     _env.UpdateDataPagerState(dataPagerState);
 
+                    addToInitLog?.Invoke(LogLevel.Debug, $"Journal {journalNumber:#,#;;0} Recovered (requireHeaderUpdate: {journalReader.RequireHeaderUpdate})");
+
                     if (journalReader.RequireHeaderUpdate) //this should prevent further load of transactions
                     {
                         requireHeaderUpdate = true;
                         break;
                     }
-
-                    addToInitLog?.Invoke(LogLevel.Debug, $"Journal {journalNumber:#,#;;0} Recovered");
                 }
                 catch (InvalidJournalException)
                 {
@@ -464,6 +464,9 @@ namespace Voron.Impl.Journal
                     throw;
                 }
             }
+
+            Debug.Assert(skippedInvalidJournals || _env.CurrentStateRecord.DataPagerState.NumberOfAllocatedPages >= dataPagerState.NumberOfAllocatedPages,
+                $"Published data pager state ({_env.CurrentStateRecord.DataPagerState.NumberOfAllocatedPages} pages) is behind the state recovery produced ({dataPagerState.NumberOfAllocatedPages} pages)");
 
             if (_env.Options.Encryption.IsEnabled == false) // for encryption, we already use AEAD, so no need
             {

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -1427,6 +1427,14 @@ namespace Voron
             internal Action<long> BeforeLinkFiles;
 
             internal bool SimulateCannotLinkJournals;
+
+            internal Func<long, PartialJournalWriteFailure> SimulatePartialJournalWriteFailure;
+
+            internal sealed class PartialJournalWriteFailure
+            {
+                public long NumberOf4KbsToWrite;
+                public Exception Error;
+            }
         }
     }
 }

--- a/test/FastTests/Voron/SharedJournal/SharedJournalTests.cs
+++ b/test/FastTests/Voron/SharedJournal/SharedJournalTests.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations.Indexes;
 using Raven.Server.Utils;
 using Tests.Infrastructure;
 using Voron;
@@ -893,7 +892,7 @@ public class SharedJournalTests(ITestOutputHelper output) : RavenTestBase(output
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
     public async Task SharedJournalsCanHandleFailures()
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(new Options { RunInMemory = false }))
         {
             await new Users_ByName().ExecuteAsync(store);
 
@@ -907,7 +906,9 @@ public class SharedJournalTests(ITestOutputHelper output) : RavenTestBase(output
             await Indexes.WaitForIndexingAsync(store);
 
             var database = await GetDatabase(store.Database);
-            database.IndexStore.SharedJournals.Env.ForTestingPurposesOnly().ModifyNewLowLevelTransaction = t => t.ThrowSimulateErrorOnCommitStage2();
+
+            database.IndexStore.SharedJournals.Env.ForTestingPurposesOnly().ModifyNewLowLevelTransaction =
+                t => t.ActionToCallJustBeforeWritingToJournal = () => throw new InvalidOperationException("Simulation error");
 
             using (var session = store.OpenSession())
             {
@@ -920,8 +921,29 @@ public class SharedJournalTests(ITestOutputHelper output) : RavenTestBase(output
 
             database.IndexStore.SharedJournals.Env.ForTestingPurposesOnly().ModifyNewLowLevelTransaction = null;
 
-            await store.Maintenance.SendAsync(new DeleteIndexErrorsOperation());
-            await store.Maintenance.SendAsync(new EnableIndexOperation(new Users_ByName().IndexName));
+            // RavenDB-27156: a failed merged commit is non-recoverable for the environments taking part
+            // in it - they are marked as catastrophically failed, which forces the database to be
+            // unloaded and reloaded. Recovery replays the journals and indexing resumes on its own.
+            var reloaded = await WaitForValueAsync(async () =>
+            {
+                try
+                {
+                    return await GetDatabase(store.Database) != database;
+                }
+                catch
+                {
+                    return false; // the database is being unloaded / briefly locked
+                }
+            }, true);
+            Assert.True(reloaded, "the database was not reloaded after the failed shared-journal commit");
+
+            // the reloaded database initializes its indexes asynchronously
+            var indexLoaded = await WaitForValueAsync(async () =>
+            {
+                var db = await GetDatabase(store.Database);
+                return db.IndexStore.GetIndex(new Users_ByName().IndexName) != null;
+            }, true);
+            Assert.True(indexLoaded, "the index was not loaded after the database reload");
 
             using (var session = store.OpenSession())
             {

--- a/test/FastTests/Voron/SharedJournal/SharedJournalTests.cs
+++ b/test/FastTests/Voron/SharedJournal/SharedJournalTests.cs
@@ -917,7 +917,7 @@ public class SharedJournalTests(ITestOutputHelper output) : RavenTestBase(output
                 session.SaveChanges();
             }
 
-            await Assert.ThrowsAsync<InvalidOperationException>(() => Indexes.WaitForIndexingAsync(store));
+            await Assert.ThrowsAnyAsync<Exception>(() => Indexes.WaitForIndexingAsync(store));
 
             database.IndexStore.SharedJournals.Env.ForTestingPurposesOnly().ModifyNewLowLevelTransaction = null;
 

--- a/test/SlowTests/Voron/Issues/RavenDB_27156.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27156.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
@@ -276,6 +277,115 @@ public class RavenDB_27156(ITestOutputHelper output) : RavenTestBase(output)
             _stop = true;
             _thread.Join();
             _mergeSubmitted.Dispose();
+        }
+    }
+
+    // A journal skipped via IgnoreInvalidJournalErrors may have grown the data pager (and the data file) for
+    // transactions applied before the corruption point. The published pager state must reflect that growth -
+    // otherwise the environment state claims a smaller mapping than the file recovery actually produced.
+    [RavenFact(RavenTestCategory.Voron)]
+    public void SkippedInvalidJournal_AfterDataPagerGrowth_PublishesGrownDataPagerState()
+    {
+        var path = NewDataPath();
+        IOExtensions.DeleteDirectory(path);
+
+        long tx2Start4Kb, tx3Start4Kb;
+
+        // phase 1: synced baseline, then - in one journal - a big tx (grows the pager on replay) followed by
+        // two small txs. tx2 gets corrupted on disk; tx3 stays valid so the journal reader classifies the
+        // journal as invalid (invalid tx followed by a valid one) instead of as a torn tail.
+        {
+            var options = StorageEnvironmentOptions.ForPathForTests(path);
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.InitialLogFileSize = 64 * 1024 * 1024;
+
+            using var env = new StorageEnvironment(options);
+
+            using (var tx = env.WriteTransaction())
+            {
+                tx.CreateTree("tree").Add("baseline", "baseline-value");
+                tx.Commit();
+            }
+            env.FlushLogToDataFile();
+            Assert.True(env.SyncDataFileImmediately(), "failed to sync the baseline");
+
+            using (var tx = env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("tree");
+                for (int i = 0; i < 5000; i++)
+                    tree.Add($"items/{i:D6}", i + "-" + new string((char)('a' + i % 26), 300));
+                tx.Commit();
+            }
+            tx2Start4Kb = env.CurrentStateRecord.Journal.Last4KWritePosition;
+
+            using (var tx = env.WriteTransaction())
+            {
+                tx.CreateTree("tree").Add("second", "second-value");
+                tx.Commit();
+            }
+            tx3Start4Kb = env.CurrentStateRecord.Journal.Last4KWritePosition;
+            Assert.True(tx3Start4Kb > tx2Start4Kb);
+
+            using (var tx = env.WriteTransaction())
+            {
+                tx.CreateTree("tree").Add("third", "third-value");
+                tx.Commit();
+            }
+            Assert.Equal(0, env.CurrentStateRecord.Journal.Number); // everything must be in a single journal
+        }
+
+        // corrupt tx2's transaction header on disk
+        var journalFile = Directory.GetFiles(Path.Combine(path, "Journals"), "*.journal").Single();
+        using (var file = new FileStream(journalFile, FileMode.Open, FileAccess.ReadWrite))
+        {
+            file.Position = tx2Start4Kb * 4096;
+            var garbage = new byte[512];
+            Array.Fill(garbage, (byte)0xDE);
+            file.Write(garbage);
+        }
+
+        // phase 2: reopen with the dangerous flag - recovery replays the big tx (growing the data pager and
+        // the file), hits the corrupted tx, finds the valid tx after it and skips the whole journal
+        {
+            var options = StorageEnvironmentOptions.ForPathForTests(path);
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.InitialLogFileSize = 64 * 1024 * 1024;
+            options.IgnoreInvalidJournalErrors = true;
+            options.OnRecoveryError += (_, _) => { };
+            var initLog = new List<string>();
+            options.AddToInitLog = (_, msg) => { lock (initLog) initLog.Add(msg); };
+
+            using var env = new StorageEnvironment(options);
+
+            // guard the scenario: the skip path must have been taken (not the torn-tail / clean-end paths)
+            Assert.Contains(initLog, m => m.Contains("Encountered invalid journal"));
+
+            // the pin: the published pager state must cover the data file recovery produced
+            var dataFileLength = new FileInfo(Path.Combine(path, "Raven.voron")).Length;
+            var state = env.CurrentStateRecord;
+            Assert.True(state.DataPagerState.TotalAllocatedSize >= dataFileLength,
+                $"published data pager state ({state.DataPagerState.TotalAllocatedSize} bytes) does not cover the data file recovery produced ({dataFileLength} bytes)");
+
+            // the synced baseline must survive; what remains visible of the skipped journal's transactions is
+            // indeterminate under the dangerous flag (applied-then-discarded pages can stay reachable), so no
+            // assertion is made on it
+            using (var rtx = env.ReadTransaction())
+            {
+                var tree = rtx.ReadTree("tree");
+                Assert.NotNull(tree);
+                Assert.Equal("baseline-value", tree.Read("baseline").Reader.ToStringValue());
+            }
+
+            // and the environment must remain fully usable
+            using (var tx = env.WriteTransaction())
+            {
+                tx.CreateTree("tree").Add("after-recovery", "after-recovery-value");
+                tx.Commit();
+            }
+            using (var rtx = env.ReadTransaction())
+                Assert.Equal("after-recovery-value", rtx.ReadTree("tree").Read("after-recovery").Reader.ToStringValue());
         }
     }
 }

--- a/test/SlowTests/Voron/Issues/RavenDB_27156.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27156.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Voron.SharedJournal;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Impl.Journal;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_27156(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Voron)]
+    public void FailedSharedJournalWrite_WithPendingFlushStateUpdate_PoisonsBranchAndRecoversOnRestart()
+        => RunScenario(flushPendingDuringDoomedCommit: true);
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void FailedSharedJournalWrite_WithoutPendingFlush_PoisonsBranchAndRecoversOnRestart()
+        => RunScenario(flushPendingDuringDoomedCommit: false);
+
+    private void RunScenario(bool flushPendingDuringDoomedCommit)
+    {
+        var rootPath = NewDataPath(suffix: "root");
+        var branchPath = NewDataPath(suffix: "branch");
+        IOExtensions.DeleteDirectory(rootPath);
+        IOExtensions.DeleteDirectory(branchPath);
+
+        var values = new Dictionary<string, string>();
+
+        // ----- phase 1: seed, then fail a shared-journal write on the root -----
+        {
+            using var rootOptions = StorageEnvironmentOptions.ForPathForTests(rootPath);
+            rootOptions.ManualFlushing = true;
+            rootOptions.ManualSyncing = true;
+
+            using var root = new StorageEnvironment(rootOptions);
+            using var scope = root.Journal.SharedJournalsScope();
+            using var pump = new MergerPump(root);
+
+            StorageEnvironment branch = null;
+            var releaseFlusher = new ManualResetEventSlim(false);
+            Task flushTask = Task.CompletedTask;
+            try
+            {
+                branch = SharedJournalTests.CreateBranchEnv(branchPath, root);
+
+                // committed data - lives in the branch scratch file until a flush moves it to the data file
+                for (int c = 0; c < 3; c++)
+                {
+                    using var tx = branch.WriteTransaction();
+                    var tree = tx.CreateTree("tree");
+                    for (int i = 0; i < 32; i++)
+                    {
+                        var key = $"key-{c}-{i}";
+                        var value = $"{c}-{i}-" + new string((char)('a' + i % 26), 128);
+                        tree.Add(key, value);
+                        values[key] = value;
+                    }
+                    tx.Commit();
+                }
+
+                if (flushPendingDuringDoomedCommit)
+                {
+                    // park the flusher right after it copied the pages to the data file and installed
+                    // _updateJournalStateAfterFlush - the doomed commit applies it in CommitStage1, and
+                    // its rollback is what corrupted the scratch state before the fix
+                    var installed = new ManualResetEventSlim(false);
+                    branch.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = () =>
+                    {
+                        installed.Set();
+                        releaseFlusher.Wait();
+                    };
+                    flushTask = Task.Run(() => branch.FlushLogToDataFile());
+                    Assert.True(installed.Wait(TimeSpan.FromSeconds(30)), "flush did not reach the journal-state-update stage");
+                }
+
+                // fail the next merged commit on the root (one-shot): throw just before the actual
+                // journal write, so the branch entries are not yet released with success
+                var armed = 1;
+                root.ForTestingPurposesOnly().ModifyNewLowLevelTransaction = t =>
+                {
+                    if (Interlocked.Exchange(ref armed, 0) == 1)
+                        t.ActionToCallJustBeforeWritingToJournal = () => throw new InvalidOperationException("RavenDB-27156 simulated commit-stage-2 write failure");
+                };
+
+                using (var tx = branch.WriteTransaction())
+                {
+                    var tree = tx.CreateTree("tree");
+                    tree.Add("doomed", "doomed");
+                    var doomedEx = Assert.Throws<InvalidOperationException>(() => tx.Commit());
+                    Output.WriteLine($"doomed commit failed with: {doomedEx.Message}");
+                }
+
+                // the fix: the branch env taking part in the failed merged commit must be marked as
+                // catastrophically failed, so it refuses further transactions instead of serving
+                // corrupted state
+                Assert.True(branch.Options.IsCatastrophicFailureSet, "branch env was not marked as catastrophically failed");
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using var tx = branch.WriteTransaction();
+                });
+
+                releaseFlusher.Set();
+                var flushEx = Record.Exception(() => flushTask.Wait(TimeSpan.FromSeconds(30)));
+                if (flushEx != null)
+                    Output.WriteLine($"flush completion: {flushEx.GetType().Name}: {flushEx.Message}");
+            }
+            finally
+            {
+                releaseFlusher.Set();
+                branch?.Dispose();
+            }
+        }
+
+        // ----- phase 2: restart - recovery replays the journals; the doomed write never reached the
+        // journal (it threw before the write), so its data is simply absent and no committed data is lost -----
+        {
+            using var rootOptions = StorageEnvironmentOptions.ForPathForTests(rootPath);
+            rootOptions.ManualFlushing = true;
+            rootOptions.ManualSyncing = true;
+
+            using var root = new StorageEnvironment(rootOptions);
+            using var scope = root.Journal.SharedJournalsScope();
+            using var pump = new MergerPump(root);
+
+            using var branch = SharedJournalTests.CreateBranchEnv(branchPath, root);
+            using var rtx = branch.ReadTransaction();
+            var tree = rtx.ReadTree("tree");
+            Assert.NotNull(tree);
+            foreach (var (key, expected) in values)
+            {
+                var read = tree.Read(key);
+                Assert.True(read != null, $"value for '{key}' is gone after restart");
+                Assert.Equal(expected, read.Reader.ToStringValue());
+            }
+
+            Assert.Null(tree.Read("doomed"));
+        }
+    }
+
+    // standing merger mimicking SharedIndexJournals.WriteSharedJournals, including its failure
+    // handling (swap SharedJournalState + SetException on all pending branch commits)
+    private sealed class MergerPump : IDisposable
+    {
+        private readonly ManualResetEventSlim _mergeSubmitted = new(false);
+        private readonly Thread _thread;
+        private volatile bool _stop;
+
+        public MergerPump(StorageEnvironment root)
+        {
+            root.Journal.BranchJournalMerger = new SharedJournalTests.MyJournalMerger(_mergeSubmitted);
+            _thread = new Thread(() =>
+            {
+                while (_stop == false)
+                {
+                    if (_mergeSubmitted.Wait(TimeSpan.FromMilliseconds(50)) == false)
+                        continue;
+                    _mergeSubmitted.Reset();
+                    try
+                    {
+                        using var tx = root.WriteTransaction();
+                        tx.Commit();
+                    }
+                    catch (Exception e)
+                    {
+                        Interlocked.Exchange(ref root.Journal.SharedJournalState, new SharedJournalState()).SetException(e);
+                    }
+                }
+            }) { IsBackground = true, Name = "RavenDB_27156 merger pump" };
+            _thread.Start();
+        }
+
+        public void Dispose()
+        {
+            _stop = true;
+            _thread.Join();
+            _mergeSubmitted.Dispose();
+        }
+    }
+}

--- a/test/SlowTests/Voron/Issues/RavenDB_27156.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27156.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
@@ -21,6 +22,101 @@ public class RavenDB_27156(ITestOutputHelper output) : RavenTestBase(output)
     [RavenFact(RavenTestCategory.Voron)]
     public void FailedSharedJournalWrite_WithoutPendingFlush_PoisonsBranchAndRecoversOnRestart()
         => RunScenario(flushPendingDuringDoomedCommit: false);
+
+    // Generic torn-tail recovery bug behind the wrong-page reads / AccessViolation seen after a failed
+    // shared-journal write (no shared journals needed): a journal that grew the data pager and then ends in
+    // a torn tail must still publish the grown pager state, else DataPagerState < NextPageNumber and reads fault.
+    [RavenFact(RavenTestCategory.Voron)]
+    public void TornJournalTail_AfterDataPagerGrowth_RecoversWithPagerCoveringNextPage()
+    {
+        var path = NewDataPath();
+        IOExtensions.DeleteDirectory(path);
+
+        var expected = new Dictionary<string, string>();
+
+        // phase 1: a big tx (grows the pager on replay) then a torn-tail tx, both in one journal. Manual
+        // flush/sync keeps everything in the journal so recovery has to rebuild and grow the data pager.
+        {
+            var options = StorageEnvironmentOptions.ForPathForTests(path);
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.InitialLogFileSize = 64 * 1024 * 1024; // one journal holds the big tx + the torn tail
+
+            var env = new StorageEnvironment(options);
+            try
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    var tree = tx.CreateTree("tree");
+                    for (int i = 0; i < 5000; i++)
+                    {
+                        var key = $"items/{i:D6}";
+                        var value = i + "-" + new string((char)('a' + i % 26), 300);
+                        tree.Add(key, value);
+                        expected[key] = value;
+                    }
+                    tx.Commit();
+                }
+
+                Output.WriteLine($"after big tx: NextPageNumber={env.NextPageNumber}");
+
+                var armed = 1;
+                env.Options.ForTestingPurposesOnly().SimulatePartialJournalWriteFailure = total =>
+                {
+                    if (Interlocked.Exchange(ref armed, 0) == 0)
+                        return null;
+                    return new StorageEnvironmentOptions.TestingStuff.PartialJournalWriteFailure
+                    {
+                        NumberOf4KbsToWrite = total / 2,
+                        Error = new IOException("RavenDB-27156 simulated torn journal write")
+                    };
+                };
+
+                // incompressible value: the write must span several 4KB blocks so writing half leaves a real
+                // torn tail (a compressible value collapses to one block and writing half writes nothing)
+                var tailBytes = new byte[32 * 1024];
+                new Random(1234).NextBytes(tailBytes);
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree("tree").Add("torn-tail", Convert.ToBase64String(tailBytes));
+                    Assert.ThrowsAny<Exception>(() => tx.Commit());
+                }
+            }
+            finally
+            {
+                Record.Exception(() => env.Dispose()); // env is catastrophically failed after the torn write
+            }
+        }
+
+        // phase 2: reopen and recover
+        {
+            var options = StorageEnvironmentOptions.ForPathForTests(path);
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+            options.InitialLogFileSize = 64 * 1024 * 1024;
+            options.OnRecoveryError += (_, _) => { }; // continue past the torn tail (as a running server does) instead of throwing at it
+
+            using var env = new StorageEnvironment(options);
+
+            var state = env.CurrentStateRecord;
+            Output.WriteLine($"recovered: NextPageNumber={state.NextPageNumber} dataPagerAllocPages={state.DataPagerState.NumberOfAllocatedPages}");
+
+            // without the fix the pager stays at its pre-growth size (e.g. allocPages=8 vs NextPageNumber=212)
+            Assert.True(state.DataPagerState.NumberOfAllocatedPages >= state.NextPageNumber,
+                $"data pager undersized after torn-tail recovery: allocPages={state.DataPagerState.NumberOfAllocatedPages} < NextPageNumber={state.NextPageNumber} (RavenDB-27156)");
+
+            using var rtx = env.ReadTransaction();
+            var tree = rtx.ReadTree("tree");
+            Assert.NotNull(tree);
+            foreach (var (key, value) in expected)
+            {
+                var read = tree.Read(key);
+                Assert.True(read != null, $"value for '{key}' is gone after recovery");
+                Assert.Equal(value, read.Reader.ToStringValue());
+            }
+            Assert.Null(tree.Read("torn-tail"));
+        }
+    }
 
     private void RunScenario(bool flushPendingDuringDoomedCommit)
     {

--- a/test/SlowTests/Voron/Issues/RavenDB_27156_e2e.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27156_e2e.cs
@@ -72,18 +72,17 @@ public class RavenDB_27156_e2e(ITestOutputHelper output) : RavenTestBase(output)
             };
         };
 
-        // trigger a branch commit -> root merge write -> torn failure
         try
         {
             await InsertItems(store, 500, 200);
         }
         catch
         {
-            // expected: the torn write faults the merged commit
+            // the async index failure may unload the database mid-insert
         }
 
-        // let the failure fault and unload the indexes before we force a reload
-        await Task.Delay(TimeSpan.FromSeconds(10));
+        Assert.True(await WaitForValueAsync(() => Volatile.Read(ref fired) == 1, true, timeout: 30_000),
+            "the torn shared-journal write never fired");
 
         shared.Env.Options.ForTestingPurposesOnly().SimulatePartialJournalWriteFailure = null;
         await Server.ServerStore.DatabasesLandlord.RestartDatabaseAsync(store.Database);
@@ -99,6 +98,7 @@ public class RavenDB_27156_e2e(ITestOutputHelper output) : RavenTestBase(output)
 
         // self-heal: no document loss, every index back to Normal and fully re-indexed
         Assert.Equal(750, docCount);
+        Assert.Equal(3, finalStats.Length);
         Assert.All(finalStats, s => Assert.Equal(IndexState.Normal, s.State));
         Assert.All(finalStats, s => Assert.Equal(docCount, s.EntriesCount));
     }

--- a/test/SlowTests/Voron/Issues/RavenDB_27156_e2e.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27156_e2e.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+// End-to-end companion of RavenDB_27156 (originally RavenDB-24520): a torn journal write on the
+// shared @SharedJournals root faults every index sharing the journal, then the database must self-heal on
+// reload with no document loss. Before the recovery fix this intermittently crashed the process with an
+// AccessViolation (the least-flushed branch recovered with an undersized data pager).
+public class RavenDB_27156_e2e(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class Item
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
+    }
+
+    private static IndexDefinition MapIndex(string name) => new()
+    {
+        Name = name,
+        Maps = { "from i in docs.Items select new { i.Name, i.Value }" }
+    };
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task TornJournalWrite_OnSharedRoot_FaultsAllIndexes_ThenRecoversWithoutDataLoss()
+    {
+        using var store = GetDocumentStore(new Options
+        {
+            RunInMemory = false,
+            ModifyDatabaseRecord = r =>
+            {
+                r.Settings[RavenConfiguration.GetKey(x => x.Storage.MaxJournalFileSize)] = "16";
+            }
+        });
+
+        // three map indexes -> three branch envs sharing the root journal
+        foreach (var n in new[] { "Idx/A", "Idx/B", "Idx/C" })
+            await store.Maintenance.SendAsync(new PutIndexesOperation(MapIndex(n)));
+
+        await InsertItems(store, 0, 500);
+        Indexes.WaitForIndexing(store);
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        var shared = database.IndexStore.SharedJournals;
+        Assert.NotNull(shared);
+
+        var indexes = database.IndexStore.GetIndexes().ToList();
+        Assert.All(indexes, idx => Assert.NotNull(idx._environment.Options.RootJournal));
+
+        // arm a one-shot torn write on the shared root: write half the batch then throw
+        var fired = 0;
+        var injected = new IOException("RavenDB-27156 simulated torn journal write (disk full mid-write)");
+        shared.Env.Options.ForTestingPurposesOnly().SimulatePartialJournalWriteFailure = total =>
+        {
+            if (Interlocked.CompareExchange(ref fired, 1, 0) != 0)
+                return null;
+            return new StorageEnvironmentOptions.TestingStuff.PartialJournalWriteFailure
+            {
+                NumberOf4KbsToWrite = total / 2,
+                Error = injected
+            };
+        };
+
+        // trigger a branch commit -> root merge write -> torn failure
+        try
+        {
+            await InsertItems(store, 500, 200);
+        }
+        catch
+        {
+            // expected: the torn write faults the merged commit
+        }
+
+        // let the failure fault and unload the indexes before we force a reload
+        await Task.Delay(TimeSpan.FromSeconds(10));
+
+        shared.Env.Options.ForTestingPurposesOnly().SimulatePartialJournalWriteFailure = null;
+        await Server.ServerStore.DatabasesLandlord.RestartDatabaseAsync(store.Database);
+
+        await InsertItems(store, 700, 50); // a small post-recovery write must succeed
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(2));
+
+        long docCount;
+        using (var session = store.OpenAsyncSession())
+            docCount = await session.Query<Item>().CountAsync();
+
+        var finalStats = await store.Maintenance.SendAsync(new GetIndexesStatisticsOperation());
+
+        // self-heal: no document loss, every index back to Normal and fully re-indexed
+        Assert.Equal(750, docCount);
+        Assert.All(finalStats, s => Assert.Equal(IndexState.Normal, s.State));
+        Assert.All(finalStats, s => Assert.Equal(docCount, s.EntriesCount));
+    }
+
+    private static async Task InsertItems(IDocumentStore store, int start, int count)
+    {
+        using var bulk = store.BulkInsert();
+        for (int i = start; i < start + count; i++)
+            await bulk.StoreAsync(new Item { Name = $"item-{i}", Value = i }, $"items/{i}");
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27156

### Additional description

Fixes two related bugs behind intermittent `ACCESS_VIOLATION` and `Requested ReadOnly page #X. Got #Y` crashes that follow a failed shared-journal write (disk full / IO error) on the `@SharedJournals` root.

### Bug 1 - a failed merged write only poisoned the root environment

When a merged shared-journal write fails, only the **root** environment was marked catastrophically failed. The **branch** environments taking part in that commit had their commit task faulted but kept running. A branch commit that had already applied its pending journal-flush state update in stage 1 and then rolled back left in-memory scratch state inconsistent (freed scratch entries resurrected). The next indexing write transaction reused those positions, producing wrong-page reads and, intermittently, an `AccessViolation` in the merger-vs-unload window.

**Fix:** `SharedJournalState.SetException` now marks **every** environment participating in the failed merged write (both queued and already-merged records) as catastrophically failed before faulting its commit task. A commit failure is non-recoverable - we do not know what reached the shared journal - so all participants must restart. All environments of a database share a single catastrophic-failure notification, so this is still one database unload + reload per incident.

### Bug 2 - recovery left the data pager undersized after an incomplete final transaction

Fixing Bug 1 forced the restart, but the reload itself was buggy: it still intermittently hit `Requested ReadOnly page #X. Got #Y` or `AccessViolation` during post-reload indexing, on the least-flushed branch.

`RecoverDatabase` replays each journal's valid transactions, growing the data pager (and file) to cover the pages they touch and advancing `NextPageNumber`. It published the recovered pager state (`UpdateDataPagerState`) only **after** the `if (RequireHeaderUpdate) break;`. When the last journal ends with an incomplete (partially written) transaction - exactly what a torn write leaves - recovery applies the valid transactions before it (growing the pager), detects the incomplete tail, sets `RequireHeaderUpdate`, and breaks **before** publishing. The environment then came up with `DataPagerState` smaller than `NextPageNumber`: the pager claimed fewer pages than the B-tree references. Reading a page in that gap returned the wrong page, or read past the real memory mapping and faulted.

The least-flushed branch is the usual victim because it has the most data still in the journals, so its large pager growth lands in the same journal as the failed write's incomplete tail.

**Fix:** move `UpdateDataPagerState` before the `RequireHeaderUpdate` break so the grown pager state is always published, keeping `DataPagerState` consistent with `NextPageNumber`. This is generic to recovery, not shared-journal specific.

### How the two relate

Bug 1's fix (force all participants to restart) is what routinely exercised the torn-tail recovery path and exposed Bug 2. Both are needed: Bug 1 stops corrupted branches from serving/mutating bad state; Bug 2 makes the resulting restart recover into a consistent state.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
