### PR TITLE
RavenDB-27130 - Fix High unmanaged memory usage when updating a document

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.Debug.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.Debug.cs
@@ -40,9 +40,7 @@ namespace Raven.Server.Documents.Revisions
                     using (_storage.GetKeyPrefix(context, doc.LowerId, out Slice prefixSlice))
                     {
                         _storage.DeleteRevisionFromTable(context, collectionTable, new Dictionary<string, Table>(), doc, collectionName, context.GetChangeVector(doc.ChangeVector), _storage._database.Time.GetUtcNow().Ticks, doc.Flags);
-                        IncrementCountOfRevisions(context, prefixSlice, -1);
-                        if (doc.Flags.Contain(DocumentFlags.Conflicted) || doc.Flags.Contain(DocumentFlags.Resolved))
-                            _storage.IncrementCountOfConflictRevisions(context, collectionTable, prefixSlice, -1);
+                        _storage.UpdateRevisionCountsByOne(context, doc.Flags, prefixSlice, table, increment: false);
                     }
                     
                     tx.Commit();
@@ -70,9 +68,7 @@ namespace Raven.Server.Documents.Revisions
                     var holder = table.SeekOneBackwardFrom(_parent.RevisionsSchema.Indexes[Schemas.Revisions.IdAndEtagSlice], lowerIdPrefix, compoundPrefix);
                     var lastRevision = TableValueToRevision(context, ref holder.Reader, DocumentFields.ChangeVector | DocumentFields.LowerId);
                     _parent.DeleteRevisionFromTable(context, table, new Dictionary<string, Table>(), lastRevision, collectionName, context.GetChangeVector(lastRevision.ChangeVector), _parent._database.Time.GetUtcNow().Ticks, lastRevision.Flags);
-                    IncrementCountOfRevisions(context, lowerIdPrefix, -1);
-                    if (lastRevision.Flags.Contain(DocumentFlags.Conflicted) || lastRevision.Flags.Contain(DocumentFlags.Resolved))
-                        _parent.IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, -1);
+                    _parent.UpdateRevisionCountsByOne(context, lastRevision.Flags, lowerIdPrefix, table, increment: false);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.Debug.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.Debug.cs
@@ -41,6 +41,8 @@ namespace Raven.Server.Documents.Revisions
                     {
                         _storage.DeleteRevisionFromTable(context, collectionTable, new Dictionary<string, Table>(), doc, collectionName, context.GetChangeVector(doc.ChangeVector), _storage._database.Time.GetUtcNow().Ticks, doc.Flags);
                         IncrementCountOfRevisions(context, prefixSlice, -1);
+                        if (doc.Flags.Contain(DocumentFlags.Conflicted) || doc.Flags.Contain(DocumentFlags.Resolved))
+                            _storage.IncrementCountOfConflictRevisions(context, collectionTable, prefixSlice, -1);
                     }
                     
                     tx.Commit();
@@ -69,6 +71,8 @@ namespace Raven.Server.Documents.Revisions
                     var lastRevision = TableValueToRevision(context, ref holder.Reader, DocumentFields.ChangeVector | DocumentFields.LowerId);
                     _parent.DeleteRevisionFromTable(context, table, new Dictionary<string, Table>(), lastRevision, collectionName, context.GetChangeVector(lastRevision.ChangeVector), _parent._database.Time.GetUtcNow().Ticks, lastRevision.Flags);
                     IncrementCountOfRevisions(context, lowerIdPrefix, -1);
+                    if (lastRevision.Flags.Contain(DocumentFlags.Conflicted) || lastRevision.Flags.Contain(DocumentFlags.Resolved))
+                        _parent.IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, -1);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -26,9 +26,11 @@ using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
+using Voron.Data.BTrees;
 using Voron.Data.Tables;
 using Voron.Exceptions;
 using Voron.Impl;
+using static Elastic.Clients.Elasticsearch.JoinField;
 using static Raven.Server.Documents.DocumentsStorage;
 using static Raven.Server.Documents.Schemas.Revisions;
 using static Raven.Server.Documents.Schemas.Tombstones;
