### PR TITLE
RavenDB-27175 Subscriptions - make it easier to inspect the current state

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -43,6 +43,7 @@ namespace Raven.Client.Documents.Subscriptions
         internal TcpClient _tcpClient;
         protected bool _disposed;
         protected Task _subscriptionTask;
+        private CancellationToken _externalToken;
         protected Stream _stream;
         protected int _forcedTopologyUpdateAttempts = 0;
 
@@ -64,7 +65,9 @@ namespace Raven.Client.Documents.Subscriptions
 
         public event Action<Exception> OnUnexpectedSubscriptionError;
 
-        private SubscriptionWorkerStatus _status = new SubscriptionWorkerStatus(SubscriptionWorkerState.NotStarted, exception: null, DateTime.UtcNow);
+        private SubscriptionWorkerStatus _status = new SubscriptionWorkerStatus(SubscriptionWorkerState.NotStarted, exception: null, DateTime.UtcNow, failingSinceUtc: null);
+
+        private DateTime? _failingSinceUtc;
 
         /// <summary>
         /// What the worker is doing right now - connecting, waiting for the server to send documents, processing a
@@ -81,17 +84,32 @@ namespace Raven.Client.Documents.Subscriptions
         /// </summary>
         public event Action<AbstractSubscriptionWorker<TBatch, TType>, SubscriptionWorkerStatus> OnStateChanged;
 
