### PR TITLE
RavenDB-27173 Advanced.RegisterForConcurrencyCheck

### DIFF
--- a/src/Raven.Client/Documents/Session/IAdvancedDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAdvancedDocumentSessionOperations.cs
@@ -181,6 +181,43 @@ namespace Raven.Client.Documents.Session
         string GetChangeVectorFor<T>(T instance);
 
         /// <summary>
+        ///     Registers an explicit optimistic concurrency check for a document, without loading it into the
+        ///     session and without a remote call. The next <c>SaveChanges</c> will verify the document against
+        ///     the server and throw a <see cref="Raven.Client.Exceptions.ConcurrencyException"/> if it no longer
+        ///     matches. The check is honored regardless of the session's <see cref="OptimisticConcurrencyMode"/>.
+        ///     <para>
+        ///     The <paramref name="changeVector"/> is typically obtained from another session via
+        ///     <see cref="GetChangeVectorFor{T}"/>. Its value controls the check:
+        ///     </para>
+        ///     <list type="bullet">
+        ///         <item><description>A non-empty change vector: the document must still have this change vector.</description></item>
+        ///         <item><description><see cref="string.Empty"/>: the document must not exist.</description></item>
+        ///         <item><description><c>null</c>: disables the concurrency check for this id.</description></item>
+        ///     </list>
+        ///     <para>
+        ///     The registration always wins over what the session itself knows about the id. Loading the document
+        ///     afterwards does not replace the registered change vector, and a document written in the same batch
+        ///     with its own change vector check does not suppress the registered check. Registering the same id
+        ///     twice keeps the last value.
+        ///     </para>
+        ///     <para>
+        ///     The registration is one shot. A successful <c>SaveChanges</c> consumes it, so later calls on the
+        ///     same session do not check the id again. A failed <c>SaveChanges</c> keeps it, so it can be retried.
+        ///     Call this method with a <c>null</c> change vector, or <see cref="Clear"/>, to cancel it earlier.
+        ///     </para>
+        ///     <para>
+        ///     Not supported when <see cref="SessionOptions.TransactionMode"/> is
+        ///     <see cref="Raven.Client.Documents.Session.TransactionMode.ClusterWide"/>, and not supported in a
+        ///     <see cref="SessionOptions.NoTracking"/> session, because such a session cannot call
+        ///     <c>SaveChanges</c> at all.
+        ///     </para>
+        /// </summary>
+        /// <param name="id">The document id to verify during the next SaveChanges.</param>
+        /// <param name="changeVector">The change vector the document is expected to still have, <see cref="string.Empty"/> to assert absence, or <c>null</c> to disable the check for this id.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="id"/> is null or empty.</exception>
+        void RegisterForConcurrencyCheck(string id, string changeVector);
+
+        /// <summary>
         ///     Gets all the counter names for the specified entity.
         /// </summary>
         /// <param name="instance">The instance.</param>

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -412,6 +412,24 @@ namespace Raven.Client.Documents.Session
             return null;
         }
 
+        /// <summary>
+        /// Registers an explicit optimistic concurrency check for a document, without loading it into the
+        /// session and without a remote call. The next SaveChanges verifies the document against the server
+        /// and throws a <see cref="Raven.Client.Exceptions.ConcurrencyException"/> if it no longer matches.
+        /// The check is honored regardless of the session's <see cref="OptimisticConcurrencyMode"/>, and it
+        /// overrides anything the session itself tracked for that id.
+        /// A non-empty change vector requires the document to still have it, <see cref="string.Empty"/> asserts
+        /// the document does not exist, and <c>null</c> disables the check for this id.
+        /// The registration is one shot - a successful SaveChanges consumes it.
+        /// </summary>
+        public void RegisterForConcurrencyCheck(string id, string changeVector)
+        {
+            if (string.IsNullOrEmpty(id))
+                throw new ArgumentNullException(nameof(id));
+
+            TrackedEntities.ForceRegister(id, changeVector);
+        }
+
         public DateTime? GetLastModifiedFor<T>(T instance)
         {
             if (instance == null)
@@ -954,6 +972,9 @@ more responsive application.
                     case CommandType.CompareExchangeDELETE:
                     case CommandType.CompareExchangePUT:
                         break;
+                    case CommandType.BatchTrackChanges:
+                        throw new NotSupportedException(
+                            $"{nameof(RegisterForConcurrencyCheck)} is not supported when using a cluster transaction.");
                     default:
                         throw new NotSupportedException($"The command '{command.Type}' is not supported in a cluster session.");
                 }