@@ -161,6 +163,7 @@ namespace Raven.Server.Documents.Revisions
         private void CreateTrees(Transaction tx)
         {
             tx.CreateTree(RevisionsCountSlice);
+            tx.CreateTree(ConflictRevisionsCountSlice);
             _documentsStorage.TombstonesSchema.Create(tx, RevisionsTombstonesSlice, 16);
         }
 
@@ -424,6 +427,9 @@ namespace Raven.Server.Documents.Revisions
                 using (GetKeyPrefix(context, lowerId, out Slice lowerIdPrefix))
                 {
                     IncrementCountOfRevisions(context, lowerIdPrefix, 1);
+                    if (flags.Contain(DocumentFlags.Conflicted) || flags.Contain(DocumentFlags.Resolved))
+                        IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, 1);
+                    
                     DeleteOldRevisions(context, table, lowerIdPrefix, collectionName, configuration, nonPersistentFlags, changeVector, lastModifiedTicks, documentDeleted: false, skipForceCreated: false);
                 }
             }
@@ -591,6 +597,7 @@ namespace Raven.Server.Documents.Revisions
             public long PreviousCount;
             public long Remaining;
             public int Skip;
+            public long ConflictRevisionsDeleted;
         }
 
         private DeleteOldRevisionsResult DeleteOldRevisions(DocumentsOperationContext context, Table table, Slice lowerIdPrefix, CollectionName collectionName,
@@ -632,6 +639,9 @@ namespace Raven.Server.Documents.Revisions
 
             IncrementCountOfRevisions(context, lowerIdPrefix, -deleted);
             result.Remaining = result.PreviousCount - deleted;
+
+            if (result.ConflictRevisionsDeleted > 0)
+                IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, -result.ConflictRevisionsDeleted);
 
             if (ShouldAddConflictRevisionNotification(conflicted, nonPersistentFlags, deleted))
             {
@@ -705,6 +715,10 @@ namespace Raven.Server.Documents.Revisions
                 using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
                 {
                     IncrementCountOfRevisions(context, prefixSlice, -1);
+
+                    var deletedFlags = TableValueToFlags((int)RevisionsTable.Flags, ref deleted.Reader);
+                    if (deletedFlags.Contain(DocumentFlags.Conflicted) || deletedFlags.Contain(DocumentFlags.Resolved))
+                        IncrementCountOfConflictRevisions(context, table, prefixSlice, -1, afterAdding: false);
                 }
 
                 return true;
@@ -850,6 +864,8 @@ namespace Raven.Server.Documents.Revisions
 
                 maxEtagDeleted = Math.Max(maxEtagDeleted, lastRevisionToDelete.Etag);
                 DeleteRevisionFromTable(context, table, writeTables, lastRevisionToDelete, collectionName, changeVector, lastModifiedTicks, tombstoneFlags);
+                if (lastRevisionToDelete.Flags.Contain(DocumentFlags.Conflicted) || lastRevisionToDelete.Flags.Contain(DocumentFlags.Resolved))
+                    result.ConflictRevisionsDeleted++;
 
                 deleted++;
                 lastRevisionToDelete = revision;
@@ -868,6 +884,8 @@ namespace Raven.Server.Documents.Revisions
                 {
                     maxEtagDeleted = Math.Max(maxEtagDeleted, lastRevisionToDelete.Etag);
                     DeleteRevisionFromTable(context, table, writeTables, lastRevisionToDelete, collectionName, changeVector, lastModifiedTicks, tombstoneFlags);
+                    if (lastRevisionToDelete.Flags.Contain(DocumentFlags.Conflicted) || lastRevisionToDelete.Flags.Contain(DocumentFlags.Resolved))
+                        result.ConflictRevisionsDeleted++;
                     deleted++;
                 }
             }
