### PR TITLE
RavenDB-27174 better handling for subscription checks on @metadata.@refresh = nul, etc

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -60,6 +60,26 @@ namespace Raven.Server.Documents.Queries.AST
                     QueryExpression inner = HandleMetadataNullComparison(ne.Expression);
                     return ReferenceEquals(inner, ne.Expression) ? ne : new NegatedExpression(inner);
 
+                case MethodExpression method when method.Name.Value.Equals("intersect", StringComparison.OrdinalIgnoreCase):
+                    // intersect(...) combines boolean statements as well, so the comparisons
+                    // can sit inside its arguments
+                    List<QueryExpression> arguments = null;
+                    for (int i = 0; i < method.Arguments.Count; i++)
+                    {
+                        QueryExpression argument = HandleMetadataNullComparison(method.Arguments[i]);
+                        if (arguments == null)
+                        {
+                            if (ReferenceEquals(argument, method.Arguments[i]))
+                                continue;
+
+                            arguments = new List<QueryExpression>(method.Arguments);
+                        }
+
+                        arguments[i] = argument;
+                    }
+
+                    return arguments == null ? method : new MethodExpression(method.Name, arguments);
+
                 case BinaryExpression { Operator: OperatorType.And or OperatorType.Or } logical:
                     QueryExpression left = HandleMetadataNullComparison(logical.Left);
                     QueryExpression right = HandleMetadataNullComparison(logical.Right);

--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -35,32 +35,36 @@ namespace Raven.Server.Documents.Queries.AST
         }
 
         /// <summary>
-        /// Rewrites '@metadata'.'@refresh' = null into "not exists(@refresh)" and
-        /// '@metadata'.'@refresh' != null into "exists(@refresh)".
-        /// A document with no '@refresh' at all reads as undefined in JavaScript, and
-        /// 'undefined === null' is false, so the comparison has to be expressed as an
-        /// existence check instead. Callers apply this to a boolean clause (a subscription
-        /// where clause or a query filter clause) before visiting it.
+        /// Rewrites a null comparison against a metadata property into an existence check:
+        /// '@metadata'.'@refresh' = null becomes "not exists(...)" and
+        /// '@metadata'.'@refresh' != null becomes "exists(...)".
+        /// A document that carries no such metadata property at all reads as undefined in
+        /// JavaScript, and 'undefined === null' is false, so the comparison has to be
+        /// expressed as an existence check instead. This applies to any property under
+        /// '@metadata' - '@refresh', '@expires', '@archive-at', '@archived' and
+        /// user defined metadata alike - since they are all absent rather than null when
+        /// unset. Callers apply this to a boolean clause (a subscription where clause or a
+        /// query filter clause) before visiting it.
         /// </summary>