@@ -2547,6 +2568,7 @@ more responsive application.
 
                     _session.DeferredCommands.Clear();
                     _session.DeferredCommandsDictionary.Clear();
+                    _session.TrackedEntities.ClearForcedRegistrations();
                 }
 
                 public void ClearDeletedEntities()
@@ -2964,6 +2986,11 @@ more responsive application.
     {
         private readonly Dictionary<string, string> _trackedEntities = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+        // Explicit registrations made via RegisterForConcurrencyCheck. These are kept apart from _trackedEntities so
+        // that tracking operations (loads, refreshes, evictions) can neither override nor remove them, and so that
+        // they are honored in every OptimisticConcurrencyMode. A null value disables the check for that id.
+        private Dictionary<string, string> _forcedEntities;
+
         private readonly bool _shouldTrack;
 
         public TrackedEntitiesHolder(bool shouldTrack)
@@ -2971,12 +2998,26 @@ more responsive application.
             _shouldTrack = shouldTrack;
         }
 
-        public bool Any()
+        /// <summary>
+        /// Registers an explicit concurrency check for an id, bypassing the session's OptimisticConcurrencyMode.
+        /// The entry is included in the next SaveChanges batch and overrides any tracked value for the id.
+        /// A null change vector disables the check for the id, string.Empty asserts the document does not exist,
+        /// and any other value is verified against the server.
+        /// </summary>
+        public void ForceRegister(string id, string changeVector)
         {
-            if (_shouldTrack)
-                return _trackedEntities.Any();
+            _forcedEntities ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _forcedEntities[id] = changeVector;
+        }
 
-            return false;
+        /// <summary>
+        /// Registered checks are one shot - the next SaveChanges verifies them and then they are done.
+        /// Holding on to them would make every later SaveChanges on this session re-assert a change vector that
+        /// this very session has already validated and replaced.
+        /// </summary>
+        public void ClearForcedRegistrations()
+        {
+            _forcedEntities = null;
         }
 
         public void TryRemove(string id)
@@ -2995,8 +3036,8 @@ more responsive application.
 
         public void Clear()
         {
-            if (_shouldTrack)
-                _trackedEntities.Clear();
+            _trackedEntities.Clear();
+            _forcedEntities = null;
         }
 
         public bool TryGetValue(string id, out string cv)
@@ -3035,11 +3076,47 @@ more responsive application.
 
         public void PrepareForEntitiesTrack(InMemoryDocumentSessionOperations.SaveChangesData result)
         {
-            if (Any() == false)
+            Dictionary<string, string> entitiesToCheck = BuildEntitiesToCheck();
+            if (entitiesToCheck == null)
                 return;
 
-            result.TrackChangesCommandData = new BatchTrackChangesCommandData(_trackedEntities, result.IdsAlreadyCheckedForConcurrency);
+            result.TrackChangesCommandData = new BatchTrackChangesCommandData(entitiesToCheck, GetIdsToSkip(result.IdsAlreadyCheckedForConcurrency));
             result.SessionCommands.Insert(0, result.TrackChangesCommandData);
+        }
+
+        private Dictionary<string, string> BuildEntitiesToCheck()
+        {
+            bool hasTracked = _shouldTrack && _trackedEntities.Count > 0;
+
+            if (_forcedEntities == null)
+                return hasTracked ? _trackedEntities : null;
+
+            Dictionary<string, string> entitiesToCheck = hasTracked
+                ? new Dictionary<string, string>(_trackedEntities, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (KeyValuePair<string, string> forced in _forcedEntities)
+            {
+                // an explicit registration overrides whatever the session tracked for this id
+                if (forced.Value == null)
+                    entitiesToCheck.Remove(forced.Key);
+                else
+                    entitiesToCheck[forced.Key] = forced.Value;
+            }
+
+            return entitiesToCheck.Count > 0 ? entitiesToCheck : null;
+        }
+
+        private HashSet<string> GetIdsToSkip(HashSet<string> idsAlreadyCheckedForConcurrency)
+        {
+            // a write that carries its own change vector check makes the tracked read check redundant, but it must
+            // not swallow a check that the user registered explicitly
+            if (_forcedEntities == null || idsAlreadyCheckedForConcurrency.Count == 0)
+                return idsAlreadyCheckedForConcurrency;
+
+            var idsToSkip = new HashSet<string>(idsAlreadyCheckedForConcurrency, StringComparer.OrdinalIgnoreCase);
+            idsToSkip.ExceptWith(_forcedEntities.Keys);
+            return idsToSkip;
         }
     }
 

