### PR TITLE
RavenDB-26984 & RavenDB-27072

### DIFF
--- a/docker/quill/README.md
+++ b/docker/quill/README.md
@@ -217,13 +217,13 @@ curl -sk -X POST https://dashboard.<your-slug>.myquill.ai/api/apps/$SLUG/setup/c
   -H "X-Api-Key: $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"type":"iframe","agentId":"product-catalog","allowedOrigins":[]}'
-#   -> {"widgetId":"wgt_..."}
+#   -> {"channelId":"..."}
 
 # (e) mint a per-user embed link for the channel (short-lived, invocation-capped)
 curl -sk -X POST https://dashboard.<your-slug>.myquill.ai/api/apps/$SLUG/embed-links \
   -H "X-Api-Key: $API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"widgetId":"wgt_...","ttlSeconds":3600,"maxInvocations":100}'
+  -d '{"channelId":"...","ttlSeconds":3600,"maxInvocations":100}'
 #   -> {"token":"...","url":"https://public.<your-slug>.myquill.ai/apps/'$SLUG'/embed/<token>", ...}
 ```
 
@@ -251,7 +251,7 @@ curl -sk -N -X POST https://public.<your-slug>.myquill.ai/apps/<app-slug>/embed/
 ```bash
 cd docker/quill/compose
 docker compose down                 # stop + remove the container; keep the volume
-docker compose down -v              # also drop quill-data (wipes @quill-config + per-app DBs)
+docker compose down -v              # also drop quill-data (wipes quill-config + per-app DBs)
 ```
 ```bash
 docker rm -f nw-postgres            # if you used the throwaway Postgres