@@ -1181,23 +1199,41 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        private long GetConflictRevisionsCount(
-            DocumentsOperationContext context, Table table, Slice prefixSlice)
+        private long GetConflictRevisionsCount(DocumentsOperationContext context, Table table, Slice prefixSlice)
         {
-            long conflictCount = 0;
-            foreach (var read in table.SeekForwardFrom(RevisionsSchema.Indexes[IdAndEtagSlice], prefixSlice, skip: 0, startsWith: true))
+            var tree = context.Transaction.InnerTransaction.ReadTree(ConflictRevisionsCountSlice);
+            var readNumber = tree.Read(prefixSlice);
+            if (readNumber != null)
+                return readNumber.Reader.ReadLittleEndianInt64();
+
+            return IncrementCountOfConflictRevisions(context, table, prefixSlice, 0);
+        }
+
+        private long IncrementCountOfConflictRevisions(DocumentsOperationContext context, Table table, Slice prefixedLowerId, long delta, bool afterAdding = true)
+        {
+            var originalDelta = delta; // DIAG
+            var tree = context.Transaction.InnerTransaction.ReadTree(ConflictRevisionsCountSlice);
+            var firstTouch = tree.Read(prefixedLowerId) == null; // DIAG
+            if (tree.Read(prefixedLowerId) == null)
             {
-                var tvr = read.Result.Reader;
-                using (var revision = TableValueToRevision(context, ref tvr, DocumentFields.Default))
+                // If no entry exists in the tree, and we increment `after adding` the revision to the table,
+                // ignore the provided delta, count all conflict revisions
+                // for the document, and store that count as a new entry.
+                if (afterAdding)
+                    delta = 0;
+                foreach (var read in table.SeekForwardFrom(RevisionsSchema.Indexes[IdAndEtagSlice], prefixedLowerId, skip: 0, startsWith: true))
                 {
-                    if (revision.Flags.Contain(DocumentFlags.Conflicted) || revision.Flags.Contain(DocumentFlags.Resolved))
-                        conflictCount++;
+                    var tvr = read.Result.Reader;
+                    using (var revision = TableValueToRevision(context, ref tvr, DocumentFields.Default))
+                    {
+                        if (revision.Flags.Contain(DocumentFlags.Conflicted) || revision.Flags.Contain(DocumentFlags.Resolved))
+                            delta++;
+                    }
                 }
             }
 
-            return conflictCount;
+            return tree.Increment(prefixedLowerId, delta);
         }
-
 
         private IEnumerable<Document> GetAllRevisions(DocumentsOperationContext context, Table table, Slice prefixSlice,
             long? maxDeletesUponUpdate,
@@ -1285,10 +1321,14 @@ namespace Raven.Server.Documents.Revisions
                 using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
                 {
                     IncrementCountOfRevisions(context, prefixSlice, -1);
+
+                    var deletedFlags = TableValueToFlags((int)RevisionsTable.Flags, ref tvr);
+                    if (deletedFlags.Contain(DocumentFlags.Conflicted) || deletedFlags.Contain(DocumentFlags.Resolved))
+                        IncrementCountOfConflictRevisions(context, table, prefixSlice, -1, afterAdding: false);
                 }
 
                 revisionEtag = TableValueToEtag((int)RevisionsTable.Etag, ref tvr);
-
+                
                 table.Delete(tvr.Id);
             }
             else
@@ -1449,6 +1489,9 @@ namespace Raven.Server.Documents.Revisions
                 }
 
                 IncrementCountOfRevisions(context, lowerIdPrefix, 1);
+                if (flags.Contain(DocumentFlags.Conflicted) || flags.Contain(DocumentFlags.Resolved))
+                    IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, 1);
+
                 DeleteOldRevisions(context, table, lowerIdPrefix, collectionName, configuration, nonPersistentFlags, changeVector, lastModifiedTicks,
                     documentDeleted: true, skipForceCreated: false);
             }
@@ -1500,6 +1543,9 @@ namespace Raven.Server.Documents.Revisions
                 tvb.Add(Bits.SwapBytes(revision.LastModified.Ticks));
                 table.Set(tvb);
             }
+
+            using (GetKeyPrefix(context, lowerId, out var lowerIdPrefix))
+                IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, 1);
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2020,6 +2066,8 @@ namespace Raven.Server.Documents.Revisions
             var deleted = DeleteRevisionsInternal(context, table, lowerId, collectionName, changeVector, lastModifiedTicks, revisionsToDelete,
                 result, tombstoneFlags);
             IncrementCountOfRevisions(context, prefixSlice, -deleted);
+            if (result.ConflictRevisionsDeleted > 0)
+                IncrementCountOfConflictRevisions(context, table, prefixSlice, -result.ConflictRevisionsDeleted);
 
             result.Remaining = revisionsPreviousCount - deleted;
             var moreWork = result.HasMore && result.Remaining > 0;