--- a/test/FastTests/Client/OptimisticConcurrencyModeTests.cs
+++ b/test/FastTests/Client/OptimisticConcurrencyModeTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
 using Tests.Infrastructure;
 using Xunit;
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -366,6 +368,533 @@ namespace FastTests.Client
 
             var ex = Assert.Throws<InvalidOperationException>(() => conventions.OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes);
             Assert.Contains(nameof(DocumentConventions.OptimisticConcurrencyMode), ex.Message);
+        }
+
+        private class SimpleDoc
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_WithEmptyId_ShouldThrow()
+        {
+            using var store = GetDocumentStore();
+            using var session = store.OpenSession();
+
+            Assert.Throws<ArgumentNullException>(() => session.Advanced.RegisterForConcurrencyCheck(null, "cv"));
+            Assert.Throws<ArgumentNullException>(() => session.Advanced.RegisterForConcurrencyCheck(string.Empty, "cv"));
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_ThrowsWhenRegisteredDocumentWasModified()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            // capture the change vector of the watched document in one session
+            string changeVector;
+            using (var sessionA = store.OpenSession())
+            {
+                changeVector = sessionA.Advanced.GetChangeVectorFor(sessionA.Load<SimpleDoc>("docs/watched"));
+            }
+
+            // a different session modifies the watched document in the background
+            using (var background = store.OpenSession())
+            {
+                background.Load<SimpleDoc>("docs/watched").Name = "Changed";
+                background.SaveChanges();
+            }
+
+            // this session uses the default None mode, proving the registered check is honored regardless of mode
+            using (var sessionB = store.OpenSession())
+            {
+                sessionB.Load<SimpleDoc>("docs/other").Name = "Edited";
+                sessionB.Advanced.RegisterForConcurrencyCheck("docs/watched", changeVector);
+
+                var e = Assert.Throws<ConcurrencyException>(() => sessionB.SaveChanges());
+                Assert.Equal("docs/watched", e.Id);
+            }
+
+            // the whole batch must have been rolled back, so docs/other is untouched
+            using (var verify = store.OpenSession())
+            {
+                Assert.Equal("Other", verify.Load<SimpleDoc>("docs/other").Name);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_SucceedsWhenRegisteredDocumentUnchanged()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            string changeVector;
+            using (var sessionA = store.OpenSession())
+            {
+                changeVector = sessionA.Advanced.GetChangeVectorFor(sessionA.Load<SimpleDoc>("docs/watched"));
+            }
+
+            using (var sessionB = store.OpenSession())
+            {
+                sessionB.Load<SimpleDoc>("docs/other").Name = "Edited";
+                sessionB.Advanced.RegisterForConcurrencyCheck("docs/watched", changeVector);
+                sessionB.SaveChanges();
+            }
+
+            using (var verify = store.OpenSession())
+            {
+                Assert.Equal("Edited", verify.Load<SimpleDoc>("docs/other").Name);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_EmptyChangeVectorAssertsDocumentDoesNotExist()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            // the document we assert absent is created by another session
+            using (var background = store.OpenSession())
+            {
+                background.Store(new SimpleDoc { Name = "Now exists" }, "docs/watched");
+                background.SaveChanges();
+            }
+
+            using (var sessionB = store.OpenSession())
+            {
+                sessionB.Load<SimpleDoc>("docs/other").Name = "Edited";
+                sessionB.Advanced.RegisterForConcurrencyCheck("docs/watched", string.Empty);
+
+                Assert.Throws<ConcurrencyException>(() => sessionB.SaveChanges());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_EmptyChangeVectorSucceedsWhenDocumentStillAbsent()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            using (var sessionB = store.OpenSession())
+            {
+                sessionB.Load<SimpleDoc>("docs/other").Name = "Edited";
+                sessionB.Advanced.RegisterForConcurrencyCheck("docs/missing", string.Empty);
+                sessionB.SaveChanges();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_NullChangeVectorDisablesCheckForId()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            using (var sessionB = store.OpenSession(new SessionOptions { OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads }))
+            {
+                // under WritesAndReads this load is auto-tracked and would normally trigger a concurrency check
+                sessionB.Load<SimpleDoc>("docs/watched");
+                sessionB.Load<SimpleDoc>("docs/other").Name = "Edited";
+
+                using (var background = store.OpenSession())
+                {
+                    background.Load<SimpleDoc>("docs/watched").Name = "Changed";
+                    background.SaveChanges();
+                }
+
+                // explicitly disable the check for the watched document
+                sessionB.Advanced.RegisterForConcurrencyCheck("docs/watched", null);
+
+                sessionB.SaveChanges();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_IsConsumedByASuccessfulSaveChanges_AfterModify()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var watched = session.Load<SimpleDoc>("docs/watched");
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", session.Advanced.GetChangeVectorFor(watched));
+
+                watched.Name = "Changed";
+                session.SaveChanges(); // the check passes, and this very session advances the change vector
+
+                session.Load<SimpleDoc>("docs/other").Name = "Edited";
+                session.SaveChanges(); // must not re-assert the change vector this session already replaced
+            }
+
+            using (var verify = store.OpenSession())
+            {
+                Assert.Equal("Changed", verify.Load<SimpleDoc>("docs/watched").Name);
+                Assert.Equal("Edited", verify.Load<SimpleDoc>("docs/other").Name);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_IsConsumedByASuccessfulSaveChanges_AfterDelete()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var watched = session.Load<SimpleDoc>("docs/watched");
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", session.Advanced.GetChangeVectorFor(watched));
+
+                session.Delete(watched);
+                session.SaveChanges(); // the check passes, and this very session deletes the document
+
+                session.Load<SimpleDoc>("docs/other").Name = "Edited";
+                session.SaveChanges(); // must not assert the old change vector against this session's own tombstone
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_IsKeptWhenSaveChangesFails()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            string staleChangeVector;
+            using (var sessionA = store.OpenSession())
+            {
+                staleChangeVector = sessionA.Advanced.GetChangeVectorFor(sessionA.Load<SimpleDoc>("docs/watched"));
+            }
+
+            using (var background = store.OpenSession())
+            {
+                background.Load<SimpleDoc>("docs/watched").Name = "Changed";
+                background.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.Load<SimpleDoc>("docs/other").Name = "Edited";
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", staleChangeVector);
+
+                Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+
+                // a failed save must not consume the registration, so a retry fails the same way
+                Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_ExplicitChangeVector_IsNotOverwrittenByALaterLoad()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            string staleChangeVector;
+            using (var sessionA = store.OpenSession())
+            {
+                staleChangeVector = sessionA.Advanced.GetChangeVectorFor(sessionA.Load<SimpleDoc>("docs/watched"));
+            }
+
+            using (var background = store.OpenSession())
+            {
+                background.Load<SimpleDoc>("docs/watched").Name = "Changed";
+                background.SaveChanges();
+            }
+
+            using (var session = store.OpenSession(new SessionOptions { OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads }))
+            {
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", staleChangeVector);
+
+                // loading the watched document must not replace the explicitly registered change vector
+                session.Load<SimpleDoc>("docs/watched");
+
+                session.Load<SimpleDoc>("docs/other").Name = "Edited";
+
+                var e = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+                Assert.Equal("docs/watched", e.Id);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_DisabledCheck_SurvivesALaterLoad()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            using (var session = store.OpenSession(new SessionOptions { OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads }))
+            {
+                // disable the check first, then load - the outcome must not depend on this order
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", null);
+                session.Load<SimpleDoc>("docs/watched");
+
+                using (var background = store.OpenSession())
+                {
+                    background.Load<SimpleDoc>("docs/watched").Name = "Changed";
+                    background.SaveChanges();
+                }
+
+                session.Load<SimpleDoc>("docs/other").Name = "Edited";
+
+                session.SaveChanges();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_IsHonored_WhenDocumentIsAlsoWrittenWithItsOwnConcurrencyCheck()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.SaveChanges();
+            }
+
+            string staleChangeVector;
+            using (var sessionA = store.OpenSession())
+            {
+                staleChangeVector = sessionA.Advanced.GetChangeVectorFor(sessionA.Load<SimpleDoc>("docs/watched"));
+            }
+
+            using (var background = store.OpenSession())
+            {
+                background.Load<SimpleDoc>("docs/watched").Name = "Changed";
+                background.SaveChanges();
+            }
+
+            using (var session = store.OpenSession(new SessionOptions { OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes }))
+            {
+                var watched = session.Load<SimpleDoc>("docs/watched"); // tracked with the current change vector
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", staleChangeVector);
+
+                watched.Name = "Edited";
+
+                // the write carries its own check, which uses the current change vector and would pass,
+                // so only the explicitly registered (stale) check can fail this save
+                Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_LastRegistrationForAnIdWins()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", "A:1-aaaaaaaaaaaaaaaaaaaaaa");
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", null); // cancels the check
+
+                session.Load<SimpleDoc>("docs/other").Name = "Edited";
+                session.SaveChanges();
+            }
+
+            using (var verify = store.OpenSession())
+            {
+                Assert.Equal("Edited", verify.Load<SimpleDoc>("docs/other").Name);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_IsClearedByAdvancedClear()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.Store(new SimpleDoc { Name = "Other" }, "docs/other");
+                seed.SaveChanges();
+            }
+
+            string staleChangeVector;
+            using (var sessionA = store.OpenSession())
+            {
+                staleChangeVector = sessionA.Advanced.GetChangeVectorFor(sessionA.Load<SimpleDoc>("docs/watched"));
+            }
+
+            using (var background = store.OpenSession())
+            {
+                background.Load<SimpleDoc>("docs/watched").Name = "Changed";
+                background.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", staleChangeVector);
+                session.Advanced.Clear();
+
+                session.Load<SimpleDoc>("docs/other").Name = "Edited";
+                session.SaveChanges();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_OnItsOwn_SendsExactlyOneRequest()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenSession())
+            {
+                seed.Store(new SimpleDoc { Name = "Original" }, "docs/watched");
+                seed.SaveChanges();
+            }
+
+            string changeVector;
+            using (var sessionA = store.OpenSession())
+            {
+                changeVector = sessionA.Advanced.GetChangeVectorFor(sessionA.Load<SimpleDoc>("docs/watched"));
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", changeVector);
+                session.SaveChanges();
+
+                Assert.Equal(1, session.Advanced.NumberOfRequests);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_DisabledOnly_SendsNoRequest()
+        {
+            using var store = GetDocumentStore();
+            using var session = store.OpenSession();
+
+            session.Advanced.RegisterForConcurrencyCheck("docs/watched", "A:1-aaaaaaaaaaaaaaaaaaaaaa");
+            session.Advanced.RegisterForConcurrencyCheck("docs/watched", null);
+
+            session.SaveChanges();
+
+            Assert.Equal(0, session.Advanced.NumberOfRequests);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task RegisterForConcurrencyCheck_WorksInAnAsyncSession()
+        {
+            using var store = GetDocumentStore();
+
+            using (var seed = store.OpenAsyncSession())
+            {
+                await seed.StoreAsync(new SimpleDoc { Name = "Original" }, "docs/watched");
+                await seed.StoreAsync(new SimpleDoc { Name = "Other" }, "docs/other");
+                await seed.SaveChangesAsync();
+            }
+
+            string staleChangeVector;
+            using (var sessionA = store.OpenAsyncSession())
+            {
+                staleChangeVector = sessionA.Advanced.GetChangeVectorFor(await sessionA.LoadAsync<SimpleDoc>("docs/watched"));
+            }
+
+            using (var background = store.OpenAsyncSession())
+            {
+                (await background.LoadAsync<SimpleDoc>("docs/watched")).Name = "Changed";
+                await background.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                (await session.LoadAsync<SimpleDoc>("docs/other")).Name = "Edited";
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", staleChangeVector);
+
+                var e = await Assert.ThrowsAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+                Assert.Equal("docs/watched", e.Id);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_IsNotSupportedInANoTrackingSession()
+        {
+            // a NoTracking session rejects SaveChanges as soon as the batch holds any command, so a registered
+            // check can never reach the server from such a session
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession(new SessionOptions { NoTracking = true }))
+            {
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", "A:1-aaaaaaaaaaaaaaaaaaaaaa");
+
+                Assert.Throws<InvalidOperationException>(() => session.SaveChanges());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void RegisterForConcurrencyCheck_IsNotSupportedInAClusterWideSession()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                session.Advanced.RegisterForConcurrencyCheck("docs/watched", "A:1-aaaaaaaaaaaaaaaaaaaaaa");
+
+                var e = Assert.Throws<NotSupportedException>(() => session.SaveChanges());
+                Assert.Contains(nameof(IAdvancedDocumentSessionOperations.RegisterForConcurrencyCheck), e.Message);
+            }
         }
     }
 }


### PR DESCRIPTION
Add Advanced.RegisterForConcurrencyCheck to register an external optimistic concurrency check without a remote call.
Allowing offline mode for read only checks

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27173

### Additional description

We can now call `RegisterForConcurrencyCheck()` to pass the id / cv of a document.
That would be included in the _read_ check, so we can do an offline optimistic concurrency while verifying that document (that we aren't changed) haven't changed.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