--- a/src/Raven.Quill.Web/src/api/generated/server-api.ts
+++ b/src/Raven.Quill.Web/src/api/generated/server-api.ts
@@ -1266,6 +1266,8 @@ export interface components {
         ConnectRequest: {
             provider: string;
             connectionString: string;
+            /** @default  */
+            slug: string;
         };
         ConnectResult: {
             success: boolean;
@@ -1331,6 +1333,8 @@ export interface components {
             provider: string;
             connectionString: string;
             schemas?: null | string[];
+            /** @default  */
+            slug: string;
         };
         DiscoverResponse: {
             catalogName?: null | string;
@@ -1431,6 +1435,7 @@ export interface components {
             apiKey: string;
         };
         MapRequest: {
+            slug?: string;
             /** Format: int64 */
             taskId?: null | number;
             disabled?: null | boolean;
@@ -1604,6 +1609,8 @@ export interface components {
         };
         SuggestCdcRequest: {
             intentPrompt: null | string;
+            /** @default  */
+            slug: string;
         };
         SuggestCdcResponse: {
             configuration: null | components["schemas"]["CdcSinkConfiguration"];
@@ -1615,6 +1622,8 @@ export interface components {
             /** Format: int32 */
             maxRows?: null | number;
             sourceTableSchema?: null | string;
+            /** @default  */
+            slug: string;
         };
         TestMappingResponse: {
             results: components["schemas"]["TestMappingRowResponse"][];

--- a/src/Raven.Quill.Web/src/api/generated/server-api.ts
+++ b/src/Raven.Quill.Web/src/api/generated/server-api.ts
@@ -341,7 +341,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/apps/{slug}/iframe/{widgetId}/customization": {
+    "/api/apps/{slug}/iframe/{channelId}/customization": {
         parameters: {
             query?: never;
             header?: never;
@@ -421,7 +421,7 @@ export interface paths {
         /** @description Lists the app's active embed links (non-expired, non-revoked), most recent first. Each item carries its token, the channel + agent it targets, the bound parameters, the TTL/cap, and how many turns it has consumed — so the operator can audit and revoke links. */
         get: operations["embedLinks.list"];
         put?: never;
-        /** @description Mints a per-user embed link for an iFrame channel (by widgetId). Parameters are validated against the channel's agent and bound into the link server-side (never client-supplied). ttlSeconds and maxInvocations are bounded; both default when omitted. Returns the opaque token + an absolute, paste-ready embed URL. */
+        /** @description Mints a per-user embed link for an iFrame channel (by channelId). Parameters are validated against the channel's agent and bound into the link server-side (never client-supplied). ttlSeconds and maxInvocations are bounded; both default when omitted. Returns the opaque token + an absolute, paste-ready embed URL. */
         post: operations["embedLinks.mint"];
         delete?: never;
         options?: never;
@@ -1241,7 +1241,7 @@ export interface components {
             active: number;
         };
         ChannelSummaryResponse: {
-            widgetId: string;
+            channelId: string;
             type: components["schemas"]["ChannelType"];
             agentId: string;
             displayName: string;
@@ -1360,7 +1360,7 @@ export interface components {
         };
         EmbedLinkSummaryResponse: {
             token: string;
-            widgetId: string;
+            channelId: string;
             agentId: string;
             parameters: {
                 [key: string]: string;
@@ -1455,7 +1455,7 @@ export interface components {
             sparkline: number[];
         };
         MintEmbedLinkRequest: {
-            widgetId: string;
+            channelId: string;
             parameters?: null | {
                 [key: string]: string;
             };
@@ -1525,7 +1525,7 @@ export interface components {
             displayName?: null | string;
         };
         ProvisionChannelResponse: {
-            widgetId: string;
+            channelId: string;
         };
         ProvisionRequest: {
             appName: string;
@@ -2460,7 +2460,7 @@ export interface operations {
             header?: never;
             path: {
                 slug: string;
-                widgetId: string;
+                channelId: string;
             };
             cookie?: never;
         };
@@ -2492,7 +2492,7 @@ export interface operations {
             header?: never;
             path: {
                 slug: string;
-                widgetId: string;
+                channelId: string;
             };
             cookie?: never;
         };
@@ -3942,11 +3942,11 @@ export const API_ENDPOINTS = {
         revoke: (slug: string, token: string) => `/apps/${encodeURIComponent(slug)}/embed-links/${encodeURIComponent(token)}`,
     },
     iframe: {
-        getCustomization: (slug: string, widgetId: string) => `/apps/${encodeURIComponent(slug)}/iframe/${encodeURIComponent(widgetId)}/customization`,
+        getCustomization: (slug: string, channelId: string) => `/apps/${encodeURIComponent(slug)}/iframe/${encodeURIComponent(channelId)}/customization`,
         getDefaultCustomization: (slug: string) => `/apps/${encodeURIComponent(slug)}/iframe/default-customization`,
         getStyleGuide: (slug: string) => `/apps/${encodeURIComponent(slug)}/iframe/style-guide`,
         preview: (slug: string) => `/apps/${encodeURIComponent(slug)}/iframe/preview`,
-        updateCustomization: (slug: string, widgetId: string) => `/apps/${encodeURIComponent(slug)}/iframe/${encodeURIComponent(widgetId)}/customization`,
+        updateCustomization: (slug: string, channelId: string) => `/apps/${encodeURIComponent(slug)}/iframe/${encodeURIComponent(channelId)}/customization`,
         updateDefaultCustomization: (slug: string) => `/apps/${encodeURIComponent(slug)}/iframe/default-customization`,
     },
     settings: {
@@ -4033,11 +4033,11 @@ export function createServerApi(client: ApiClient) {
             revoke: (slug: string, token: string) => client.delete<void, ApiErrorResponse>(API_ENDPOINTS.embedLinks.revoke(slug, token)),
         },
         iframe: {
-            getCustomization: (slug: string, widgetId: string) => client.get<IFrameCustomizationResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.getCustomization(slug, widgetId)),
+            getCustomization: (slug: string, channelId: string) => client.get<IFrameCustomizationResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.getCustomization(slug, channelId)),
             getDefaultCustomization: (slug: string) => client.get<IFrameDefaultCustomizationResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.getDefaultCustomization(slug)),
             getStyleGuide: (slug: string) => client.get<IFrameStyleGuideResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.getStyleGuide(slug)),
             preview: (slug: string, searchParams?: { title?: string; }) => client.get<IFramePreviewResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.preview(slug), { searchParams }),
-            updateCustomization: (slug: string, widgetId: string, request: UpdateIFrameCustomizationRequest) => client.put<IFrameCustomizationResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.updateCustomization(slug, widgetId), request),
+            updateCustomization: (slug: string, channelId: string, request: UpdateIFrameCustomizationRequest) => client.put<IFrameCustomizationResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.updateCustomization(slug, channelId), request),
             updateDefaultCustomization: (slug: string, request: UpdateIFrameCustomizationRequest) => client.put<IFrameDefaultCustomizationResponse, ApiErrorResponse>(API_ENDPOINTS.iframe.updateDefaultCustomization(slug), request),
         },
         settings: {

--- a/src/Raven.Quill.Web/src/api/queries/web-widget-queries.ts
+++ b/src/Raven.Quill.Web/src/api/queries/web-widget-queries.ts
@@ -10,10 +10,10 @@ const customizationsKey = (slug: string) => [baseKey, "customization", slug];
 export function createWebWidgetQueries(api: ServerApi["iframe"]) {
     return {
         customizationsKey,
-        customization: (slug: string, widgetId: string) =>
+        customization: (slug: string, channelId: string) =>
             queryOptions({
-                queryKey: [...customizationsKey(slug), widgetId],
-                queryFn: () => api.getCustomization(slug, widgetId),
+                queryKey: [...customizationsKey(slug), channelId],
+                queryFn: () => api.getCustomization(slug, channelId),
             }),
         defaultCustomization: (slug: string) =>
             queryOptions({

--- a/src/Raven.Quill.Web/src/mocks/channels-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/channels-mocks.ts
@@ -4,11 +4,11 @@ import { apiHttp } from "./api-http";
 export const channelsMocks = {
     list: (channels: ChannelSummaryResponse[] = sampleChannels) =>
         apiHttp.get("/api/apps/{slug}/channels", ({ response }) => response(200).json(channels)),
-    create: (result: ProvisionChannelResponse = { widgetId: SAMPLE_WEB_WIDGET_ID }) =>
+    create: (result: ProvisionChannelResponse = { channelId: SAMPLE_CHANNEL_ID }) =>
         apiHttp.post("/api/apps/{slug}/setup/channel", ({ response }) => response(200).json(result)),
     update: (channels: ChannelSummaryResponse[] = sampleChannels) =>
         apiHttp.put("/api/apps/{slug}/channels/{channelId}", async ({ params, request, response }) => {
-            const channel = channels.find((candidate) => candidate.widgetId === params.channelId);
+            const channel = channels.find((candidate) => candidate.channelId === params.channelId);
 
             if (!channel) {
                 return response(404).json({ error: `Unknown channel: ${params.channelId}` });
@@ -25,13 +25,13 @@ export const channelsMocks = {
     delete: () => apiHttp.delete("/api/apps/{slug}/channels/{channelId}", ({ response }) => response(204).empty()),
 };
 
-// Realistic, URL-safe channel ids (provisioning mints `wgt_<32 hex>`); the web
+// Realistic, URL-safe channel ids (provisioning mints a 32-hex id); the web
 // id is shared with the embed-links mocks so the channel detail route resolves.
-export const SAMPLE_WEB_WIDGET_ID = "wgt_4a1f9c2b7d8e4f6a9b0c1d2e3f405162";
+export const SAMPLE_CHANNEL_ID = "4a1f9c2b7d8e4f6a9b0c1d2e3f405162";
 
 export const sampleChannels: ChannelSummaryResponse[] = [
     {
-        widgetId: SAMPLE_WEB_WIDGET_ID,
+        channelId: SAMPLE_CHANNEL_ID,
         type: "IFrame",
         agentId: "agents/sales",
         displayName: "Website widget",
@@ -39,7 +39,7 @@ export const sampleChannels: ChannelSummaryResponse[] = [
         createdAt: "2026-05-03T09:00:00Z",
     },
     {
-        widgetId: "tlg_2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e",
+        channelId: "tlg_2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e",
         type: "Telegram",
         agentId: "agents/faq",
         displayName: "Telegram bot",

--- a/src/Raven.Quill.Web/src/mocks/embed-links-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/embed-links-mocks.ts
@@ -1,5 +1,5 @@
 import type { ApiErrorResponse, EmbedLinkSummaryResponse, MintEmbedLinkResponse } from "@/api/generated/server-api";
-import { SAMPLE_WEB_WIDGET_ID } from "./channels-mocks";
+import { SAMPLE_CHANNEL_ID } from "./channels-mocks";
 import { apiHttp } from "./api-http";
 
 export const embedLinksMocks = {
@@ -22,7 +22,7 @@ const fromNow = (offsetMs: number) => new Date(Date.now() + offsetMs).toISOStrin
 export const sampleEmbedLinks: EmbedLinkSummaryResponse[] = [
     {
         token: "3f2a9c1b4d5e6f708192a3b4c5d6e7f8",
-        widgetId: SAMPLE_WEB_WIDGET_ID,
+        channelId: SAMPLE_CHANNEL_ID,
         agentId: "agents/sales",
         parameters: { customerId: "users/1" },
         createdAt: fromNow(-3 * DAY_MS),
@@ -32,7 +32,7 @@ export const sampleEmbedLinks: EmbedLinkSummaryResponse[] = [
     },
     {
         token: "9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d",
-        widgetId: SAMPLE_WEB_WIDGET_ID,
+        channelId: SAMPLE_CHANNEL_ID,
         agentId: "agents/sales",
         parameters: { customerId: "users/42" },
         createdAt: fromNow(-2 * DAY_MS),
@@ -42,7 +42,7 @@ export const sampleEmbedLinks: EmbedLinkSummaryResponse[] = [
     },
     {
         token: "1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f",
-        widgetId: SAMPLE_WEB_WIDGET_ID,
+        channelId: SAMPLE_CHANNEL_ID,
         agentId: "agents/sales",
         parameters: { customerId: "users/108" },
         createdAt: fromNow(-10 * DAY_MS),

--- a/src/Raven.Quill.Web/src/mocks/iframe-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/iframe-mocks.ts
@@ -105,7 +105,7 @@ export const iframeMocks = {
             defaultCss: SAMPLE_DEFAULT_CSS,
         },
     ) =>
-        apiHttp.get("/api/apps/{slug}/iframe/{widgetId}/customization", ({ response }) =>
+        apiHttp.get("/api/apps/{slug}/iframe/{channelId}/customization", ({ response }) =>
             response(200).json(customization),
         ),
     updateCustomization: (
@@ -114,7 +114,7 @@ export const iframeMocks = {
             defaultCss: SAMPLE_DEFAULT_CSS,
         },
     ) =>
-        apiHttp.put("/api/apps/{slug}/iframe/{widgetId}/customization", async ({ request, response }) => {
+        apiHttp.put("/api/apps/{slug}/iframe/{channelId}/customization", async ({ request, response }) => {
             const body = await request.json();
             return response(200).json({ style: body.style, css: body.css, ...appDefault });
         }),

--- a/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { SAMPLE_WEB_WIDGET_ID } from "@/mocks/channels-mocks";
+import { SAMPLE_CHANNEL_ID } from "@/mocks/channels-mocks";
 import { embedLinksMocks } from "@/mocks/embed-links-mocks";
 import { AppChannelDetail } from "./app-channel-detail";
 
@@ -9,8 +9,8 @@ const meta = {
     parameters: {
         page: { title: "Channel" },
         router: {
-            initialPath: `/apps/demo/channels/${SAMPLE_WEB_WIDGET_ID}`,
-            path: "/apps/:slug/channels/:widgetId",
+            initialPath: `/apps/demo/channels/${SAMPLE_CHANNEL_ID}`,
+            path: "/apps/:slug/channels/:channelId",
         },
     },
 } satisfies Meta<typeof AppChannelDetail>;

--- a/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.tsx
@@ -14,11 +14,11 @@ import { GenerateEmbedLinkDialog } from "@/pages/apps/channels/generate-embed-li
 import { SectionCard } from "@/pages/apps/section-card";
 
 export function AppChannelDetail() {
-    const { slug = "", widgetId = "" } = useParams();
+    const { slug = "", channelId = "" } = useParams();
     const channelsQuery = useQuery(api.queries.channels.list(slug));
     const agentsQuery = useQuery(api.queries.agents.list(slug));
 
-    const channel = channelsQuery.data?.find((candidate) => candidate.widgetId === widgetId);
+    const channel = channelsQuery.data?.find((candidate) => candidate.channelId === channelId);
     const agent = agentsQuery.data?.find((candidate) => candidate.agentId === channel?.agentId);
 
     const onRetry = async () => {
@@ -64,7 +64,7 @@ export function AppChannelDetail() {
                                     <p className="text-sm text-muted-foreground">
                                         {channel.type ? CHANNEL_TYPE_LABELS[channel.type] : "—"}
                                         {agent?.name ? ` · ${agent.name}` : ""}
-                                        <span className="font-mono"> · {channel.widgetId}</span>
+                                        <span className="font-mono"> · {channel.channelId}</span>
                                     </p>
                                 </div>
                                 {isIFrame && (
@@ -72,7 +72,7 @@ export function AppChannelDetail() {
                                         <Link
                                             to={appRoutes.app(
                                                 slug,
-                                                `web-widget/${encodeURIComponent(channel.widgetId)}/customize`,
+                                                `web-widget/${encodeURIComponent(channel.channelId)}/customize`,
                                             )}
                                         >
                                             <Palette aria-hidden="true" />
@@ -86,7 +86,7 @@ export function AppChannelDetail() {
                                 <>
                                     <EmbedLinkApiDocs
                                         slug={slug}
-                                        widgetId={channel.widgetId}
+                                        channelId={channel.channelId}
                                         parameterNames={agent?.parameters ?? []}
                                     />
                                     <SectionCard
@@ -94,7 +94,7 @@ export function AppChannelDetail() {
                                         action={
                                             <GenerateEmbedLinkDialog
                                                 slug={slug}
-                                                widgetId={channel.widgetId}
+                                                channelId={channel.channelId}
                                                 displayName={channel.displayName}
                                                 parameterNames={agent?.parameters ?? []}
                                                 trigger={
@@ -105,7 +105,7 @@ export function AppChannelDetail() {
                                             />
                                         }
                                     >
-                                        <ChannelActiveLinks slug={slug} widgetId={channel.widgetId} />
+                                        <ChannelActiveLinks slug={slug} channelId={channel.channelId} />
                                     </SectionCard>
                                 </>
                             ) : (
@@ -113,7 +113,7 @@ export function AppChannelDetail() {
                             )}
                         </div>
                     ) : (
-                        <Alert variant="destructive">No channel “{widgetId}” in this app.</Alert>
+                        <Alert variant="destructive">No channel “{channelId}” in this app.</Alert>
                     ))}
             </ApiState>
         </div>

--- a/src/Raven.Quill.Web/src/pages/apps/app-web-widget-customize.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-web-widget-customize.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { SAMPLE_WEB_WIDGET_ID } from "@/mocks/channels-mocks";
+import { SAMPLE_CHANNEL_ID } from "@/mocks/channels-mocks";
 import { iframeHandlers, iframeMocks, SAMPLE_DEFAULT_CSS } from "@/mocks/iframe-mocks";
 import { AppWebWidgetCustomize } from "./app-web-widget-customize";
 
@@ -9,8 +9,8 @@ const meta = {
     parameters: {
         page: { title: "Web widget appearance" },
         router: {
-            initialPath: `/apps/demo/web-widget/${SAMPLE_WEB_WIDGET_ID}/customize`,
-            path: "/apps/:slug/web-widget/:widgetId/customize",
+            initialPath: `/apps/demo/web-widget/${SAMPLE_CHANNEL_ID}/customize`,
+            path: "/apps/:slug/web-widget/:channelId/customize",
         },
     },
 } satisfies Meta<typeof AppWebWidgetCustomize>;
@@ -61,12 +61,12 @@ export const DarkPreset: Story = {
     },
 };
 
-// The widgetId in the URL isn't a web widget in this app — the page shows a not-found alert.
+// The channelId in the URL isn't a web widget in this app — the page shows a not-found alert.
 export const UnknownWidget: Story = {
     parameters: {
         router: {
-            initialPath: "/apps/demo/web-widget/wgt_unknown/customize",
-            path: "/apps/:slug/web-widget/:widgetId/customize",
+            initialPath: "/apps/demo/web-widget/unknown/customize",
+            path: "/apps/:slug/web-widget/:channelId/customize",
         },
     },
 };

--- a/src/Raven.Quill.Web/src/pages/apps/app-web-widget-customize.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-web-widget-customize.tsx
@@ -9,17 +9,17 @@ import { useWebWidgetStyleSave } from "@/pages/apps/channels/use-web-widget-styl
 import { WebWidgetStyleEditor } from "@/pages/apps/channels/web-widget-style-editor";
 
 export function AppWebWidgetCustomize() {
-    const { slug = "", widgetId = "" } = useParams();
+    const { slug = "", channelId = "" } = useParams();
 
     const channelsQuery = useQuery(api.queries.channels.list(slug));
-    const channel = channelsQuery.data?.find((candidate) => candidate.widgetId === widgetId);
+    const channel = channelsQuery.data?.find((candidate) => candidate.channelId === channelId);
     // Customization is web-widget-only, and the widget-scoped endpoints 404 for anything else. Gate the
-    // widget-scoped queries on the channel being an iFrame so an unknown or non-iFrame widgetId resolves
+    // widget-scoped queries on the channel being an iFrame so an unknown or non-iFrame channelId resolves
     // to the not-found alert below instead of a generic "could not load" error from a request bound to fail.
     const isWebWidget = channel?.type === "IFrame";
 
     const customizationQuery = useQuery({
-        ...api.queries.webWidget.customization(slug, widgetId),
+        ...api.queries.webWidget.customization(slug, channelId),
         enabled: isWebWidget,
     });
     const styleGuideQuery = useQuery({ ...api.queries.webWidget.styleGuide(slug), enabled: isWebWidget });
@@ -30,8 +30,8 @@ export function AppWebWidgetCustomize() {
     });
 
     const saveMutation = useWebWidgetStyleSave({
-        save: (update) => api.services.iframe.updateCustomization(slug, widgetId, update),
-        invalidateKeys: [api.queries.webWidget.customization(slug, widgetId).queryKey],
+        save: (update) => api.services.iframe.updateCustomization(slug, channelId, update),
+        invalidateKeys: [api.queries.webWidget.customization(slug, channelId).queryKey],
         successMessage: "Customization saved",
     });
 
@@ -45,7 +45,7 @@ export function AppWebWidgetCustomize() {
     return (
         <div className="grid gap-5">
             <Link
-                to={appRoutes.app(slug, `channels/${encodeURIComponent(widgetId)}`)}
+                to={appRoutes.app(slug, `channels/${encodeURIComponent(channelId)}`)}
                 className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
             >
                 <ArrowLeft className="size-3.5" aria-hidden="true" />
@@ -69,7 +69,7 @@ export function AppWebWidgetCustomize() {
                 loadingLabel="Loading customization..."
             >
                 {!isWebWidget ? (
-                    <Alert variant="destructive">No web widget “{widgetId}” in this app.</Alert>
+                    <Alert variant="destructive">No web widget “{channelId}” in this app.</Alert>
                 ) : (
                     <>
                         <div className="grid gap-1">

--- a/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
@@ -37,7 +37,7 @@ export function ChannelGroups({ slug }: { slug: string }) {
 
     const activeLinkCounts = new Map<string, number>();
     for (const link of embedLinksQuery.data ?? []) {
-        activeLinkCounts.set(link.widgetId, (activeLinkCounts.get(link.widgetId) ?? 0) + 1);
+        activeLinkCounts.set(link.channelId, (activeLinkCounts.get(link.channelId) ?? 0) + 1);
     }
 
     const onRetry = async () => {
@@ -100,11 +100,11 @@ export function ChannelGroups({ slug }: { slug: string }) {
                                 <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
                                     {group.channels.map((channel) => (
                                         <ChannelCard
-                                            key={channel.widgetId}
+                                            key={channel.channelId}
                                             slug={slug}
                                             channel={channel}
                                             agent={agentsQuery.data?.find((x) => x.agentId === channel.agentId)}
-                                            activeLinkCount={activeLinkCounts.get(channel.widgetId) ?? 0}
+                                            activeLinkCount={activeLinkCounts.get(channel.channelId) ?? 0}
                                             isLinkCountLoading={embedLinksQuery.isPending}
                                         />
                                     ))}
@@ -142,7 +142,7 @@ function ChannelCard({
             <CardHeader>
                 <CardTitle className="min-w-0 truncate">
                     <Link
-                        to={appRoutes.app(slug, `channels/${channel.widgetId}`)}
+                        to={appRoutes.app(slug, `channels/${channel.channelId}`)}
                         className="after:absolute after:inset-0 after:content-[''] hover:underline"
                         title="Open details"
                     >
@@ -185,7 +185,7 @@ function ChannelCard({
                 {isIFrame && (
                     <GenerateEmbedLinkDialog
                         slug={slug}
-                        widgetId={channel.widgetId}
+                        channelId={channel.channelId}
                         displayName={channel.displayName}
                         parameterNames={agent?.parameters ?? []}
                         trigger={

--- a/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
@@ -25,7 +25,7 @@ export function ChannelsSection({ slug }: { slug: string }) {
 
     const activeLinkCounts = new Map<string, number>();
     for (const link of embedLinksQuery.data ?? []) {
-        activeLinkCounts.set(link.widgetId, (activeLinkCounts.get(link.widgetId) ?? 0) + 1);
+        activeLinkCounts.set(link.channelId, (activeLinkCounts.get(link.channelId) ?? 0) + 1);
     }
 
     const onRetry = async () => {
@@ -55,10 +55,10 @@ export function ChannelsSection({ slug }: { slug: string }) {
                         {channelsQuery.data.map((channel) => {
                             const agent = agentsQuery.data?.find((x) => x.agentId === channel.agentId);
                             return (
-                                <TableRow key={channel.widgetId}>
+                                <TableRow key={channel.channelId}>
                                     <TableCell className="font-medium">
                                         <Link
-                                            to={appRoutes.app(slug, `channels/${channel.widgetId}`)}
+                                            to={appRoutes.app(slug, `channels/${channel.channelId}`)}
                                             className="hover:underline"
                                             title="Open details"
                                         >
@@ -79,7 +79,7 @@ export function ChannelsSection({ slug }: { slug: string }) {
                                         ) : embedLinksQuery.isPending ? (
                                             <Skeleton className="h-4 w-6" />
                                         ) : (
-                                            (activeLinkCounts.get(channel.widgetId) ?? 0).toLocaleString()
+                                            (activeLinkCounts.get(channel.channelId) ?? 0).toLocaleString()
                                         )}
                                     </TableCell>
                                     <TableCell className="text-muted-foreground">
@@ -88,7 +88,7 @@ export function ChannelsSection({ slug }: { slug: string }) {
                                     <TableCell className="text-right">
                                         <div className="flex items-center justify-end gap-1">
                                             <Link
-                                                to={appRoutes.app(slug, `channels/${channel.widgetId}`)}
+                                                to={appRoutes.app(slug, `channels/${channel.channelId}`)}
                                                 title="Open details"
                                                 className="mx-1"
                                             >
@@ -97,7 +97,7 @@ export function ChannelsSection({ slug }: { slug: string }) {
                                             {channel.type === "IFrame" && (
                                                 <GenerateEmbedLinkDialog
                                                     slug={slug}
-                                                    widgetId={channel.widgetId}
+                                                    channelId={channel.channelId}
                                                     displayName={channel.displayName}
                                                     parameterNames={agent?.parameters ?? []}
                                                     trigger={

--- a/src/Raven.Quill.Web/src/pages/apps/channels/channel-active-links.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/channel-active-links.tsx
@@ -9,14 +9,14 @@ import { ApiState } from "@/components/data/api-state";
 import { VirtualDataTable } from "@/components/table/virtual-data-table";
 import { createActiveLinkColumns } from "@/pages/apps/channels/channel-active-links-columns";
 
-export function ChannelActiveLinks({ slug, widgetId }: { slug: string; widgetId: string }) {
+export function ChannelActiveLinks({ slug, channelId }: { slug: string; channelId: string }) {
     const linksQuery = useQuery(api.queries.embedLinks.list(slug));
 
     // react-table (and its row models) want stable references across renders; "use no memo" opts this
     // file out of the React Compiler, so the data and columns are memoized explicitly.
     const links = useMemo(
-        () => (linksQuery.data ?? []).filter((link) => link.widgetId === widgetId),
-        [linksQuery.data, widgetId],
+        () => (linksQuery.data ?? []).filter((link) => link.channelId === channelId),
+        [linksQuery.data, channelId],
     );
     const columns = useMemo(() => createActiveLinkColumns(slug), [slug]);
 

--- a/src/Raven.Quill.Web/src/pages/apps/channels/delete-channel-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/delete-channel-dialog.tsx
@@ -29,7 +29,7 @@ export function DeleteChannelDialog({ slug, channel, trigger }: DeleteChannelDia
     const queryClient = useQueryClient();
 
     const deleteMutation = useMutation({
-        mutationFn: () => api.services.channels.delete(slug, channel.widgetId),
+        mutationFn: () => api.services.channels.delete(slug, channel.channelId),
         onSuccess: async () => {
             await Promise.all([
                 invalidateChannelQueries(queryClient, slug),

--- a/src/Raven.Quill.Web/src/pages/apps/channels/edit-channel-sheet.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/edit-channel-sheet.tsx
@@ -84,7 +84,7 @@ function EditChannelForm({
     const updateMutation = useMutation({
         mutationFn: (values: EditChannelFormData) =>
             // Update is a partial edit: null fields are left unchanged on the server.
-            api.services.channels.update(slug, channel.widgetId, {
+            api.services.channels.update(slug, channel.channelId, {
                 displayName: values.displayName.trim(),
                 allowedOrigins: values.shouldReplaceAllowedOrigins
                     ? values.allowedOrigins.map((origin) => origin.value.trim()).filter(Boolean)

--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-api-docs.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-api-docs.tsx
@@ -46,13 +46,13 @@ function readLanguage(): Language {
 
 type EmbedLinkApiDocsProps = {
     slug: string;
-    widgetId: string;
+    channelId: string;
     parameterNames: string[];
 };
 
-export function EmbedLinkApiDocs({ slug, widgetId, parameterNames }: EmbedLinkApiDocsProps) {
+export function EmbedLinkApiDocs({ slug, channelId, parameterNames }: EmbedLinkApiDocsProps) {
     const hasParameters = parameterNames.length > 0;
-    const requests = buildRequestSnippets(slug, widgetId, parameterNames);
+    const requests = buildRequestSnippets(slug, channelId, parameterNames);
 
     const [isOpen, setIsOpen] = useState(readIsOpen);
     const [language, setLanguage] = useState<Language>(readLanguage);
@@ -69,7 +69,7 @@ export function EmbedLinkApiDocs({ slug, widgetId, parameterNames }: EmbedLinkAp
     };
 
     const fields = [
-        { name: "widgetId", description: "The web widget channel the link is minted for (already filled in)." },
+        { name: "channelId", description: "The web widget channel the link is minted for (already filled in)." },
         {
             name: "ttlSeconds",
             description: `Link lifetime in seconds, ${MIN_TTL_SECONDS}–${MAX_TTL_SECONDS.toLocaleString()} (default ${DEFAULT_TTL_SECONDS.toLocaleString()}).`,
@@ -147,24 +147,30 @@ export function EmbedLinkApiDocs({ slug, widgetId, parameterNames }: EmbedLinkAp
 
 const API_KEY_PLACEHOLDER = "<your QUILL_API_KEY>";
 
-function buildRequestSnippets(slug: string, widgetId: string, parameterNames: string[]): Record<Language, string> {
+function buildRequestSnippets(slug: string, channelId: string, parameterNames: string[]): Record<Language, string> {
     const url = buildMintEmbedLinkUrl(slug);
     const hasParameters = parameterNames.length > 0;
 
     return {
-        bash: buildCurlSnippet(url, widgetId, parameterNames, "curl", "\\"),
-        powershell: buildCurlSnippet(url, widgetId, parameterNames, "curl.exe", "`"),
-        csharp: buildCSharpSnippet(url, widgetId, parameterNames, hasParameters),
-        python: buildPythonSnippet(url, widgetId, parameterNames, hasParameters),
-        node: buildNodeSnippet(url, widgetId, parameterNames, hasParameters),
+        bash: buildCurlSnippet(url, channelId, parameterNames, "curl", "\\"),
+        powershell: buildCurlSnippet(url, channelId, parameterNames, "curl.exe", "`"),
+        csharp: buildCSharpSnippet(url, channelId, parameterNames, hasParameters),
+        python: buildPythonSnippet(url, channelId, parameterNames, hasParameters),
+        node: buildNodeSnippet(url, channelId, parameterNames, hasParameters),
     };
 }
 
 // bash continues lines with "\", PowerShell with a backtick; PowerShell also needs curl.exe so
 // it doesn't resolve to the Invoke-WebRequest alias on Windows PowerShell 5.1.
-function buildCurlSnippet(url: string, widgetId: string, parameterNames: string[], curl: string, continuation: string) {
+function buildCurlSnippet(
+    url: string,
+    channelId: string,
+    parameterNames: string[],
+    curl: string,
+    continuation: string,
+) {
     const body: Record<string, unknown> = {
-        widgetId,
+        channelId,
         ttlSeconds: DEFAULT_TTL_SECONDS,
         maxInvocations: DEFAULT_MAX_INVOCATIONS,
     };
@@ -186,7 +192,7 @@ function buildCurlSnippet(url: string, widgetId: string, parameterNames: string[
     ].join("\n");
 }
 
-function buildCSharpSnippet(url: string, widgetId: string, parameterNames: string[], hasParameters: boolean) {
+function buildCSharpSnippet(url: string, channelId: string, parameterNames: string[], hasParameters: boolean) {
     const parameterEntries = parameterNames.map((name) => `[${JSON.stringify(name)}] = "<value>"`).join(", ");
 
     return [
@@ -200,7 +206,7 @@ function buildCSharpSnippet(url: string, widgetId: string, parameterNames: strin
         `    "${url}",`,
         "    new",
         "    {",
-        `        widgetId = "${widgetId}",`,
+        `        channelId = "${channelId}",`,
         `        ttlSeconds = ${DEFAULT_TTL_SECONDS},`,
         `        maxInvocations = ${DEFAULT_MAX_INVOCATIONS},`,
         ...(hasParameters ? [`        parameters = new Dictionary<string, string> { ${parameterEntries} },`] : []),
@@ -212,7 +218,7 @@ function buildCSharpSnippet(url: string, widgetId: string, parameterNames: strin
     ].join("\n");
 }
 
-function buildPythonSnippet(url: string, widgetId: string, parameterNames: string[], hasParameters: boolean) {
+function buildPythonSnippet(url: string, channelId: string, parameterNames: string[], hasParameters: boolean) {
     const parameterEntries = parameterNames.map((name) => `${JSON.stringify(name)}: "<value>"`).join(", ");
 
     return [
@@ -222,7 +228,7 @@ function buildPythonSnippet(url: string, widgetId: string, parameterNames: strin
         `    "${url}",`,
         `    headers={"X-Api-Key": "${API_KEY_PLACEHOLDER}"},`,
         "    json={",
-        `        "widgetId": "${widgetId}",`,
+        `        "channelId": "${channelId}",`,
         `        "ttlSeconds": ${DEFAULT_TTL_SECONDS},`,
         `        "maxInvocations": ${DEFAULT_MAX_INVOCATIONS},`,
         ...(hasParameters ? [`        "parameters": {${parameterEntries}},`] : []),
@@ -233,7 +239,7 @@ function buildPythonSnippet(url: string, widgetId: string, parameterNames: strin
     ].join("\n");
 }
 
-function buildNodeSnippet(url: string, widgetId: string, parameterNames: string[], hasParameters: boolean) {
+function buildNodeSnippet(url: string, channelId: string, parameterNames: string[], hasParameters: boolean) {
     const parameterEntries = parameterNames.map((name) => `${JSON.stringify(name)}: "<value>"`).join(", ");
 
     return [
@@ -244,7 +250,7 @@ function buildNodeSnippet(url: string, widgetId: string, parameterNames: string[
         '        "Content-Type": "application/json",',
         "    },",
         "    body: JSON.stringify({",
-        `        widgetId: "${widgetId}",`,
+        `        channelId: "${channelId}",`,
         `        ttlSeconds: ${DEFAULT_TTL_SECONDS},`,
         `        maxInvocations: ${DEFAULT_MAX_INVOCATIONS},`,
         ...(hasParameters ? [`        parameters: { ${parameterEntries} },`] : []),

--- a/src/Raven.Quill.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
@@ -32,7 +32,7 @@ import {
 
 type GenerateEmbedLinkDialogProps = {
     slug: string;
-    widgetId: string;
+    channelId: string;
     displayName: string;
     /** The agent's declared parameter names — one value is bound per name at mint time. */
     parameterNames: string[];
@@ -85,7 +85,7 @@ type GenerateEmbedLinkFormData = z.infer<typeof generateEmbedLinkSchema>;
 
 export function GenerateEmbedLinkDialog({
     slug,
-    widgetId,
+    channelId,
     displayName,
     parameterNames,
     trigger,
@@ -122,7 +122,7 @@ export function GenerateEmbedLinkDialog({
         const parameters = Object.fromEntries(values.parameters.map(({ name, value }) => [name, value.trim()]));
 
         mintMutation.mutate({
-            widgetId,
+            channelId,
             parameters: values.parameters.length > 0 ? parameters : undefined,
             ttlSeconds,
             maxInvocations: values.maxInvocations,

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-store.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-store.ts
@@ -84,7 +84,7 @@ export const useSetupWizardStore = create<SetupWizardState>((set) => ({
     setConnectKey: (key) => set({ connectKey: key }),
     setAppliedMapKey: (key) => set({ appliedMapKey: key }),
     setMapTablesKey: (key) => set({ mapTablesKey: key }),
-    invalidateMapping: () => set({ appliedMapKey: null }),
+    invalidateMapping: () => set({ appliedMapKey: null, mapTablesKey: null }),
     setMapActiveTable: (table) => set({ mapActiveTable: table }),
     focusMapTable: (table) =>
         set((state) => ({

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connect-source-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connect-source-step.ts
@@ -7,9 +7,13 @@ import { discoverTables } from "@/pages/setup/add-app-wizard/steps/verify/use-di
 import { useFormContext } from "react-hook-form";
 
 export function computeConnectKey(
-    connection: Pick<AppFormData["externalConnection"], "provider" | "connectionString">,
+    connection: Pick<AppFormData["externalConnection"], "provider" | "connectionString" | "slug">,
 ): string {
-    return JSON.stringify({ provider: connection.provider, connectionString: connection.connectionString });
+    return JSON.stringify({
+        provider: connection.provider,
+        connectionString: connection.connectionString,
+        slug: connection.slug,
+    });
 }
 
 export function useConnectSourceStep() {
@@ -25,9 +29,11 @@ export function useConnectSourceStep() {
             return;
         }
 
+        const slug = formValues.slug;
         const connectResult = await api.services.setup.connect({
             connectionString: formValues.connectionString,
             provider: formValues.provider,
+            slug,
         });
 
         if (!connectResult.success) {
@@ -35,7 +41,7 @@ export function useConnectSourceStep() {
         }
 
         const schemas = store.discoverSchemas;
-        const discoverResult = await discoverTables(formValues, schemas);
+        const discoverResult = await discoverTables(formValues, schemas, slug);
 
         setDiscoverResult(discoverResult, schemas);
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
@@ -30,15 +30,17 @@ type ImportResult = {
 };
 
 export function useImportConfig() {
-    const { setValue } = useFormContext<AppFormData>();
+    const { setValue, getValues } = useFormContext<AppFormData>();
 
     return useMutation<ImportResult, Error, File>({
         mutationFn: async (file) => {
             const config = await parseConfigFile(file);
+            const slug = getValues("externalConnection").slug;
 
             const connectResult = await api.services.setup.connect({
                 connectionString: config.connectionString,
                 provider: config.provider,
+                slug,
             });
 
             if (!connectResult.success) {
@@ -51,6 +53,7 @@ export function useImportConfig() {
             const discoverResult = await discoverTables(
                 { provider: config.provider, connectionString: config.connectionString },
                 schemas,
+                slug,
             );
 
             if (!discoverResult.success) {
@@ -99,7 +102,13 @@ export function useImportConfig() {
             store.setDiscoverResult(discoverResult, schemas);
             store.resetMapTablesUiState();
 
-            store.setConnectKey(computeConnectKey(config));
+            store.setConnectKey(
+                computeConnectKey({
+                    provider: config.provider,
+                    connectionString: config.connectionString,
+                    slug: getValues("externalConnection").slug,
+                }),
+            );
             store.setAppliedMapKey(
                 computeMapKey({ source: "manual", aiPrompt: "", selectedTables: verifySchemaTables }),
             );

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-map-tables-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-map-tables-step.ts
@@ -35,6 +35,7 @@ export function useMapTablesStep() {
 
         await api.services.setup.map({
             tables: mapFormTablesToDto(formTables),
+            slug: getValues("externalConnection").slug,
         });
 
         const firstTable = formTables[0];

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map/use-map-schema-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map/use-map-schema-step.ts
@@ -35,7 +35,7 @@ export function useMapSchemaStep() {
 
         const tables =
             source === "ai-suggested"
-                ? await suggestTables(aiPrompt)
+                ? await suggestTables(aiPrompt, getValues("externalConnection").slug)
                 : scaffoldTables(selectedTables, store.discoverResult);
 
         setValue("mapTables.tables", tables);
@@ -44,9 +44,10 @@ export function useMapSchemaStep() {
     };
 }
 
-async function suggestTables(aiPrompt: string): Promise<AppFormData["mapTables"]["tables"]> {
+async function suggestTables(aiPrompt: string, slug: string): Promise<AppFormData["mapTables"]["tables"]> {
     const result = await api.services.setup.suggestCdc({
         intentPrompt: aiPrompt.trim(),
+        slug,
     });
 
     if (result.status !== "Success" || !result.configuration) {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/preview/preview-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/preview/preview-step.tsx
@@ -78,6 +78,11 @@ function PreviewResult() {
         name: "preview.maxRows",
     });
 
+    const slug = useWatch({
+        control,
+        name: "externalConnection.slug",
+    });
+
     const selectedTable = tables?.find((t) => getTableLabel(t) === selectedTableLabel);
 
     const testMappingQuery = useQuery({
@@ -85,6 +90,7 @@ function PreviewResult() {
             sourceTableName: selectedTable?.sourceTableName ?? "",
             sourceTableSchema: selectedTable?.sourceTableSchema,
             maxRows,
+            slug,
         }),
         enabled: !!selectedTable && Boolean(maxRows),
     });

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-discover-tables.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-discover-tables.ts
@@ -14,11 +14,13 @@ export function normalizeDiscoverSchemas(schemas: string[] | undefined): string[
 export function discoverTables(
     connection: Pick<AppFormData["externalConnection"], "provider" | "connectionString">,
     schemas: string[],
+    slug: string,
 ) {
     return api.services.setup.discover({
         provider: connection.provider,
         connectionString: connection.connectionString,
         schemas: schemas.length > 0 ? schemas : null,
+        slug,
     });
 }
 
@@ -28,7 +30,10 @@ export function useDiscoverTablesMutation() {
     const setDiscoverResult = useSetupWizardStore((state) => state.setDiscoverResult);
 
     return useMutation({
-        mutationFn: (schemas: string[]) => discoverTables(getValues("externalConnection"), schemas),
+        mutationFn: (schemas: string[]) => {
+            const connection = getValues("externalConnection");
+            return discoverTables(connection, schemas, connection.slug);
+        },
         onSuccess: (result, schemas) => setDiscoverResult(result, schemas),
         onError: (error) => {
             toast.error(error instanceof Error ? error.message : "Could not discover tables.");

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/channels/channels-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/channels/channels-step.tsx
@@ -62,7 +62,7 @@ export function ChannelsStep() {
                             emptyMessage="No channels yet."
                         >
                             {channels.map((channel) => (
-                                <TableRow key={channel.widgetId}>
+                                <TableRow key={channel.channelId}>
                                     <TableCell className="font-medium">{channel.displayName}</TableCell>
                                     <TableCell>
                                         <StatusIndicator

--- a/src/Raven.Quill.Web/src/routes.tsx
+++ b/src/Raven.Quill.Web/src/routes.tsx
@@ -233,13 +233,13 @@ const appPages: AppRouteDefinition[] = [
     {
         // Channel detail — active embed links for one channel. No navigation entry:
         // reached by opening a channel from the Channels list.
-        path: "channels/:widgetId",
+        path: "channels/:channelId",
         title: "Channel",
         element: <AppChannelDetail />,
     },
     {
         // Per-widget embed styling editor + live preview. Reached from channel detail.
-        path: "web-widget/:widgetId/customize",
+        path: "web-widget/:channelId/customize",
         title: "Web widget appearance",
         element: <AppWebWidgetCustomize />,
     },

--- a/src/Raven.Quill/Agents/AgentRouter.cs
+++ b/src/Raven.Quill/Agents/AgentRouter.cs
@@ -1,4 +1,3 @@
-using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
@@ -82,8 +81,6 @@ internal sealed class AgentRouter(IDocumentStore store) : IAgentRouter
         preview.LastAgentReply = reply;
 
         await session.StoreAsync(preview, id, ct);
-        session.Advanced.GetMetadataFor(preview)[Constants.Documents.Metadata.Collection] = ConversationPreview.Collection;
-
         await session.SaveChangesAsync(ct);
         return;
     }

--- a/src/Raven.Quill/Channels/EmbedLink.cs
+++ b/src/Raven.Quill/Channels/EmbedLink.cs
@@ -26,7 +26,7 @@ internal sealed class EmbedLink
 
     public string? Id { get; set; }
 
-    public string WidgetId { get; set; } = "";
+    public string ChannelId { get; set; } = "";
 
     public string AgentId { get; set; } = "";
 

--- a/src/Raven.Quill/Contracts/ChannelSummaryResponse.cs
+++ b/src/Raven.Quill/Contracts/ChannelSummaryResponse.cs
@@ -4,7 +4,7 @@ namespace Raven.Quill.Contracts;
 
 // no secrets: never projects binding id / allowed-origins
 public sealed record ChannelSummaryResponse(
-    string WidgetId,
+    string ChannelId,
     ChannelType Type,
     string AgentId,
     string DisplayName,

--- a/src/Raven.Quill/Contracts/EmbedLinkSummaryResponse.cs
+++ b/src/Raven.Quill/Contracts/EmbedLinkSummaryResponse.cs
@@ -4,7 +4,7 @@ namespace Raven.Quill.Contracts;
 
 public sealed record EmbedLinkSummaryResponse(
     string Token,
-    string WidgetId,
+    string ChannelId,
     string AgentId,
     Dictionary<string, string> Parameters,
     DateTime CreatedAt,
@@ -14,7 +14,7 @@ public sealed record EmbedLinkSummaryResponse(
 {
     internal static EmbedLinkSummaryResponse From(EmbedLink link) => new(
         StripPrefix(link.Id),
-        link.WidgetId,
+        link.ChannelId,
         link.AgentId,
         link.Parameters,
         link.CreatedAt,

--- a/src/Raven.Quill/Contracts/MintEmbedLinkRequest.cs
+++ b/src/Raven.Quill/Contracts/MintEmbedLinkRequest.cs
@@ -1,7 +1,7 @@
 namespace Raven.Quill.Contracts;
 
 public sealed record MintEmbedLinkRequest(
-    string WidgetId,
+    string ChannelId,
     Dictionary<string, string>? Parameters = null,
     int? TtlSeconds = null,
     int? MaxInvocations = null);

--- a/src/Raven.Quill/Contracts/ProvisionChannelResponse.cs
+++ b/src/Raven.Quill/Contracts/ProvisionChannelResponse.cs
@@ -1,3 +1,3 @@
 namespace Raven.Quill.Contracts;
 
-public sealed record ProvisionChannelResponse(string WidgetId);
+public sealed record ProvisionChannelResponse(string ChannelId);

--- a/src/Raven.Quill/Contracts/SuggestCdcRequest.cs
+++ b/src/Raven.Quill/Contracts/SuggestCdcRequest.cs
@@ -1,3 +1,3 @@
 namespace Raven.Quill.Contracts;
 
-public sealed record SuggestCdcRequest(string? IntentPrompt);
+public sealed record SuggestCdcRequest(string? IntentPrompt, string Slug = "");

--- a/src/Raven.Quill/Endpoints/ChannelsEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/ChannelsEndpoints.cs
@@ -104,11 +104,11 @@ public static class ChannelsEndpoints
 
         using var session = store.OpenAsyncSession(app.Database);
 
-        var widgetId = "wgt_" + Guid.NewGuid().ToString("N");
+        var channelId = Guid.NewGuid().ToString("N");
 
         await session.StoreAsync(new Channel
         {
-            Id = Channel.IdPrefix + widgetId,
+            Id = Channel.IdPrefix + channelId,
             Type = ChannelType.IFrame,
             DisplayName = body.DisplayName ?? ChannelType.IFrame.ToString(),
             AgentId = config.Identifier,
@@ -120,10 +120,10 @@ public static class ChannelsEndpoints
         await session.SaveChangesAsync(ct);
 
         logger.LogInformation(
-            "Provisioned iFrame channel slug={Slug} widgetId={WidgetId} agentId={AgentId}",
-            app.Slug, widgetId, config.Identifier);
+            "Provisioned iFrame channel slug={Slug} channelId={ChannelId} agentId={AgentId}",
+            app.Slug, channelId, config.Identifier);
 
-        return Results.Ok(new ProvisionChannelResponse(widgetId));
+        return Results.Ok(new ProvisionChannelResponse(channelId));
     }
 
     private static IResult ProvisionTelegramAsync() => NotImplementedChannel(ChannelType.Telegram);

--- a/src/Raven.Quill/Endpoints/EmbedEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/EmbedEndpoints.cs
@@ -322,7 +322,7 @@ public static class EmbedEndpoints
             if (link is null)
                 return null;
 
-            channel = await session.LoadAsync<Channel>(Channel.IdPrefix + link.WidgetId, ct);
+            channel = await session.LoadAsync<Channel>(Channel.IdPrefix + link.ChannelId, ct);
 
             if (resolveStyle && channel is { Type: ChannelType.IFrame })
             {

--- a/src/Raven.Quill/Endpoints/EmbedLinksEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/EmbedLinksEndpoints.cs
@@ -28,7 +28,7 @@ public static class EmbedLinksEndpoints
         group.MapPost("/embed-links", MintAsync)
             .WithName("embedLinks.mint")
             .WithDescription(
-                "Mints a per-user embed link for an iFrame channel (by widgetId). Parameters are " +
+                "Mints a per-user embed link for an iFrame channel (by channelId). Parameters are " +
                 "validated against the channel's agent and bound into the link server-side (never " +
                 "client-supplied). ttlSeconds and maxInvocations are bounded; both default " +
                 "when omitted. Returns the opaque token + an absolute, paste-ready embed URL.")
@@ -84,8 +84,8 @@ public static class EmbedLinksEndpoints
         HttpContext ctx,
         CancellationToken ct)
     {
-        if (body is null || string.IsNullOrWhiteSpace(body.WidgetId))
-            return Results.BadRequest(new ApiErrorResponse("widgetId is required"));
+        if (body is null || string.IsNullOrWhiteSpace(body.ChannelId))
+            return Results.BadRequest(new ApiErrorResponse("channelId is required"));
 
         var app = await AppLookup.LoadAppAsync(store, slug, ct);
         if (app is null)
@@ -93,15 +93,15 @@ public static class EmbedLinksEndpoints
 
         Channel? channel;
         using (var session = store.OpenAsyncSession(app.Database))
-            channel = await session.LoadAsync<Channel>(Channel.IdPrefix + body.WidgetId, ct);
+            channel = await session.LoadAsync<Channel>(Channel.IdPrefix + body.ChannelId, ct);
 
         if (channel is null || channel.Type != ChannelType.IFrame)
             return Results.NotFound(new ApiErrorResponse(
-                $"no iframe channel '{body.WidgetId}' in app '{slug}'"));
+                $"no iframe channel '{body.ChannelId}' in app '{slug}'"));
 
         if (channel.Enabled == false)
             return Results.BadRequest(new ApiErrorResponse(
-                $"the iframe channel '{body.WidgetId}' is disabled", Code: "channel_disabled"));
+                $"the iframe channel '{body.ChannelId}' is disabled", Code: "channel_disabled"));
 
         var config = await AgentLookup.FindAsync(store, app.Database, channel.AgentId, ct);
         if (config is null)
@@ -131,7 +131,7 @@ public static class EmbedLinksEndpoints
             var link = new EmbedLink
             {
                 Id = EmbedLink.IdPrefix + token,
-                WidgetId = channel.Id!.Substring(Channel.IdPrefix.Length),
+                ChannelId = channel.Id!.Substring(Channel.IdPrefix.Length),
                 AgentId = config.Identifier,
                 Parameters = parameters,
                 ExpiresAt = expiresAt,
@@ -149,8 +149,8 @@ public static class EmbedLinksEndpoints
         var publicHost = ApplianceHost.WithSubdomain(ctx.Request.Host, "public");
         var url = $"{ctx.Request.Scheme}://{publicHost.ToUriComponent()}{ctx.Request.PathBase}/apps/{app.Slug}/embed/{token}";
         logger.LogInformation(
-            "Minted embed link slug={Slug} widgetId={WidgetId} agentId={AgentId} ttlSeconds={Ttl} maxInvocations={Max}",
-            app.Slug, body.WidgetId, config.Identifier, ttlSeconds, maxInvocations);
+            "Minted embed link slug={Slug} channelId={ChannelId} agentId={AgentId} ttlSeconds={Ttl} maxInvocations={Max}",
+            app.Slug, body.ChannelId, config.Identifier, ttlSeconds, maxInvocations);
 
         return Results.Ok(new MintEmbedLinkResponse(token, url, expiresAt, maxInvocations));
     }

--- a/src/Raven.Quill/Endpoints/Helpers/AppLookup.cs
+++ b/src/Raven.Quill/Endpoints/Helpers/AppLookup.cs
@@ -17,6 +17,7 @@ internal static class AppLookup
     {
         using var session = store.OpenAsyncSession();
         session.Delete($"apps/{slug}");
+        session.Delete(WizardState.DocumentIdFor(slug));   // the app's in-progress wizard doc, if any
         await session.SaveChangesAsync(ct);
     }
 

--- a/src/Raven.Quill/Endpoints/IFrameCustomizationEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/IFrameCustomizationEndpoints.cs
@@ -15,13 +15,13 @@ public static class IFrameCustomizationEndpoints
     {
         var group = app.MapGroup("/api/apps/{slug}/iframe").WithTags("iframe").RequireAuthorization();
 
-        group.MapGet("/{widgetId}/customization", GetCustomizationAsync)
+        group.MapGet("/{channelId}/customization", GetCustomizationAsync)
             .WithName("iframe.getCustomization")
             .WithDescription("Returns a web-widget channel's own embed style plus the resolved app default, for the styling editor.")
             .Produces<IFrameCustomizationResponse>()
             .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound);
 
-        group.MapPut("/{widgetId}/customization", UpdateCustomizationAsync)
+        group.MapPut("/{channelId}/customization", UpdateCustomizationAsync)
             .WithName("iframe.updateCustomization")
             .WithDescription("Saves a web-widget channel's embed style: a built-in preset, custom CSS, or (with a null style) follow the app default.")
             .Accepts<UpdateIFrameCustomizationRequest>("application/json")
@@ -58,7 +58,7 @@ public static class IFrameCustomizationEndpoints
 
     private static async Task<IResult> GetCustomizationAsync(
         string slug,
-        string widgetId,
+        string channelId,
         IDocumentStore store,
         CancellationToken ct)
     {
@@ -67,9 +67,9 @@ public static class IFrameCustomizationEndpoints
             return Results.NotFound(new ApiErrorResponse($"no app with slug '{slug}'"));
 
         using var session = store.OpenAsyncSession(app.Database);
-        var channel = await LoadIFrameChannelAsync(session, widgetId, ct);
+        var channel = await LoadIFrameChannelAsync(session, channelId, ct);
         if (channel is null)
-            return Results.NotFound(new ApiErrorResponse($"no iFrame channel '{widgetId}' in app '{slug}'"));
+            return Results.NotFound(new ApiErrorResponse($"no iFrame channel '{channelId}' in app '{slug}'"));
 
         var defaults = await session.LoadAsync<IFrameStyleDefaults>(IFrameStyleDefaults.DocumentId, ct);
         return Results.Ok(BuildCustomizationResponse(channel, defaults));
@@ -77,7 +77,7 @@ public static class IFrameCustomizationEndpoints
 
     private static async Task<IResult> UpdateCustomizationAsync(
         string slug,
-        string widgetId,
+        string channelId,
         UpdateIFrameCustomizationRequest body,
         IDocumentStore store,
         ILogger<IFrameCustomizationLogger> logger,
@@ -93,9 +93,9 @@ public static class IFrameCustomizationEndpoints
             return Results.NotFound(new ApiErrorResponse($"no app with slug '{slug}'"));
 
         using var session = store.OpenAsyncSession(app.Database);
-        var channel = await LoadIFrameChannelAsync(session, widgetId, ct);
+        var channel = await LoadIFrameChannelAsync(session, channelId, ct);
         if (channel is null)
-            return Results.NotFound(new ApiErrorResponse($"no iFrame channel '{widgetId}' in app '{slug}'"));
+            return Results.NotFound(new ApiErrorResponse($"no iFrame channel '{channelId}' in app '{slug}'"));
 
         channel.Style = body.Style;
         channel.CustomCss = body.Style == IFrameStyle.Custom ? body.Css : null;
@@ -103,8 +103,8 @@ public static class IFrameCustomizationEndpoints
 
         var defaults = await session.LoadAsync<IFrameStyleDefaults>(IFrameStyleDefaults.DocumentId, ct);
         logger.LogInformation(
-            "Updated iFrame customization slug={Slug} widgetId={WidgetId} style={Style}",
-            app.Slug, widgetId, channel.Style?.ToString() ?? "(app default)");
+            "Updated iFrame customization slug={Slug} channelId={ChannelId} style={Style}",
+            app.Slug, channelId, channel.Style?.ToString() ?? "(app default)");
         return Results.Ok(BuildCustomizationResponse(channel, defaults));
     }
 
@@ -214,9 +214,9 @@ public static class IFrameCustomizationEndpoints
     }
 
     private static async Task<Channel?> LoadIFrameChannelAsync(
-        IAsyncDocumentSession session, string widgetId, CancellationToken ct)
+        IAsyncDocumentSession session, string channelId, CancellationToken ct)
     {
-        var channel = await session.LoadAsync<Channel>(Channel.IdPrefix + widgetId, ct);
+        var channel = await session.LoadAsync<Channel>(Channel.IdPrefix + channelId, ct);
         return channel is { Type: ChannelType.IFrame } ? channel : null;
     }
 

--- a/src/Raven.Quill/Endpoints/WizardEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/WizardEndpoints.cs
@@ -7,7 +7,6 @@ using Raven.Client.Documents.Operations.CdcSink;
 using Raven.Client.Documents.Operations.CdcSink.Schema;
 using Raven.Client.Documents.Operations.CdcSink.Test;
 using Raven.Client.Documents.Operations.ETL.SQL;
-using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Quill.AiHelper;
 using Raven.Quill.Contracts;
@@ -18,7 +17,8 @@ namespace Raven.Quill.Endpoints;
 
 public static class WizardEndpoints
 {
-    private const string WizardSourceProbeName = "_wizard-source-probe";
+    // the source connection string's name on the app DB once provisioned (used when the map didn't set one)
+    private const string SourceConnectionStringName = "wizard-source";
 
     private const string DefaultIntentPrompt =
         "Propose a sensible RavenDB CDC document model from the discovered relational schema: " +
@@ -73,23 +73,16 @@ public static class WizardEndpoints
         ILogger<WizardLogger> logger,
         CancellationToken ct)
     {
-        if (TryRejectInvalidRequest(body?.Provider, body?.ConnectionString, out var factoryName, out var error))
+        if (TryRejectInvalidRequest(body?.Provider, body?.ConnectionString, body?.Slug, out var factoryName, out var error))
             return error;
 
-        var sqlConnectionString = new SqlConnectionString
-        {
-            Name = WizardSourceProbeName,
-            FactoryName = factoryName,
-            ConnectionString = body!.ConnectionString,
-        };
-        await store.Maintenance.ForDatabase(store.Database).SendAsync(
-            new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString), ct);
+        var connectionString = body!.ConnectionString;
 
         ConnectResult result;
         try
         {
             result = await store.Maintenance.ForDatabase(store.Database).SendAsync(
-                new TestSqlConnectionOperation(factoryName, body.ConnectionString), ct);
+                new TestSqlConnectionOperation(factoryName, connectionString), ct);
         }
         catch (Exception ex)
         {
@@ -101,12 +94,19 @@ public static class WizardEndpoints
         for (var i = 0; i < result.Errors.Count; i++)
             result.Errors[i] = WizardErrorFormatter.FormatConnectionError(result.Errors[i].Message);
 
-        await PersistAsync(store, state =>
+        var wizardId = WizardState.DocumentIdFor(body.Slug);
+        using (var session = store.OpenAsyncSession())
         {
-            state.Provider = factoryName;
-            state.LastVerifyResult = result;
-            state.LastVerifyAt = DateTime.UtcNow;
-        }, ct);
+            var state = new WizardState
+            {
+                Provider = factoryName,
+                SourceConnectionString = connectionString,
+                LastVerifyResult = result,
+                LastVerifyAt = DateTime.UtcNow,
+            };
+            await session.StoreAsync(state, wizardId, ct);
+            await session.SaveChangesAsync(ct);
+        }
 
         return Results.Ok(result);
     }
@@ -117,12 +117,12 @@ public static class WizardEndpoints
         ILogger<WizardLogger> logger,
         CancellationToken ct)
     {
-        if (TryRejectInvalidRequest(body?.Provider, body?.ConnectionString, out var factoryName, out var error))
+        if (TryRejectInvalidRequest(body?.Provider, body?.ConnectionString, body?.Slug, out var factoryName, out var error))
             return error;
 
         var sqlConnectionString = new SqlConnectionString
         {
-            Name = WizardSourceProbeName,
+            Name = SourceConnectionStringName,
             FactoryName = factoryName,
             ConnectionString = body!.ConnectionString,
         };
@@ -132,6 +132,14 @@ public static class WizardEndpoints
             .Select(s => s.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
+
+        var wizardId = WizardState.DocumentIdFor(body.Slug);
+        using var session = store.OpenAsyncSession();
+
+        // fail fast before the live schema enumeration if the wizard was never started for this app
+        var state = await session.LoadAsync<WizardState>(wizardId, ct);
+        if (state is null)
+            return Results.BadRequest(new ApiErrorResponse($"no slug {body.Slug} found"));
 
         CdcSinkSourceSchema schema;
         try
@@ -146,12 +154,11 @@ public static class WizardEndpoints
             schema.Errors.Add(ex.ToString());
         }
 
-        await PersistAsync(store, state =>
-        {
-            state.Provider = factoryName;
-            state.LastDiscoveredSchema = schema;
-            state.LastDiscoverAt = DateTime.UtcNow;
-        }, ct);
+        state.Provider = factoryName;
+        state.LastDiscoveredSchema = schema;
+        state.LastDiscoverAt = DateTime.UtcNow;
+        await session.StoreAsync(state, wizardId, ct);
+        await session.SaveChangesAsync(ct);
 
         return Results.Ok(DiscoverResponse.From(schema));
     }
@@ -164,13 +171,15 @@ public static class WizardEndpoints
     {
         if (body is null)
             return Results.BadRequest(new ApiErrorResponse("request body required"));
+        if (string.IsNullOrWhiteSpace(body.Slug))
+            return Results.BadRequest(new ApiErrorResponse("slug is required"));
 
         var cdcConfig = body.ToClientConfiguration();
 
         if (string.IsNullOrWhiteSpace(cdcConfig.Name))
             cdcConfig.Name = "wizard-cdc";
         if (string.IsNullOrWhiteSpace(cdcConfig.ConnectionStringName))
-            cdcConfig.ConnectionStringName = WizardSourceProbeName;
+            cdcConfig.ConnectionStringName = SourceConnectionStringName;
 
         if (!cdcConfig.Validate(out var errors, validateName: true, validateConnection: false))
         {
@@ -178,11 +187,17 @@ public static class WizardEndpoints
             return Results.BadRequest(new ApiErrorResponse(Errors: errors.ToArray()));
         }
 
-        await PersistAsync(store, state =>
+        var wizardId = WizardState.DocumentIdFor(body.Slug);
+        using (var session = store.OpenAsyncSession())
         {
+            var state = await session.LoadAsync<WizardState>(wizardId, ct);
+            if (state is null)
+                return Results.BadRequest(new ApiErrorResponse($"no slug {body.Slug} found"));
             state.LastMapConfiguration = cdcConfig;
             state.LastMapAt = DateTime.UtcNow;
-        }, ct);
+            await session.StoreAsync(state, wizardId, ct);
+            await session.SaveChangesAsync(ct);
+        }
 
         return Results.Ok(cdcConfig);
     }
@@ -196,12 +211,14 @@ public static class WizardEndpoints
     {
         if (body is null)
             return Results.BadRequest(new ApiErrorResponse("request body is required"));
+        if (string.IsNullOrWhiteSpace(body.Slug))
+            return Results.BadRequest(new ApiErrorResponse("slug is required"));
 
         var intentPrompt = string.IsNullOrWhiteSpace(body.IntentPrompt) ? DefaultIntentPrompt : body.IntentPrompt!;
 
         WizardState? state;
         using (var session = store.OpenAsyncSession())
-            state = await session.LoadAsync<WizardState>(WizardState.DocumentId, ct);
+            state = await session.LoadAsync<WizardState>(WizardState.DocumentIdFor(body.Slug), ct);
 
         if (state?.LastDiscoveredSchema is null)
             return Results.BadRequest(new ApiErrorResponse("no discovered schema found; call /api/setup/discover first"));
@@ -231,10 +248,12 @@ public static class WizardEndpoints
     {
         if (body is null || string.IsNullOrWhiteSpace(body.SourceTableName))
             return Results.BadRequest(new ApiErrorResponse("sourceTableName is required"));
+        if (string.IsNullOrWhiteSpace(body.Slug))
+            return Results.BadRequest(new ApiErrorResponse("slug is required"));
 
         WizardState? state;
         using (var session = store.OpenAsyncSession())
-            state = await session.LoadAsync<WizardState>(WizardState.DocumentId, ct);
+            state = await session.LoadAsync<WizardState>(WizardState.DocumentIdFor(body.Slug), ct);
 
         if (state?.LastMapConfiguration is null)
             return Results.BadRequest(new ApiErrorResponse("no map configuration found; call /api/setup/map first"));
@@ -242,6 +261,13 @@ public static class WizardEndpoints
         var request = new TestCdcSinkMappingRequest
         {
             Configuration = state.LastMapConfiguration,
+            // inline source creds off the wizard doc — no probe connection string exists on the config DB
+            Connection = new SqlConnectionString
+            {
+                Name = SourceConnectionStringName,
+                FactoryName = state.Provider,
+                ConnectionString = state.SourceConnectionString,
+            },
             SourceTableSchema = body.SourceTableSchema,
             SourceTableName = body.SourceTableName,
             RowSelector = TestCdcSinkRowSelector.First,
@@ -289,13 +315,19 @@ public static class WizardEndpoints
             return Results.BadRequest(new ApiErrorResponse($"slug '{slug}' is reserved"));
 
         CdcSinkConfiguration cdcConfig;
+        string sourceConnectionString;
+        string? sourceProvider;
         using (var session = store.OpenAsyncSession(new Client.Documents.Session.SessionOptions { NoTracking = true }))
         {
-            var state = await session.LoadAsync<WizardState>(WizardState.DocumentId, ct);
+            var state = await session.LoadAsync<WizardState>(WizardState.DocumentIdFor(slug), ct);
             if (state?.LastMapConfiguration is null)
                 return Results.BadRequest(new ApiErrorResponse("no map configuration found; call /api/setup/map first"));
+            if (string.IsNullOrEmpty(state.SourceConnectionString))
+                return Results.BadRequest(new ApiErrorResponse("no source connection found; call /api/setup/connect first"));
 
             cdcConfig = state.LastMapConfiguration;
+            sourceConnectionString = state.SourceConnectionString;
+            sourceProvider = state.Provider;
         }
 
         bool created;
@@ -312,21 +344,12 @@ public static class WizardEndpoints
         if (!created)
             return Results.Conflict(new ApiErrorResponse(DatabaseExistsMessage(slug)));
 
-        var probes = await store.Maintenance.ForDatabase(store.Database).SendAsync(
-            new GetConnectionStringsOperation(WizardSourceProbeName, ConnectionStringType.Sql), ct);
-
-        if (probes.SqlConnectionStrings is null ||
-            !probes.SqlConnectionStrings.TryGetValue(WizardSourceProbeName, out var probeCs))
-        {
-            return Results.BadRequest(new ApiErrorResponse(
-                $"probe connection string '{WizardSourceProbeName}' is not registered on the config DB; call /api/setup/connect first."));
-        }
-
+        // transplant the source creds captured at connect (held on the wizard doc) onto the app DB
         var transplantedCs = new SqlConnectionString
         {
             Name = cdcConfig.ConnectionStringName,
-            FactoryName = probeCs.FactoryName,
-            ConnectionString = probeCs.ConnectionString,
+            FactoryName = sourceProvider,
+            ConnectionString = sourceConnectionString,
         };
         await store.Maintenance.ForDatabase(slug).SendAsync(
             new PutConnectionStringOperation<SqlConnectionString>(transplantedCs), ct);
@@ -337,10 +360,6 @@ public static class WizardEndpoints
         // Shared app-creation: read-model indexes + expiration/revisions + the apps/{slug} doc.
         var app = await AppProvisioner.CreateAppAsync(store, slug, body.AppName, cdcConfig.Name, ct);
 
-        // the wizard is done with the source credentials; the probe CS must not outlive it
-        await store.Maintenance.ForDatabase(store.Database).SendAsync(
-            new RemoveConnectionStringOperation<SqlConnectionString>(new SqlConnectionString { Name = WizardSourceProbeName }), ct);
-
         logger.LogInformation("Provisioned app slug={Slug} id={Id} cdcTask={CdcTaskName}",
             app.Slug, app.Id, app.CdcTaskName);
 
@@ -350,13 +369,19 @@ public static class WizardEndpoints
     private static string DatabaseExistsMessage(string slug) =>
         $"database '{slug}' already exists; delete it in RavenDB Studio (or choose another name) and run the setup wizard again";
 
-    private static bool TryRejectInvalidRequest(string? provider, string? connectionString, out string factoryName, out IResult error)
+    private static bool TryRejectInvalidRequest(string? provider, string? connectionString, string? slug, out string factoryName, out IResult error)
     {
         factoryName = string.Empty;
 
         if (string.IsNullOrWhiteSpace(provider) || string.IsNullOrWhiteSpace(connectionString))
         {
             error = Results.BadRequest(new ApiErrorResponse("provider and connectionString are required"));
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(slug))
+        {
+            error = Results.BadRequest(new ApiErrorResponse("slug is required"));
             return true;
         }
 
@@ -368,34 +393,6 @@ public static class WizardEndpoints
 
         error = default!;
         return false;
-    }
-
-    // one retry on OCC clash: absorbs a wizard-step double-click without livelocking
-    private static async Task PersistAsync(
-        IDocumentStore store,
-        Action<WizardState> mutate,
-        CancellationToken ct)
-    {
-        const int MaxAttempts = 2;
-        for (var attempt = 1;; attempt++)
-        {
-            using var session = store.OpenAsyncSession();
-            session.Advanced.OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes;
-
-            var state = await session.LoadAsync<WizardState>(WizardState.DocumentId, ct)
-                        ?? new WizardState();
-            mutate(state);
-            await session.StoreAsync(state, WizardState.DocumentId, ct);
-
-            try
-            {
-                await session.SaveChangesAsync(ct);
-                return;
-            }
-            catch (ConcurrencyException) when (attempt < MaxAttempts)
-            {
-            }
-        }
     }
 
     internal sealed class WizardLogger;

--- a/src/Raven.Quill/Infrastructure/QuillConventions.cs
+++ b/src/Raven.Quill/Infrastructure/QuillConventions.cs
@@ -1,0 +1,17 @@
+using Raven.Client.Documents.Conventions;
+using Raven.Quill.Channels;
+using Raven.Quill.Metrics;
+
+namespace Raven.Quill.Infrastructure;
+
+// Maps Quill's own documents to @-prefixed system collections so they group under Studio's
+// system folder, out of the default collections view. Single source of truth: applied to the
+// production stores in RavenStoreFactory and mirrored onto QuillTests' stores.
+public static class QuillConventions
+{
+    public static string FindCollectionName(Type type) =>
+        type == typeof(Channel) ? "@channels"
+        : type == typeof(EmbedLink) ? "@embed-links"
+        : type == typeof(ConversationPreview) ? ConversationPreview.Collection // "@ConversationPreviews"
+        : DocumentConventions.DefaultGetCollectionName(type);
+}

--- a/src/Raven.Quill/Infrastructure/RavenStoreFactory.cs
+++ b/src/Raven.Quill/Infrastructure/RavenStoreFactory.cs
@@ -22,6 +22,7 @@ public static class RavenStoreFactory
         {
             Urls = [options.RavenUrl],
             Database = options.ConfigDatabase,
+            Conventions = { FindCollectionName = QuillConventions.FindCollectionName },
         };
         store.Initialize();
         return store;
@@ -106,7 +107,7 @@ public static class RavenStoreFactory
             Urls = [connectUrl],
             Database = options.ConfigDatabase,
             Certificate = adminCert,
-            Conventions = { DisableTopologyUpdates = true },
+            Conventions = { DisableTopologyUpdates = true, FindCollectionName = QuillConventions.FindCollectionName },
         };
         secured.Initialize();
         store = secured;

--- a/src/Raven.Quill/Metrics/ConversationPreview.cs
+++ b/src/Raven.Quill/Metrics/ConversationPreview.cs
@@ -9,7 +9,7 @@ internal sealed class ConversationPreview
     internal const string IdPrefix = "conversation-previews/";
 
     // System (@) collection: keeps this internal read-model out of the tables/collections views by the
-    // same @-filter that hides @conversations. Forced via metadata at the write site (no naming convention).
+    // same @-filter that hides @conversations. Mapped via QuillConventions.FindCollectionName.
     // No hyphen, so the raw index map can reference it as docs.@ConversationPreviews.
     internal const string Collection = "@ConversationPreviews";
 
@@ -21,7 +21,7 @@ internal sealed class ConversationPreview
 
     public string Agent { get; set; } = "";
 
-    // full channel document id (channels/<widgetId>) of the serving channel; empty for a direct chat
+    // full channel document id (channels/<guid>) of the serving channel; empty for a direct chat
     public string ChannelId { get; set; } = "";
 
     // the conversation's bound (agent-declared) parameters, shown in the list

--- a/src/Raven.Quill/Metrics/MetricsReadService.cs
+++ b/src/Raven.Quill/Metrics/MetricsReadService.cs
@@ -262,18 +262,18 @@ internal static class MetricsReadService
         await session.Advanced.Eagerly.ExecuteAllPendingLazyOperationsAsync(ct);
 
         var channels = (await lazyChannels.Value).Values;
-        var nameByWidget = channels
+        var nameByChannel = channels
             .Where(c => c.Id is not null)
             .ToDictionary(c => c.Id![Channel.IdPrefix.Length..],
                 c => string.IsNullOrWhiteSpace(c.DisplayName) ? c.Id![Channel.IdPrefix.Length..] : c.DisplayName,
                 StringComparer.OrdinalIgnoreCase);
-        if (nameByWidget.Count == 0)
+        if (nameByChannel.Count == 0)
             return new SeriesData([], []);
 
-        var keys = nameByWidget.Keys
-            .Where(k => k != TimeAxisKey)   // a WidgetId colliding with the reserved time axis can't be represented — drop it
+        var keys = nameByChannel.Keys
+            .Where(k => k != TimeAxisKey)   // a channel id colliding with the reserved time axis can't be represented — drop it
             .OrderBy(k => k, StringComparer.OrdinalIgnoreCase).ToArray();
-        var seriesKeys = keys.Select(k => new SeriesKey(k, nameByWidget[k])).ToArray();
+        var seriesKeys = keys.Select(k => new SeriesKey(k, nameByChannel[k])).ToArray();
 
         var points = new Dictionary<string, object>[buckets.Count];
         for (var b = 0; b < buckets.Count; b++)
@@ -282,11 +282,11 @@ internal static class MetricsReadService
         foreach (var link in (await lazyLinks.Value).Values)
         {
             if (link.CreatedAt < period.Start || link.CreatedAt >= period.End) continue;
-            if (link.WidgetId is null || nameByWidget.ContainsKey(link.WidgetId) == false) continue;
-            if (link.WidgetId == TimeAxisKey) continue;   // dropped from keys above
+            if (link.ChannelId is null || nameByChannel.ContainsKey(link.ChannelId) == false) continue;
+            if (link.ChannelId == TimeAxisKey) continue;   // dropped from keys above
             var i = period.IndexOf(link.CreatedAt);
             if (i < 0) continue;
-            points[i][link.WidgetId] = (long)points[i][link.WidgetId] + 1L;
+            points[i][link.ChannelId] = (long)points[i][link.ChannelId] + 1L;
         }
 
         return new SeriesData(points, seriesKeys);

--- a/src/Raven.Quill/Wizard/ConnectRequest.cs
+++ b/src/Raven.Quill/Wizard/ConnectRequest.cs
@@ -2,4 +2,5 @@ namespace Raven.Quill.Wizard;
 
 public sealed record ConnectRequest(
     string Provider,
-    string ConnectionString);
+    string ConnectionString,
+    string Slug = "");

--- a/src/Raven.Quill/Wizard/DiscoverRequest.cs
+++ b/src/Raven.Quill/Wizard/DiscoverRequest.cs
@@ -3,4 +3,5 @@ namespace Raven.Quill.Wizard;
 public sealed record DiscoverRequest(
     string Provider,
     string ConnectionString,
-    string[]? Schemas = null);
+    string[]? Schemas = null,
+    string Slug = "");

--- a/src/Raven.Quill/Wizard/MapRequest.cs
+++ b/src/Raven.Quill/Wizard/MapRequest.cs
@@ -4,6 +4,8 @@ namespace Raven.Quill.Wizard;
 
 public sealed class MapRequest
 {
+    public string Slug { get; init; } = string.Empty;
+
     public long? TaskId { get; init; }
 
     public bool? Disabled { get; set; }

--- a/src/Raven.Quill/Wizard/TestMappingRequest.cs
+++ b/src/Raven.Quill/Wizard/TestMappingRequest.cs
@@ -3,4 +3,5 @@ namespace Raven.Quill.Wizard;
 public sealed record TestMappingRequest(
     string SourceTableName,
     int? MaxRows = null,
-    string? SourceTableSchema = null);
+    string? SourceTableSchema = null,
+    string Slug = "");

--- a/src/Raven.Quill/Wizard/WizardState.cs
+++ b/src/Raven.Quill/Wizard/WizardState.cs
@@ -5,9 +5,11 @@ namespace Raven.Quill.Wizard;
 
 internal sealed class WizardState
 {
-    public const string DocumentId = "wizard-state";
+    public static string DocumentIdFor(string slug) => $"wizard-state/{slug}";
 
     public string? Provider { get; set; }
+
+    public string? SourceConnectionString { get; set; }
 
     public ConnectResult? LastVerifyResult { get; set; }
     public DateTime? LastVerifyAt { get; set; }

--- a/test/QuillTests/AiHelperSuggestCdcEndpointTests.cs
+++ b/test/QuillTests/AiHelperSuggestCdcEndpointTests.cs
@@ -199,6 +199,7 @@ public class AiHelperSuggestCdcEndpointTests(ITestOutputHelper output, QuillAiHe
 
     private static async Task SeedDiscoveredSchemaAsync(QuillHost host)
     {
+        await host.SetupConnectAsync(new ConnectRequest("SqlClient", "invalid"));
         await host.SetupDiscoverAsync(new DiscoverRequest("SqlClient", "invalid"));
     }
 

--- a/test/QuillTests/AppDatabaseFeaturesTests.cs
+++ b/test/QuillTests/AppDatabaseFeaturesTests.cs
@@ -13,7 +13,10 @@ public class AppDatabaseFeaturesTests(ITestOutputHelper output) : RavenTestBase(
     [RavenFact(RavenTestCategory.Quill)]
     public async Task ConfigureAsync_enables_expiration_and_embedlinks_revisions()
     {
-        var store = GetDocumentStore();
+        var store = GetDocumentStore(new Options
+        {
+            ModifyDocumentStore = s => s.Conventions.FindCollectionName = QuillConventions.FindCollectionName,
+        });
 
         await AppDatabaseFeatures.ConfigureAsync(store, store.Database, CancellationToken.None);
 
@@ -23,9 +26,9 @@ public class AppDatabaseFeaturesTests(ITestOutputHelper output) : RavenTestBase(
         Assert.False(record.Expiration.Disabled);
 
         Assert.NotNull(record.Revisions);
-        // collection key is "EmbedLinks" (CLR type pluralized), NOT the "embed-links/" id prefix
+        // collection key is the @-prefixed system collection from QuillConventions, NOT the "embed-links/" id prefix
         var collectionName = store.Conventions.GetCollectionName(typeof(EmbedLink));
-        Assert.Equal("EmbedLinks", collectionName);
+        Assert.Equal("@embed-links", collectionName);
         var coll = record.Revisions.Collections[collectionName];
         Assert.False(coll.Disabled);
         Assert.False(coll.PurgeOnDelete);
@@ -37,7 +40,10 @@ public class AppDatabaseFeaturesTests(ITestOutputHelper output) : RavenTestBase(
     [RavenFact(RavenTestCategory.Quill)]
     public async Task ConfigureAsync_deploys_conversation_metrics_index()
     {
-        var store = GetDocumentStore();
+        var store = GetDocumentStore(new Options
+        {
+            ModifyDocumentStore = s => s.Conventions.FindCollectionName = QuillConventions.FindCollectionName,
+        });
 
         await AppDatabaseFeatures.ConfigureAsync(store, store.Database, CancellationToken.None);
 
@@ -48,7 +54,10 @@ public class AppDatabaseFeaturesTests(ITestOutputHelper output) : RavenTestBase(
     [RavenFact(RavenTestCategory.Quill)]
     public async Task EmbedLink_updates_produce_revisions()
     {
-        var store = GetDocumentStore();
+        var store = GetDocumentStore(new Options
+        {
+            ModifyDocumentStore = s => s.Conventions.FindCollectionName = QuillConventions.FindCollectionName,
+        });
         await AppDatabaseFeatures.ConfigureAsync(store, store.Database, CancellationToken.None);
 
         var id = EmbedLink.IdPrefix + Guid.NewGuid().ToString("N");
@@ -57,7 +66,7 @@ public class AppDatabaseFeaturesTests(ITestOutputHelper output) : RavenTestBase(
             await session.StoreAsync(new EmbedLink
             {
                 Id = id,
-                WidgetId = "wgt_x",
+                ChannelId = "x",
                 AgentId = "a",
                 ExpiresAt = DateTime.UtcNow.AddHours(1),
                 MaxInvocations = 5,

--- a/test/QuillTests/AppOverviewEndpointTests.cs
+++ b/test/QuillTests/AppOverviewEndpointTests.cs
@@ -26,7 +26,7 @@ public class AppOverviewEndpointTests(ITestOutputHelper output) : QuillTestBase(
         await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "support", Array.Empty<string>()));
         await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "support", Array.Empty<string>()));
         var gamma = await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "support", Array.Empty<string>()));
-        await app.UpdateChannelAsync(gamma.WidgetId, new UpdateChannelRequest(null, null, Enabled: false));
+        await app.UpdateChannelAsync(gamma.ChannelId, new UpdateChannelRequest(null, null, Enabled: false));
 
         var overview = await app.GetOverviewAsync();
         Assert.Equal(app.Slug, overview.Slug);

--- a/test/QuillTests/AppUsageEndpointTests.cs
+++ b/test/QuillTests/AppUsageEndpointTests.cs
@@ -68,7 +68,7 @@ public class AppUsageEndpointTests(ITestOutputHelper output) : QuillTestBase(out
             {
                 await session.StoreAsync(new EmbedLink
                 {
-                    WidgetId = channel.WidgetId,
+                    ChannelId = channel.ChannelId,
                     AgentId = agentId,
                     ExpiresAt = now.AddHours(1),
                     MaxInvocations = 5,
@@ -87,11 +87,11 @@ public class AppUsageEndpointTests(ITestOutputHelper output) : QuillTestBase(out
 
         var channelData = usage.ConversationsByChannel;
         var channelKey = Assert.Single(channelData.Keys);
-        Assert.Equal(channel.WidgetId, channelKey.Key);
+        Assert.Equal(channel.ChannelId, channelKey.Key);
         Assert.Equal("Support Widget", channelKey.Label);
         long channelTotal = 0;
         foreach (var point in channelData.Points)
-            channelTotal += ((JsonElement)point[channel.WidgetId]).GetInt64();
+            channelTotal += ((JsonElement)point[channel.ChannelId]).GetInt64();
         Assert.Equal(2, channelTotal);
 
         var products = usage.TopTables.Single(t => t.Name == "Products");
@@ -160,15 +160,15 @@ public class AppUsageEndpointTests(ITestOutputHelper output) : QuillTestBase(out
         await using var app = await NewAppAsync();
 
         var now = DateTime.UtcNow;
-        // EP mints random wgt_ ids; literal "t"/"alpha" ids must be seeded directly
+        // EP mints random guid ids; literal "t"/"alpha" ids must be seeded directly
         using (var session = app.Store.OpenAsyncSession(app.Slug))
         {
             foreach (var id in new[] { "t", "alpha" })
                 await session.StoreAsync(
                     new Channel { Type = ChannelType.IFrame, DisplayName = id, AgentId = "demo", Enabled = true, CreatedAt = now },
                     $"{Channel.IdPrefix}{id}");
-            await session.StoreAsync(new EmbedLink { WidgetId = "t", AgentId = "demo", ExpiresAt = now.AddHours(1), MaxInvocations = 5, ConversationId = "chats/x", CreatedAt = now }, $"{EmbedLink.IdPrefix}{Guid.NewGuid():N}");
-            await session.StoreAsync(new EmbedLink { WidgetId = "alpha", AgentId = "demo", ExpiresAt = now.AddHours(1), MaxInvocations = 5, ConversationId = "chats/y", CreatedAt = now }, $"{EmbedLink.IdPrefix}{Guid.NewGuid():N}");
+            await session.StoreAsync(new EmbedLink { ChannelId = "t", AgentId = "demo", ExpiresAt = now.AddHours(1), MaxInvocations = 5, ConversationId = "chats/x", CreatedAt = now }, $"{EmbedLink.IdPrefix}{Guid.NewGuid():N}");
+            await session.StoreAsync(new EmbedLink { ChannelId = "alpha", AgentId = "demo", ExpiresAt = now.AddHours(1), MaxInvocations = 5, ConversationId = "chats/y", CreatedAt = now }, $"{EmbedLink.IdPrefix}{Guid.NewGuid():N}");
             await session.SaveChangesAsync();
         }
 

--- a/test/QuillTests/ChannelLifecycleEndpointsTests.cs
+++ b/test/QuillTests/ChannelLifecycleEndpointsTests.cs
@@ -19,7 +19,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
     public async Task Channels_list_returns_the_created_channel()
     {
         await using var app = await NewAppAsync();
-        var widgetId = await ProvisionIFrameChannelAsync(app);
+        var channelId = await ProvisionIFrameChannelAsync(app);
 
         var resp = await Host.Client.GetAsync(QuillRoutes.Channels(app.Slug));
         Assert.True(resp.IsSuccessStatusCode, await resp.Content.ReadAsStringAsync());
@@ -27,7 +27,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
         var items = await resp.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal(1, items.GetArrayLength());
         var item = items[0];
-        Assert.Equal(widgetId, item.GetProperty("widgetId").GetString());
+        Assert.Equal(channelId, item.GetProperty("channelId").GetString());
         Assert.Equal("IFrame", item.GetProperty("type").GetString());
         Assert.Equal("demo-agent", item.GetProperty("agentId").GetString());
         Assert.True(item.GetProperty("enabled").GetBoolean());
@@ -55,14 +55,14 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
     public async Task Channel_edit_toggles_enabled_and_updates_display_name()
     {
         await using var app = await NewAppAsync();
-        var widgetId = await ProvisionIFrameChannelAsync(app);
+        var channelId = await ProvisionIFrameChannelAsync(app);
 
-        var summary = await app.UpdateChannelAsync(widgetId, new UpdateChannelRequest("Storefront bot", null, Enabled: false));
+        var summary = await app.UpdateChannelAsync(channelId, new UpdateChannelRequest("Storefront bot", null, Enabled: false));
         Assert.Equal("Storefront bot", summary.DisplayName);
         Assert.False(summary.Enabled);
 
         using var session = app.Store.OpenAsyncSession(app.Slug);
-        var channel = await session.LoadAsync<Channel>($"channels/{widgetId}");
+        var channel = await session.LoadAsync<Channel>($"channels/{channelId}");
         Assert.Equal("Storefront bot", channel.DisplayName);
         Assert.False(channel.Enabled);
     }
@@ -71,9 +71,9 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
     public async Task Channel_edit_rejects_invalid_origin()
     {
         await using var app = await NewAppAsync();
-        var widgetId = await ProvisionIFrameChannelAsync(app);
+        var channelId = await ProvisionIFrameChannelAsync(app);
 
-        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => app.UpdateChannelAsync(widgetId, new UpdateChannelRequest(null, new[] { "not-a-url" }, null)));
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => app.UpdateChannelAsync(channelId, new UpdateChannelRequest(null, new[] { "not-a-url" }, null)));
         Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
     }
 
@@ -82,7 +82,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
     {
         await using var app = await NewAppAsync();
 
-        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => app.UpdateChannelAsync("wgt_nope", new UpdateChannelRequest(null, null, false)));
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => app.UpdateChannelAsync("nope", new UpdateChannelRequest(null, null, false)));
         Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
     }
 
@@ -90,7 +90,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
     public async Task Channel_delete_removes_channel_and_allows_reprovision()
     {
         await using var app = await NewAppAsync();
-        var widgetId = await ProvisionIFrameChannelAsync(app);
+        var channelId = await ProvisionIFrameChannelAsync(app);
 
         using (var session = app.Store.OpenAsyncSession(app.Slug))
         {
@@ -98,15 +98,15 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
             Assert.Empty(bindings);
         }
 
-        await app.DeleteChannelAsync(widgetId);
+        await app.DeleteChannelAsync(channelId);
 
         using (var session = app.Store.OpenAsyncSession(app.Slug))
         {
-            Assert.Null(await session.LoadAsync<Channel>($"channels/{widgetId}"));
+            Assert.Null(await session.LoadAsync<Channel>($"channels/{channelId}"));
         }
 
         var reChannel = await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "demo-agent", new[] { "http://localhost" }));
-        Assert.False(string.IsNullOrEmpty(reChannel.WidgetId));
+        Assert.False(string.IsNullOrEmpty(reChannel.ChannelId));
     }
 
     [RavenFact(RavenTestCategory.Quill)]
@@ -114,7 +114,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
     {
         await using var app = await NewAppAsync();
 
-        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => app.DeleteChannelAsync("wgt_nope"));
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => app.DeleteChannelAsync("nope"));
         Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
     }
 
@@ -124,8 +124,8 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
         await using var appA = await NewAppAsync();
         await using var appB = await NewAppAsync();
 
-        var restrictedWidgetId = await ProvisionIFrameChannelAsync(appA);
-        var restrictedToken = await MintLinkAsync(appA, restrictedWidgetId);
+        var restrictedChannelId = await ProvisionIFrameChannelAsync(appA);
+        var restrictedToken = await MintLinkAsync(appA, restrictedChannelId);
         // raw: asserts the CSP response header, which the string-body wrapper can't expose.
         var restricted = await Host.Client.GetAsync(QuillRoutes.EmbedPage(appA.Slug, restrictedToken));
         Assert.Equal(HttpStatusCode.OK, restricted.StatusCode);
@@ -134,7 +134,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
 
         await SeedDemoAgentAsync(appB);
         var openChannel = await appB.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "demo-agent", Array.Empty<string>()));
-        var openToken = await MintLinkAsync(appB, openChannel.WidgetId);
+        var openToken = await MintLinkAsync(appB, openChannel.ChannelId);
         var open = await Host.Client.GetAsync(QuillRoutes.EmbedPage(appB.Slug, openToken));
         Assert.Equal(HttpStatusCode.OK, open.StatusCode);
         var openCsp = Assert.Single(open.Headers.GetValues("Content-Security-Policy"));
@@ -149,12 +149,12 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
         await using var app = await NewAppAsync();
 
         var token = Guid.NewGuid().ToString("N");
-        const string widgetId = "wgt_telegram_x";
+        const string channelId = "telegram-x";
         using (var session = app.Store.OpenAsyncSession(app.Slug))
         {
             await session.StoreAsync(new Channel
             {
-                Id = $"channels/{widgetId}",
+                Id = $"channels/{channelId}",
                 Type = ChannelType.Telegram,
                 AgentId = "demo-agent",
                 Enabled = true,
@@ -162,7 +162,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
             await session.StoreAsync(new EmbedLink
             {
                 Id = $"embed-links/{token}",
-                WidgetId = widgetId,
+                ChannelId = channelId,
                 AgentId = "demo-agent",
                 ExpiresAt = DateTime.UtcNow.AddHours(1),
                 MaxInvocations = 10,
@@ -185,12 +185,12 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
         await using var app = await NewAppAsync();
 
         var token = Guid.NewGuid().ToString("N");
-        const string widgetId = "wgt_ghost_agent";
+        const string channelId = "ghost-agent";
         using (var session = app.Store.OpenAsyncSession(app.Slug))
         {
             await session.StoreAsync(new Channel
             {
-                Id = $"channels/{widgetId}",
+                Id = $"channels/{channelId}",
                 Type = ChannelType.IFrame,
                 AgentId = "ghost-agent",
                 Enabled = true,
@@ -198,7 +198,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
             await session.StoreAsync(new EmbedLink
             {
                 Id = $"embed-links/{token}",
-                WidgetId = widgetId,
+                ChannelId = channelId,
                 AgentId = "ghost-agent",
                 ExpiresAt = DateTime.UtcNow.AddHours(1),
                 MaxInvocations = 10,
@@ -221,14 +221,14 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
     public async Task Channel_lifecycle_provision_update_delete_reprovision()
     {
         await using var app = await NewAppAsync();
-        var widgetId = await ProvisionIFrameChannelAsync(app);
+        var channelId = await ProvisionIFrameChannelAsync(app);
 
-        await app.UpdateChannelAsync(widgetId, new UpdateChannelRequest(null, null, Enabled: false));
+        await app.UpdateChannelAsync(channelId, new UpdateChannelRequest(null, null, Enabled: false));
 
-        await app.DeleteChannelAsync(widgetId);
+        await app.DeleteChannelAsync(channelId);
 
         var reChannel = await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "demo-agent", new[] { "http://localhost" }));
-        Assert.NotEqual(widgetId, reChannel.WidgetId);
+        Assert.NotEqual(channelId, reChannel.ChannelId);
     }
 
     [RavenFact(RavenTestCategory.Quill)]
@@ -324,7 +324,7 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
     {
         await SeedDemoAgentAsync(app, agentId);
         var channel = await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, agentId, new[] { "http://localhost" }));
-        return channel.WidgetId;
+        return channel.ChannelId;
     }
 
     private static async Task<string> SeedDemoAgentAsync(QuillApp app, string agentId = "demo-agent")
@@ -339,9 +339,9 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
         return app.Host.ConnectionStringName;
     }
 
-    private static async Task<string> MintLinkAsync(QuillApp app, string widgetId)
+    private static async Task<string> MintLinkAsync(QuillApp app, string channelId)
     {
-        var minted = await app.MintEmbedLinkAsync(new MintEmbedLinkRequest(widgetId, new Dictionary<string, string>(), 3600, 50));
+        var minted = await app.MintEmbedLinkAsync(new MintEmbedLinkRequest(channelId, new Dictionary<string, string>(), 3600, 50));
         return minted.Token;
     }
 

--- a/test/QuillTests/ChannelStatsEndpointsTests.cs
+++ b/test/QuillTests/ChannelStatsEndpointsTests.cs
@@ -22,7 +22,7 @@ public class ChannelStatsEndpointsTests(ITestOutputHelper output) : QuillTestBas
         await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "agent", Array.Empty<string>()));
         await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "agent", Array.Empty<string>()));
         var gamma = await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "agent", Array.Empty<string>()));
-        await app.UpdateChannelAsync(gamma.WidgetId, new UpdateChannelRequest(null, null, Enabled: false));
+        await app.UpdateChannelAsync(gamma.ChannelId, new UpdateChannelRequest(null, null, Enabled: false));
 
         var stats = await app.GetChannelStatsAsync();
         Assert.Equal(3, stats.Total);

--- a/test/QuillTests/CollectionNamingSmugglerTests.cs
+++ b/test/QuillTests/CollectionNamingSmugglerTests.cs
@@ -1,0 +1,57 @@
+using QuillTests.E2E.Fixtures;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Smuggler;
+using Raven.Quill.Channels;
+using Raven.Quill.Contracts;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace QuillTests;
+
+// Proves RavenDB's smuggler treats Quill's @-prefixed collections (@channels, @embed-links) like any other:
+// export → import round-trips the docs AND the embed-link revision, landing them back in the same @-named collections.
+public class CollectionNamingSmugglerTests(ITestOutputHelper output) : QuillTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task At_prefixed_collections_survive_export_import_with_revisions()
+    {
+        await using var app = await NewAppAsync();
+        await app.ProvisionAgentAsync(new AiAgentConfiguration
+        {
+            Identifier = "demo-agent",
+            Name = "Demo Agent",
+            SystemPrompt = "You are a placeholder demo agent.",
+            ConnectionStringName = app.Host.ConnectionStringName,
+        });
+
+        var channelId = (await app.ProvisionChannelAsync(
+            new ProvisionChannelRequest(ChannelType.IFrame, "demo-agent", new[] { "http://localhost" }))).ChannelId;
+        var token = (await app.MintEmbedLinkAsync(
+            new MintEmbedLinkRequest(channelId, new Dictionary<string, string>(), 3600, 50))).Token;
+
+        var channelDocId = Channel.IdPrefix + channelId;
+        var embedLinkDocId = EmbedLink.IdPrefix + token;
+
+        var file = GetTempFileName();
+        var export = await app.Store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+        await export.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+        // import into a fresh, convention-less DB: reads below go by id + metadata, so the @-names must survive on their own
+        using var target = GetDocumentStore();
+        var import = await target.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+        await import.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+        using var session = target.OpenAsyncSession();
+
+        var channel = await session.LoadAsync<Channel>(channelDocId);
+        Assert.NotNull(channel);
+        Assert.Equal("@channels", session.Advanced.GetMetadataFor(channel)["@collection"]!.ToString());
+
+        var link = await session.LoadAsync<EmbedLink>(embedLinkDocId);
+        Assert.NotNull(link);
+        Assert.Equal("@embed-links", session.Advanced.GetMetadataFor(link)["@collection"]!.ToString());
+
+        var revisions = await session.Advanced.Revisions.GetForAsync<EmbedLink>(embedLinkDocId);
+        Assert.NotEmpty(revisions);
+    }
+}

--- a/test/QuillTests/ConversationsEndpointTests.cs
+++ b/test/QuillTests/ConversationsEndpointTests.cs
@@ -23,7 +23,7 @@ public class ConversationsEndpointTests(ITestOutputHelper output) : QuillTestBas
         });
         var channel = await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "demo", Array.Empty<string>(), "Support Widget"));
         await SeedConversationAsync(app.Store, app.Slug, "chats/recent", "order-support", now.AddMinutes(-10),
-            turns: [("user", "hello"), ("assistant", "hi there")], channelWidgetId: channel.WidgetId);
+            turns: [("user", "hello"), ("assistant", "hi there")], channelId: channel.ChannelId);
         await SeedConversationAsync(app.Store, app.Slug, "chats/old", "billing", now.AddDays(-3));
 
         var list = (await app.GetConversationsAsync(year: now.Year)).Conversations;
@@ -68,7 +68,7 @@ public class ConversationsEndpointTests(ITestOutputHelper output) : QuillTestBas
         for (var i = 0; i < 3; i++)
         {
             var channel = await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "demo", Array.Empty<string>(), $"Widget {i}"));
-            await SeedConversationAsync(app.Store, app.Slug, $"chats/c{i}", "demo", now.AddMinutes(-(i + 1)), channelWidgetId: channel.WidgetId);
+            await SeedConversationAsync(app.Store, app.Slug, $"chats/c{i}", "demo", now.AddMinutes(-(i + 1)), channelId: channel.ChannelId);
         }
         // Calls MetricsReadService directly to count round-trips, so it waits for indexing explicitly.
         await app.WaitForIndexingAsync();
@@ -127,7 +127,7 @@ public class ConversationsEndpointTests(ITestOutputHelper output) : QuillTestBas
         });
         var channel = await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "demo", Array.Empty<string>()));
 
-        var nonConversation = await Assert.ThrowsAsync<QuillHttpException>(() => app.GetConversationAsync($"channels/{channel.WidgetId}"));
+        var nonConversation = await Assert.ThrowsAsync<QuillHttpException>(() => app.GetConversationAsync($"channels/{channel.ChannelId}"));
         Assert.Equal(HttpStatusCode.NotFound, nonConversation.StatusCode);
 
         var unknown = await Assert.ThrowsAsync<QuillHttpException>(() => app.GetConversationAsync("chats/does-not-exist"));

--- a/test/QuillTests/E2E/ApplianceFullFlowTests.cs
+++ b/test/QuillTests/E2E/ApplianceFullFlowTests.cs
@@ -180,11 +180,11 @@ public class ApplianceFullFlowTests(ITestOutputHelper output) : CdcSinkIntegrati
         Assert.True(channelResp.IsSuccessStatusCode,
             $"channel returned {channelResp.StatusCode}: {await channelResp.Content.ReadAsStringAsync()}");
         var channelJson = await channelResp.Content.ReadFromJsonAsync<JsonElement>();
-        var widgetId = channelJson.GetProperty("widgetId").GetString();
-        Assert.False(string.IsNullOrEmpty(widgetId));
+        var channelId = channelJson.GetProperty("channelId").GetString();
+        Assert.False(string.IsNullOrEmpty(channelId));
 
         var linkResp = await client.PostAsJsonAsync($"/api/apps/{slug}/embed-links",
-            new { widgetId, ttlSeconds = 3600, maxInvocations = 10 });
+            new { channelId, ttlSeconds = 3600, maxInvocations = 10 });
         Assert.True(linkResp.IsSuccessStatusCode,
             $"mint embed-link returned {linkResp.StatusCode}: {await linkResp.Content.ReadAsStringAsync()}");
         var linkJson = await linkResp.Content.ReadFromJsonAsync<JsonElement>();

--- a/test/QuillTests/E2E/ApplianceFullFlowTests.cs
+++ b/test/QuillTests/E2E/ApplianceFullFlowTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using QuillTests.E2E.Fixtures;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.CdcSink.Test;
@@ -56,10 +57,14 @@ public class ApplianceFullFlowTests(ITestOutputHelper output) : CdcSinkIntegrati
         using var sqlTeardown = WithSqlDatabase(MigrationProvider.NpgSQL,
             out var pgConnStr, out _, dataSet: "northwind-full", includeData: true);
 
+        // the app id the FE supplies from the first wizard step; every step carries it so the per-app wizard doc lines up
+        const string appSlug = "northwind-demo";
+
         var connectResp = await client.PostAsJsonAsync("/api/setup/connect", new
         {
             provider         = "Npgsql",
             connectionString = pgConnStr,
+            slug             = appSlug,
         });
         Assert.True(connectResp.IsSuccessStatusCode,
             $"connect returned {connectResp.StatusCode}: {await connectResp.Content.ReadAsStringAsync()}");
@@ -68,7 +73,7 @@ public class ApplianceFullFlowTests(ITestOutputHelper output) : CdcSinkIntegrati
             $"connect (reachability) should succeed against a live Postgres; payload: {connect}");
 
         var discoverResp = await client.PostAsJsonAsync("/api/setup/discover",
-            new { provider = "Npgsql", connectionString = pgConnStr });
+            new { provider = "Npgsql", connectionString = pgConnStr, slug = appSlug });
         Assert.True(discoverResp.IsSuccessStatusCode,
             $"discover returned {discoverResp.StatusCode}: {await discoverResp.Content.ReadAsStringAsync()}");
         var schema = await discoverResp.Content.ReadFromJsonAsync<JsonElement>();
@@ -89,15 +94,16 @@ public class ApplianceFullFlowTests(ITestOutputHelper output) : CdcSinkIntegrati
         var configFixturePath = Path.Combine(AppContext.BaseDirectory, "E2E", "Fixtures", "northwind-cdc-config.json");
         Assert.True(File.Exists(configFixturePath),
             $"Pre-built CDC config fixture missing at {configFixturePath}. Populated by the W3 Map slice.");
-        var configJson = await File.ReadAllTextAsync(configFixturePath);
+        var configNode = JsonNode.Parse(await File.ReadAllTextAsync(configFixturePath))!;
+        configNode["slug"] = appSlug;   // the FE-supplied app id keys the wizard doc; the fixture is otherwise app-agnostic
 
         var mapResp = await client.PostAsync("/api/setup/map",
-            new StringContent(configJson, Encoding.UTF8, "application/json"));
+            new StringContent(configNode.ToJsonString(), Encoding.UTF8, "application/json"));
         Assert.True(mapResp.IsSuccessStatusCode,
             $"map returned {mapResp.StatusCode}: {await mapResp.Content.ReadAsStringAsync()}");
 
         var testResp = await client.PostAsJsonAsync("/api/setup/test-mapping",
-            new { sourceTableName = "customers", maxRows = 50 });
+            new { sourceTableName = "customers", maxRows = 50, slug = appSlug });
         Assert.True(testResp.IsSuccessStatusCode,
             $"test-mapping returned {testResp.StatusCode}: {await testResp.Content.ReadAsStringAsync()}");
         var testResult = await testResp.Content.ReadFromJsonAsync<TestCdcSinkMappingResult>();
@@ -106,7 +112,7 @@ public class ApplianceFullFlowTests(ITestOutputHelper output) : CdcSinkIntegrati
             $"expected non-empty test-mapping result; errors=[{string.Join("; ", testResult.Errors)}]");
 
         var provisionResp = await client.PostAsJsonAsync("/api/setup/provision",
-            new { appName = "Northwind Demo", slug = "northwind-demo" });
+            new { appName = "Northwind Demo", slug = appSlug });
         Assert.True(provisionResp.IsSuccessStatusCode,
             $"provision returned {provisionResp.StatusCode}: {await provisionResp.Content.ReadAsStringAsync()}");
         var provisionJson = await provisionResp.Content.ReadFromJsonAsync<JsonElement>();

--- a/test/QuillTests/E2E/Fixtures/ConversationSeed.cs
+++ b/test/QuillTests/E2E/Fixtures/ConversationSeed.cs
@@ -23,18 +23,18 @@ public static class ConversationSeed
     /// Writes the <c>ConversationPreview</c> read-model doc; production co-writes it on every turn.
     private static Task SeedPreviewAsync(
         IDocumentStore store, string database, string conversationId, string agent, DateTime lastMessageAt,
-        string? channelWidgetId = null, string lastUserPrompt = "", string lastAgentReply = "",
+        string? channelId = null, string lastUserPrompt = "", string lastAgentReply = "",
         IReadOnlyDictionary<string, string>? parameters = null) =>
         AgentRouter.UpsertPreviewAsync(store,
             new AgentRequest(database, AgentId: agent, ConversationId: conversationId, Prompt: lastUserPrompt,
-                ChannelId: channelWidgetId is null ? "" : Channel.IdPrefix + channelWidgetId, Parameters: parameters ?? new Dictionary<string, string>()),
+                ChannelId: channelId is null ? "" : Channel.IdPrefix + channelId, Parameters: parameters ?? new Dictionary<string, string>()),
             agent, conversationId, reply: lastAgentReply, nowUtc: lastMessageAt, CancellationToken.None);
 
     /// Seeds a <c>@conversations</c> doc so the metric index can aggregate it without running a live turn.
     public static async Task SeedConversationAsync(
         IDocumentStore store, string database, string id, string agent, DateTime createdAt,
         int messages = 1, long tokens = 0, (string Role, string Text)[]? turns = null,
-        IReadOnlyDictionary<string, object>? parameters = null, string? channelWidgetId = null,
+        IReadOnlyDictionary<string, object>? parameters = null, string? channelId = null,
         IReadOnlyList<(string Role, object? Content)>? richMessages = null)
     {
         var conversation = new SeedConversation
@@ -62,7 +62,7 @@ public static class ConversationSeed
         // production co-writes the preview on every turn, so a seeded conversation must too
         var lastUser = turns is null ? "" : (turns.LastOrDefault(t => t.Role == "user").Text ?? "");
         var lastAgent = turns is null ? "" : (turns.LastOrDefault(t => t.Role is "assistant" or "agent").Text ?? "");
-        await SeedPreviewAsync(store, database, id, agent, createdAt, channelWidgetId,
+        await SeedPreviewAsync(store, database, id, agent, createdAt, channelId,
             lastUserPrompt: lastUser, lastAgentReply: lastAgent,
             parameters: parameters?.ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? ""));
     }

--- a/test/QuillTests/E2E/Fixtures/QuillCollectionFixtures.cs
+++ b/test/QuillTests/E2E/Fixtures/QuillCollectionFixtures.cs
@@ -63,10 +63,10 @@ public abstract class QuillAiHelperTestBase(ITestOutputHelper output, QuillAiHel
         await base.InitializeAsync();   // Host is the shared AI host, built via the override above
         Mock.Reset();
 
-        // wizard-state is a config-DB singleton shared across the collection; clear it so a test starts clean
-        // (no-op for the agent class, which never writes one)
+        // the wizard doc is keyed per app; the suggest wrappers use DefaultWizardSlug, so clear that one so a
+        // test starts clean (no-op for the agent class, which never writes one)
         using var session = Host.Config.OpenAsyncSession();
-        session.Delete(WizardState.DocumentId);
+        session.Delete(WizardState.DocumentIdFor(QuillHost.DefaultWizardSlug));
         await session.SaveChangesAsync();
     }
 }

--- a/test/QuillTests/E2E/Fixtures/QuillHost.cs
+++ b/test/QuillTests/E2E/Fixtures/QuillHost.cs
@@ -16,6 +16,10 @@ public sealed class QuillHost : IAsyncDisposable
 {
     private const string SeededConnectionStringBaseName = "quill-seeded-llm";
 
+    /// The app id the wizard wrappers send when a test doesn't care which app it is. Per-app-isolation tests
+    /// pass explicit slugs instead. Matches the id the AI-helper base resets between tests.
+    public const string DefaultWizardSlug = "wizard-test-app";
+
     private readonly ApplianceWebApplicationFactory _factory;
     private readonly ConcurrentDictionary<string, QuillApp> _apps = new();
 
@@ -111,15 +115,21 @@ public sealed class QuillHost : IAsyncDisposable
     public Task<QuillUsageResponse> GetSettingsUsageAsync(int year, int? month = null, int? day = null) =>
         QuillHttp.GetAsync<QuillUsageResponse>(Client, $"{QuillRoutes.SettingsUsage}?{Periods.Query(year, month, day)}");
 
-    public Task<ConnectResult> SetupConnectAsync(ConnectRequest body) =>
-        QuillHttp.PostAsync<ConnectResult>(Client, QuillRoutes.SetupConnect, body);
+    public Task<ConnectResult> SetupConnectAsync(ConnectRequest body, string slug = DefaultWizardSlug) =>
+        QuillHttp.PostAsync<ConnectResult>(Client, QuillRoutes.SetupConnect, body with { Slug = slug });
 
-    public Task<DiscoverResponse> SetupDiscoverAsync(DiscoverRequest body) =>
-        QuillHttp.PostAsync<DiscoverResponse>(Client, QuillRoutes.SetupDiscover, body);
+    public Task<DiscoverResponse> SetupDiscoverAsync(DiscoverRequest body, string slug = DefaultWizardSlug) =>
+        QuillHttp.PostAsync<DiscoverResponse>(Client, QuillRoutes.SetupDiscover, body with { Slug = slug });
+
+    public Task<CdcSinkConfiguration> SetupMapAsync(MapRequest body) =>
+        QuillHttp.PostAsync<CdcSinkConfiguration>(Client, QuillRoutes.SetupMap, body);
 
     /// A non-success AI status still returns HTTP 200 with the status on the payload.
-    public Task<SuggestCdcResponse> SuggestCdcAsync(SuggestCdcRequest body) =>
-        QuillHttp.PostAsync<SuggestCdcResponse>(Client, QuillRoutes.SuggestCdc, body);
+    public Task<SuggestCdcResponse> SuggestCdcAsync(SuggestCdcRequest body, string slug = DefaultWizardSlug) =>
+        QuillHttp.PostAsync<SuggestCdcResponse>(Client, QuillRoutes.SuggestCdc, body with { Slug = slug });
+
+    public Task<TestMappingResponse> TestMappingAsync(TestMappingRequest body, string slug = DefaultWizardSlug) =>
+        QuillHttp.PostAsync<TestMappingResponse>(Client, QuillRoutes.SetupTestMapping, body with { Slug = slug });
 
     /// Creates the app the real way (DB named for the slug). The DB is not tracked as a <see cref="QuillApp"/>,
     /// so it is not deleted per-call; it is reclaimed when this host's server is disposed (own-server / collection host).

--- a/test/QuillTests/E2E/Fixtures/QuillHttpExtensions.cs
+++ b/test/QuillTests/E2E/Fixtures/QuillHttpExtensions.cs
@@ -113,6 +113,7 @@ internal static class QuillRoutes
     // wizard (config-DB scoped)
     public const string SetupConnect = "/api/setup/connect";
     public const string SetupDiscover = "/api/setup/discover";
+    public const string SetupMap = "/api/setup/map";
     public const string SetupProvision = "/api/setup/provision";
     public const string SetupTestMapping = "/api/setup/test-mapping";
     public const string SuggestCdc = "/api/setup/suggest/cdc";

--- a/test/QuillTests/E2E/Fixtures/QuillTestBase.cs
+++ b/test/QuillTests/E2E/Fixtures/QuillTestBase.cs
@@ -64,6 +64,7 @@ public abstract class QuillTestBase : RavenTestBase
         {
             Server = server,
             ModifyDatabaseName = _ => "quill-config",
+            ModifyDocumentStore = s => s.Conventions.FindCollectionName = QuillConventions.FindCollectionName,
         });
 
         if (longLived)
@@ -85,6 +86,7 @@ public abstract class QuillTestBase : RavenTestBase
             Server = host.Server,
             // the delete endpoint hard-deletes the database, so teardown must not race it
             DeleteDatabaseOnDispose = false,
+            ModifyDocumentStore = s => s.Conventions.FindCollectionName = QuillConventions.FindCollectionName,
         });
 
         await AppProvisioner.CreateAppAsync(host.Config, slug, appName: slug, cdcTaskName: $"{slug}-cdc", CancellationToken.None);

--- a/test/QuillTests/E2E/Fixtures/northwind-cdc-config.json
+++ b/test/QuillTests/E2E/Fixtures/northwind-cdc-config.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Northwind CdcSinkConfiguration for the W3 Map step of the E2E test. Targets the full canonical Northwind dump shipped under the 'northwind-full' dataset (test/SlowTests/Data/npgsql.northwind-full.{create,insert}.sql) -- 830 orders / 91 customers / 77 products. All Postgres tables are lowercase plural; column names use snake_case lowercase since the dump declares everything unquoted.",
   "Name": "wizard-cdc",
-  "ConnectionStringName": "_wizard-source-probe",
+  "ConnectionStringName": "wizard-source",
   "Tables": [
     {
       "CollectionName": "Customers",

--- a/test/QuillTests/EmbedLinksTests.cs
+++ b/test/QuillTests/EmbedLinksTests.cs
@@ -18,7 +18,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     {
         await using var h = await HarnessAsync();
 
-        var minted = await h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(h.WidgetId, new(), TtlSeconds: 3600, MaxInvocations: 50));
+        var minted = await h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(h.ChannelId, new(), TtlSeconds: 3600, MaxInvocations: 50));
 
         Assert.Matches("^[a-f0-9]{32}$", minted.Token);
         Assert.EndsWith($"/apps/{h.Slug}/embed/{minted.Token}", minted.Url);
@@ -35,7 +35,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
         var req = new HttpRequestMessage(HttpMethod.Post, QuillRoutes.EmbedLinks(h.Slug))
         {
             Content = JsonContent.Create(
-                new { widgetId = h.WidgetId, parameters = new Dictionary<string, string>(), ttlSeconds = 3600, maxInvocations = 50 }),
+                new { channelId = h.ChannelId, parameters = new Dictionary<string, string>(), ttlSeconds = 3600, maxInvocations = 50 }),
         };
         req.Headers.Host = "dashboard.egor-ai.example";
 
@@ -54,7 +54,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     {
         await using var h = await HarnessAsync(provisionChannel: false);
 
-        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest("wgt_nope", null, 3600, 10)));
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest("nope", null, 3600, 10)));
 
         Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
     }
@@ -64,9 +64,9 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     {
         await using var h = await HarnessAsync();
 
-        await h.App.UpdateChannelAsync(h.WidgetId, new UpdateChannelRequest(null, null, Enabled: false));
+        await h.App.UpdateChannelAsync(h.ChannelId, new UpdateChannelRequest(null, null, Enabled: false));
 
-        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(h.WidgetId, null, 3600, 10)));
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(h.ChannelId, null, 3600, 10)));
 
         Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         Assert.Contains("channel_disabled", ex.Body);
@@ -77,12 +77,12 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     {
         await using var h = await HarnessAsync(provisionChannel: false);
 
-        const string widgetId = "wgt_ghost";
+        const string channelId = "ghost";
         using (var session = h.Store.OpenAsyncSession(h.Database))
         {
             await session.StoreAsync(new Channel
             {
-                Id = Channel.IdPrefix + widgetId,
+                Id = Channel.IdPrefix + channelId,
                 Type = ChannelType.IFrame,
                 AgentId = "deleted-agent",
                 AllowedOrigins = [],
@@ -92,7 +92,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
             await session.SaveChangesAsync();
         }
 
-        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(widgetId, null, 3600, 10)));
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(channelId, null, 3600, 10)));
 
         Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
     }
@@ -106,7 +106,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     {
         await using var h = await HarnessAsync();
 
-        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(h.WidgetId, null, ttlSeconds, maxInvocations)));
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(h.ChannelId, null, ttlSeconds, maxInvocations)));
 
         Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
     }
@@ -115,13 +115,13 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Mint_requires_the_agents_declared_parameters()
     {
         await using var h = await HarnessAsync(provisionChannel: false);
-        var widgetId = await ProvisionParamAgentChannelAsync(h.App);
+        var channelId = await ProvisionParamAgentChannelAsync(h.App);
 
-        var missing = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(widgetId, null, 3600, 10)));
+        var missing = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(channelId, null, 3600, 10)));
         Assert.Equal(HttpStatusCode.BadRequest, missing.StatusCode);
 
         var ok = await h.App.MintEmbedLinkAsync(new MintEmbedLinkRequest(
-            widgetId, new Dictionary<string, string> { ["customerId"] = "companies/1-A" }, 3600, 10));
+            channelId, new Dictionary<string, string> { ["customerId"] = "companies/1-A" }, 3600, 10));
         Assert.False(string.IsNullOrEmpty(ok.Token));
     }
 
@@ -129,15 +129,15 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task List_returns_live_links_newest_first_and_excludes_revoked_and_expired()
     {
         await using var h = await HarnessAsync(provisionChannel: false);
-        var widgetId = await ProvisionParamAgentChannelAsync(h.App);
+        var channelId = await ProvisionParamAgentChannelAsync(h.App);
 
-        var older = await MintAsync(h.App, widgetId,
+        var older = await MintAsync(h.App, channelId,
             parameters: new Dictionary<string, string> { ["customerId"] = "companies/1-A" });
-        var newer = await MintAsync(h.App, widgetId,
+        var newer = await MintAsync(h.App, channelId,
             parameters: new Dictionary<string, string> { ["customerId"] = "companies/2-A" });
-        var expired = await MintAsync(h.App, widgetId,
+        var expired = await MintAsync(h.App, channelId,
             parameters: new Dictionary<string, string> { ["customerId"] = "companies/3-A" });
-        var revoked = await MintAsync(h.App, widgetId,
+        var revoked = await MintAsync(h.App, channelId,
             parameters: new Dictionary<string, string> { ["customerId"] = "companies/4-A" });
 
         // Pin distinct CreatedAt so the newest-first ordering doesn't ride on clock resolution.
@@ -161,7 +161,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
         Assert.Equal("companies/2-A", first.Parameters["customerId"]);
         Assert.Equal(0, first.InvocationCount);
         Assert.Equal(50, first.MaxInvocations);
-        Assert.False(string.IsNullOrEmpty(first.WidgetId));
+        Assert.False(string.IsNullOrEmpty(first.ChannelId));
     }
 
     [RavenFact(RavenTestCategory.Quill)]
@@ -177,7 +177,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Minted_link_serves_the_page_and_opens_a_chat_stream()
     {
         await using var h = await HarnessAsync();
-        var token = await MintAsync(h.App, h.WidgetId);
+        var token = await MintAsync(h.App, h.ChannelId);
 
         // raw: asserts the RESPONSE Content-Type header (page → text/html, chat → NDJSON), which the string-body wrappers can't expose.
         var page = await Host.Client.GetAsync(QuillRoutes.EmbedPage(h.Slug, token));
@@ -211,7 +211,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     {
         await using var h = await HarnessAsync();
 
-        var token = await MintAsync(h.App, h.WidgetId);
+        var token = await MintAsync(h.App, h.ChannelId);
 
         using (var cfg = Host.Config.OpenAsyncSession())
         {
@@ -227,7 +227,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Embed_unknown_slug_returns_404()
     {
         await using var h = await HarnessAsync();
-        var token = await MintAsync(h.App, h.WidgetId);
+        var token = await MintAsync(h.App, h.ChannelId);
 
         var pageEx = await Assert.ThrowsAsync<QuillHttpException>(() => Host.GetEmbedPageAsync("other-app", token));
         Assert.Equal(HttpStatusCode.NotFound, pageEx.StatusCode);
@@ -244,7 +244,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Embed_malformed_slug_segment_returns_404(string slug)
     {
         await using var h = await HarnessAsync();
-        var token = await MintAsync(h.App, h.WidgetId);
+        var token = await MintAsync(h.App, h.ChannelId);
 
         var pageEx = await Assert.ThrowsAsync<QuillHttpException>(() => Host.GetEmbedPageAsync(slug, token));
         Assert.Equal(HttpStatusCode.NotFound, pageEx.StatusCode);
@@ -257,7 +257,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Old_style_embed_url_returns_404()
     {
         await using var h = await HarnessAsync();
-        var token = await MintAsync(h.App, h.WidgetId);
+        var token = await MintAsync(h.App, h.ChannelId);
 
         var oldPage = await h.Client.GetAsync($"/embed/{token}");
         Assert.Equal(HttpStatusCode.NotFound, oldPage.StatusCode);
@@ -276,7 +276,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Chat_enforces_the_invocation_cap()
     {
         await using var h = await HarnessAsync();
-        var token = await MintAsync(h.App, h.WidgetId, maxInvocations: 1);
+        var token = await MintAsync(h.App, h.ChannelId, maxInvocations: 1);
 
         // Set the cap directly: no LLM in a unit run, and a failed turn would be refunded.
         using (var session = h.Store.OpenAsyncSession(h.Database))
@@ -295,7 +295,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     {
         // This test REQUIRES the turn to fail; the shared demo CS points at a closed port, so it always does.
         await using var h = await HarnessAsync();
-        var token = await MintAsync(h.App, h.WidgetId, maxInvocations: 1);
+        var token = await MintAsync(h.App, h.ChannelId, maxInvocations: 1);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
@@ -313,7 +313,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Expired_link_returns_410()
     {
         await using var h = await HarnessAsync();
-        var token = await MintAsync(h.App, h.WidgetId);
+        var token = await MintAsync(h.App, h.ChannelId);
 
         using (var session = h.Store.OpenAsyncSession(h.Database))
         {
@@ -333,7 +333,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Revoked_link_returns_410()
     {
         await using var h = await HarnessAsync();
-        var token = await MintAsync(h.App, h.WidgetId);
+        var token = await MintAsync(h.App, h.ChannelId);
 
         await h.App.RevokeEmbedLinkAsync(token);
 
@@ -346,7 +346,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     {
         // Allowed list excludes localhost on purpose, so the self-origin rule is what passes it.
         await using var h = await HarnessAsync(origins: new[] { "http://customer.example" });
-        var token = await MintAsync(h.App, h.WidgetId);
+        var token = await MintAsync(h.App, h.ChannelId);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
@@ -366,7 +366,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Empty_allowed_origins_skips_the_origin_check()
     {
         await using var h = await HarnessAsync(origins: Array.Empty<string>());
-        var token = await MintAsync(h.App, h.WidgetId);
+        var token = await MintAsync(h.App, h.ChannelId);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var resp = await h.App.SendEmbedChatAsync(token, "hi", origin: "http://anywhere.example", ct: cts.Token);
@@ -377,9 +377,9 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Disabled_channel_makes_minted_links_return_410()
     {
         await using var h = await HarnessAsync();
-        var token = await MintAsync(h.App, h.WidgetId);
+        var token = await MintAsync(h.App, h.ChannelId);
 
-        await h.App.UpdateChannelAsync(h.WidgetId, new UpdateChannelRequest(null, null, Enabled: false));
+        await h.App.UpdateChannelAsync(h.ChannelId, new UpdateChannelRequest(null, null, Enabled: false));
 
         var pageEx = await Assert.ThrowsAsync<QuillHttpException>(() => h.App.GetEmbedPageAsync(token));
         Assert.Equal(HttpStatusCode.Gone, pageEx.StatusCode);
@@ -392,7 +392,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Conversation_is_bound_to_the_link_across_turns()
     {
         await using var h = await HarnessAsync();
-        var token = await MintAsync(h.App, h.WidgetId, maxInvocations: 5);
+        var token = await MintAsync(h.App, h.ChannelId, maxInvocations: 5);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await h.App.SendEmbedChatAsync(token, "one", ct: cts.Token);
@@ -407,8 +407,8 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     public async Task Chat_body_cannot_inject_parameters_they_come_from_the_link()
     {
         await using var h = await HarnessAsync(provisionChannel: false);
-        var widgetId = await ProvisionParamAgentChannelAsync(h.App);
-        var token = await MintAsync(h.App, widgetId,
+        var channelId = await ProvisionParamAgentChannelAsync(h.App);
+        var token = await MintAsync(h.App, channelId,
             parameters: new Dictionary<string, string> { ["customerId"] = "companies/1-A" });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -421,7 +421,7 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
     {
         var app = await NewAppAsync();
 
-        var widgetId = "";
+        var channelId = "";
         if (provisionChannel)
         {
             await app.ProvisionAgentAsync(new AiAgentConfiguration
@@ -433,18 +433,18 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
             });
             var channel = await app.ProvisionChannelAsync(
                 new ProvisionChannelRequest(ChannelType.IFrame, "demo-agent", origins ?? Array.Empty<string>()));
-            widgetId = channel.WidgetId;
+            channelId = channel.ChannelId;
         }
 
-        return new Harness(app, widgetId);
+        return new Harness(app, channelId);
     }
 
     private static async Task<string> MintAsync(
-        QuillApp app, string widgetId,
+        QuillApp app, string channelId,
         int ttlSeconds = 3600, int maxInvocations = 50, Dictionary<string, string>? parameters = null)
     {
         var minted = await app.MintEmbedLinkAsync(
-            new MintEmbedLinkRequest(widgetId, parameters ?? new Dictionary<string, string>(), ttlSeconds, maxInvocations));
+            new MintEmbedLinkRequest(channelId, parameters ?? new Dictionary<string, string>(), ttlSeconds, maxInvocations));
         return minted.Token;
     }
 
@@ -474,10 +474,10 @@ public class EmbedLinksTests(ITestOutputHelper output) : QuillTestBase(output)
 
         var channel = await app.ProvisionChannelAsync(
             new ProvisionChannelRequest(ChannelType.IFrame, "param-agent", Array.Empty<string>()));
-        return channel.WidgetId;
+        return channel.ChannelId;
     }
 
-    private sealed record Harness(QuillApp App, string WidgetId) : IAsyncDisposable
+    private sealed record Harness(QuillApp App, string ChannelId) : IAsyncDisposable
     {
         public HttpClient Client => App.Host.Client;
         public string Slug => App.Slug;

--- a/test/QuillTests/EmbedPageHistoryTests.cs
+++ b/test/QuillTests/EmbedPageHistoryTests.cs
@@ -25,7 +25,7 @@ public class EmbedPageHistoryTests(ITestOutputHelper output) : QuillTestBase(out
         var channel = await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "demo", Array.Empty<string>()));
 
         // ConversationId is set directly: the mint EP doesn't expose it (the server binds it on the first live-LLM turn).
-        var token = (await app.MintEmbedLinkAsync(new MintEmbedLinkRequest(channel.WidgetId))).Token;
+        var token = (await app.MintEmbedLinkAsync(new MintEmbedLinkRequest(channel.ChannelId))).Token;
         using (var session = app.Store.OpenAsyncSession(app.Slug))
         {
             var link = await session.LoadAsync<EmbedLink>(EmbedLink.IdPrefix + token);
@@ -51,7 +51,7 @@ public class EmbedPageHistoryTests(ITestOutputHelper output) : QuillTestBase(out
         });
         var channel = await app.ProvisionChannelAsync(new ProvisionChannelRequest(ChannelType.IFrame, "demo", Array.Empty<string>()));
 
-        var token = (await app.MintEmbedLinkAsync(new MintEmbedLinkRequest(channel.WidgetId))).Token;
+        var token = (await app.MintEmbedLinkAsync(new MintEmbedLinkRequest(channel.ChannelId))).Token;
 
         var html = await app.GetEmbedPageAsync(token);
 

--- a/test/QuillTests/WizardAgentEndpointsTests.cs
+++ b/test/QuillTests/WizardAgentEndpointsTests.cs
@@ -225,18 +225,17 @@ public class WizardAgentEndpointsTests(ITestOutputHelper output) : QuillTestBase
     }
 
     [RavenFact(RavenTestCategory.Quill)]
-    public async Task Channel_endpoint_returns_widgetId_for_known_app()
+    public async Task Channel_endpoint_returns_channelId_for_known_app()
     {
         await using var app = await NewAppAsync();
         await SeedDemoAgentAsync(app);
 
         var provisioned = await app.ProvisionChannelAsync(
             new ProvisionChannelRequest(ChannelType.IFrame, "demo-agent", new[] { "http://localhost" }));
-        var widgetId = provisioned.WidgetId;
-        Assert.False(string.IsNullOrEmpty(widgetId), "widgetId was empty");
-        Assert.StartsWith("wgt_", widgetId);
-        Assert.True(widgetId.Length >= 26,
-            $"widgetId length {widgetId.Length} is below the 128-bit-entropy floor (expected ≥26 incl. 'wgt_' prefix): '{widgetId}'");
+        var channelId = provisioned.ChannelId;
+        Assert.False(string.IsNullOrEmpty(channelId), "channelId was empty");
+        // Guid "N": 32 hex chars, 128 bits of entropy, no prefix
+        Assert.Equal(32, channelId.Length);
     }
 
     [RavenFact(RavenTestCategory.Quill)]
@@ -293,23 +292,23 @@ public class WizardAgentEndpointsTests(ITestOutputHelper output) : QuillTestBase
         await using var app = await NewAppAsync();
         await SeedDemoAgentAsync(app);
 
-        var widgetId1 = (await app.ProvisionChannelAsync(
-            new ProvisionChannelRequest(ChannelType.IFrame, "demo-agent", new[] { "http://site-a.example" }, "Site A"))).WidgetId;
+        var channelId1 = (await app.ProvisionChannelAsync(
+            new ProvisionChannelRequest(ChannelType.IFrame, "demo-agent", new[] { "http://site-a.example" }, "Site A"))).ChannelId;
 
-        var widgetId2 = (await app.ProvisionChannelAsync(
-            new ProvisionChannelRequest(ChannelType.IFrame, "demo-agent", new[] { "http://site-b.example" }, "Site B"))).WidgetId;
+        var channelId2 = (await app.ProvisionChannelAsync(
+            new ProvisionChannelRequest(ChannelType.IFrame, "demo-agent", new[] { "http://site-b.example" }, "Site B"))).ChannelId;
 
-        Assert.NotEqual(widgetId1, widgetId2);
+        Assert.NotEqual(channelId1, channelId2);
 
         using var session = app.Store.OpenAsyncSession(app.Slug);
         var channels = await session.Advanced.LoadStartingWithAsync<Channel>("channels/");
         Assert.Equal(2, channels.Count());
 
-        var channelA = await session.LoadAsync<Channel>($"channels/{widgetId1}");
+        var channelA = await session.LoadAsync<Channel>($"channels/{channelId1}");
         Assert.Equal("Site A", channelA.DisplayName);
         Assert.Equal(new[] { "http://site-a.example" }, channelA.AllowedOrigins);
 
-        var channelB = await session.LoadAsync<Channel>($"channels/{widgetId2}");
+        var channelB = await session.LoadAsync<Channel>($"channels/{channelId2}");
         Assert.Equal("Site B", channelB.DisplayName);
         Assert.Equal(new[] { "http://site-b.example" }, channelB.AllowedOrigins);
     }
@@ -419,7 +418,7 @@ public class WizardAgentEndpointsTests(ITestOutputHelper output) : QuillTestBase
         using var session = app.Store.OpenAsyncSession(app.Slug);
         var ch = await session.Query<Channel>().FirstAsync();
         var collection = session.Advanced.GetMetadataFor(ch)["@collection"]!.ToString();
-        Assert.Equal("Channels", collection);
+        Assert.Equal("@channels", collection);
     }
 
     [RavenFact(RavenTestCategory.Quill)]

--- a/test/QuillTests/WizardProvisionEndpointTests.cs
+++ b/test/QuillTests/WizardProvisionEndpointTests.cs
@@ -1,8 +1,6 @@
 using System.Net;
 using QuillTests.E2E.Fixtures;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Operations.ConnectionStrings;
-using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Quill.Wizard;
 using Tests.Infrastructure;
 using Xunit;
@@ -13,8 +11,6 @@ namespace QuillTests;
 public class WizardProvisionEndpointTests(ITestOutputHelper output, QuillCollectionHost collection)
     : QuillTestBase(output, collection)
 {
-    private const string WizardSourceProbeName = "_wizard-source-probe";
-
     [RavenFact(RavenTestCategory.Quill)]
     public async Task Provision_with_invalid_explicit_slug_returns_400()
     {
@@ -46,10 +42,9 @@ public class WizardProvisionEndpointTests(ITestOutputHelper output, QuillCollect
     [RavenFact(RavenTestCategory.Quill)]
     public async Task Provision_with_duplicate_slug_returns_409()
     {
-        await SeedWizardMapAsync(Host.Config);
-        await RegisterProbeAsync(Host.Config);
-
         var taken = "taken-" + Guid.NewGuid().ToString("N");
+        await SeedWizardMapAsync(Host.Config, taken);
+
         await Host.ProvisionAsync(new ProvisionRequest("First App", taken));
 
         var ex = await Assert.ThrowsAsync<QuillHttpException>(() => Host.ProvisionAsync(new ProvisionRequest(UniqueAppName(), taken)));
@@ -61,11 +56,10 @@ public class WizardProvisionEndpointTests(ITestOutputHelper output, QuillCollect
     [RavenFact(RavenTestCategory.Quill)]
     public async Task Provision_normalizes_explicit_slug_before_uniqueness_gate()
     {
-        await SeedWizardMapAsync(Host.Config);
-        await RegisterProbeAsync(Host.Config);
-
         var suffix = Guid.NewGuid().ToString("N");
         var normalized = $"my-custom-app-{suffix}";
+        await SeedWizardMapAsync(Host.Config, normalized);
+
         await Host.ProvisionAsync(new ProvisionRequest("First App", normalized));
 
         // messy slug normalizes to the already-provisioned one
@@ -78,10 +72,8 @@ public class WizardProvisionEndpointTests(ITestOutputHelper output, QuillCollect
     [RavenFact(RavenTestCategory.Quill)]
     public async Task Provision_returns_409_when_slug_is_already_provisioned()
     {
-        await SeedWizardMapAsync(Host.Config);
-        await RegisterProbeAsync(Host.Config);
-
         var slug = "twice-" + Guid.NewGuid().ToString("N");
+        await SeedWizardMapAsync(Host.Config, slug);
         await Host.ProvisionAsync(new ProvisionRequest("First App", slug));
 
         var second = await Assert.ThrowsAsync<QuillHttpException>(() => Host.ProvisionAsync(new ProvisionRequest("Second App", slug)));
@@ -93,10 +85,8 @@ public class WizardProvisionEndpointTests(ITestOutputHelper output, QuillCollect
     [RavenFact(RavenTestCategory.Quill)]
     public async Task Provision_uses_explicit_slug_override()
     {
-        await SeedWizardMapAsync(Host.Config);
-        await RegisterProbeAsync(Host.Config);
-
         var slug = "override-" + Guid.NewGuid().ToString("N");
+        await SeedWizardMapAsync(Host.Config, slug);
         var response = await Host.ProvisionAsync(new ProvisionRequest("Pretty Display Name", slug));
 
         Assert.Equal(slug, response.Slug);
@@ -111,26 +101,11 @@ public class WizardProvisionEndpointTests(ITestOutputHelper output, QuillCollect
     }
 
     [RavenFact(RavenTestCategory.Quill)]
-    public async Task Provision_removes_the_probe_connection_string()
-    {
-        await SeedWizardMapAsync(Host.Config);
-        await RegisterProbeAsync(Host.Config);
-
-        var slug = "probe-clean-" + Guid.NewGuid().ToString("N");
-        await Host.ProvisionAsync(new ProvisionRequest("Probe Clean", slug));
-
-        var result = await Host.Config.Maintenance.ForDatabase(Host.Config.Database)
-            .SendAsync(new GetConnectionStringsOperation(WizardSourceProbeName, ConnectionStringType.Sql));
-        Assert.True(result.SqlConnectionStrings is null || result.SqlConnectionStrings.ContainsKey(WizardSourceProbeName) == false);
-    }
-
-    [RavenFact(RavenTestCategory.Quill)]
     public async Task Provision_derives_slug_from_app_name_when_no_override()
     {
-        await SeedWizardMapAsync(Host.Config);
-        await RegisterProbeAsync(Host.Config);
-
         var suffix = Guid.NewGuid().ToString("N");
+        await SeedWizardMapAsync(Host.Config, $"derive-me-{suffix}");
+
         var response = await Host.ProvisionAsync(new ProvisionRequest($"Derive Me {suffix}"));
 
         Assert.Equal($"derive-me-{suffix}", response.Slug);
@@ -138,25 +113,21 @@ public class WizardProvisionEndpointTests(ITestOutputHelper output, QuillCollect
 
     private static string UniqueAppName() => "App " + Guid.NewGuid().ToString("N");
 
-    private static async Task SeedWizardMapAsync(IDocumentStore store)
+    private static async Task SeedWizardMapAsync(IDocumentStore store, string slug)
     {
         var cdc = AiHelperSamples.BuildCdcConfig();
         cdc.Disabled = true;
         cdc.SkipInitialLoad = true;
 
         using var session = store.OpenAsyncSession();
-        await session.StoreAsync(new WizardState { Provider = "Npgsql", LastMapConfiguration = cdc }, WizardState.DocumentId);
-        await session.SaveChangesAsync();
-    }
-
-    private static async Task RegisterProbeAsync(IDocumentStore store)
-    {
-        await store.Maintenance.ForDatabase(store.Database).SendAsync(
-            new PutConnectionStringOperation<SqlConnectionString>(new SqlConnectionString
+        await session.StoreAsync(
+            new WizardState
             {
-                Name = WizardSourceProbeName,
-                FactoryName = "Npgsql",
-                ConnectionString = "Host=localhost;Database=src",
-            }));
+                Provider = "Npgsql",
+                SourceConnectionString = "Host=localhost;Database=src",
+                LastMapConfiguration = cdc,
+            },
+            WizardState.DocumentIdFor(slug));
+        await session.SaveChangesAsync();
     }
 }

--- a/test/QuillTests/WizardSourceConnectionFlowTests.cs
+++ b/test/QuillTests/WizardSourceConnectionFlowTests.cs
@@ -8,27 +8,31 @@ namespace QuillTests;
 
 public class WizardSourceConnectionFlowTests(ITestOutputHelper output) : QuillTestBase(output)
 {
-    private const string WizardSourceProbeName = "_wizard-source-probe";
-
     [RavenFact(RavenTestCategory.Quill)]
-    public async Task Discover_uses_inline_connection_string_and_does_not_persist_probe()
+    public async Task Discover_uses_inline_connection_string_and_persists_no_connection_string()
     {
         await using var host = await NewHostAsync();
+
+        // raw: seed the wizard doc connect would create, so discover (which now requires it) runs standalone
+        using (var session = host.Config.OpenAsyncSession())
+        {
+            await session.StoreAsync(new WizardState(), WizardState.DocumentIdFor(QuillHost.DefaultWizardSlug));
+            await session.SaveChangesAsync();
+        }
 
         // unreachable source: success=false with errors, not an HTTP error
         var discover = await host.SetupDiscoverAsync(new DiscoverRequest("SqlClient", "invalid"));
         Assert.False(discover.Success);
         Assert.NotEmpty(discover.Errors);
 
-        // maintenance op: discover must NOT persist the probe CS
+        // the source is used inline; discover persists nothing as a config-DB connection string
         var result = await host.Config.Maintenance.ForDatabase(host.Config.Database)
-            .SendAsync(new GetConnectionStringsOperation(WizardSourceProbeName, ConnectionStringType.Sql));
-
-        Assert.True(result.SqlConnectionStrings is null || result.SqlConnectionStrings.ContainsKey(WizardSourceProbeName) == false);
+            .SendAsync(new GetConnectionStringsOperation());
+        Assert.True(result.SqlConnectionStrings is null || result.SqlConnectionStrings.Count == 0);
     }
 
     [RavenFact(RavenTestCategory.Quill)]
-    public async Task Connect_persists_probe_connection_string_and_reports_reachability()
+    public async Task Connect_stores_the_source_on_the_wizard_doc_and_reports_reachability()
     {
         await using var host = await NewHostAsync();
 
@@ -39,16 +43,18 @@ public class WizardSourceConnectionFlowTests(ITestOutputHelper output) : QuillTe
         Assert.Contains("Could not connect to the source database", error.Message);
         Assert.DoesNotContain("Exception", error.Message);
         Assert.DoesNotContain("   at ", error.Message);
-
         Assert.False(string.IsNullOrEmpty(error.Details));
 
-        // maintenance op: probe CS persisted on the config DB; Provision transplants it later
-        var result = await host.Config.Maintenance.ForDatabase(host.Config.Database)
-            .SendAsync(new GetConnectionStringsOperation(WizardSourceProbeName, ConnectionStringType.Sql));
-        var probe = Assert.Single(result.SqlConnectionStrings!).Value;
+        // the source connection string lives on the per-app wizard doc, not as a config-DB connection string
+        using (var session = host.Config.OpenAsyncSession())
+        {
+            var state = await session.LoadAsync<WizardState>(WizardState.DocumentIdFor(QuillHost.DefaultWizardSlug));
+            Assert.Equal("Microsoft.Data.SqlClient", state!.Provider);
+            Assert.Equal("invalid", state.SourceConnectionString);
+        }
 
-        Assert.Equal(WizardSourceProbeName, probe.Name);
-        Assert.Equal("Microsoft.Data.SqlClient", probe.FactoryName);
-        Assert.Equal("invalid", probe.ConnectionString);
+        var result = await host.Config.Maintenance.ForDatabase(host.Config.Database)
+            .SendAsync(new GetConnectionStringsOperation());
+        Assert.True(result.SqlConnectionStrings is null || result.SqlConnectionStrings.Count == 0);
     }
 }

--- a/test/QuillTests/WizardStateIsolationTests.cs
+++ b/test/QuillTests/WizardStateIsolationTests.cs
@@ -1,0 +1,192 @@
+using System.Net;
+using QuillTests.E2E.Fixtures;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Quill.Wizard;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace QuillTests;
+
+[Collection(QuillWizardCollection.Name)]
+public class WizardStateIsolationTests(ITestOutputHelper output, QuillCollectionHost collection)
+    : QuillTestBase(output, collection)
+{
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Map_persists_a_separate_wizard_doc_per_app()
+    {
+        var (a, b) = TwoSlugs();
+        await StartWizardAsync(a);
+        await StartWizardAsync(b);
+
+        await Host.SetupMapAsync(MapRequestFor(a, name: $"{a}-cdc"));
+        await Host.SetupMapAsync(MapRequestFor(b, name: $"{b}-cdc"));
+
+        var stateA = await LoadWizardStateAsync(a);
+        var stateB = await LoadWizardStateAsync(b);
+
+        Assert.Equal($"{a}-cdc", stateA!.LastMapConfiguration!.Name);
+        Assert.Equal($"{b}-cdc", stateB!.LastMapConfiguration!.Name);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Discover_persists_a_separate_wizard_doc_per_app()
+    {
+        var (a, b) = TwoSlugs();
+        await StartWizardAsync(a);
+        await StartWizardAsync(b);
+
+        await Host.SetupDiscoverAsync(new DiscoverRequest("SqlClient", "invalid"), slug: a);
+        await Host.SetupDiscoverAsync(new DiscoverRequest("Npgsql", "invalid"), slug: b);
+
+        var stateA = await LoadWizardStateAsync(a);
+        var stateB = await LoadWizardStateAsync(b);
+
+        Assert.Equal("Microsoft.Data.SqlClient", stateA!.Provider);
+        Assert.Equal("Npgsql", stateB!.Provider);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Provision_reads_the_map_config_of_its_own_app()
+    {
+        var (mine, other) = TwoSlugs();
+
+        await SeedWizardMapAsync(mine, collection: "MyOrders");
+        await SeedWizardMapAsync(other, collection: "OtherOrders");
+
+        await Host.ProvisionAsync(new ProvisionRequest("Mine", mine));
+
+        var cdc = await Host.GetCdcAsync(mine);
+        Assert.Equal("MyOrders", cdc.Tables[0].CollectionName);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Provision_transplants_the_connecting_operators_own_source_not_a_concurrent_one()
+    {
+        var (mine, other) = TwoSlugs();
+        const string mySource = "invalid-mine";
+        const string otherSource = "invalid-other";
+
+        await Host.SetupConnectAsync(new ConnectRequest("Npgsql", mySource), slug: mine);
+        await Host.SetupMapAsync(MapRequestFor(mine, name: $"{mine}-cdc"));
+
+        // a second operator connects to a different source before I provision
+        await Host.SetupConnectAsync(new ConnectRequest("Npgsql", otherSource), slug: other);
+
+        await Host.ProvisionAsync(new ProvisionRequest("Mine", mine));
+
+        // raw: the source credentials get transplanted onto the app DB under the mapped connection-string name
+        var strings = await Host.Config.Maintenance.ForDatabase(mine).SendAsync(
+            new GetConnectionStringsOperation("src", ConnectionStringType.Sql));
+
+        Assert.Equal(mySource, strings.SqlConnectionStrings!["src"].ConnectionString);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Deleting_an_app_removes_its_wizard_doc()
+    {
+        await using var app = await NewAppAsync();
+        await SeedWizardMapAsync(app.Slug, collection: "Orders");
+
+        await Host.DeleteAppAsync(app.Slug);
+
+        Assert.Null(await LoadWizardStateAsync(app.Slug));
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Connect_starts_a_fresh_wizard_doc_dropping_leftovers()
+    {
+        var (slug, _) = TwoSlugs();
+        await SeedWizardMapAsync(slug, collection: "Stale");
+
+        await StartWizardAsync(slug);
+
+        var state = await LoadWizardStateAsync(slug);
+        Assert.Equal("Microsoft.Data.SqlClient", state!.Provider);
+        Assert.Null(state.LastMapConfiguration);
+        Assert.Null(state.LastDiscoveredSchema);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Wizard_step_rejects_an_empty_slug()
+    {
+        // empty slug: no app to key the wizard doc by
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(
+            () => Host.SetupDiscoverAsync(new DiscoverRequest("SqlClient", "invalid"), slug: ""));
+
+        Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Discover_before_connect_returns_400()
+    {
+        var (slug, _) = TwoSlugs();
+
+        // no connect for this slug, so there is no wizard doc to discover into
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(
+            () => Host.SetupDiscoverAsync(new DiscoverRequest("SqlClient", "invalid"), slug: slug));
+
+        Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Map_before_connect_returns_400()
+    {
+        var (slug, _) = TwoSlugs();
+
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(
+            () => Host.SetupMapAsync(MapRequestFor(slug, name: $"{slug}-cdc")));
+
+        Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+    }
+
+    private static (string A, string B) TwoSlugs()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        return ($"iso-a-{suffix}", $"iso-b-{suffix}");
+    }
+
+    // connect is the first step: it creates the per-app wizard doc that discover/map then require
+    private Task StartWizardAsync(string slug) =>
+        Host.SetupConnectAsync(new ConnectRequest("SqlClient", "invalid"), slug: slug);
+
+    private async Task<WizardState?> LoadWizardStateAsync(string slug)
+    {
+        using var session = Host.Config.OpenAsyncSession();
+        return await session.LoadAsync<WizardState>(WizardState.DocumentIdFor(slug));
+    }
+
+    private async Task SeedWizardMapAsync(string slug, string collection)
+    {
+        var cdc = AiHelperSamples.BuildCdcConfig();
+        cdc.Tables[0].CollectionName = collection;
+        cdc.Disabled = true;
+        cdc.SkipInitialLoad = true;
+
+        using var session = Host.Config.OpenAsyncSession();
+        await session.StoreAsync(
+            new WizardState
+            {
+                Provider = "Npgsql",
+                SourceConnectionString = "Host=localhost;Database=src",
+                LastMapConfiguration = cdc,
+            },
+            WizardState.DocumentIdFor(slug));
+        await session.SaveChangesAsync();
+    }
+
+    private static MapRequest MapRequestFor(string slug, string name)
+    {
+        var sample = AiHelperSamples.BuildCdcConfig();
+        return new MapRequest
+        {
+            Slug = slug,
+            Name = name,
+            ConnectionStringName = sample.ConnectionStringName,
+            Tables = sample.Tables,
+            Postgres = sample.Postgres,
+            Disabled = true,
+            SkipInitialLoad = true,
+        };
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26984 
https://issues.hibernatingrhinos.com/issue/RavenDB-27072

### Additional description

- Rename widget->channel identifiers; move Channels/EmbedLinks to @-prefixed collections
- Support concurrent setup-wizard runs

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