@@ -2160,6 +2208,8 @@ namespace Raven.Server.Documents.Revisions
                 }
 
                 IncrementCountOfRevisions(context, lowerIdPrefix, 1);
+                if (flags.Contain(DocumentFlags.Conflicted) || flags.Contain(DocumentFlags.Resolved))
+                    IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, 1);
             }
         }
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -426,15 +426,20 @@ namespace Raven.Server.Documents.Revisions
 
                 using (GetKeyPrefix(context, lowerId, out Slice lowerIdPrefix))
                 {
-                    IncrementCountOfRevisions(context, lowerIdPrefix, 1);
-                    if (flags.Contain(DocumentFlags.Conflicted) || flags.Contain(DocumentFlags.Resolved))
-                        IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, 1);
-                    
+                    UpdateRevisionCountsByOne(context, flags, lowerIdPrefix, table);
                     DeleteOldRevisions(context, table, lowerIdPrefix, collectionName, configuration, nonPersistentFlags, changeVector, lastModifiedTicks, documentDeleted: false, skipForceCreated: false);
                 }
             }
 
             return true;
+        }
+
+        private void UpdateRevisionCountsByOne(DocumentsOperationContext context, DocumentFlags flags, Slice lowerIdPrefix, Table table, bool increment = true, bool tableUpdated = true)
+        {
+            var delta = increment ? 1 : -1;
+            IncrementCountOfRevisions(context, lowerIdPrefix, delta);
+            if (flags.Contain(DocumentFlags.Conflicted) || flags.Contain(DocumentFlags.Resolved))
+                IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, delta, tableUpdated);
         }
 
         private BlittableJsonReaderObject AddCounterAndTimeSeriesSnapshotsIfNeeded(DocumentsOperationContext context, string id, BlittableJsonReaderObject document)
@@ -597,7 +602,6 @@ namespace Raven.Server.Documents.Revisions
             public long PreviousCount;
             public long Remaining;
             public int Skip;
-            public long ConflictRevisionsDeleted;
         }
 
         private DeleteOldRevisionsResult DeleteOldRevisions(DocumentsOperationContext context, Table table, Slice lowerIdPrefix, CollectionName collectionName,
@@ -636,12 +640,7 @@ namespace Raven.Server.Documents.Revisions
             }
 
             var deleted = DeleteRevisionsInternal(context, table, lowerIdPrefix, collectionName, changeVector, lastModifiedTicks, revisionsToDelete, result, tombstoneFlags: flags);
-
-            IncrementCountOfRevisions(context, lowerIdPrefix, -deleted);
             result.Remaining = result.PreviousCount - deleted;
-
-            if (result.ConflictRevisionsDeleted > 0)
-                IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, -result.ConflictRevisionsDeleted);
 
             if (ShouldAddConflictRevisionNotification(conflicted, nonPersistentFlags, deleted))
             {
@@ -714,11 +713,8 @@ namespace Raven.Server.Documents.Revisions
                 using (TableValueToSlice(context, (int)RevisionsTable.LowerId, ref deleted.Reader, out Slice lowerId))
                 using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
                 {
-                    IncrementCountOfRevisions(context, prefixSlice, -1);
-
                     var deletedFlags = TableValueToFlags((int)RevisionsTable.Flags, ref deleted.Reader);
-                    if (deletedFlags.Contain(DocumentFlags.Conflicted) || deletedFlags.Contain(DocumentFlags.Resolved))
-                        IncrementCountOfConflictRevisions(context, table, prefixSlice, -1, afterAdding: false);
+                    UpdateRevisionCountsByOne(context, deletedFlags, prefixSlice, table, increment: false, tableUpdated: false);
                 }
 
                 return true;
@@ -864,10 +860,8 @@ namespace Raven.Server.Documents.Revisions
 
                 maxEtagDeleted = Math.Max(maxEtagDeleted, lastRevisionToDelete.Etag);
                 DeleteRevisionFromTable(context, table, writeTables, lastRevisionToDelete, collectionName, changeVector, lastModifiedTicks, tombstoneFlags);
-                if (lastRevisionToDelete.Flags.Contain(DocumentFlags.Conflicted) || lastRevisionToDelete.Flags.Contain(DocumentFlags.Resolved))
-                    result.ConflictRevisionsDeleted++;
-
                 deleted++;
+                UpdateRevisionCountsByOne(context, lastRevisionToDelete.Flags, lowerIdPrefix, table, increment: false);
                 lastRevisionToDelete = revision;
             }
 