-        public static QueryExpression HandleMetadataRefresh(QueryExpression qe)
+        public static QueryExpression HandleMetadataNullComparison(QueryExpression qe)
         {
             // the comparison may sit anywhere in the clause, so we recurse through the
             // logical operators and negations to reach it
             switch (qe)
             {
                 case NegatedExpression ne:
-                    QueryExpression inner = HandleMetadataRefresh(ne.Expression);
+                    QueryExpression inner = HandleMetadataNullComparison(ne.Expression);
                     return ReferenceEquals(inner, ne.Expression) ? ne : new NegatedExpression(inner);
 
                 case BinaryExpression { Operator: OperatorType.And or OperatorType.Or } logical:
-                    QueryExpression left = HandleMetadataRefresh(logical.Left);
-                    QueryExpression right = HandleMetadataRefresh(logical.Right);
+                    QueryExpression left = HandleMetadataNullComparison(logical.Left);
+                    QueryExpression right = HandleMetadataNullComparison(logical.Right);
                     if (ReferenceEquals(left, logical.Left) && ReferenceEquals(right, logical.Right))
                         return logical;
                     return new BinaryExpression(left, right, logical.Operator) { Parenthesis = logical.Parenthesis };
 
                 case BinaryExpression { Operator: OperatorType.Equal or OperatorType.NotEqual } be:
-                    if (IsMetadataRefreshField(be.Left) == false ||
+                    if (IsMetadataProperty(be.Left) == false ||
                         be.Right is not ValueExpression { Value: ValueTokenType.Null })
                         return qe;
                     MethodExpression me = new MethodExpression("exists", [be.Left]);
@@ -73,15 +77,14 @@ namespace Raven.Server.Documents.Queries.AST
             }
         }
 
-        private static bool IsMetadataRefreshField(QueryExpression qe)
+        private static bool IsMetadataProperty(QueryExpression qe)
         {
-            // the field may be written with or without the from alias, so we match on the
-            // '@metadata'.'@refresh' suffix: both '@metadata'.'@refresh' and e.'@metadata'.'@refresh'
+            // a property directly under '@metadata', written with or without the from alias,
+            // so we match on the path shape: both '@metadata'.'X' and e.'@metadata'.'X'
             if (qe is not FieldExpression fe || fe.Compound.Count < 2)
                 return false;
 
-            return fe.Compound[^1] == Constants.Documents.Metadata.Refresh &&
-                   fe.Compound[^2] == Constants.Documents.Metadata.Key;
+            return fe.Compound[^2] == Constants.Documents.Metadata.Key;
         }
 
         public override void VisitInclude(List<QueryExpression> includes)

--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -43,11 +43,14 @@ namespace Raven.Server.Documents.Queries.AST
         /// JavaScript, and 'undefined === null' is false, so the absent case has to be
         /// spelled out as an existence check. The original comparison is kept alongside it
         /// so a property that is present and explicitly null still matches. This applies to
-        /// any property under '@metadata' - '@refresh', '@expires', '@archive-at',
-        /// '@archived' and user defined metadata alike. Callers apply this to a boolean
-        /// clause (a subscription where clause or a query filter clause) before visiting it.
+        /// the server owned metadata properties - the ones under '@metadata' whose name
+        /// starts with '@', such as '@refresh', '@expires', '@archive-at' and '@archived' -
+        /// since those are removed rather than set to null when they do not apply. User
+        /// defined metadata is left alone and compares exactly as written. Callers apply
+        /// this to a boolean clause (a subscription where clause or a query filter clause)
+        /// before visiting it.
         /// </summary>
-        public static QueryExpression HandleMetadataNullComparison(QueryExpression qe)
+        internal static QueryExpression HandleMetadataNullComparison(QueryExpression qe)
         {
             // the comparison may sit anywhere in the clause, so we recurse through the
             // logical operators and negations to reach it
@@ -65,7 +68,7 @@ namespace Raven.Server.Documents.Queries.AST
                     return new BinaryExpression(left, right, logical.Operator) { Parenthesis = logical.Parenthesis };
 
                 case BinaryExpression { Operator: OperatorType.Equal or OperatorType.NotEqual } be:
-                    if (IsMetadataProperty(be.Left) == false ||
+                    if (IsSystemMetadataProperty(be.Left) == false ||
                         be.Right is not ValueExpression { Value: ValueTokenType.Null })
                         return qe;
 
@@ -87,14 +90,20 @@ namespace Raven.Server.Documents.Queries.AST
             }
         }
 
-        private static bool IsMetadataProperty(QueryExpression qe)
+        private static bool IsSystemMetadataProperty(QueryExpression qe)
         {
             // a property directly under '@metadata', written with or without the from alias,
             // so we match on the path shape: both '@metadata'.'X' and e.'@metadata'.'X'
             if (qe is not FieldExpression fe || fe.Compound.Count < 2)
                 return false;
 
-            return fe.Compound[^2] == Constants.Documents.Metadata.Key;
+            if (fe.Compound[^2] != Constants.Documents.Metadata.Key)
+                return false;
+
+            // only the server owned properties, which are removed rather than nulled out
+            StringSegment property = fe.Compound[^1];
+
+            return property.Length > 0 && property[0] == '@';
         }
 
         public override void VisitInclude(List<QueryExpression> includes)

--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Raven.Client;
 using Sparrow;
 
 namespace Raven.Server.Documents.Queries.AST
@@ -31,6 +32,56 @@ namespace Raven.Server.Documents.Queries.AST
                 }
             }
 
+        }
+
+        /// <summary>
+        /// Rewrites '@metadata'.'@refresh' = null into "not exists(@refresh)" and
+        /// '@metadata'.'@refresh' != null into "exists(@refresh)".
+        /// A document with no '@refresh' at all reads as undefined in JavaScript, and
+        /// 'undefined === null' is false, so the comparison has to be expressed as an
+        /// existence check instead. Callers apply this to a boolean clause (a subscription
+        /// where clause or a query filter clause) before visiting it.
+        /// </summary>
+        public static QueryExpression HandleMetadataRefresh(QueryExpression qe)
+        {
+            // the comparison may sit anywhere in the clause, so we recurse through the
+            // logical operators and negations to reach it
+            switch (qe)
+            {
+                case NegatedExpression ne:
+                    QueryExpression inner = HandleMetadataRefresh(ne.Expression);
+                    return ReferenceEquals(inner, ne.Expression) ? ne : new NegatedExpression(inner);
+
+                case BinaryExpression { Operator: OperatorType.And or OperatorType.Or } logical:
+                    QueryExpression left = HandleMetadataRefresh(logical.Left);
+                    QueryExpression right = HandleMetadataRefresh(logical.Right);
+                    if (ReferenceEquals(left, logical.Left) && ReferenceEquals(right, logical.Right))
+                        return logical;
+                    return new BinaryExpression(left, right, logical.Operator) { Parenthesis = logical.Parenthesis };
+
+                case BinaryExpression { Operator: OperatorType.Equal or OperatorType.NotEqual } be:
+                    if (IsMetadataRefreshField(be.Left) == false ||
+                        be.Right is not ValueExpression { Value: ValueTokenType.Null })
+                        return qe;
+                    MethodExpression me = new MethodExpression("exists", [be.Left]);
+                    if (be.Operator is not OperatorType.NotEqual)
+                        return new NegatedExpression(me);
+                    return me;
+
+                default:
+                    return qe;
+            }
+        }
+
+        private static bool IsMetadataRefreshField(QueryExpression qe)
+        {
+            // the field may be written with or without the from alias, so we match on the
+            // '@metadata'.'@refresh' suffix: both '@metadata'.'@refresh' and e.'@metadata'.'@refresh'
+            if (qe is not FieldExpression fe || fe.Compound.Count < 2)
+                return false;
+
+            return fe.Compound[^1] == Constants.Documents.Metadata.Refresh &&
+                   fe.Compound[^2] == Constants.Documents.Metadata.Key;
         }
 
         public override void VisitInclude(List<QueryExpression> includes)

