### PR TITLE
RavenDB-27185 Treat ModelInference and Persistence as load-phase steps when reading task load errors in tests

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -248,7 +248,7 @@ namespace FastTests
 
                 var errors = database.TaskErrorsStorage.ReadItemErrorsOfTask(TaskTypeExtensions.GetTaskCategoryFromEtlType(config.EtlType), $"{config.Name}/{config.Transforms.First().Name}");
 
-                return errors.Where(error => error.Step == (int)TaskErrorStep.Load);
+                return errors.Where(error => IsLoadPhaseStep(error.Step));
             }
 
             public async Task<IEnumerable<TaskProcessErrorTableValue>> GetProcessLoadErrorsAsync<T>(string databaseName, EtlConfiguration<T> config) where T : ConnectionString
@@ -257,7 +257,12 @@ namespace FastTests
 
                 var errors = database.TaskErrorsStorage.ReadProcessErrorsOfTask(TaskTypeExtensions.GetTaskCategoryFromEtlType(config.EtlType), $"{config.Name}/{config.Transforms.First().Name}");
 
-                return errors.Where(error => error.Step == (int)TaskErrorStep.Load);
+                return errors.Where(error => IsLoadPhaseStep(error.Step));
+            }
+            
+            private static bool IsLoadPhaseStep(long step)
+            {
+                return (TaskErrorStep)step is TaskErrorStep.Load or TaskErrorStep.ModelInference or TaskErrorStep.Persistence;
             }
 
             public async Task<IEnumerable<TaskItemErrorTableValue>> GetItemTransformationErrorsAsync<T>(string databaseName, EtlConfiguration<T> config) where T : ConnectionString


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27185/Tests-GenAI-load-errors-are-invisible-to-Etl.GetLoadErrorsAsync-helpers

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