-        /// <remarks>
-        /// Called only from the task running the subscription, so the read of the current status below does not
-        /// need to be synchronized with another writer.
-        /// </remarks>
+        // Called only from the task running the subscription, no synchronization needed
         private void SetState(SubscriptionWorkerState state, Exception exception = null)
         {
-            SubscriptionWorkerStatus current = _status;
-            if (current.State == state && ReferenceEquals(current.Exception, exception))
-                return; // same state, keep SinceUtc pointing at when we actually entered it
+            DateTime now = DateTime.UtcNow;
 
-            SubscriptionWorkerStatus status = new SubscriptionWorkerStatus(state, exception, DateTime.UtcNow);
+            switch (state)
+            {
+                case SubscriptionWorkerState.WaitingForDocuments:
+                case SubscriptionWorkerState.Processing:
+                    _failingSinceUtc = null; // we are talking to the server, whatever went wrong before is over
+                    break;
+
+                case SubscriptionWorkerState.Retrying:
+                case SubscriptionWorkerState.Faulted:
+                    _failingSinceUtc ??= now; // keep the first time we failed, so that the user can see how long we've been failing
+                    break;
+
+                case SubscriptionWorkerState.Connecting:
+                    break; // intentionally skipped, a step of every retry as well as of a healthy start, so it carries the streak over
+            }
+
+            SubscriptionWorkerStatus current = _status;
+            if (current.State == state && ReferenceEquals(current.Exception, exception) && current.FailingSinceUtc == _failingSinceUtc)
+                return; // same state, no need to change anything
+
+            SubscriptionWorkerStatus status = new SubscriptionWorkerStatus(state, exception, now, _failingSinceUtc);
             Volatile.Write(ref _status, status);
 
             Action<AbstractSubscriptionWorker<TBatch, TType>, SubscriptionWorkerStatus> onStateChanged = OnStateChanged;
@@ -203,6 +221,8 @@ namespace Raven.Client.Documents.Subscriptions
         {
             if (_subscriptionTask != null)
                 throw new InvalidOperationException("The subscription is already running");
+
+            _externalToken = ct;
 
             if (ct != default)
             {
@@ -864,7 +884,10 @@ namespace Raven.Client.Documents.Subscriptions
             }
             catch (Exception e)
             {
-                SetState(SubscriptionWorkerState.Faulted, e);
+                // caller asked us to stop, the failure isn't a problem
+                if (_disposed == false && _externalToken.IsCancellationRequested == false)
+                    SetState(SubscriptionWorkerState.Faulted, e);
+
                 throw;
             }
             finally

--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -53,7 +53,12 @@ namespace Raven.Client.Documents.Subscriptions
         /// </summary>
         public event AfterAcknowledgmentAction AfterAcknowledgment;
 
-        internal event Action OnEstablishedSubscriptionConnection;
+        /// <summary>
+        /// Raised whenever the worker has successfully connected to the server, both for the initial connection
+        /// and for every reconnection. Pair it with <see cref="OnSubscriptionConnectionRetry"/> to track whether
+        /// the worker is currently connected, instead of waiting for the next batch to arrive.
+        /// </summary>
+        public event Action OnEstablishedSubscriptionConnection;
 
         public event Action<Exception> OnSubscriptionConnectionRetry;
 

--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -64,6 +64,53 @@ namespace Raven.Client.Documents.Subscriptions
 
         public event Action<Exception> OnUnexpectedSubscriptionError;
 
+        private SubscriptionWorkerStatus _status = new SubscriptionWorkerStatus(SubscriptionWorkerState.NotStarted, exception: null, DateTime.UtcNow);
+
+        /// <summary>
+        /// What the worker is doing right now - connecting, waiting for the server to send documents, processing a
+        /// batch, retrying after a failure, or stopped. The returned snapshot is immutable, so the state and the
+        /// exception that produced it always belong together.
+        /// </summary>
+        public SubscriptionWorkerStatus Status => Volatile.Read(ref _status);
+
+        /// <summary>
+        /// Raised on every change to <see cref="Status"/>, for callers that would rather be told than poll. The
+        /// worker that changed state is passed along with the snapshot that was just installed, so that a single
+        /// handler can serve several workers. Exceptions thrown by a handler are logged and swallowed, so that
+        /// watching the worker cannot break it.
+        /// </summary>
+        public event Action<AbstractSubscriptionWorker<TBatch, TType>, SubscriptionWorkerStatus> OnStateChanged;
+
+        /// <remarks>
+        /// Called only from the task running the subscription, so the read of the current status below does not
+        /// need to be synchronized with another writer.
+        /// </remarks>
+        private void SetState(SubscriptionWorkerState state, Exception exception = null)
+        {
+            SubscriptionWorkerStatus current = _status;
+            if (current.State == state && ReferenceEquals(current.Exception, exception))
+                return; // same state, keep SinceUtc pointing at when we actually entered it
+
+            SubscriptionWorkerStatus status = new SubscriptionWorkerStatus(state, exception, DateTime.UtcNow);
+            Volatile.Write(ref _status, status);
+
+            Action<AbstractSubscriptionWorker<TBatch, TType>, SubscriptionWorkerStatus> onStateChanged = OnStateChanged;
+            if (onStateChanged == null)
+                return;
+
+            try
+            {
+                onStateChanged(this, status);
+            }
+            catch (Exception e)
+            {
+                // a failing handler must not take the subscription down with it, and must not replace the
+                // exception we are in the middle of reporting
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Subscription '{_options.SubscriptionName}'. {nameof(OnStateChanged)} handler threw while reporting '{status}'.", e);
+            }
+        }
+
         internal AbstractSubscriptionWorker(SubscriptionWorkerOptions options, string dbName, IRavenLogger logger)
         {
             if (string.IsNullOrEmpty(options.SubscriptionName))
@@ -125,6 +172,13 @@ namespace Raven.Client.Documents.Subscriptions
             }
             finally
             {
+                if (_subscriptionTask == null)
+                {
+                    // a worker that was never run has no task to report Stopped for itself, and cannot be racing
+                    // with one either
+                    SetState(SubscriptionWorkerState.Stopped);
+                }
+
                 OnDisposed(this);
             }
         }
@@ -507,6 +561,9 @@ namespace Raven.Client.Documents.Subscriptions
                     if (_processingCts.IsCancellationRequested)
                         return;
 
+                    // set before raising the event, so that a handler reading Status sees that we are connected
+                    SetState(SubscriptionWorkerState.WaitingForDocuments);
+
                     OnEstablishedSubscriptionConnection?.Invoke();
 
                     await ProcessSubscriptionInternalAsync(contextPool, tcpStreamCopy, buffer, context).ConfigureAwait(false);
@@ -533,6 +590,8 @@ namespace Raven.Client.Documents.Subscriptions
                 while (_processingCts.IsCancellationRequested == false)
                 {
                     var incomingBatch = await PrepareBatchAsync(contextPool, tcpStreamCopy, buffer, batch, notifiedSubscriber).ConfigureAwait(false);
+
+                    SetState(SubscriptionWorkerState.Processing);
 
                     notifiedSubscriber = Task.Run(async () => // the 2'nd thread
                     {
@@ -612,6 +671,13 @@ namespace Raven.Client.Documents.Subscriptions
 
                 throw;
             }
+
+            // The read above was started before the subscriber ran, on purpose, so we stay Processing for as long as it
+            // is in flight. Now that the subscriber is done, the server is the only thing left to wait for - unless its
+            // batch already arrived while we were processing, in which case we go straight on to processing that one and
+            // never waited at all.
+            if (readFromServer.IsCompleted == false)
+                SetState(SubscriptionWorkerState.WaitingForDocuments);
 
             BatchFromServer incomingBatch = await readFromServer.ConfigureAwait(false); // wait for batch reading to end
 
@@ -792,6 +858,26 @@ namespace Raven.Client.Documents.Subscriptions
 
         internal async Task RunSubscriptionAsync()
         {
+            try
+            {
+                await RunSubscriptionInternalAsync().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                SetState(SubscriptionWorkerState.Faulted, e);
+                throw;
+            }
+            finally
+            {
+                // reached on the paths that end the worker without surfacing an error - cancellation and disposal -
+                // while a worker that gave up on a failure keeps reporting it
+                if (Status.State != SubscriptionWorkerState.Faulted)
+                    SetState(SubscriptionWorkerState.Stopped);
+            }
+        }
+
+        private async Task RunSubscriptionInternalAsync()
+        {
             while (_processingCts.IsCancellationRequested == false)
             {
                 try
@@ -800,6 +886,7 @@ namespace Raven.Client.Documents.Subscriptions
                         throw new InvalidOperationException("SimulateUnexpectedException");
 
                     CloseTcpClient();
+                    SetState(SubscriptionWorkerState.Connecting);
                     if (_logger.IsInfoEnabled)
                     {
                         _logger.Info($"Subscription '{_options.SubscriptionName}'. Connecting to server...");
@@ -831,6 +918,9 @@ namespace Raven.Client.Documents.Subscriptions
                         (bool shouldTryToReconnect, _redirectNode) = CheckIfShouldReconnectWorker(ex, AssertLastConnectionFailure, OnUnexpectedSubscriptionError);
                         if (shouldTryToReconnect)
                         {
+                            // set before waiting, so that the state is accurate for the whole of the retry delay
+                            SetState(SubscriptionWorkerState.Retrying, ex);
+
                             await TimeoutManager.WaitFor(GetTimeToWaitBeforeConnectionRetry(), _processingCts.Token).ConfigureAwait(false);
 
                             if (_redirectNode == null)

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerState.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerState.cs
@@ -1,0 +1,50 @@
+namespace Raven.Client.Documents.Subscriptions;
+
+/// <summary>
+/// The stage a subscription worker is currently in. Read it through
+/// <see cref="AbstractSubscriptionWorker{TBatch,TType}.Status"/>.
+/// </summary>
+public enum SubscriptionWorkerState
+{
+    /// <summary>
+    /// The worker was created but none of the Run overloads was called yet, so it is not doing anything.
+    /// </summary>
+    NotStarted,
+
+    /// <summary>
+    /// Opening a connection to the server, which includes resolving the node that owns the subscription and
+    /// the TCP handshake. This is also the state while reconnecting after a failure.
+    /// </summary>
+    Connecting,
+
+    /// <summary>
+    /// Connected to the server and waiting for it to send the next batch. The worker is healthy and idle -
+    /// there is nothing for it to process right now.
+    /// </summary>
+    WaitingForDocuments,
+
+    /// <summary>
+    /// A batch was received and handed to the subscriber callback. The state stays here until the callback
+    /// returned and the batch was acknowledged to the server.
+    /// </summary>
+    Processing,
+
+    /// <summary>
+    /// The connection failed and the worker is going to reconnect.
+    /// <see cref="SubscriptionWorkerStatus.Exception"/> holds the failure that caused it.
+    /// </summary>
+    Retrying,
+
+    /// <summary>
+    /// The worker gave up - the failure it hit cannot be recovered from by reconnecting, so it stopped and the
+    /// task returned from Run completed with that failure. <see cref="SubscriptionWorkerStatus.Exception"/>
+    /// holds it. This state is terminal.
+    /// </summary>
+    Faulted,
+
+    /// <summary>
+    /// The worker stopped on request - it was disposed, or the cancellation token passed to Run was cancelled.
+    /// This state is terminal.
+    /// </summary>
+    Stopped
+}

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerStatus.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerStatus.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Raven.Client.Documents.Subscriptions;
+
+/// <summary>
+/// An immutable snapshot of what a subscription worker was doing at a single point in time. Taking a snapshot
+/// keeps the state and the failure that produced it consistent with each other, which reading two separate
+/// properties would not.
+/// </summary>
+public sealed class SubscriptionWorkerStatus
+{
+    /// <summary>
+    /// The stage the worker was in.
+    /// </summary>
+    public SubscriptionWorkerState State { get; }
+
+    /// <summary>
+    /// The failure that led to the current state. Set for <see cref="SubscriptionWorkerState.Retrying"/> and
+    /// <see cref="SubscriptionWorkerState.Faulted"/>, <c>null</c> otherwise.
+    /// </summary>
+    public Exception Exception { get; }
+
+    /// <summary>
+    /// When the worker entered this state. Repeatedly reaching the same state does not move it, so a worker that
+    /// keeps alternating between processing batches will report the time its current batch started, and one that
+    /// cannot get past connecting will report how long it has been stuck.
+    /// </summary>
+    public DateTime SinceUtc { get; }
+
+    internal SubscriptionWorkerStatus(SubscriptionWorkerState state, Exception exception, DateTime sinceUtc)
+    {
+        State = state;
+        Exception = exception;
+        SinceUtc = sinceUtc;
+    }
+
+    public override string ToString()
+    {
+        if (Exception == null)
+            return $"{State} since {SinceUtc:O}";
+
+        return $"{State} since {SinceUtc:O} because of {Exception.GetType().Name}: {Exception.Message}";
+    }
+}

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerStatus.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionWorkerStatus.cs
@@ -16,29 +16,47 @@ public sealed class SubscriptionWorkerStatus
 
     /// <summary>
     /// The failure that led to the current state. Set for <see cref="SubscriptionWorkerState.Retrying"/> and
-    /// <see cref="SubscriptionWorkerState.Faulted"/>, <c>null</c> otherwise.
+    /// <see cref="SubscriptionWorkerState.Faulted"/>, <c>null</c> otherwise. On a worker that keeps failing this
+    /// is the most recent failure, which is not necessarily the one that started the trouble - see
+    /// <see cref="FailingSinceUtc"/>.
     /// </summary>
     public Exception Exception { get; }
 
     /// <summary>
-    /// When the worker entered this state. Repeatedly reaching the same state does not move it, so a worker that
-    /// keeps alternating between processing batches will report the time its current batch started, and one that
-    /// cannot get past connecting will report how long it has been stuck.
+    /// When the worker entered this state, and nothing more than that. Reaching the same state again does not
+    /// move it, so a worker that keeps processing batches reports the time its current batch started. A worker
+    /// that cannot reach the server, however, alternates between <see cref="SubscriptionWorkerState.Connecting"/>
+    /// and <see cref="SubscriptionWorkerState.Retrying"/>, so this moves on every attempt. Use
+    /// <see cref="FailingSinceUtc"/> to tell how long it has been in trouble.
     /// </summary>
     public DateTime SinceUtc { get; }
 
-    internal SubscriptionWorkerStatus(SubscriptionWorkerState state, Exception exception, DateTime sinceUtc)
+    /// <summary>
+    /// When the worker last stopped being able to talk to the server, or <c>null</c> while it is connected.
+    /// Unlike <see cref="SinceUtc"/> this survives the whole reconnect cycle, so it answers "how long has this
+    /// worker been broken?" for a worker that is retrying in a loop. It is cleared as soon as the worker is
+    /// connected again, which makes a non-<c>null</c> value the thing to alert on.
+    /// </summary>
+    public DateTime? FailingSinceUtc { get; }
+
+    internal SubscriptionWorkerStatus(SubscriptionWorkerState state, Exception exception, DateTime sinceUtc, DateTime? failingSinceUtc)
     {
         State = state;
         Exception = exception;
         SinceUtc = sinceUtc;
+        FailingSinceUtc = failingSinceUtc;
     }
 
     public override string ToString()
     {
-        if (Exception == null)
-            return $"{State} since {SinceUtc:O}";
+        string text = $"{State} since {SinceUtc:O}";
 
-        return $"{State} since {SinceUtc:O} because of {Exception.GetType().Name}: {Exception.Message}";
+        if (FailingSinceUtc != null)
+            text += $", failing since {FailingSinceUtc:O}";
+
+        if (Exception != null)
+            text += $" because of {Exception.GetType().Name}: {Exception.Message}";
+
+        return text;
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForGetSubscription.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForGetSubscription.cs
@@ -69,7 +69,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Subscriptions
             if (subscriptionList == null)
                 return new DynamicJsonArray();
 
-            return new DynamicJsonArray(subscriptionList.Select(w => ShardedSubscriptionWorkerInfo.Create(w.Key, w.Value).ToJson()));
+            return new DynamicJsonArray(subscriptionList.Select(w => ShardedSubscriptionWorkerInfo.Create(w.Key, w.Value, disposeTimeUtc: null).ToJson()));
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Subscriptions.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Subscriptions.cs
@@ -174,7 +174,9 @@ public partial class ShardedDatabaseContext
             {
             }
 
-            public static ShardedSubscriptionWorkerInfo Create(string shard, ShardedSubscriptionWorker w)
+            // disposeTimeUtc is when the worker was disposed, or null for a worker that is still running. It has no
+            // default on purpose: filling it in for a live worker reports a dispose that never happened.
+            public static ShardedSubscriptionWorkerInfo Create(string shard, ShardedSubscriptionWorker w, DateTime? disposeTimeUtc)
             {
                 string address = null;
                 try
@@ -193,7 +195,7 @@ public partial class ShardedDatabaseContext
                 return new ShardedSubscriptionWorkerInfo()
                 {
                     Shard = shard,
-                    DisposeTimeUtc = DateTime.UtcNow,
+                    DisposeTimeUtc = disposeTimeUtc,
                     Exception = w.SubscriptionTask.Exception?.ToString(),
                     IsCanceled = w.SubscriptionTask.IsCanceled,
                     IsFaulted = w.SubscriptionTask.IsFaulted,

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
@@ -229,6 +229,6 @@ public sealed class SubscriptionConnectionsStateOrchestrator : AbstractSubscript
         if (_recentShardedWorkers.Count > 10)
             _recentShardedWorkers.TryDequeue(out _);
 
-        _recentShardedWorkers.Enqueue(ShardedSubscriptionWorkerInfo.Create(w.Key, w.Value));
+        _recentShardedWorkers.Enqueue(ShardedSubscriptionWorkerInfo.Create(w.Key, w.Value, disposeTimeUtc: DateTime.UtcNow));
     }
 }

--- a/test/SlowTests/Issues/RavenDB_27175.cs
+++ b/test/SlowTests/Issues/RavenDB_27175.cs
@@ -252,6 +252,111 @@ public class RavenDB_27175(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task StatusIsStoppedWhenTheCancellationTokenPassedToRunIsCancelled()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var name = await store.Subscriptions.CreateAsync<Company>();
+
+            using (var worker = store.Subscriptions.GetSubscriptionWorker<Company>(name))
+            using (var connected = new ManualResetEventSlim())
+            using (var cts = new CancellationTokenSource())
+            {
+                worker.OnEstablishedSubscriptionConnection += () => connected.Set();
+
+                var run = worker.Run(_ => { }, cts.Token);
+
+                Assert.True(connected.Wait(_reasonableWaitTime), "initial connection wasn't established");
+
+                // let the worker park inside the idle read - a cancellation that lands in the narrow startup
+                // window before the first read is observed at a loop-condition check instead, which exits
+                // cleanly and would hide the behavior this test pins down
+                await Task.Delay(2000);
+
+                cts.Cancel();
+
+                // the status is final by the time the task completes - SetState runs before the task
+                // transitions to its terminal state
+                Assert.True(await Task.WhenAny(run, Task.Delay(_reasonableWaitTime)) == run,
+                    "the Run task didn't complete after the token was cancelled");
+
+                // SubscriptionWorkerState.Stopped is documented as: "The worker stopped on request - it was
+                // disposed, or the cancellation token passed to Run was cancelled."
+                Assert.Equal(SubscriptionWorkerState.Stopped, worker.Status.State);
+                Assert.Null(worker.Status.Exception);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task FailingSinceUtcSurvivesTheRetryCycleAndIsClearedOnRecovery()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var name = await store.Subscriptions.CreateAsync<Company>();
+
+            using (var worker = store.Subscriptions.GetSubscriptionWorker<Company>(new SubscriptionWorkerOptions(name)
+                   {
+                       // short enough to get through several attempts quickly, long enough that the clock tells
+                       // the timestamps of two consecutive attempts apart
+                       TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(100)
+                   }))
+            using (var cts = new CancellationTokenSource(_reasonableWaitTime))
+            {
+                var changes = new BlockingCollection<SubscriptionWorkerStatus>();
+
+                worker.OnStateChanged += (_, status) => changes.Add(status);
+
+                SubscriptionWorkerStatus NextStatus(SubscriptionWorkerState state)
+                {
+                    while (true)
+                    {
+                        var status = changes.Take(cts.Token);
+                        if (status.State == state)
+                            return status;
+                    }
+                }
+
+                // no documents are ever stored here, so the state is the only indication of what the worker is doing
+                _ = worker.Run(_ => { });
+
+                // a healthy worker is not failing
+                Assert.Null(NextStatus(SubscriptionWorkerState.WaitingForDocuments).FailingSinceUtc);
+
+                // an exception the worker keeps reconnecting from, so that it stays broken instead of recovering
+                // on its own the way a dropped connection would
+                worker.ForTestingPurposesOnly().SimulateUnexpectedException = true;
+
+                await DropConnectionAsync(store, name);
+
+                var first = NextStatus(SubscriptionWorkerState.Retrying);
+
+                Assert.NotNull(first.FailingSinceUtc);
+
+                // every further attempt is a state change of its own, so SinceUtc moves - but they are all the
+                // same stretch of being broken, which is what FailingSinceUtc has to keep pointing at
+                var later = first;
+                while (later.SinceUtc == first.SinceUtc)
+                    later = NextStatus(SubscriptionWorkerState.Retrying);
+
+                Assert.True(later.SinceUtc > first.SinceUtc, $"'{later}' should have been entered after '{first}'");
+                Assert.Equal(first.FailingSinceUtc, later.FailingSinceUtc);
+
+                // let it through
+                worker.ForTestingPurposesOnly().SimulateUnexpectedException = false;
+
+                // Connecting is a step of every retry as well as the first thing a healthy worker does, so it
+                // neither starts nor ends the stretch - it carries it over
+                Assert.Equal(first.FailingSinceUtc, NextStatus(SubscriptionWorkerState.Connecting).FailingSinceUtc);
+
+                // and reaching the server clears it
+                Assert.Null(NextStatus(SubscriptionWorkerState.WaitingForDocuments).FailingSinceUtc);
+                Assert.Null(worker.Status.FailingSinceUtc);
+            }
+        }
+    }
+
     private async Task DropConnectionAsync(Raven.Client.Documents.IDocumentStore store, string subscriptionName)
     {
         var db = await Databases.GetDocumentDatabaseInstanceFor(store, store.Database);

--- a/test/SlowTests/Issues/RavenDB_27175.cs
+++ b/test/SlowTests/Issues/RavenDB_27175.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using ITestOutputHelper = Xunit.ITestOutputHelper;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27175(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private readonly TimeSpan _reasonableWaitTime = TimeSpan.FromSeconds(60);
+
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public void OnEstablishedSubscriptionConnectionIsPartOfThePublicApi()
+    {
+        // tests can see Raven.Client internals, so the accessibility has to be asserted explicitly
+        var @event = typeof(SubscriptionWorker<Company>).GetEvent(nameof(SubscriptionWorker<Company>.OnEstablishedSubscriptionConnection));
+
+        Assert.NotNull(@event);
+        Assert.True(@event.AddMethod.IsPublic);
+        Assert.True(@event.RemoveMethod.IsPublic);
+    }
+
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task CanBeNotifiedOnReconnectionOfAnIdleSubscription()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var name = await store.Subscriptions.CreateAsync<Company>();
+
+            using (var worker = store.Subscriptions.GetSubscriptionWorker<Company>(new SubscriptionWorkerOptions(name)
+                   {
+                       TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(16)
+                   }))
+            using (var firstConnection = new ManualResetEventSlim())
+            using (var reconnection = new ManualResetEventSlim())
+            using (var retry = new ManualResetEventSlim())
+            {
+                var connections = 0;
+
+                worker.OnEstablishedSubscriptionConnection += () =>
+                {
+                    if (Interlocked.Increment(ref connections) == 1)
+                        firstConnection.Set();
+                    else
+                        reconnection.Set();
+                };
+
+                worker.OnSubscriptionConnectionRetry += _ => retry.Set();
+
+                // no documents are ever stored here, so the events are the only indication that we are connected
+                _ = worker.Run(_ => { });
+
+                Assert.True(firstConnection.Wait(_reasonableWaitTime), "initial connection wasn't established");
+
+                await DropConnectionAsync(store, name);
+
+                Assert.True(retry.Wait(_reasonableWaitTime), "OnSubscriptionConnectionRetry wasn't raised");
+                Assert.True(reconnection.Wait(_reasonableWaitTime), "OnEstablishedSubscriptionConnection wasn't raised on reconnection");
+            }
+        }
+    }
+
+    private async Task DropConnectionAsync(Raven.Client.Documents.IDocumentStore store, string subscriptionName)
+    {
+        var db = await Databases.GetDocumentDatabaseInstanceFor(store, store.Database);
+        using (db.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+        using (ctx.OpenReadTransaction())
+        {
+            var connectionsState = db.SubscriptionStorage.GetSubscriptionConnectionsState(ctx, subscriptionName);
+            Assert.NotNull(connectionsState);
+            Assert.NotEmpty(connectionsState.GetConnections().ToList());
+
+            connectionsState.DropSubscription(new SubscriptionClosedException($"Simulating a broken connection for '{subscriptionName}'", canReconnect: true));
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_27175.cs
+++ b/test/SlowTests/Issues/RavenDB_27175.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,6 +66,189 @@ public class RavenDB_27175(ITestOutputHelper output) : RavenTestBase(output)
                 Assert.True(retry.Wait(_reasonableWaitTime), "OnSubscriptionConnectionRetry wasn't raised");
                 Assert.True(reconnection.Wait(_reasonableWaitTime), "OnEstablishedSubscriptionConnection wasn't raised on reconnection");
             }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public void WorkerStatusIsPartOfThePublicApi()
+    {
+        // tests can see Raven.Client internals, so the accessibility has to be asserted explicitly
+        var status = typeof(SubscriptionWorker<Company>).GetProperty(nameof(SubscriptionWorker<Company>.Status));
+
+        Assert.NotNull(status);
+        Assert.True(status.GetMethod.IsPublic);
+
+        var stateChanged = typeof(SubscriptionWorker<Company>).GetEvent(nameof(SubscriptionWorker<Company>.OnStateChanged));
+
+        Assert.NotNull(stateChanged);
+        Assert.True(stateChanged.AddMethod.IsPublic);
+        Assert.True(stateChanged.RemoveMethod.IsPublic);
+
+        Assert.True(typeof(SubscriptionWorkerStatus).IsPublic);
+        Assert.True(typeof(SubscriptionWorkerState).IsPublic);
+    }
+
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task StatusFollowsTheWorkerFromConnectingThroughProcessing()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Company { Name = "RavenDB" });
+                session.SaveChanges();
+            }
+
+            var name = await store.Subscriptions.CreateAsync<Company>();
+
+            using (var worker = store.Subscriptions.GetSubscriptionWorker<Company>(name))
+            using (var processed = new ManualResetEventSlim())
+            {
+                Assert.Equal(SubscriptionWorkerState.NotStarted, worker.Status.State);
+                Assert.Null(worker.Status.Exception);
+
+                var observed = new ConcurrentQueue<SubscriptionWorkerState>();
+                var raisedBy = new ConcurrentQueue<object>();
+
+                worker.OnStateChanged += (sender, status) =>
+                {
+                    raisedBy.Enqueue(sender);
+                    observed.Enqueue(status.State);
+                };
+
+                var stateWhileProcessing = SubscriptionWorkerState.NotStarted;
+
+                _ = worker.Run(_ =>
+                {
+                    stateWhileProcessing = worker.Status.State;
+                    processed.Set();
+                });
+
+                Assert.True(processed.Wait(_reasonableWaitTime), "the batch was never handed to the subscriber");
+
+                Assert.Equal(SubscriptionWorkerState.Processing, stateWhileProcessing);
+
+                // once the subscriber returned and the batch was acknowledged, the worker is idle again
+                Assert.Equal(SubscriptionWorkerState.WaitingForDocuments,
+                    await WaitForValueAsync(() => worker.Status.State, SubscriptionWorkerState.WaitingForDocuments));
+
+                Assert.Equal(new[]
+                {
+                    SubscriptionWorkerState.Connecting,
+                    SubscriptionWorkerState.WaitingForDocuments,
+                    SubscriptionWorkerState.Processing
+                }, observed.Take(3).ToArray());
+
+                Assert.NotEmpty(raisedBy);
+                Assert.All(raisedBy, sender => Assert.Same(worker, sender));
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task StatusReportsRetryingWithTheFailureThatCausedIt()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var name = await store.Subscriptions.CreateAsync<Company>();
+
+            using (var worker = store.Subscriptions.GetSubscriptionWorker<Company>(new SubscriptionWorkerOptions(name)
+                   {
+                       // long enough that Retrying is still the state while the worker waits out the delay
+                       TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1)
+                   }))
+            using (var connected = new ManualResetEventSlim())
+            {
+                var retrying = new TaskCompletionSource<SubscriptionWorkerStatus>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                worker.OnStateChanged += (_, status) =>
+                {
+                    switch (status.State)
+                    {
+                        case SubscriptionWorkerState.WaitingForDocuments:
+                            connected.Set();
+                            break;
+
+                        case SubscriptionWorkerState.Retrying:
+                            retrying.TrySetResult(status);
+                            break;
+                    }
+                };
+
+                // no documents are ever stored here, so the state is the only indication of what the worker is doing
+                _ = worker.Run(_ => { });
+
+                Assert.True(connected.Wait(_reasonableWaitTime), "initial connection wasn't established");
+                Assert.Equal(SubscriptionWorkerState.WaitingForDocuments, worker.Status.State);
+                Assert.Null(worker.Status.Exception);
+
+                await DropConnectionAsync(store, name);
+
+                var status = await retrying.Task.WaitAsync(_reasonableWaitTime);
+
+                Assert.NotNull(status.Exception);
+                Assert.Contains($"Simulating a broken connection for '{name}'", status.Exception.ToString());
+
+                // and the worker recovers on its own, clearing the failure
+                Assert.Equal(SubscriptionWorkerState.WaitingForDocuments,
+                    await WaitForValueAsync(() => worker.Status.State, SubscriptionWorkerState.WaitingForDocuments));
+
+                Assert.Null(worker.Status.Exception);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task StatusIsFaultedWithTheFailureWhenTheWorkerGivesUp()
+    {
+        using (var store = GetDocumentStore())
+        using (var worker = store.Subscriptions.GetSubscriptionWorker<Company>(new SubscriptionWorkerOptions("no-such-subscription")))
+        {
+            var ex = await Assert.ThrowsAsync<SubscriptionDoesNotExistException>(() => worker.Run(_ => { }));
+
+            Assert.Equal(SubscriptionWorkerState.Faulted, worker.Status.State);
+            Assert.Same(ex, worker.Status.Exception);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task StatusIsStoppedAfterDispose()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var name = await store.Subscriptions.CreateAsync<Company>();
+
+            var worker = store.Subscriptions.GetSubscriptionWorker<Company>(name);
+            using (var connected = new ManualResetEventSlim())
+            {
+                worker.OnEstablishedSubscriptionConnection += () => connected.Set();
+
+                _ = worker.Run(_ => { });
+
+                Assert.True(connected.Wait(_reasonableWaitTime), "initial connection wasn't established");
+
+                await worker.DisposeAsync();
+
+                Assert.Equal(SubscriptionWorkerState.Stopped, worker.Status.State);
+                Assert.Null(worker.Status.Exception);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task StatusIsStoppedAfterDisposingAWorkerThatWasNeverRun()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var name = await store.Subscriptions.CreateAsync<Company>();
+
+            var worker = store.Subscriptions.GetSubscriptionWorker<Company>(name);
+
+            Assert.Equal(SubscriptionWorkerState.NotStarted, worker.Status.State);
+
+            await worker.DisposeAsync();
+
+            Assert.Equal(SubscriptionWorkerState.Stopped, worker.Status.State);
         }
     }
 


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27175

### Additional description

OnSubscriptionConnectionRetry told you the connection broke, but the counterpart telling you it came back was internal. On an idle subscription the only public "we are healthy again" signal was a batch arriving, which may never happen, so the client-side view of the worker stayed stuck in the broken state.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