@@ -884,9 +878,8 @@ namespace Raven.Server.Documents.Revisions
                 {
                     maxEtagDeleted = Math.Max(maxEtagDeleted, lastRevisionToDelete.Etag);
                     DeleteRevisionFromTable(context, table, writeTables, lastRevisionToDelete, collectionName, changeVector, lastModifiedTicks, tombstoneFlags);
-                    if (lastRevisionToDelete.Flags.Contain(DocumentFlags.Conflicted) || lastRevisionToDelete.Flags.Contain(DocumentFlags.Resolved))
-                        result.ConflictRevisionsDeleted++;
                     deleted++;
+                    UpdateRevisionCountsByOne(context, lastRevisionToDelete.Flags, lowerIdPrefix, table, increment: false);
                 }
             }
 
@@ -1209,17 +1202,15 @@ namespace Raven.Server.Documents.Revisions
             return IncrementCountOfConflictRevisions(context, table, prefixSlice, 0);
         }
 
-        private long IncrementCountOfConflictRevisions(DocumentsOperationContext context, Table table, Slice prefixedLowerId, long delta, bool afterAdding = true)
+        private long IncrementCountOfConflictRevisions(DocumentsOperationContext context, Table table, Slice prefixedLowerId, long delta, bool tableUpdated = true)
         {
-            var originalDelta = delta; // DIAG
             var tree = context.Transaction.InnerTransaction.ReadTree(ConflictRevisionsCountSlice);
-            var firstTouch = tree.Read(prefixedLowerId) == null; // DIAG
             if (tree.Read(prefixedLowerId) == null)
             {
                 // If no entry exists in the tree, and we increment `after adding` the revision to the table,
                 // ignore the provided delta, count all conflict revisions
                 // for the document, and store that count as a new entry.
-                if (afterAdding)
+                if (tableUpdated)
                     delta = 0;
                 foreach (var read in table.SeekForwardFrom(RevisionsSchema.Indexes[IdAndEtagSlice], prefixedLowerId, skip: 0, startsWith: true))
                 {
@@ -1320,11 +1311,8 @@ namespace Raven.Server.Documents.Revisions
                 using (TableValueToSlice(context, (int)RevisionsTable.LowerId, ref tvr, out Slice lowerId))
                 using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
                 {
-                    IncrementCountOfRevisions(context, prefixSlice, -1);
-
                     var deletedFlags = TableValueToFlags((int)RevisionsTable.Flags, ref tvr);
-                    if (deletedFlags.Contain(DocumentFlags.Conflicted) || deletedFlags.Contain(DocumentFlags.Resolved))
-                        IncrementCountOfConflictRevisions(context, table, prefixSlice, -1, afterAdding: false);
+                    UpdateRevisionCountsByOne(context, deletedFlags, prefixSlice, table, increment: false, tableUpdated: false);
                 }
 
                 revisionEtag = TableValueToEtag((int)RevisionsTable.Etag, ref tvr);
@@ -1488,9 +1476,7 @@ namespace Raven.Server.Documents.Revisions
                     table.Insert(tvb);
                 }
 
-                IncrementCountOfRevisions(context, lowerIdPrefix, 1);
-                if (flags.Contain(DocumentFlags.Conflicted) || flags.Contain(DocumentFlags.Resolved))
-                    IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, 1);
+                UpdateRevisionCountsByOne(context, flags, lowerIdPrefix, table);
 
                 DeleteOldRevisions(context, table, lowerIdPrefix, collectionName, configuration, nonPersistentFlags, changeVector, lastModifiedTicks,
                     documentDeleted: true, skipForceCreated: false);
@@ -2063,11 +2049,8 @@ namespace Raven.Server.Documents.Revisions
             var lastModifiedTicks = _database.Time.GetUtcNow().Ticks;
             var result = new DeleteOldRevisionsResult() { PreviousCount = revisionsPreviousCount };
             var revisionsToDelete = getRevisions.Invoke(table, result);
-            var deleted = DeleteRevisionsInternal(context, table, lowerId, collectionName, changeVector, lastModifiedTicks, revisionsToDelete,
+            var deleted = DeleteRevisionsInternal(context, table, prefixSlice, collectionName, changeVector, lastModifiedTicks, revisionsToDelete,
                 result, tombstoneFlags);
-            IncrementCountOfRevisions(context, prefixSlice, -deleted);
-            if (result.ConflictRevisionsDeleted > 0)
-                IncrementCountOfConflictRevisions(context, table, prefixSlice, -result.ConflictRevisionsDeleted);
 
             result.Remaining = revisionsPreviousCount - deleted;
             var moreWork = result.HasMore && result.Remaining > 0;
@@ -2207,9 +2190,7 @@ namespace Raven.Server.Documents.Revisions
                     table.Insert(tvb);
                 }
 
-                IncrementCountOfRevisions(context, lowerIdPrefix, 1);
-                if (flags.Contain(DocumentFlags.Conflicted) || flags.Contain(DocumentFlags.Resolved))
-                    IncrementCountOfConflictRevisions(context, table, lowerIdPrefix, 1);
+                UpdateRevisionCountsByOne(context, flags, lowerIdPrefix, table);
             }
         }
 