--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -43,12 +43,12 @@ namespace Raven.Server.Documents.Queries.AST
         /// JavaScript, and 'undefined === null' is false, so the absent case has to be
         /// spelled out as an existence check. The original comparison is kept alongside it
         /// so a property that is present and explicitly null still matches. This applies to
-        /// the server owned metadata properties - the ones under '@metadata' whose name
-        /// starts with '@', such as '@refresh', '@expires', '@archive-at' and '@archived' -
-        /// since those are removed rather than set to null when they do not apply. User
-        /// defined metadata is left alone and compares exactly as written. Callers apply
-        /// this to a boolean clause (a subscription where clause or a query filter clause)
-        /// before visiting it.
+        /// properties under '@metadata' whose name starts with '@', the reserved namespace
+        /// RavenDB uses for '@refresh', '@expires', '@archive-at', '@archived' and the like,
+        /// because those are removed rather than set to null when they do not apply.
+        /// Metadata whose name does not start with '@' is left alone and compares exactly as
+        /// written. Callers apply this to a boolean clause (a subscription where clause or a
+        /// query filter clause) before visiting it.
         /// </summary>
         internal static QueryExpression HandleMetadataNullComparison(QueryExpression qe)
         {
@@ -100,7 +100,7 @@ namespace Raven.Server.Documents.Queries.AST
             if (fe.Compound[^2] != Constants.Documents.Metadata.Key)
                 return false;
 
-            // only the server owned properties, which are removed rather than nulled out
+            // only the reserved '@' prefixed names, which are removed rather than nulled out
             StringSegment property = fe.Compound[^1];
 
             return property.Length > 0 && property[0] == '@';

--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -35,16 +35,17 @@ namespace Raven.Server.Documents.Queries.AST
         }
 
         /// <summary>
-        /// Rewrites a null comparison against a metadata property into an existence check:
-        /// '@metadata'.'@refresh' = null becomes "not exists(...)" and
-        /// '@metadata'.'@refresh' != null becomes "exists(...)".
+        /// Widens a null comparison against a metadata property so that it also covers the
+        /// property being absent:
+        /// '@metadata'.'@refresh' = null becomes "not exists(...) or ... = null" and
+        /// '@metadata'.'@refresh' != null becomes "exists(...) and ... != null".
         /// A document that carries no such metadata property at all reads as undefined in
