### PR TITLE
RavenDB-27179 Fix Corax dropping documents missing the field on `A an…

### DIFF
--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.NotEndsWith.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.NotEndsWith.cs
@@ -19,6 +19,9 @@ namespace Corax.Querying.Matches.TermProviders
 
         private CompactTree.Iterator<TLookupIterator> _iterator;
 
+        private bool _nullsReturned;
+        private bool _nonExistingReturned;
+
         public NotEndsWithTermProvider(Querying.IndexSearcher searcher, CompactTree tree, in FieldMetadata field, CompactKey endsWith)
         {
             _searcher = searcher;
@@ -39,10 +42,32 @@ namespace Corax.Querying.Matches.TermProviders
         public void Reset()
         {
             _iterator.Reset();
+            _nullsReturned = false;
+            _nonExistingReturned = false;
         }
 
         public bool Next(out TermMatch term)
         {
+            if (_nullsReturned == false)
+            {
+                _nullsReturned = true;
+                if (_searcher.TryGetPostingListForNull(_field, out var nullPostingListId))
+                {
+                    term = _searcher.TermQuery(_field, nullPostingListId, 1D);
+                    return true;
+                }
+            }
+
+            if (_nonExistingReturned == false)
+            {
+                _nonExistingReturned = true;
+                if (_searcher.TryGetPostingListForNonExisting(_field, out var nonExistingPostingListId))
+                {
+                    term = _searcher.TermQuery(_field, nonExistingPostingListId, 1D);
+                    return true;
+                }
+            }
+
             var suffix = _endsWith.Decoded();
             while (_iterator.MoveNext(out var key, out _, out _))
             {

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.NotStartsWith.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.NotStartsWith.cs
@@ -22,6 +22,9 @@ namespace Corax.Querying.Matches.TermProviders
 
         private CompactTree.Iterator<TLookupIterator> _iterator;
 
+        private bool _nullsReturned;
+        private bool _nonExistingReturned;
+
 
         public NotStartsWithTermProvider(Querying.IndexSearcher searcher, CompactTree tree, in FieldMetadata field, CompactKey startWith, bool validatePostfixLen, CancellationToken token)
         {
@@ -45,10 +48,32 @@ namespace Corax.Querying.Matches.TermProviders
         public void Reset()
         {
             _iterator.Reset();
+            _nullsReturned = false;
+            _nonExistingReturned = false;
         }
 
         public bool Next(out TermMatch term)
         {
+            if (_nullsReturned == false)
+            {
+                _nullsReturned = true;
+                if (_searcher.TryGetPostingListForNull(_field, out var nullPostingListId))
+                {
+                    term = _searcher.TermQuery(_field, nullPostingListId, 1D);
+                    return true;
+                }
+            }
+
+            if (_nonExistingReturned == false)
+            {
+                _nonExistingReturned = true;
+                if (_searcher.TryGetPostingListForNonExisting(_field, out var nonExistingPostingListId))
+                {
+                    term = _searcher.TermQuery(_field, nonExistingPostingListId, 1D);
+                    return true;
+                }
+            }
+
             var startWith = _startWith.Decoded();
             while (_iterator.MoveNext(out var key, out _, out _))
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -709,12 +709,13 @@ public static class CoraxQueryBuilder
         
         switch (methodType)
         {
+            // Do NOT use the internally negated primitive here: NotStartsWith / NotEndsWith enumerate only the
+            // terms that exist in the field, so documents that are missing that field are excluded. That is wrong
+            // for `A and not (startsWith(field, x))` - the negation must apply to the whole left-hand set, which
+            // includes documents missing the field. Falling through to NoOpt makes HandleNegatedAnd use
+            // AndNot(left, <positive match>), which keeps those documents (matching Lucene and Corax 2.0).
             case MethodType.StartsWith:
-                match = HandleStartsWith(builderParameters, inner,  exact, ref builderParameters.StreamingDisabled, negated: true);
-                return true;
             case MethodType.EndsWith:
-                match = HandleEndsWith(builderParameters, inner,  exact, ref builderParameters.StreamingDisabled, negated: true);
-                return true;
             default:
                 goto NoOpt;
         }

--- a/test/SlowTests/Issues/RavenDB_27179.cs
+++ b/test/SlowTests/Issues/RavenDB_27179.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27179 : RavenTestBase
+    {
+        public RavenDB_27179(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Movie
+        {
+            public string Title { get; set; }
+            public string Tagline { get; set; }
+        }
+
+        private class Movies_ByTagline : AbstractIndexCreationTask<Movie>
+        {
+            public Movies_ByTagline()
+            {
+                Map = movies => from m in movies
+                                select new
+                                {
+                                    m.Title,
+                                    m.Tagline
+                                };
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void NegatedStartsWithInAndMustKeepDocumentsMissingTheField(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Movie { Title = "a", Tagline = "hello world" }); // has tagline
+                session.Store(new Movie { Title = "b" });                          // no tagline
+                session.Store(new Movie { Title = "c", Tagline = "another one" }); // has tagline
+                session.Store(new Movie { Title = "d" });                          // no tagline
+                session.SaveChanges();
+            }
+
+            new Movies_ByTagline().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                // No tagline starts with "zzz", so `not startsWith(Tagline, "zzz")` must keep every document,
+                // including the two that have no Tagline field at all.
+                // The `exists(Title) and ...` form is what triggers the negated-AND code path in Corax.
+                var results = session.Advanced
+                    .RawQuery<Movie>("from index \"Movies/ByTagline\" where exists(Title) and not (startsWith(Tagline, $p))")
+                    .AddParameter("p", "zzz")
+                    .ToList();
+
+                Assert.Equal(4, results.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27179

### Additional description

`A and not (startsWith(field, x))` (same for `endsWith`) was silently dropping every document that has no value for the negated field (field missing or null) on Corax. Standalone `where not (startsWith(...))` was unaffected — only the `AND`-combined form.

Root cause: `HandleNegatedAnd` routed `startsWith`/`endsWith` through the internally-negated primitive (`NotStartsWithTermProvider` / `NotEndsWithTermProvider`), which only iterates the field's terms tree. Documents without a term for that field never appear there, so `And(left, notStartsWith)` excluded them.

Two changes, kept together since they address the same root cause at different layers:
1. `NotStartsWithTermProvider` / `NotEndsWithTermProvider` now also emit the field's null and non-existing posting lists, so the primitive itself returns the true complement. This only helps on index versions that support the non-existing posting list (`IndexVersion.UseNonExistingPostingList`); older indexes still have no way to enumerate field-missing documents from this primitive.
2. `TryUseNegatedQuery` no longer routes `startsWith`/`endsWith` to that primitive from `AND`; `HandleNegatedAnd` now falls back to `AndNot(left, <positive match>)`, which is correct on every index version (it excludes from `left` rather than enumerating the complement) and is also the same code path already used for standalone `not (...)`.

Benchmarked both strategies (`bench/Micro.Benchmark`, not included in this PR) to confirm the fallback isn't a regression: for a selective prefix (the realistic case) `AndNot` is ~90x faster and allocates ~1000x less at 1M docs (12.5 ms / 6 MB vs 1.16 s / 6 GB), and at 50M the old primitive fails outright with a memoization-size exception. The old primitive is only faster for a prefix matching ~99% of values, a case it also returns wrong for pre-fix.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