--- a/src/Raven.Server/Documents/Schemas/Revisions.cs
+++ b/src/Raven.Server/Documents/Schemas/Revisions.cs
@@ -32,6 +32,7 @@ namespace Raven.Server.Documents.Schemas
         internal static readonly Slice AllRevisionsEtagsSlice;
         internal static readonly Slice CollectionRevisionsEtagsSlice;
         internal static readonly Slice RevisionsCountSlice;
+        internal static readonly Slice ConflictRevisionsCountSlice;
         internal static readonly Slice RevisionsTombstonesSlice;
         internal static readonly Slice RevisionsPrefix;
         internal static Slice ResolvedFlagByEtagSlice;
@@ -70,6 +71,7 @@ namespace Raven.Server.Documents.Schemas
                 Slice.From(ctx, "AllRevisionsEtags", ByteStringType.Immutable, out AllRevisionsEtagsSlice);
                 Slice.From(ctx, "CollectionRevisionsEtags", ByteStringType.Immutable, out CollectionRevisionsEtagsSlice);
                 Slice.From(ctx, "RevisionsCount", ByteStringType.Immutable, out RevisionsCountSlice);
+                Slice.From(ctx, "ConflictRevisionsCountSlice", ByteStringType.Immutable, out ConflictRevisionsCountSlice);
                 Slice.From(ctx, "RevisionsBucketAndEtag", ByteStringType.Immutable, out RevisionsBucketAndEtagSlice);
                 Slice.From(ctx, nameof(ResolvedFlagByEtagSlice), ByteStringType.Immutable, out ResolvedFlagByEtagSlice);
                 Slice.From(ctx, RevisionsTombstones, ByteStringType.Immutable, out RevisionsTombstonesSlice);