-        /// JavaScript, and 'undefined === null' is false, so the comparison has to be
-        /// expressed as an existence check instead. This applies to any property under
-        /// '@metadata' - '@refresh', '@expires', '@archive-at', '@archived' and
-        /// user defined metadata alike - since they are all absent rather than null when
-        /// unset. Callers apply this to a boolean clause (a subscription where clause or a
-        /// query filter clause) before visiting it.
+        /// JavaScript, and 'undefined === null' is false, so the absent case has to be
+        /// spelled out as an existence check. The original comparison is kept alongside it
+        /// so a property that is present and explicitly null still matches. This applies to
+        /// any property under '@metadata' - '@refresh', '@expires', '@archive-at',
+        /// '@archived' and user defined metadata alike. Callers apply this to a boolean
+        /// clause (a subscription where clause or a query filter clause) before visiting it.
         /// </summary>
         public static QueryExpression HandleMetadataNullComparison(QueryExpression qe)
         {
@@ -67,10 +68,19 @@ namespace Raven.Server.Documents.Queries.AST
                     if (IsMetadataProperty(be.Left) == false ||
                         be.Right is not ValueExpression { Value: ValueTokenType.Null })
                         return qe;
-                    MethodExpression me = new MethodExpression("exists", [be.Left]);
-                    if (be.Operator is not OperatorType.NotEqual)
-                        return new NegatedExpression(me);
-                    return me;
+
+                    // 'be' is reused as the explicit null half of the result, so the original
+                    // comparison keeps matching a property that is present and set to null
+                    MethodExpression exists = new MethodExpression("exists", [be.Left]);
+
+                    if (be.Operator is OperatorType.NotEqual)
+                    {
+                        // present, and holding something other than null
+                        return new BinaryExpression(exists, be, OperatorType.And) { Parenthesis = true };
+                    }
+
+                    // absent entirely, or present and explicitly null
+                    return new BinaryExpression(new NegatedExpression(exists), be, OperatorType.Or) { Parenthesis = true };
 
                 default:
                     return qe;

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -131,7 +131,7 @@ function __actual_func(args) {
             }
 
             stringBuilder.Append("  return ");
-            queryVisitor.VisitExpression(JavascriptCodeQueryVisitor.HandleMetadataRefresh(query.Filter));
+            queryVisitor.VisitExpression(JavascriptCodeQueryVisitor.HandleMetadataNullComparison(query.Filter));
 
             stringBuilder.Append(@";
 

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -131,7 +131,7 @@ function __actual_func(args) {
             }
 
             stringBuilder.Append("  return ");
-            queryVisitor.VisitExpression(query.Filter);
+            queryVisitor.VisitExpression(JavascriptCodeQueryVisitor.HandleMetadataRefresh(query.Filter));
 
             stringBuilder.Append(@";
 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -367,20 +367,48 @@ namespace Raven.Server.Documents.TcpHandlers
         {
             // handle '@metadata'.'@refresh' = null and '@metadata'.'@refresh' != null
             // in a special manner, turning them into exists calls for better support
-            
+
             // @refresh = null is translated to "not exists(@refresh)"
             // @refresh != null is translated to "exists(@refresh)"
-            if (qe is not BinaryExpression be)
-                return qe;
-            if (be.Operator is not OperatorType.Equal && be.Operator is not OperatorType.NotEqual)
-                return qe;
-            if (be.Left is not FieldExpression { FieldValueWithoutAlias: Constants.Documents.Metadata.Refresh } || 
-                be.Right is not ValueExpression { Value: ValueTokenType.Null })
-                return qe;
-            var me = new MethodExpression("exists", [be.Left]);
-            if (be.Operator is not OperatorType.NotEqual)
-                return new NegatedExpression(me);
-            return me;
+
+            // this is applied anywhere in the where clause, so we recurse through the
+            // logical operators and negations to reach the actual comparisons
+            switch (qe)
+            {
+                case NegatedExpression ne:
+                    QueryExpression inner = HandleRefresh(ne.Expression);
+                    return ReferenceEquals(inner, ne.Expression) ? ne : new NegatedExpression(inner);
+
+                case BinaryExpression { Operator: OperatorType.And or OperatorType.Or } logical:
+                    QueryExpression left = HandleRefresh(logical.Left);
+                    QueryExpression right = HandleRefresh(logical.Right);
+                    if (ReferenceEquals(left, logical.Left) && ReferenceEquals(right, logical.Right))
+                        return logical;
+                    return new BinaryExpression(left, right, logical.Operator) { Parenthesis = logical.Parenthesis };
+
+                case BinaryExpression { Operator: OperatorType.Equal or OperatorType.NotEqual } be:
+                    if (IsMetadataRefreshField(be.Left) == false ||
+                        be.Right is not ValueExpression { Value: ValueTokenType.Null })
+                        return qe;
+                    MethodExpression me = new MethodExpression("exists", [be.Left]);
+                    if (be.Operator is not OperatorType.NotEqual)
+                        return new NegatedExpression(me);
+                    return me;
+
+                default:
+                    return qe;
+            }
+        }
+
+        private static bool IsMetadataRefreshField(QueryExpression qe)
+        {
+            // the field may be written with or without the from alias, so we match on the
+            // '@metadata'.'@refresh' suffix: both '@metadata'.'@refresh' and e.'@metadata'.'@refresh'
+            if (qe is not FieldExpression fe || fe.Compound.Count < 2)
+                return false;
+
+            return fe.Compound[^1] == Constants.Documents.Metadata.Refresh &&
+                   fe.Compound[^2] == Constants.Documents.Metadata.Key;
         }
 
         protected override async Task OnClientAckAsync(string clientReplyChangeVector)

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Acornima;
-using Raven.Client;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions;
 using Raven.Client.Util;
@@ -311,7 +310,7 @@ namespace Raven.Server.Documents.TcpHandlers
             if (q.Where != null)
             {
                 writer.Write("if (");
-                QueryExpression modified = HandleRefresh(q.Where);
+                QueryExpression modified = JavascriptCodeQueryVisitor.HandleMetadataRefresh(q.Where);
                 new JavascriptCodeQueryVisitor(writer.GetStringBuilder(), q).VisitExpression(modified);
                 writer.WriteLine(" )");
                 writer.WriteLine("{");
@@ -361,54 +360,6 @@ namespace Raven.Server.Documents.TcpHandlers
                 Includes = includes?.ToArray(),
                 CounterIncludes = counterIncludes?.ToArray()
             };
-        }
-
-        private static QueryExpression HandleRefresh(QueryExpression qe)
-        {
-            // handle '@metadata'.'@refresh' = null and '@metadata'.'@refresh' != null
-            // in a special manner, turning them into exists calls for better support
-
-            // @refresh = null is translated to "not exists(@refresh)"
-            // @refresh != null is translated to "exists(@refresh)"
-
-            // this is applied anywhere in the where clause, so we recurse through the
-            // logical operators and negations to reach the actual comparisons
-            switch (qe)
-            {
-                case NegatedExpression ne:
-                    QueryExpression inner = HandleRefresh(ne.Expression);
-                    return ReferenceEquals(inner, ne.Expression) ? ne : new NegatedExpression(inner);
-
-                case BinaryExpression { Operator: OperatorType.And or OperatorType.Or } logical:
-                    QueryExpression left = HandleRefresh(logical.Left);
-                    QueryExpression right = HandleRefresh(logical.Right);
-                    if (ReferenceEquals(left, logical.Left) && ReferenceEquals(right, logical.Right))
-                        return logical;
-                    return new BinaryExpression(left, right, logical.Operator) { Parenthesis = logical.Parenthesis };
-
-                case BinaryExpression { Operator: OperatorType.Equal or OperatorType.NotEqual } be:
-                    if (IsMetadataRefreshField(be.Left) == false ||
-                        be.Right is not ValueExpression { Value: ValueTokenType.Null })
-                        return qe;
-                    MethodExpression me = new MethodExpression("exists", [be.Left]);
-                    if (be.Operator is not OperatorType.NotEqual)
-                        return new NegatedExpression(me);
-                    return me;
-
-                default:
-                    return qe;
-            }
-        }
-
-        private static bool IsMetadataRefreshField(QueryExpression qe)
-        {
-            // the field may be written with or without the from alias, so we match on the
-            // '@metadata'.'@refresh' suffix: both '@metadata'.'@refresh' and e.'@metadata'.'@refresh'
-            if (qe is not FieldExpression fe || fe.Compound.Count < 2)
-                return false;
-
-            return fe.Compound[^1] == Constants.Documents.Metadata.Refresh &&
-                   fe.Compound[^2] == Constants.Documents.Metadata.Key;
         }
 
         protected override async Task OnClientAckAsync(string clientReplyChangeVector)

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -310,7 +310,7 @@ namespace Raven.Server.Documents.TcpHandlers
             if (q.Where != null)
             {
                 writer.Write("if (");
-                QueryExpression modified = JavascriptCodeQueryVisitor.HandleMetadataRefresh(q.Where);
+                QueryExpression modified = JavascriptCodeQueryVisitor.HandleMetadataNullComparison(q.Where);
                 new JavascriptCodeQueryVisitor(writer.GetStringBuilder(), q).VisitExpression(modified);
                 writer.WriteLine(" )");
                 writer.WriteLine("{");

--- a/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
@@ -79,10 +79,49 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
         }
     }
 
+    // the rewrite is not '@refresh' specific - any property under '@metadata' is absent
+    // rather than null when unset, so all of them need the same treatment.
+    // none of the three documents carries '@expires', '@archived' or 'Origin'.
+
+    [RavenTheory(RavenTestCategory.Subscriptions)]
+    [RavenData("'@metadata'.'@expires'", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("'@metadata'.'@archive-at'", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("'@metadata'.'@archived'", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("'@metadata'.'Origin'", DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanHandleAnyMetadataPropertyInSubscription(Options options, string field)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var query = $"from Things as t where t.{field} = null";
+            Assert.Equal(3, await RunSubscription(store, new SubscriptionCreationOptions { Query = query }));
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData("'@metadata'.'@expires'", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("'@metadata'.'@archive-at'", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("'@metadata'.'@archived'", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("'@metadata'.'Origin'", DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanHandleAnyMetadataPropertyInFilterClause(Options options, string field)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            await CreateThings(store);
+
+            Assert.Equal(3, await RunQuery(store, $"from Things as t filter t.{field} = null"));
+            Assert.Equal(0, await RunQuery(store, $"from Things as t filter t.{field} != null"));
+        }
+    }
+
     private static async Task<int> RunFilterQuery(IDocumentStore store, string query)
     {
         await CreateThings(store);
 
+        return await RunQuery(store, query);
+    }
+
+    private static async Task<int> RunQuery(IDocumentStore store, string query)
+    {
         using (var session = store.OpenAsyncSession())
         {
             var results = await session.Advanced

--- a/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
@@ -113,6 +113,78 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
         }
     }
 
+    // a metadata property that is present but explicitly null still counts as null, so the
+    // widened comparison has to match it as well as a property that is missing altogether
+
+    [RavenTheory(RavenTestCategory.Subscriptions)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task ExplicitNullMetadataPropertyMatchesInSubscription(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+            {
+                Query = "from Things as t where t.'@metadata'.'Origin' = null"
+            });
+
+            await CreateThingsWithOrigin(store);
+
+            // the document with no 'Origin' and the one with an explicitly null 'Origin'
+            Assert.Equal(2, await RunSubscriptionWorker(store, id));
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task ExplicitNullMetadataPropertyMatchesInFilterClause(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            await CreateThingsWithOrigin(store);
+
+            await AssertOriginIsPresentAndNull(store);
+
+            Assert.Equal(2, await RunQuery(store, "from Things as t filter t.'@metadata'.'Origin' = null"));
+            Assert.Equal(1, await RunQuery(store, "from Things as t filter t.'@metadata'.'Origin' != null"));
+        }
+    }
+
+    // guards the two tests above: they only prove anything if the server really stored
+    // 'Origin' as a present-but-null property rather than dropping it
+    private static async Task AssertOriginIsPresentAndNull(IDocumentStore store)
+    {
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced
+                .AsyncRawQuery<Thing>("from Things as t where t.Name = 'explicit-null'")
+                .WaitForNonStaleResults()
+                .ToListAsync();
+
+            var metadata = session.Advanced.GetMetadataFor(Assert.Single(results));
+
+            Assert.True(metadata.ContainsKey("Origin"), "'Origin' was dropped instead of being stored as null");
+            Assert.Null(metadata["Origin"]);
+        }
+    }
+
+    private static async Task CreateThingsWithOrigin(IDocumentStore store)
+    {
+        using (var session = store.OpenAsyncSession())
+        {
+            var withOrigin = new Thing { Name = "with" };
+            await session.StoreAsync(withOrigin);
+            session.Advanced.GetMetadataFor(withOrigin)["Origin"] = "web";
+
+            var explicitNull = new Thing { Name = "explicit-null" };
+            await session.StoreAsync(explicitNull);
+            session.Advanced.GetMetadataFor(explicitNull)["Origin"] = null;
+
+            await session.StoreAsync(new Thing { Name = "missing" });
+
+            await session.SaveChangesAsync();
+        }
+    }
+
     private static async Task<int> RunFilterQuery(IDocumentStore store, string query)
     {
         await CreateThings(store);
@@ -154,6 +226,11 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
 
         await CreateThings(store);
 
+        return await RunSubscriptionWorker(store, id);
+    }
+
+    private static async Task<int> RunSubscriptionWorker(IDocumentStore store, string id)
+    {
         var worker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
         {
             CloseWhenNoDocsLeft = true

--- a/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
@@ -128,6 +128,8 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
 
             await CreateThingsWithOrigin(store);
 
+            await AssertOriginIsPresentAndNull(store);
+
             // the document with no origin and the one with an explicitly null origin
             Assert.Equal(2, await RunSubscriptionWorker(store, id));
         }

--- a/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
@@ -52,6 +52,48 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
         }
     }
 
+    // a query 'filter' clause is evaluated as JavaScript through the same visitor as a
+    // subscription where clause, so it gets the same '@refresh' handling
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData("from Things as t filter t.'@metadata'.'@refresh' = null", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("from Things filter '@metadata'.'@refresh' = null", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("from Things as t filter t.'@metadata'.'@refresh' = null and t.Name != 'none'", DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanHandleMetadataRefreshInFilterClause(Options options, string query)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            Assert.Equal(2, await RunFilterQuery(store, query));
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData("from Things as t filter t.'@metadata'.'@refresh' != null", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("from Things filter '@metadata'.'@refresh' != null", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("from Things as t filter t.Name != 'none' and not (t.'@metadata'.'@refresh' = null)", DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanHandleNOTMetadataRefreshInFilterClause(Options options, string query)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            Assert.Equal(1, await RunFilterQuery(store, query));
+        }
+    }
+
+    private static async Task<int> RunFilterQuery(IDocumentStore store, string query)
+    {
+        await CreateThings(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Advanced
+                .AsyncRawQuery<Thing>(query)
+                .WaitForNonStaleResults()
+                .ToListAsync();
+
+            return results.Count;
+        }
+    }
+
     private static async Task CreateThings(IDocumentStore store)
     {
         using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using FastTests.Client.Subscriptions;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Documents.Subscriptions;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -79,16 +80,15 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
         }
     }
 
-    // the rewrite is not '@refresh' specific - any property under '@metadata' is absent
-    // rather than null when unset, so all of them need the same treatment.
-    // none of the three documents carries '@expires', '@archived' or 'Origin'.
+    // the rewrite is not '@refresh' specific - every server owned metadata property is
+    // absent rather than null when unset, so all of them need the same treatment.
+    // none of the three documents carries '@expires', '@archive-at' or '@archived'.
 
     [RavenTheory(RavenTestCategory.Subscriptions)]
     [RavenData("'@metadata'.'@expires'", DatabaseMode = RavenDatabaseMode.All)]
     [RavenData("'@metadata'.'@archive-at'", DatabaseMode = RavenDatabaseMode.All)]
     [RavenData("'@metadata'.'@archived'", DatabaseMode = RavenDatabaseMode.All)]
-    [RavenData("'@metadata'.'Origin'", DatabaseMode = RavenDatabaseMode.All)]
-    public async Task CanHandleAnyMetadataPropertyInSubscription(Options options, string field)
+    public async Task CanHandleAnySystemMetadataPropertyInSubscription(Options options, string field)
     {
         using (var store = GetDocumentStore(options))
         {
@@ -101,8 +101,7 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
     [RavenData("'@metadata'.'@expires'", DatabaseMode = RavenDatabaseMode.All)]
     [RavenData("'@metadata'.'@archive-at'", DatabaseMode = RavenDatabaseMode.All)]
     [RavenData("'@metadata'.'@archived'", DatabaseMode = RavenDatabaseMode.All)]
-    [RavenData("'@metadata'.'Origin'", DatabaseMode = RavenDatabaseMode.All)]
-    public async Task CanHandleAnyMetadataPropertyInFilterClause(Options options, string field)
+    public async Task CanHandleAnySystemMetadataPropertyInFilterClause(Options options, string field)
     {
         using (var store = GetDocumentStore(options))
         {
@@ -124,12 +123,12 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
         {
             var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
             {
-                Query = "from Things as t where t.'@metadata'.'Origin' = null"
+                Query = $"from Things as t where t.'@metadata'.'{OriginProperty}' = null"
             });
 
             await CreateThingsWithOrigin(store);
 
-            // the document with no 'Origin' and the one with an explicitly null 'Origin'
+            // the document with no origin and the one with an explicitly null origin
             Assert.Equal(2, await RunSubscriptionWorker(store, id));
         }
     }
@@ -144,13 +143,30 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
 
             await AssertOriginIsPresentAndNull(store);
 
-            Assert.Equal(2, await RunQuery(store, "from Things as t filter t.'@metadata'.'Origin' = null"));
-            Assert.Equal(1, await RunQuery(store, "from Things as t filter t.'@metadata'.'Origin' != null"));
+            Assert.Equal(2, await RunQuery(store, $"from Things as t filter t.'@metadata'.'{OriginProperty}' = null"));
+            Assert.Equal(1, await RunQuery(store, $"from Things as t filter t.'@metadata'.'{OriginProperty}' != null"));
         }
     }
 
-    // guards the two tests above: they only prove anything if the server really stored
-    // 'Origin' as a present-but-null property rather than dropping it
+    // user defined metadata does not get the rewrite, so it compares exactly as written:
+    // only the document whose 'Origin' is explicitly null is equal to null, and the one
+    // that has no 'Origin' at all reads as undefined and is therefore not equal to null
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task UserDefinedMetadataPropertyIsLeftAlone(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            await CreateThingsWithOrigin(store, "Origin");
+
+            Assert.Equal(1, await RunQuery(store, "from Things as t filter t.'@metadata'.'Origin' = null"));
+            Assert.Equal(2, await RunQuery(store, "from Things as t filter t.'@metadata'.'Origin' != null"));
+        }
+    }
+
+    // guards the explicit null tests: they only prove anything if the server really stored
+    // the property as present-but-null rather than dropping it
     private static async Task AssertOriginIsPresentAndNull(IDocumentStore store)
     {
         using (var session = store.OpenAsyncSession())
@@ -162,22 +178,26 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
 
             var metadata = session.Advanced.GetMetadataFor(Assert.Single(results));
 
-            Assert.True(metadata.ContainsKey("Origin"), "'Origin' was dropped instead of being stored as null");
-            Assert.Null(metadata["Origin"]);
+            Assert.True(metadata.ContainsKey(OriginProperty), $"'{OriginProperty}' was dropped instead of being stored as null");
+            Assert.Null(metadata[OriginProperty]);
         }
     }
 
-    private static async Task CreateThingsWithOrigin(IDocumentStore store)
+    // an '@' prefixed name the server does not manage itself, so it is subject to the
+    // rewrite while still being ours to set to whatever the test needs
+    private const string OriginProperty = "@origin";
+
+    private static async Task CreateThingsWithOrigin(IDocumentStore store, string property = OriginProperty)
     {
         using (var session = store.OpenAsyncSession())
         {
             var withOrigin = new Thing { Name = "with" };
             await session.StoreAsync(withOrigin);
-            session.Advanced.GetMetadataFor(withOrigin)["Origin"] = "web";
+            session.Advanced.GetMetadataFor(withOrigin)[property] = "web";
 
             var explicitNull = new Thing { Name = "explicit-null" };
             await session.StoreAsync(explicitNull);
-            session.Advanced.GetMetadataFor(explicitNull)["Origin"] = null;
+            session.Advanced.GetMetadataFor(explicitNull)[property] = null;
 
             await session.StoreAsync(new Thing { Name = "missing" });
 
@@ -231,19 +251,26 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
 
     private static async Task<int> RunSubscriptionWorker(IDocumentStore store, string id)
     {
-        var worker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
+        await using (var worker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
         {
             CloseWhenNoDocsLeft = true
-        });
-
-        var items = 0;
-        var t = worker.Run(batch =>
+        }))
         {
-            items += batch.Items.Count;
-        });
+            var items = 0;
+            var run = worker.Run(batch =>
+            {
+                items += batch.Items.Count;
+            });
 
-        var done = await Task.WhenAny(t, Task.Delay(TimeSpan.FromSeconds(30)));
-        Assert.Same(t, done);
-        return items;
+            var done = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(30)));
+            Assert.Same(run, done);
+
+            // CloseWhenNoDocsLeft closes the worker once it has drained, which surfaces as
+            // SubscriptionClosedException. Awaiting it makes any other failure fail the test
+            // instead of being swallowed as an unobserved exception.
+            await Assert.ThrowsAsync<SubscriptionClosedException>(async () => await run);
+
+            return items;
+        }
     }
 }

--- a/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
@@ -150,6 +150,32 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
         }
     }
 