--- a/test/FastTests/Issues/RavenDB-27130.cs
+++ b/test/FastTests/Issues/RavenDB-27130.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+using SchemaRevisions = Raven.Server.Documents.Schemas.Revisions;
+
+namespace FastTests.Issues
+{
+    // RavenDB-27130
+    // Verifies the per-document counters that back the revisions counts, read directly from the Voron trees:
+    //   * Schemas.Revisions.ConflictRevisionsCountSlice -> number of Conflicted/Resolved revisions of a doc
+    //   * Schemas.Revisions.RevisionsCountSlice         -> number of (all) revisions of a doc
+    // In both tests the expected numbers are derived from the actual stored revisions' @flags, so the trees
+    // are checked against reality (not against hard-coded values).
+    public class RavenDB_27130 : ReplicationTestBase
+    {
+        public RavenDB_27130(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        public async Task ConflictRevisionsCount_IsTracked_WhenAllRevisionsAreConflictRevisions()
+        {
+            const int rounds = 5;
+
+            using var store1 = GetDocumentStore();
+            using var store2 = GetDocumentStore();
+
+            // Only the conflict-revisions config governs 'Users' (there is no regular revisions config), so every
+            // revision created on the conflicting document is a Conflicted/Resolved revision.
+            var conflictConfig = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionAgeToKeep = TimeSpan.FromDays(365) };
+            await RevisionsHelper.SetupConflictedRevisionsAsync(store1, Server.ServerStore, conflictConfig);
+            await RevisionsHelper.SetupConflictedRevisionsAsync(store2, Server.ServerStore, conflictConfig);
+
+            const string id = "users/1";
+            await SetupReplicationAsync(store1, store2);
+
+            // One-way replication: store2 keeps a local (divergent) value while store1's value replicates in, so
+            // every round is a fresh conflict that store2 resolves -> conflict/resolved revisions accumulate.
+            for (var i = 0; i < rounds; i++)
+            {
+                using (var session = store2.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "local-" + i }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store1.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "remote-" + i }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                await EnsureReplicatingAsync(store1, store2);
+            }
+
+            var (expectedConflict, expectedTotal) = await GetRevisionFlagCountsAsync(store2, id);
+
+            // sanity: the scenario produced revisions, and ALL of them are conflict/resolved revisions
+            Assert.True(expectedTotal > 0, "expected some revisions to be created");
+            Assert.Equal(expectedTotal, expectedConflict);
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store2);
+            var (conflictCount, revisionsCount) = ReadCountsFromTrees(database, id);
+
+            Assert.Equal(expectedConflict, conflictCount);
+            Assert.Equal(expectedTotal, revisionsCount);
+        }
+
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        public async Task ConflictAndRegularRevisionsCounts_AreTracked()
+        {
+            using var store1 = GetDocumentStore();
+            using var store2 = GetDocumentStore();
+
+            const string id = "users/1";
+            await SetupRegularAndConflictRevisionsAsync(store1, store2, id);
+
+            var (expectedConflict, expectedTotal) = await GetRevisionFlagCountsAsync(store2, id);
+
+            // sanity: this document has BOTH regular and conflict revisions
+            Assert.True(expectedConflict > 0, "expected some conflict/resolved revisions");
+            Assert.True(expectedTotal > expectedConflict, "expected some regular (non-conflict) revisions too");
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store2);
+            var (conflictCount, revisionsCount) = ReadCountsFromTrees(database, id);
+
+            Assert.Equal(expectedConflict, conflictCount);
+            Assert.Equal(expectedTotal, revisionsCount);
+        }
+
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        public async Task Counts_AreTracked_AfterPruningByRevisionsConfiguration()
+        {
+            using var store1 = GetDocumentStore();
+            using var store2 = GetDocumentStore();
+
+            const string id = "users/1";
+            await SetupRegularAndConflictRevisionsAsync(store1, store2, id);
+
+            // tighten the collection config so most revisions (regular and conflict alike) get pruned, then
+            // enforce the configuration to actually delete them.
+            await store2.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration
+            {
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                {
+                    ["Users"] = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 2 }
+                }
+            }));
+
+            var operation = await store2.Operations.SendAsync(new EnforceRevisionsConfigurationOperation());
+            await operation.WaitForCompletionAsync();
+
+            var (expectedConflict, expectedTotal) = await GetRevisionFlagCountsAsync(store2, id);
+
+            // sanity: pruning actually removed revisions (kept at most the configured amount)
+            Assert.True(expectedTotal > 0 && expectedTotal <= 2, $"expected pruning to keep 1..2 revisions, but got {expectedTotal}");
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store2);
+            var (conflictCount, revisionsCount) = ReadCountsFromTrees(database, id);
+
+            Assert.Equal(expectedConflict, conflictCount);
+            Assert.Equal(expectedTotal, revisionsCount);
+        }
+
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        public async Task Counts_AreTracked_AfterDirectDeleteRevisions()
+        {
+            using var store1 = GetDocumentStore();
+            using var store2 = GetDocumentStore();
+
+            const string id = "users/1";
+            await SetupRegularAndConflictRevisionsAsync(store1, store2, id);
+
+            // direct delete of all the document's revisions (regular and conflict alike)
+            await store2.Maintenance.SendAsync(new DeleteRevisionsOperation(id));
+
+            var (expectedConflict, expectedTotal) = await GetRevisionFlagCountsAsync(store2, id);
+
+            // sanity: everything was deleted
+            Assert.Equal(0, expectedTotal);
+            Assert.Equal(0, expectedConflict);
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store2);
+            var (conflictCount, revisionsCount) = ReadCountsFromTrees(database, id);
+
+            Assert.Equal(expectedConflict, conflictCount);
+            Assert.Equal(expectedTotal, revisionsCount);
+        }
+
+        // Builds a document on store2 that has BOTH regular revisions (from normal updates) and Conflicted/
+        // Resolved revisions (from resolving a replication conflict), under a keep-everything collection config.
+        private async Task SetupRegularAndConflictRevisionsAsync(DocumentStore store1, DocumentStore store2, string id)
+        {
+            var configuration = new RevisionsConfiguration
+            {
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                {
+                    ["Users"] = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 1000 }
+                }
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store1, configuration: configuration);
+            await RevisionsHelper.SetupRevisionsAsync(store2, configuration: configuration);
+
+            // regular revisions from normal updates on store2
+            for (var i = 0; i < 4; i++)
+            {
+                using var session = store2.OpenAsyncSession();
+                await session.StoreAsync(new User { Name = "v" + i }, id);
+                await session.SaveChangesAsync();
+            }
+
+            // now create a conflict: store1 writes the same id divergently, then replicate -> store2 resolves it,
+            // adding Conflicted/Resolved revisions on top of the regular ones.
+            using (var session = store1.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "from-remote" }, id);
+                await session.SaveChangesAsync();
+            }
+
+            await SetupReplicationAsync(store1, store2);
+            await EnsureReplicatingAsync(store1, store2);
+        }
+
+        // number of (Conflicted|Resolved) revisions, and the total number of revisions, for a document -
+        // taken from the actual stored revisions' @flags.
+        private static async Task<(long Conflict, long Total)> GetRevisionFlagCountsAsync(IDocumentStore store, string id)
+        {
+            using var session = store.OpenAsyncSession();
+            var metadata = await session.Advanced.Revisions.GetMetadataForAsync(id, pageSize: int.MaxValue);
+
+            long conflict = metadata.Count(m =>
+            {
+                var flags = m.GetString(Constants.Documents.Metadata.Flags) ?? string.Empty;
+                return flags.Contains(nameof(DocumentFlags.Conflicted)) || flags.Contains(nameof(DocumentFlags.Resolved));
+            });
+
+            return (conflict, metadata.Count);
+        }
+
+        // reads the per-document counters straight from the Voron trees, keyed by the document's lower-id prefix.
+        private static (long Conflict, long Revisions) ReadCountsFromTrees(DocumentDatabase database, string id)
+        {
+            var revisionsStorage = database.DocumentsStorage.RevisionsStorage;
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
+            using (revisionsStorage.GetKeyPrefix(context, lowerId, out Slice prefix))
+            {
+                var conflictTree = context.Transaction.InnerTransaction.ReadTree(SchemaRevisions.ConflictRevisionsCountSlice);
+                var conflict = conflictTree?.Read(prefix)?.Reader.ReadLittleEndianInt64() ?? 0;
+
+                var revisionsTree = context.Transaction.InnerTransaction.ReadTree(SchemaRevisions.RevisionsCountSlice);
+                var revisions = revisionsTree?.Read(prefix)?.Reader.ReadLittleEndianInt64() ?? 0;
+
+                return (conflict, revisions);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-27130.cs
+++ b/test/SlowTests/Issues/RavenDB-27130.cs
@@ -15,7 +15,7 @@ using Xunit;
 using Xunit.Abstractions;
 using SchemaRevisions = Raven.Server.Documents.Schemas.Revisions;
 
-namespace FastTests.Issues
+namespace SlowTests.Issues
 {
     // RavenDB-27130
     // Verifies the per-document counters that back the revisions counts, read directly from the Voron trees:


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27130/High-unmanaged-memory-usage-when-updating-a-document

### Additional description

`GetConflictRevisionsCount` previously scanned and decompressed all revisions of a document just to inspect their flags, causing high unmanaged memory usage for documents with many large revisions.

This PR adds a persistent per-document conflict-revision counter (tree) that is updated whenever revisions are added, deleted, or marked as conflicted. Existing data is initialized lazily using flags-only reads.

New tests verify the conflict and regular revision counters across revision creation, pruning, and direct deletion.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