+    // intersect(...) combines boolean statements too, so a comparison can sit inside it
+
+    [RavenTheory(RavenTestCategory.Subscriptions)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanHandleMetadataRefreshInsideIntersect(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var query = "from Things as t where intersect(t.'@metadata'.'@refresh' = null, t.Name != 'none')";
+            Assert.Equal(2, await RunSubscription(store, new SubscriptionCreationOptions { Query = query }));
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanHandleMetadataRefreshInsideIntersectInFilterClause(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            await CreateThings(store);
+
+            Assert.Equal(2, await RunQuery(store, "from Things as t filter intersect(t.'@metadata'.'@refresh' = null, t.Name != 'none')"));
+            Assert.Equal(1, await RunQuery(store, "from Things as t filter intersect(t.'@metadata'.'@refresh' != null, t.Name != 'none')"));
+        }
+    }
+
     // user defined metadata does not get the rewrite, so it compares exactly as written:
     // only the document whose 'Origin' is explicitly null is equal to null, and the one
     // that has no 'Origin' at all reads as undefined and is therefore not equal to null

--- a/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
@@ -13,13 +13,13 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
     // out of the three documents that are created, exactly one has an '@refresh' metadata entry
 
     [RavenTheory(RavenTestCategory.Subscriptions)]
-    [InlineData("from Things as t where t.'@metadata'.'@refresh' = null")]
-    [InlineData("from Things as t where t.'@metadata'.'@refresh' == null")]
-    [InlineData("from Things where '@metadata'.'@refresh' = null and Name != 'none'")]
-    [InlineData("from Things as t where t.'@metadata'.'@refresh' = null and t.Name != 'none'")]
-    public async Task CanHandleMetadataRefreshWithAliasOrCompoundWhere(string query)
+    [RavenData("from Things as t where t.'@metadata'.'@refresh' = null", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("from Things as t where t.'@metadata'.'@refresh' == null", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("from Things where '@metadata'.'@refresh' = null and Name != 'none'", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("from Things as t where t.'@metadata'.'@refresh' = null and t.Name != 'none'", DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanHandleMetadataRefreshWithAliasOrCompoundWhere(Options options, string query)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             int items = await RunSubscription(store, new SubscriptionCreationOptions { Query = query });
             Assert.Equal(2, items);
@@ -27,22 +27,23 @@ public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(outp
     }
 
     [RavenTheory(RavenTestCategory.Subscriptions)]
-    [InlineData("from Things as t where t.'@metadata'.'@refresh' != null")]
-    [InlineData("from Things where '@metadata'.'@refresh' != null and Name != 'none'")]
-    [InlineData("from Things as t where t.'@metadata'.'@refresh' != null and t.Name != 'none'")]
-    public async Task CanHandleNOTMetadataRefreshWithAliasOrCompoundWhere(string query)
+    [RavenData("from Things as t where t.'@metadata'.'@refresh' != null", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("from Things where '@metadata'.'@refresh' != null and Name != 'none'", DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData("from Things as t where t.'@metadata'.'@refresh' != null and t.Name != 'none'", DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanHandleNOTMetadataRefreshWithAliasOrCompoundWhere(Options options, string query)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             int items = await RunSubscription(store, new SubscriptionCreationOptions { Query = query });
             Assert.Equal(1, items);
         }
     }
 
-    [RavenFact(RavenTestCategory.Subscriptions)]
-    public async Task CanHandleNegatedMetadataRefresh()
+    [RavenTheory(RavenTestCategory.Subscriptions)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanHandleNegatedMetadataRefresh(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             // "not (@refresh = null)" is the same as "@refresh != null"
             var query = "from Things as t where t.Name != 'none' and not (t.'@metadata'.'@refresh' = null)";

--- a/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-27174.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading.Tasks;
+using FastTests.Client.Subscriptions;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Subscriptions;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Client.Subscriptions;
+
+public class RavenDB_27174(ITestOutputHelper output) : SubscriptionTestBase(output)
+{
+    // out of the three documents that are created, exactly one has an '@refresh' metadata entry
+
+    [RavenTheory(RavenTestCategory.Subscriptions)]
+    [InlineData("from Things as t where t.'@metadata'.'@refresh' = null")]
+    [InlineData("from Things as t where t.'@metadata'.'@refresh' == null")]
+    [InlineData("from Things where '@metadata'.'@refresh' = null and Name != 'none'")]
+    [InlineData("from Things as t where t.'@metadata'.'@refresh' = null and t.Name != 'none'")]
+    public async Task CanHandleMetadataRefreshWithAliasOrCompoundWhere(string query)
+    {
+        using (var store = GetDocumentStore())
+        {
+            int items = await RunSubscription(store, new SubscriptionCreationOptions { Query = query });
+            Assert.Equal(2, items);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Subscriptions)]
+    [InlineData("from Things as t where t.'@metadata'.'@refresh' != null")]
+    [InlineData("from Things where '@metadata'.'@refresh' != null and Name != 'none'")]
+    [InlineData("from Things as t where t.'@metadata'.'@refresh' != null and t.Name != 'none'")]
+    public async Task CanHandleNOTMetadataRefreshWithAliasOrCompoundWhere(string query)
+    {
+        using (var store = GetDocumentStore())
+        {
+            int items = await RunSubscription(store, new SubscriptionCreationOptions { Query = query });
+            Assert.Equal(1, items);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task CanHandleNegatedMetadataRefresh()
+    {
+        using (var store = GetDocumentStore())
+        {
+            // "not (@refresh = null)" is the same as "@refresh != null"
+            var query = "from Things as t where t.Name != 'none' and not (t.'@metadata'.'@refresh' = null)";
+            int items = await RunSubscription(store, new SubscriptionCreationOptions { Query = query });
+            Assert.Equal(1, items);
+        }
+    }
+
+    private static async Task CreateThings(IDocumentStore store)
+    {
+        using (var session = store.OpenAsyncSession())
+        {
+            var future = new Thing { Name = "future" };
+            await session.StoreAsync(future);
+            session.Advanced.GetMetadataFor(future)["@refresh"] = DateTime.Today.AddDays(5).ToString("O");
+
+            await session.StoreAsync(new Thing { Name = "first" });
+            await session.StoreAsync(new Thing { Name = "second" });
+
+            await session.SaveChangesAsync();
+        }
+    }
+
+    private static async Task<int> RunSubscription(IDocumentStore store, SubscriptionCreationOptions subscriptionCreationParams)
+    {
+        string id = await store.Subscriptions.CreateAsync(subscriptionCreationParams);
+
+        await CreateThings(store);
+
+        var worker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
+        {
+            CloseWhenNoDocsLeft = true
+        });
+
+        var items = 0;
+        var t = worker.Run(batch =>
+        {
+            items += batch.Items.Count;
+        });
+
+        var done = await Task.WhenAny(t, Task.Delay(TimeSpan.FromSeconds(30)));
+        Assert.Same(t, done);
+        return items;
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27174

### Additional description

Subscriptions: '@metadata'.'@refresh' == null is not handled when the query uses an alias or a compound where clause

Also handling `@expires`, `@archived`, etc...

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
