### PR TITLE
[6.2] RavenDB-27178 - Compute the documents transaction cache incrementally instead of rescanning every collection on each write commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,7 +125,7 @@ temp
 /.idea
 .vscode
 /test/Tryouts/Databases/*
-bench/Micro.Benchmark/BenchmarkDotNet.Artifacts/
+BenchmarkDotNet.Artifacts/
 /src/Raven.Server/*.DotSettings
 /src/Raven.Pal/osxcross
 /src/Raven.Pal/*.nativecodeanalysis.xml

--- a/RavenDB.sln
+++ b/RavenDB.sln
@@ -94,6 +94,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServerStoreTxMerger.Benchma
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RequestHandler.Benchmark", "bench\RequestHandler.Benchmark\RequestHandler.Benchmark.csproj", "{4E976E13-4BEC-4826-86CD-89E64C04DC69}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentsTxCache.Benchmark", "bench\DocumentsTxCache.Benchmark\DocumentsTxCache.Benchmark.csproj", "{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -770,6 +772,24 @@ Global
 		{4E976E13-4BEC-4826-86CD-89E64C04DC69}.Validate|x64.Build.0 = Debug|Any CPU
 		{4E976E13-4BEC-4826-86CD-89E64C04DC69}.Validate|x86.ActiveCfg = Debug|Any CPU
 		{4E976E13-4BEC-4826-86CD-89E64C04DC69}.Validate|x86.Build.0 = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Debug|x64.Build.0 = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Debug|x86.Build.0 = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Release|x64.ActiveCfg = Release|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Release|x64.Build.0 = Release|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Release|x86.ActiveCfg = Release|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Release|x86.Build.0 = Release|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Validate|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Validate|Any CPU.Build.0 = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Validate|x64.ActiveCfg = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Validate|x64.Build.0 = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Validate|x86.ActiveCfg = Debug|Any CPU
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07}.Validate|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -812,6 +832,7 @@ Global
 												{BF70E6D6-9BF4-4580-85E9-E908CD7D823E} = {C3388268-F662-4D76-A25D-FC4F31CE6AA1}
 												{F3A0869F-CC53-4E09-9688-7A98A0AF2996} = {C3388268-F662-4D76-A25D-FC4F31CE6AA1}
 		{4E976E13-4BEC-4826-86CD-89E64C04DC69} = {C3388268-F662-4D76-A25D-FC4F31CE6AA1}
+		{A6DE1C1B-38F0-4E2D-9D6C-5B1D2E8F4A07} = {C3388268-F662-4D76-A25D-FC4F31CE6AA1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {032D6274-16A5-43ED-920F-D37BBD4B9628}

--- a/bench/DocumentsTxCache.Benchmark/DocumentsTxCache.Benchmark.csproj
+++ b/bench/DocumentsTxCache.Benchmark/DocumentsTxCache.Benchmark.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.29</RuntimeFrameworkVersion>
+    <AssemblyName>DocumentsTxCache.Benchmark</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <PackageId>DocumentsTxCache.Benchmark</PackageId>
+    <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\test\Tests.Infrastructure\Tests.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/bench/DocumentsTxCache.Benchmark/DocumentsTxCacheBench.cs
+++ b/bench/DocumentsTxCache.Benchmark/DocumentsTxCacheBench.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Json;
+using Raven.Client.ServerWide;
+using Raven.Client.Util;
+using Raven.Server;
+using Xunit.Abstractions;
+
+namespace DocumentsTxCache.Benchmark;
+
+[MemoryDiagnoser]
+public class DocumentsTxCacheBench
+{
+    // ConsoleTestOutputHelper marks the RavenTestBase instance as running outside of xUnit,
+    // which lifts the requirement to tag compression usage with RavenTestCategory.Compression
+    private static readonly Tests.Infrastructure.ConsoleTestOutputHelper TestOutputHelper = new Tests.Infrastructure.ConsoleTestOutputHelper();
+
+    private ActualTests _tests;
+
+    [Params(300)]
+    public int NumberOfCollections { get; set; }
+
+    [Params(StorageMode.Plain, StorageMode.Compressed, StorageMode.Encrypted)]
+    public StorageMode Mode { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _tests = new ActualTests(TestOutputHelper);
+        _tests.Initialize(NumberOfCollections, Mode);
+    }
+
+    [Benchmark]
+    public void ModifyDocumentInLoop()
+    {
+        if (_tests == null)
+        {
+            throw new InvalidOperationException("'_tests' cannot be null");
+        }
+
+        _tests.ModifyDocumentInLoop();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _tests?.Dispose();
+        _tests = null;
+    }
+}
+
+public class ActualTests : RavenTestBase
+{
+    private const int DocumentsPerCollection = 100;
+    private const int DocumentSizeInBytes = 100 * 1024;
+    private const int ModificationsPerInvocation = 5;
+
+    private IDocumentStore _store;
+    private string _docIdToModify;
+    private int _counter;
+
+    public ActualTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public string ServerUrl => Server.WebUrl;
+
+    public void Initialize(int numberOfCollections, StorageMode mode)
+    {
+        var compress = mode == StorageMode.Compressed;
+        var encrypt = mode == StorageMode.Encrypted;
+
+        string databaseName = null;
+        if (encrypt)
+        {
+            // AllowEncryptedDatabasesOverHttp is an internal field compile-gated behind
+            // ALLOW_ENCRYPTED_OVER_HTTP (off in Release); flip it on the running server via reflection
+            // so we can use an encrypted database without setting up an HTTPS/certificate server.
+            typeof(RavenServer)
+                .GetField("AllowEncryptedDatabasesOverHttp", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(Server, true);
+
+            AsyncHelpers.RunSync(() => Server.ServerStore.EnsureNotPassiveAsync());
+
+            databaseName = "DocumentsTxCacheEncrypted";
+            var key = new byte[32];
+            RandomNumberGenerator.Fill(key);
+            Server.ServerStore.PutSecretKey(Convert.ToBase64String(key), databaseName, overwrite: true);
+        }
+
+        _store = GetDocumentStore(new Options
+        {
+            // persist to disk (not the in-memory pager) so the storage file is really memory-mapped
+            RunInMemory = false,
+            Encrypted = encrypt,
+            ModifyDatabaseName = databaseName == null ? null : _ => databaseName,
+            ModifyDatabaseRecord = record => record.DocumentsCompression =
+                new DocumentsCompressionConfiguration(compressRevisions: false, compressAllCollections: compress)
+        });
+
+        // each document is a distinct ~256KB complex object (many scalar fields + a long list of
+        // line items with varied values). the last document by etag per collection is the one
+        // ComputeTransactionCache_BeforeCommit reads on every commit.
+        var seed = 0;
+        using (var bulkInsert = _store.BulkInsert())
+        {
+            for (var c = 0; c < numberOfCollections; c++)
+            {
+                var collection = $"Benchmark{c:D3}";
+
+                for (var i = 0; i < DocumentsPerCollection; i++)
+                {
+                    bulkInsert.Store(CreateComplexDocument(DocumentSizeInBytes, seed++), $"{collection}/{i}", new MetadataAsDictionary
+                    {
+                        [Constants.Documents.Metadata.Collection] = collection
+                    });
+                }
+            }
+        }
+
+        // report the on-disk size of an untouched collection so the compression ratio can be computed
+        var details = _store.Maintenance.Send(new GetDetailedCollectionStatisticsOperation());
+        if (details.Collections.TryGetValue("Benchmark001", out var stats) && stats.CountOfDocuments > 0)
+        {
+            Console.WriteLine($"[SIZES] mode={mode} docs={stats.CountOfDocuments} " +
+                              $"onDiskTotalBytes={stats.DocumentsSize.SizeInBytes} " +
+                              $"onDiskPerDocBytes={stats.DocumentsSize.SizeInBytes / stats.CountOfDocuments}");
+        }
+
+        _docIdToModify = "Benchmark000/0";
+    }
+
+    public void ModifyDocumentInLoop()
+    {
+        // the transaction cache is seeded once (during setup); every modify here is steady-state:
+        // a full collection scan in the baseline vs the incremental path in the optimized build
+        for (var iteration = 0; iteration < ModificationsPerInvocation; iteration++)
+        {
+            using (var session = _store.OpenSession())
+            {
+                var doc = session.Load<Doc>(_docIdToModify);
+                doc.Version = _counter++;
+                session.SaveChanges();
+            }
+        }
+    }
+
+    private static readonly string[] Words =
+    {
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+        "india", "juliet", "kilo", "lima", "mike", "november", "oscar", "papa",
+        "quebec", "romeo", "sierra", "tango", "uniform", "victor", "whiskey", "xray"
+    };
+
+    private static Doc CreateComplexDocument(int targetSizeInBytes, int seed)
+    {
+        var doc = new Doc
+        {
+            Name = $"Entity {seed} {Words[seed % Words.Length]}",
+            Description = $"Auto-generated complex benchmark document #{seed} exercising the documents transaction cache.",
+            Category = Words[(seed / 3) % Words.Length],
+            Version = 1,
+            Amount = 1000 + seed * 1.5,
+            IsActive = (seed & 1) == 0,
+            Tags = new List<string>(),
+            Items = new List<LineItem>()
+        };
+
+        for (var t = 0; t < 6; t++)
+            doc.Tags.Add(Words[(seed + t) % Words.Length]);
+
+        // grow the line-item list until the estimated serialized size reaches the target;
+        // values vary per item and per document, so the payload compresses realistically (not like repeated text)
+        var approxBytes = 400;
+        var i = 0;
+        while (approxBytes < targetSizeInBytes)
+        {
+            var item = new LineItem
+            {
+                Sku = $"SKU-{seed:D5}-{i:D6}",
+                ProductName = $"{Words[i % Words.Length]} {Words[(i / 5) % Words.Length]} model {i}",
+                Quantity = (i * 7 + seed) % 500 + 1,
+                UnitPrice = ((i * 13 + seed) % 100000) * 0.01,
+                Discount = (i % 25) * 0.4,
+                Notes = $"Item {i} of doc {seed}: {Words[(i + seed) % Words.Length]} {Words[(i * 3 + seed) % Words.Length]} {Words[(i * 7) % Words.Length]}."
+            };
+            doc.Items.Add(item);
+            approxBytes += 110 + item.Sku.Length + item.ProductName.Length + item.Notes.Length;
+            i++;
+        }
+
+        return doc;
+    }
+
+    public override void Dispose()
+    {
+        _store?.Dispose();
+        _store = null;
+        base.Dispose();
+    }
+}
+
+public class Doc
+{
+    public string Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public string Category { get; set; }
+    public int Version { get; set; }
+    public double Amount { get; set; }
+    public bool IsActive { get; set; }
+    public List<string> Tags { get; set; }
+    public List<LineItem> Items { get; set; }
+}
+
+public class LineItem
+{
+    public string Sku { get; set; }
+    public string ProductName { get; set; }
+    public int Quantity { get; set; }
+    public double UnitPrice { get; set; }
+    public double Discount { get; set; }
+    public string Notes { get; set; }
+}
+
+public enum StorageMode
+{
+    Plain,
+    Compressed,
+    Encrypted
+}

--- a/bench/DocumentsTxCache.Benchmark/MemStats.cs
+++ b/bench/DocumentsTxCache.Benchmark/MemStats.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Globalization;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Tests.Infrastructure;
+
+namespace DocumentsTxCache.Benchmark;
+
+// Alternative to BenchmarkDotNet's NativeMemoryProfiler (which needs an elevated, out-of-process run and
+// is unsupported with InProcessEmitToolchain): drive sustained modify load while polling the server's own
+// /admin/debug/memory/stats endpoint on a background thread, and record the peak of the memory gauges.
+// UnmanagedAllocations == NativeMemory.TotalAllocatedMemory, so a baseline commit that decompresses all
+// 300 collections' last documents shows up as a native peak the optimized build does not have.
+public static class MemStats
+{
+    private const int NumberOfCollections = 300;
+    private const int LoadBursts = 200; // each burst = ModificationsPerInvocation commits
+
+    // one compression mode per process invocation: RavenTestBase cannot be safely instantiated twice
+    // in the same process (its xUnit-logger base ctor throws on the second instance).
+    public static void Run(StorageMode mode)
+    {
+        using var tests = new ActualTests(new ConsoleTestOutputHelper());
+        tests.Initialize(NumberOfCollections, mode);
+
+        var statsUrl = $"{tests.ServerUrl}/admin/debug/memory/stats?includeThreads=false&includeMappings=false";
+        using var http = new HttpClient();
+
+        long peakUnmanaged = 0, peakManaged = 0, peakWorkingSet = 0;
+        var samples = 0;
+        var stop = false;
+
+        var sampler = Task.Run(() =>
+        {
+            while (Volatile.Read(ref stop) == false)
+            {
+                try
+                {
+                    var json = http.GetStringAsync(statsUrl).GetAwaiter().GetResult();
+                    using var doc = JsonDocument.Parse(json);
+                    var mem = doc.RootElement.GetProperty("MemoryInformation");
+                    peakUnmanaged = Math.Max(peakUnmanaged, HumaneToBytes(mem.GetProperty("UnmanagedAllocations").GetString()));
+                    peakManaged = Math.Max(peakManaged, HumaneToBytes(mem.GetProperty("ManagedAllocations").GetString()));
+                    peakWorkingSet = Math.Max(peakWorkingSet, HumaneToBytes(mem.GetProperty("WorkingSet").GetString()));
+                    samples++;
+                }
+                catch
+                {
+                    // ignore transient sampling errors
+                }
+
+                Thread.Sleep(20);
+            }
+        });
+
+        for (var i = 0; i < LoadBursts; i++)
+            tests.ModifyDocumentInLoop();
+
+        Volatile.Write(ref stop, true);
+        sampler.Wait();
+
+        Console.WriteLine(
+            $"[MEMSTATS] mode={mode} samples={samples} " +
+            $"peakUnmanagedBytes={peakUnmanaged} peakManagedBytes={peakManaged} peakWorkingSetBytes={peakWorkingSet} " +
+            $"peakUnmanagedMB={peakUnmanaged / 1024.0 / 1024.0:F1} peakManagedMB={peakManaged / 1024.0 / 1024.0:F1} peakWorkingSetMB={peakWorkingSet / 1024.0 / 1024.0:F1}");
+    }
+
+    // parses both humane sizes ("22.5 MBytes") and plain byte counts ("1288490188")
+    private static long HumaneToBytes(string s)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+            return 0;
+
+        var parts = s.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (double.TryParse(parts[0], NumberStyles.Any, CultureInfo.InvariantCulture, out var num) == false)
+            return 0;
+
+        var multiplier = parts.Length > 1
+            ? parts[1] switch
+            {
+                "KBytes" => 1024d,
+                "MBytes" => 1024d * 1024,
+                "GBytes" => 1024d * 1024 * 1024,
+                "TBytes" => 1024d * 1024 * 1024 * 1024,
+                _ => 1d
+            }
+            : 1d;
+
+        return (long)(num * multiplier);
+    }
+}

--- a/bench/DocumentsTxCache.Benchmark/Program.cs
+++ b/bench/DocumentsTxCache.Benchmark/Program.cs
@@ -1,0 +1,39 @@
+using System;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using BenchmarkDotNet.Validators;
+
+namespace DocumentsTxCache.Benchmark;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        if (args.Length > 0 && args[0] == "--memstats")
+        {
+            var mode = args.Length > 1 ? Enum.Parse<StorageMode>(args[1], ignoreCase: true) : StorageMode.Plain;
+            MemStats.Run(mode);
+            return;
+        }
+
+        // the in-process toolchain avoids BenchmarkDotNet's generated-project build,
+        // which passes a global OutDir that makes the multi-targeting Sparrow TFM outputs
+        // overwrite each other and fails the Raven.Server compilation
+        var config = new ManualConfig()
+            .WithOptions(ConfigOptions.DisableOptimizationsValidator)
+            .AddValidator(JitOptimizationsValidator.DontFailOnError)
+            .AddLogger(ConsoleLogger.Default)
+            .AddColumnProvider(DefaultColumnProviders.Instance)
+            .AddJob(Job.Default
+                .WithToolchain(InProcessEmitToolchain.Instance)
+                .WithWarmupCount(5)
+                .WithIterationCount(10)
+                .AsDefault());
+
+        BenchmarkRunner.Run(typeof(Program).Assembly, config);
+    }
+}

--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -177,7 +177,7 @@ namespace Raven.Server.Documents
                 StorageId = tvr.Id,
                 LowerId = TableValueToString(context, (int)ConflictsTable.LowerId, ref tvr),
                 Id = TableValueToId(context, (int)ConflictsTable.Id, ref tvr),
-                ChangeVector = TableValueToChangeVector(context, (int)ConflictsTable.ChangeVector, ref tvr),
+                ChangeVector = TableValueToChangeVector((int)ConflictsTable.ChangeVector, ref tvr),
                 Etag = etag = TableValueToEtag((int)ConflictsTable.Etag, ref tvr),
                 Doc = new BlittableJsonReaderObject(read, size, context),
                 Collection = TableValueToId(context, (int)ConflictsTable.Collection, ref tvr),

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -374,6 +374,8 @@ namespace Raven.Server.Documents
                 }
 
                 UpdateCollectionCachesForModifiedCollections(tx, currentCache);
+
+                AssertIncrementalCacheMatchesFullScan(tx, currentCache);
             }
             else
             {
@@ -394,6 +396,32 @@ namespace Raven.Server.Documents
                 {
                     ComputeCollectionCache(tx, new CollectionName(collection), cache, ref holder);
                 }
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private void AssertIncrementalCacheMatchesFullScan(Transaction tx, DocumentTransactionCache incremental)
+        {
+            var full = new DocumentTransactionCache { FullyComputed = true };
+            ComputeCollectionCaches(tx, full);
+
+            if (incremental.LastEtagsByCollection.Count != full.LastEtagsByCollection.Count)
+                throw new InvalidOperationException(
+                    $"Incremental documents transaction cache has {incremental.LastEtagsByCollection.Count} collection(s), a full scan has {full.LastEtagsByCollection.Count}.");
+
+            foreach (var kvp in full.LastEtagsByCollection)
+            {
+                if (incremental.LastEtagsByCollection.TryGetValue(kvp.Key, out var incrementalEntry) == false)
+                    throw new InvalidOperationException(
+                        $"Incremental documents transaction cache is missing collection '{kvp.Key}' that a full scan produced.");
+
+                if (incrementalEntry.LastDocumentEtag != kvp.Value.LastDocumentEtag ||
+                    incrementalEntry.LastTombstoneEtag != kvp.Value.LastTombstoneEtag ||
+                    incrementalEntry.LastChangeVector != kvp.Value.LastChangeVector)
+                    throw new InvalidOperationException(
+                        $"Incremental documents transaction cache diverged from a full scan for collection '{kvp.Key}': " +
+                        $"incremental (doc={incrementalEntry.LastDocumentEtag}, tombstone={incrementalEntry.LastTombstoneEtag}, cv={incrementalEntry.LastChangeVector}) " +
+                        $"vs full (doc={kvp.Value.LastDocumentEtag}, tombstone={kvp.Value.LastTombstoneEtag}, cv={kvp.Value.LastChangeVector}).");
             }
         }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -337,16 +337,24 @@ namespace Raven.Server.Documents
             return new DocumentPutAction(this, DocumentDatabase);
         }
 
+        // invoked from Environment.NewTransactionCreated, i.e. once for every new transaction (read and write)
         private void SetTransactionCache(LowLevelTransaction tx)
         {
             if (tx.Flags != TransactionFlags.ReadWrite)
             {
+                // read transactions only ever consume the cache, so hand them the last published one
                 tx.ImmutableExternalState = _documentsMetadataCache;
                 return;
             }
 
-            // a write transaction created by an async commit already inherited the cache computed by
-            // the committing transaction, which is ahead of the published one until that commit completes
+            // for a write transaction ImmutableExternalState is now the *input* to the incremental compute.
+            // before this PR it was effectively write-only on a write tx (every reader is behind
+            // IsWriteTransaction == false, and the old full-scan compute overwrote it rather than reading it),
+            // so an unconditional assignment was harmless; now it would discard the base the compute builds on.
+            // NewTransactionCreated fires *after* the async-commit clone ctor, which has already copied the
+            // committing transaction's freshly computed cache - and that is ahead of _documentsMetadataCache
+            // until the async commit completes. so we must keep an already-inherited value, and only seed the
+            // published cache for a normal fresh write tx, which has null here.
             tx.ImmutableExternalState ??= _documentsMetadataCache;
 
             tx.LastChanceToReadFromWriteTransactionBeforeCommit += ComputeTransactionCache_BeforeCommit;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -176,7 +176,7 @@ namespace Raven.Server.Documents
             exceptionAggregator.Execute(() =>
             {
                 _collectionTablesContext?.Dispose();
-                _collectionTablesReverse.Clear();
+                _collectionTablesReverse?.Clear();
                 _modifiedCollectionsScratch.Clear();
             });
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -364,30 +365,37 @@ namespace Raven.Server.Documents
                 LastTombstoneEtag = ReadLastTombstoneEtag(tx),
             };
 
+            // the previous cache is inherited through ImmutableExternalState (a fresh write tx gets the last
+            // committed one, an async-commit clone gets the committing tx's freshly computed one). when it is
+            // fully computed we start a builder from its immutable dictionary (O(1), no copy) and recompute only
+            // the modified collections; otherwise (first commit after startup) we full-scan to seed it.
+            ImmutableDictionary<string, DocumentTransactionCache.CollectionCache>.Builder builder;
             if (llt.ImmutableExternalState is DocumentTransactionCache { FullyComputed: true } previousCache)
             {
-                // the entries are immutable, a stale one is always replaced by a new instance,
-                // so they can be shared between the previous cache and the current one
-                foreach (var kvp in previousCache.LastEtagsByCollection)
-                {
-                    currentCache.LastEtagsByCollection[kvp.Key] = kvp.Value;
-                }
+                // the base is always the last *committed* cache (_documentsMetadataCache advances only on commit
+                // finalization), so no mutable state survives across transactions - a rolled-back tx leaves
+                // nothing behind here.
+                builder = previousCache.LastEtagsByCollection.ToBuilder();
 
-                UpdateCollectionCachesForModifiedCollections(tx, currentCache);
+                UpdateCollectionCachesForModifiedCollections(tx, builder);
 
-                AssertIncrementalCacheMatchesFullScan(tx, currentCache);
+                AssertIncrementalCacheMatchesFullScan(tx, builder);
             }
             else
             {
-                ComputeCollectionCaches(tx, currentCache);
+                builder = ImmutableDictionary.CreateBuilder<string, DocumentTransactionCache.CollectionCache>(StringComparer.OrdinalIgnoreCase);
+
+                ComputeCollectionCaches(tx, builder);
             }
+
+            currentCache.LastEtagsByCollection = builder.ToImmutable();
 
             // we set it on the current transaction because we aren't committed yet
             // we'll publish this after the commit finalization
             tx.LowLevelTransaction.ImmutableExternalState = currentCache;
         }
 
-        private void ComputeCollectionCaches(Transaction tx, DocumentTransactionCache cache)
+        private void ComputeCollectionCaches(Transaction tx, ImmutableDictionary<string, DocumentTransactionCache.CollectionCache>.Builder cache)
         {
             using (ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
             {
@@ -400,18 +408,18 @@ namespace Raven.Server.Documents
         }
 
         [Conditional("DEBUG")]
-        private void AssertIncrementalCacheMatchesFullScan(Transaction tx, DocumentTransactionCache incremental)
+        private void AssertIncrementalCacheMatchesFullScan(Transaction tx, ImmutableDictionary<string, DocumentTransactionCache.CollectionCache>.Builder incremental)
         {
-            var full = new DocumentTransactionCache { FullyComputed = true };
+            var full = ImmutableDictionary.CreateBuilder<string, DocumentTransactionCache.CollectionCache>(StringComparer.OrdinalIgnoreCase);
             ComputeCollectionCaches(tx, full);
 
-            if (incremental.LastEtagsByCollection.Count != full.LastEtagsByCollection.Count)
+            if (incremental.Count != full.Count)
                 throw new InvalidOperationException(
-                    $"Incremental documents transaction cache has {incremental.LastEtagsByCollection.Count} collection(s), a full scan has {full.LastEtagsByCollection.Count}.");
+                    $"Incremental documents transaction cache has {incremental.Count} collection(s), a full scan has {full.Count}.");
 
-            foreach (var kvp in full.LastEtagsByCollection)
+            foreach (var kvp in full)
             {
-                if (incremental.LastEtagsByCollection.TryGetValue(kvp.Key, out var incrementalEntry) == false)
+                if (incremental.TryGetValue(kvp.Key, out var incrementalEntry) == false)
                     throw new InvalidOperationException(
                         $"Incremental documents transaction cache is missing collection '{kvp.Key}' that a full scan produced.");
 
@@ -425,7 +433,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        private void UpdateCollectionCachesForModifiedCollections(Transaction tx, DocumentTransactionCache cache)
+        private void UpdateCollectionCachesForModifiedCollections(Transaction tx, ImmutableDictionary<string, DocumentTransactionCache.CollectionCache>.Builder cache)
         {
             // recompute only the collections this tx touched: existing ones via the reverse map (a miss is a
             // non-collection table), plus any it created. collect first, then compute - recompute mutates tx.Tables.
@@ -481,11 +489,11 @@ namespace Raven.Server.Documents
             map[tombstonesTableName] = collection;
         }
 
-        private void ComputeCollectionCache(Transaction tx, CollectionName collectionName, DocumentTransactionCache cache, ref Table.TableValueHolder holder)
+        private void ComputeCollectionCache(Transaction tx, CollectionName collectionName, ImmutableDictionary<string, DocumentTransactionCache.CollectionCache>.Builder cache, ref Table.TableValueHolder holder)
         {
             if (ReadLastDocument(tx, collectionName, CollectionTableType.Documents, ref holder) == false)
             {
-                cache.LastEtagsByCollection.Remove(collectionName.Name);
+                cache.Remove(collectionName.Name);
                 return;
             }
 
@@ -499,7 +507,7 @@ namespace Raven.Server.Documents
             {
                 colCache.LastTombstoneEtag = TableValueToEtag((int)DocumentsTable.Etag, ref holder.Reader);
             }
-            cache.LastEtagsByCollection[collectionName.Name] = colCache;
+            cache[collectionName.Name] = colCache;
         }
 
         private void UpdateDocumentTransactionCache(LowLevelTransaction obj)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -297,7 +297,7 @@ namespace Raven.Server.Documents
                     InitializeLastEtag(tx);
                     _collectionsCache = ReadCollections(tx);
                     _collectionTablesContext = new ByteStringContext(SharedMultipleUseFlag.None);
-                    _collectionTablesReverse = BuildCollectionTablesReverseMap(_collectionsCache.Values);
+                    _collectionTablesReverse = BuildCollectionTablesReverseMap(tx, _collectionsCache.Values);
 
                     var cv = GetDatabaseChangeVector(tx);
                     var lastEtagInChangeVector = ChangeVectorUtils.GetEtagById(cv, DocumentDatabase.DbBase64Id);
@@ -461,16 +461,20 @@ namespace Raven.Server.Documents
                 ComputeCollectionCache(tx, collectionName, cache, ref holder);
         }
 
-        private Dictionary<Slice, CollectionName> BuildCollectionTablesReverseMap(IEnumerable<CollectionName> collections)
+        private Dictionary<Slice, CollectionName> BuildCollectionTablesReverseMap(Transaction tx, IEnumerable<CollectionName> collections)
         {
             var map = new Dictionary<Slice, CollectionName>(SliceComparer.Instance);
             foreach (var collection in collections)
-                AddToCollectionTablesReverseMap(map, collection);
+                AddToCollectionTablesReverseMap(tx, map, collection);
             return map;
         }
 
-        private void AddToCollectionTablesReverseMap(Dictionary<Slice, CollectionName> map, CollectionName collection)
+        private void AddToCollectionTablesReverseMap(Transaction tx, Dictionary<Slice, CollectionName> map, CollectionName collection)
         {
+            // the map and its slice context are grown copy-on-write and only under the write-transaction lock,
+            // so concurrent commits can't race on the shared ByteStringContext / dictionary. assert we hold it.
+            Debug.Assert(tx.IsWriteTransaction, "The collection tables reverse map must only be modified under a write transaction");
+
             Slice.From(_collectionTablesContext, collection.GetTableName(CollectionTableType.Documents), ByteStringType.Immutable, out var documentsTableName);
             Slice.From(_collectionTablesContext, collection.GetTableName(CollectionTableType.Tombstones), ByteStringType.Immutable, out var tombstonesTableName);
             map[documentsTableName] = collection;
@@ -2816,7 +2820,7 @@ namespace Raven.Server.Documents
                     _collectionsCache = collectionNames;
 
                     var collectionTables = new Dictionary<Slice, CollectionName>(_collectionTablesReverse, SliceComparer.Instance);
-                    AddToCollectionTablesReverseMap(collectionTables, name);
+                    AddToCollectionTablesReverseMap(context.Transaction.InnerTransaction, collectionTables, name);
                     _collectionTablesReverse = collectionTables;
                 };
             }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Raven.Client;
 using Raven.Client.Documents.Changes;
@@ -21,7 +20,6 @@ using Raven.Server.Documents.Refresh;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Revisions;
-using Raven.Server.Documents.Schemas;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
@@ -34,6 +32,7 @@ using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
+using Sparrow.Threading;
 using Voron;
 using Voron.Data;
 using Voron.Data.Fixed;
@@ -78,6 +77,14 @@ namespace Raven.Server.Documents
         public Action<Transaction> OnBeforeCommit { get; protected set; }
 
         protected Dictionary<string, CollectionName> _collectionsCache;
+
+        // maps each collection's Documents and Tombstones table-name slices to its CollectionName, so the
+        // transaction-cache compute resolves a modified table to its collection with a single slice lookup
+        // (no table-name string parsing). grown copy-on-write alongside _collectionsCache; the key slices are
+        // allocated from _collectionTablesContext, which outlives the transactions that read the map.
+        private ByteStringContext _collectionTablesContext;
+        private Dictionary<Slice, CollectionName> _collectionTablesReverse;
+
         private static readonly Slice LastReplicatedEtagsSlice;
         private static readonly Slice EtagsSlice;
         private static readonly Slice LastEtagSlice;
@@ -159,6 +166,11 @@ namespace Raven.Server.Documents
             exceptionAggregator.Execute(() =>
             {
                 Environment?.Dispose();
+            });
+
+            exceptionAggregator.Execute(() =>
+            {
+                _collectionTablesContext?.Dispose();
             });
 
             exceptionAggregator.ThrowIfNeeded();
@@ -284,6 +296,8 @@ namespace Raven.Server.Documents
 
                     InitializeLastEtag(tx);
                     _collectionsCache = ReadCollections(tx);
+                    _collectionTablesContext = new ByteStringContext(SharedMultipleUseFlag.None);
+                    _collectionTablesReverse = BuildCollectionTablesReverseMap(_collectionsCache.Values);
 
                     var cv = GetDatabaseChangeVector(tx);
                     var lastEtagInChangeVector = ChangeVectorUtils.GetEtagById(cv, DocumentDatabase.DbBase64Id);
@@ -318,10 +332,15 @@ namespace Raven.Server.Documents
 
         private void SetTransactionCache(LowLevelTransaction tx)
         {
-            tx.ImmutableExternalState = _documentsMetadataCache;
-
             if (tx.Flags != TransactionFlags.ReadWrite)
+            {
+                tx.ImmutableExternalState = _documentsMetadataCache;
                 return;
+            }
+
+            // a write transaction created by an async commit already inherited the cache computed by
+            // the committing transaction, which is ahead of the published one until that commit completes
+            tx.ImmutableExternalState ??= _documentsMetadataCache;
 
             tx.LastChanceToReadFromWriteTransactionBeforeCommit += ComputeTransactionCache_BeforeCommit;
         }
@@ -334,6 +353,7 @@ namespace Raven.Server.Documents
 
             var currentCache = new DocumentTransactionCache
             {
+                FullyComputed = true,
                 LastDocumentEtag = ReadLastDocumentEtag(tx),
                 LastAttachmentsEtag = ReadLastAttachmentsEtag(tx),
                 LastConflictEtag = ReadLastConflictsEtag(tx),
@@ -344,31 +364,113 @@ namespace Raven.Server.Documents
                 LastTombstoneEtag = ReadLastTombstoneEtag(tx),
             };
 
+            if (llt.ImmutableExternalState is DocumentTransactionCache { FullyComputed: true } previousCache)
+            {
+                // the entries are immutable, a stale one is always replaced by a new instance,
+                // so they can be shared between the previous cache and the current one
+                foreach (var kvp in previousCache.LastEtagsByCollection)
+                {
+                    currentCache.LastEtagsByCollection[kvp.Key] = kvp.Value;
+                }
+
+                UpdateCollectionCachesForModifiedCollections(tx, currentCache);
+            }
+            else
+            {
+                ComputeCollectionCaches(tx, currentCache);
+            }
+
+            // we set it on the current transaction because we aren't committed yet
+            // we'll publish this after the commit finalization
+            tx.LowLevelTransaction.ImmutableExternalState = currentCache;
+        }
+
+        private void ComputeCollectionCaches(Transaction tx, DocumentTransactionCache cache)
+        {
             using (ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
             {
                 Table.TableValueHolder holder = default;
                 foreach (var collection in IterateCollectionNames(tx, ctx))
                 {
-                    var collectionName = new CollectionName(collection);
-                    if (ReadLastDocument(tx, collectionName, CollectionTableType.Documents, ref holder) == false)
-                        continue;
-
-                    var colCache = new DocumentTransactionCache.CollectionCache
-                    {
-                        LastDocumentEtag = TableValueToEtag((int)DocumentsTable.Etag, ref holder.Reader),
-                        LastChangeVector = TableValueToChangeVector(ctx, (int)DocumentsTable.ChangeVector, ref holder.Reader),
-                    };
-
-                    if (ReadLastDocument(tx, collectionName, CollectionTableType.Tombstones, ref holder))
-                    {
-                        colCache.LastTombstoneEtag = TableValueToEtag((int)DocumentsTable.Etag, ref holder.Reader);
-                    }
-                    currentCache.LastEtagsByCollection[collection] = colCache;
+                    ComputeCollectionCache(tx, ctx, new CollectionName(collection), cache, ref holder);
                 }
             }
-            // we set it on the current transaction because we aren't committed yet
-            // we'll publish this after the commit finalization
-            tx.LowLevelTransaction.ImmutableExternalState = currentCache;
+        }
+
+        private void UpdateCollectionCachesForModifiedCollections(Transaction tx, DocumentTransactionCache cache)
+        {
+            // recompute only the collections this tx touched: existing ones via the reverse map (a miss is a
+            // non-collection table), plus any it created. collect first, then compute - recompute mutates tx.Tables.
+            HashSet<CollectionName> modifiedCollections = null;
+
+            foreach (var table in tx.Tables)
+            {
+                if (_collectionTablesReverse.TryGetValue(table.Name, out var collectionName))
+                {
+                    modifiedCollections ??= new HashSet<CollectionName>(CollectionNameComparer.Instance);
+                    modifiedCollections.Add(collectionName);
+                }
+            }
+
+            if (tx.Owner is DocumentsOperationContext { Transaction: { } documentsTransaction })
+            {
+                var createdCollections = documentsTransaction.CollectionsCreatedInTransaction;
+                if (createdCollections != null)
+                {
+                    foreach (var collectionName in createdCollections)
+                    {
+                        modifiedCollections ??= new HashSet<CollectionName>(CollectionNameComparer.Instance);
+                        modifiedCollections.Add(collectionName);
+                    }
+                }
+            }
+
+            if (modifiedCollections == null)
+                return;
+
+            using (ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
+            {
+                Table.TableValueHolder holder = default;
+                foreach (var collectionName in modifiedCollections)
+                    ComputeCollectionCache(tx, ctx, collectionName, cache, ref holder);
+            }
+        }
+
+        private Dictionary<Slice, CollectionName> BuildCollectionTablesReverseMap(IEnumerable<CollectionName> collections)
+        {
+            var map = new Dictionary<Slice, CollectionName>(SliceComparer.Instance);
+            foreach (var collection in collections)
+                AddToCollectionTablesReverseMap(map, collection);
+            return map;
+        }
+
+        private void AddToCollectionTablesReverseMap(Dictionary<Slice, CollectionName> map, CollectionName collection)
+        {
+            Slice.From(_collectionTablesContext, collection.GetTableName(CollectionTableType.Documents), ByteStringType.Immutable, out var documentsTableName);
+            Slice.From(_collectionTablesContext, collection.GetTableName(CollectionTableType.Tombstones), ByteStringType.Immutable, out var tombstonesTableName);
+            map[documentsTableName] = collection;
+            map[tombstonesTableName] = collection;
+        }
+
+        private void ComputeCollectionCache(Transaction tx, JsonOperationContext ctx, CollectionName collectionName, DocumentTransactionCache cache, ref Table.TableValueHolder holder)
+        {
+            if (ReadLastDocument(tx, collectionName, CollectionTableType.Documents, ref holder) == false)
+            {
+                cache.LastEtagsByCollection.Remove(collectionName.Name);
+                return;
+            }
+
+            var colCache = new DocumentTransactionCache.CollectionCache
+            {
+                LastDocumentEtag = TableValueToEtag((int)DocumentsTable.Etag, ref holder.Reader),
+                LastChangeVector = TableValueToChangeVector(ctx, (int)DocumentsTable.ChangeVector, ref holder.Reader),
+            };
+
+            if (ReadLastDocument(tx, collectionName, CollectionTableType.Tombstones, ref holder))
+            {
+                colCache.LastTombstoneEtag = TableValueToEtag((int)DocumentsTable.Etag, ref holder.Reader);
+            }
+            cache.LastEtagsByCollection[collectionName.Name] = colCache;
         }
 
         private void UpdateDocumentTransactionCache(LowLevelTransaction obj)
@@ -2687,6 +2789,10 @@ namespace Raven.Server.Documents
                         [name.Name] = name
                     };
                     _collectionsCache = collectionNames;
+
+                    var collectionTables = new Dictionary<Slice, CollectionName>(_collectionTablesReverse, SliceComparer.Instance);
+                    AddToCollectionTablesReverseMap(collectionTables, name);
+                    _collectionTablesReverse = collectionTables;
                 };
             }
             return name;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -392,7 +392,7 @@ namespace Raven.Server.Documents
                 Table.TableValueHolder holder = default;
                 foreach (var collection in IterateCollectionNames(tx, ctx))
                 {
-                    ComputeCollectionCache(tx, ctx, new CollectionName(collection), cache, ref holder);
+                    ComputeCollectionCache(tx, new CollectionName(collection), cache, ref holder);
                 }
             }
         }
@@ -428,12 +428,9 @@ namespace Raven.Server.Documents
             if (modifiedCollections == null)
                 return;
 
-            using (ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
-            {
-                Table.TableValueHolder holder = default;
-                foreach (var collectionName in modifiedCollections)
-                    ComputeCollectionCache(tx, ctx, collectionName, cache, ref holder);
-            }
+            Table.TableValueHolder holder = default;
+            foreach (var collectionName in modifiedCollections)
+                ComputeCollectionCache(tx, collectionName, cache, ref holder);
         }
 
         private Dictionary<Slice, CollectionName> BuildCollectionTablesReverseMap(IEnumerable<CollectionName> collections)
@@ -452,7 +449,7 @@ namespace Raven.Server.Documents
             map[tombstonesTableName] = collection;
         }
 
-        private void ComputeCollectionCache(Transaction tx, JsonOperationContext ctx, CollectionName collectionName, DocumentTransactionCache cache, ref Table.TableValueHolder holder)
+        private void ComputeCollectionCache(Transaction tx, CollectionName collectionName, DocumentTransactionCache cache, ref Table.TableValueHolder holder)
         {
             if (ReadLastDocument(tx, collectionName, CollectionTableType.Documents, ref holder) == false)
             {
@@ -463,7 +460,7 @@ namespace Raven.Server.Documents
             var colCache = new DocumentTransactionCache.CollectionCache
             {
                 LastDocumentEtag = TableValueToEtag((int)DocumentsTable.Etag, ref holder.Reader),
-                LastChangeVector = TableValueToChangeVector(ctx, (int)DocumentsTable.ChangeVector, ref holder.Reader),
+                LastChangeVector = TableValueToChangeVector((int)DocumentsTable.ChangeVector, ref holder.Reader),
             };
 
             if (ReadLastDocument(tx, collectionName, CollectionTableType.Tombstones, ref holder))
@@ -1535,7 +1532,7 @@ namespace Raven.Server.Documents
             return TableValueToEtag((int)DocumentsTable.Etag, ref result.Reader);
         }
 
-        public string GetLastDocumentChangeVector(Transaction tx, JsonOperationContext ctx, string collection)
+        public string GetLastDocumentChangeVector(Transaction tx, string collection)
         {
             if (tx.IsWriteTransaction == false)
             {
@@ -1549,7 +1546,7 @@ namespace Raven.Server.Documents
             if (LastDocument(tx, collection, ref result) == false)
                 return null;
 
-            return TableValueToChangeVector(ctx, (int)DocumentsTable.ChangeVector, ref result.Reader);
+            return TableValueToChangeVector((int)DocumentsTable.ChangeVector, ref result.Reader);
         }
 
         private bool LastDocument(Transaction transaction, string collection, ref Table.TableValueHolder result)
@@ -1686,7 +1683,7 @@ namespace Raven.Server.Documents
             document.Id = TableValueToId(context, (int)DocumentsTable.Id, ref tvr);
             document.Etag = TableValueToEtag((int)DocumentsTable.Etag, ref tvr);
             document.Data = new BlittableJsonReaderObject(tvr.Read((int)DocumentsTable.Data, out int size), size, context);
-            document.ChangeVector = TableValueToChangeVector(context, (int)DocumentsTable.ChangeVector, ref tvr);
+            document.ChangeVector = TableValueToChangeVector((int)DocumentsTable.ChangeVector, ref tvr);
             document.LastModified = TableValueToDateTime((int)DocumentsTable.LastModified, ref tvr);
             document.Flags = TableValueToFlags((int)DocumentsTable.Flags, ref tvr);
             document.TransactionMarker = TableValueToShort((int)DocumentsTable.TransactionMarker, nameof(DocumentsTable.TransactionMarker), ref tvr);
@@ -1744,7 +1741,7 @@ namespace Raven.Server.Documents
                 DeletedEtag = TableValueToEtag((int)TombstoneTable.DeletedEtag, ref tvr),
                 Type = *(Tombstone.TombstoneType*)tvr.Read((int)TombstoneTable.Type, out int _),
                 TransactionMarker = *(short*)tvr.Read((int)TombstoneTable.TransactionMarker, out int _),
-                ChangeVector = TableValueToChangeVector(context, (int)TombstoneTable.ChangeVector, ref tvr),
+                ChangeVector = TableValueToChangeVector((int)TombstoneTable.ChangeVector, ref tvr),
                 LastModified = TableValueToDateTime((int)TombstoneTable.LastModified, ref tvr),
                 Flags = TableValueToFlags((int)TombstoneTable.Flags, ref tvr)
             };
@@ -3051,7 +3048,7 @@ namespace Raven.Server.Documents
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string TableValueToChangeVector(JsonOperationContext context, int index, ref TableValueReader tvr)
+        public static string TableValueToChangeVector(int index, ref TableValueReader tvr)
         {
             var ptr = tvr.Read(index, out int size);
             return Encodings.Utf8.GetString(ptr, size);

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -86,6 +86,10 @@ namespace Raven.Server.Documents
         private ByteStringContext _collectionTablesContext;
         private Dictionary<Slice, CollectionName> _collectionTablesReverse;
 
+        // scratch set for the collections modified by the committing transaction. reused across commits and cleared
+        // on each use - safe because the transaction-cache compute always runs on the single merger thread.
+        private readonly HashSet<CollectionName> _modifiedCollectionsScratch = new(CollectionNameComparer.Instance);
+
         private static readonly Slice LastReplicatedEtagsSlice;
         private static readonly Slice EtagsSlice;
         private static readonly Slice LastEtagSlice;
@@ -437,15 +441,16 @@ namespace Raven.Server.Documents
         {
             // recompute only the collections this tx touched: existing ones via the reverse map (a miss is a
             // non-collection table), plus any it created. collect first, then compute - recompute mutates tx.Tables.
-            HashSet<CollectionName> modifiedCollections = null;
+            // the scratch set is reused across commits (the compute always runs on the single merger thread). we
+            // clear it at the START of every use, never at the end - so it does not matter who left it dirty: a
+            // compute that threw, or a rolled-back tx, leaves stale entries, but the next commit wipes them here
+            // before reading. it is pure transient scratch, never stored in the published cache.
+            _modifiedCollectionsScratch.Clear();
 
             foreach (var table in tx.Tables)
             {
                 if (_collectionTablesReverse.TryGetValue(table.Name, out var collectionName))
-                {
-                    modifiedCollections ??= new HashSet<CollectionName>(CollectionNameComparer.Instance);
-                    modifiedCollections.Add(collectionName);
-                }
+                    _modifiedCollectionsScratch.Add(collectionName);
             }
 
             if (tx.Owner is DocumentsOperationContext { Transaction: { } documentsTransaction })
@@ -454,18 +459,15 @@ namespace Raven.Server.Documents
                 if (createdCollections != null)
                 {
                     foreach (var collectionName in createdCollections)
-                    {
-                        modifiedCollections ??= new HashSet<CollectionName>(CollectionNameComparer.Instance);
-                        modifiedCollections.Add(collectionName);
-                    }
+                        _modifiedCollectionsScratch.Add(collectionName);
                 }
             }
 
-            if (modifiedCollections == null)
+            if (_modifiedCollectionsScratch.Count == 0)
                 return;
 
             Table.TableValueHolder holder = default;
-            foreach (var collectionName in modifiedCollections)
+            foreach (var collectionName in _modifiedCollectionsScratch)
                 ComputeCollectionCache(tx, collectionName, cache, ref holder);
         }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -176,6 +176,8 @@ namespace Raven.Server.Documents
             exceptionAggregator.Execute(() =>
             {
                 _collectionTablesContext?.Dispose();
+                _collectionTablesReverse.Clear();
+                _modifiedCollectionsScratch.Clear();
             });
 
             exceptionAggregator.ThrowIfNeeded();

--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -38,9 +38,12 @@ namespace Raven.Server.Documents
             _context = context;
             _changes = changes;
 
+            // ComputeTransactionCache runs at the Voron layer and reaches back to this documents transaction
+            // (for the collections created in it) through Transaction.Owner, so it must be set on every tx.
+            transaction.Owner = _context;
+
             if (context.DocumentDatabase is ShardedDocumentDatabase sharded)
             {
-                transaction.Owner = _context;
                 transaction.OnBeforeCommit += sharded.ShardedDocumentsStorage.OnBeforeCommit;
                 transaction.LowLevelTransaction.OnRollBack += sharded.ShardedDocumentsStorage.OnFailure;
             }
@@ -155,6 +158,10 @@ namespace Raven.Server.Documents
                 || _counterNotifications != null
                 || _timeSeriesNotifications != null;
         }
+
+        // the collections created (first seen) in this transaction, with canonical CollectionName instances.
+        // populated synchronously by ExtractCollectionName, so it is complete while the tx is committing.
+        public IEnumerable<CollectionName> CollectionsCreatedInTransaction => _collectionCache?.Values;
 
         public bool TryGetFromCache(string collectionName, out CollectionName name)
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioCollectionFieldsHandlerProcessorForGetCollectionFields.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioCollectionFieldsHandlerProcessorForGetCollectionFields.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Studio
             }
             else
             {
-                changeVector = RequestHandler.Database.DocumentsStorage.GetLastDocumentChangeVector(context.Transaction.InnerTransaction, context, collection);
+                changeVector = RequestHandler.Database.DocumentsStorage.GetLastDocumentChangeVector(context.Transaction.InnerTransaction, collection);
                 totalResults = RequestHandler.Database.DocumentsStorage.GetNumberOfDocumentsFor(collection, context);
 
                 if (changeVector != null)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2895,7 +2895,7 @@ namespace Raven.Server.Documents.Revisions
                 LastModified = TableValueToDateTime((int)RevisionsTable.LastModified, ref tvr),
                 Flags = TableValueToFlags((int)RevisionsTable.Flags, ref tvr),
                 TransactionMarker = *(short*)tvr.Read((int)RevisionsTable.TransactionMarker, out size),
-                ChangeVector = TableValueToChangeVector(context, (int)RevisionsTable.ChangeVector, ref tvr)
+                ChangeVector = TableValueToChangeVector((int)RevisionsTable.ChangeVector, ref tvr)
             };
 
             if (size != sizeof(short))

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
@@ -67,7 +67,7 @@ public sealed class DatabaseStatsSender : AbstractDatabaseStatsSender
                 GlobalChangeVector = DocumentsStorage.GetDatabaseChangeVector(context.Documents),
                 LastIndexingErrorTime = lastIndexingErrorTime,
                 Collections = database.DocumentsStorage.GetCollections(context.Documents)
-                    .ToDictionary(x => x.Name, x => new DatabaseStatsChanged.ModifiedCollection(x.Name, x.Count, database.DocumentsStorage.GetLastDocumentChangeVector(context.Documents.Transaction.InnerTransaction, context.Documents, x.Name)))
+                    .ToDictionary(x => x.Name, x => new DatabaseStatsChanged.ModifiedCollection(x.Name, x.Count, database.DocumentsStorage.GetLastDocumentChangeVector(context.Documents.Transaction.InnerTransaction, x.Name)))
             };
         }
     }

--- a/src/Raven.Server/ServerWide/Context/DocumentTransactionCache.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentTransactionCache.cs
@@ -5,6 +5,11 @@ namespace Raven.Server.ServerWide.Context
 {
     public sealed class DocumentTransactionCache
     {
+        // set once the per-collection entries were populated by a full scan (or built incrementally
+        // on top of a fully computed cache), allowing the next commit to reuse them instead of
+        // reading the last document of every collection again
+        public bool FullyComputed;
+
         public long LastDocumentEtag;
         public long LastTombstoneEtag;
         public long LastCounterEtag;

--- a/src/Raven.Server/ServerWide/Context/DocumentTransactionCache.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentTransactionCache.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Raven.Server.ServerWide.Context
 {
@@ -27,6 +27,6 @@ namespace Raven.Server.ServerWide.Context
             public string LastChangeVector;
         }
 
-        public readonly Dictionary<string, CollectionCache> LastEtagsByCollection = new Dictionary<string, CollectionCache>(StringComparer.OrdinalIgnoreCase);
+        public ImmutableDictionary<string, CollectionCache> LastEtagsByCollection = ImmutableDictionary.Create<string, CollectionCache>(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Raven.Server/Web/Studio/Processors/StudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Processors/StudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -70,7 +70,7 @@ public sealed class StudioCollectionsHandlerProcessorForPreviewCollection : Abst
         }
         else
         {
-            changeVector = _database.DocumentsStorage.GetLastDocumentChangeVector(_context.Transaction.InnerTransaction, _context, Collection);
+            changeVector = _database.DocumentsStorage.GetLastDocumentChangeVector(_context.Transaction.InnerTransaction, Collection);
 
             if (changeVector != null)
                 etag = $"{changeVector}/{_totalResults}";

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -273,6 +273,11 @@ namespace Voron.Impl
 
             Flags = TransactionFlags.ReadWrite;
 
+            // the previous transaction just ran CommitStage1, so its ImmutableExternalState already holds
+            // the state computed by LastChanceToReadFromWriteTransactionBeforeCommit, which is more up to date
+            // than what the environment published (that happens only when the async commit completes)
+            ImmutableExternalState = previous.ImmutableExternalState;
+
             _pagerStates = new HashSet<PagerState>(ReferenceEqualityComparer<PagerState>.Default);
 
             JournalFiles = previous.JournalFiles;

--- a/test/SlowTests/Server/Documents/DocumentsTransactionCacheTests.cs
+++ b/test/SlowTests/Server/Documents/DocumentsTransactionCacheTests.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.ServerWide;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents
+{
+    public class DocumentsTransactionCacheTests : RavenTestBase
+    {
+        public DocumentsTransactionCacheTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Core | RavenTestCategory.Compression)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TransactionCacheShouldMatchStorageAfterEveryKindOfCollectionChange(bool compressed)
+        {
+            using (var store = GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    if (compressed)
+                        record.DocumentsCompression = new DocumentsCompressionConfiguration(compressRevisions: false, compressAllCollections: true);
+                }
+            }))
+            {
+                const int numberOfCollections = 20;
+                var database = await GetDatabase(store.Database);
+
+                using (var commands = store.Commands())
+                {
+                    // puts across multiple collections
+                    for (var c = 0; c < numberOfCollections; c++)
+                    {
+                        for (var i = 0; i < 3; i++)
+                        {
+                            commands.Put($"docs{c}/{i}", null, new { Data = $"initial {c}/{i}" }, CollectionMetadata(c));
+                        }
+                    }
+
+                    AssertCacheMatchesStorage(database);
+
+                    // updates
+                    for (var c = 0; c < 5; c++)
+                    {
+                        commands.Put($"docs{c}/0", null, new { Data = "updated" }, CollectionMetadata(c));
+                    }
+
+                    AssertCacheMatchesStorage(database);
+
+                    // deletes create tombstones
+                    for (var c = 5; c < 10; c++)
+                    {
+                        commands.Delete($"docs{c}/1", null);
+                    }
+
+                    AssertCacheMatchesStorage(database);
+
+                    // empty one collection completely
+                    for (var i = 0; i < 3; i++)
+                    {
+                        commands.Delete($"docs10/{i}", null);
+                    }
+
+                    AssertCacheMatchesStorage(database);
+
+                    // purge the tombstones
+                    await database.TombstoneCleaner.ExecuteCleanup();
+
+                    AssertCacheMatchesStorage(database);
+
+                    // a brand new collection
+                    commands.Put("late/1", null, new { Data = "late" }, new Dictionary<string, object>
+                    {
+                        { Constants.Documents.Metadata.Collection, "LateCollection" }
+                    });
+
+                    AssertCacheMatchesStorage(database);
+                }
+
+                // concurrent writes drive the transaction merger into async commits,
+                // where the next write transaction starts before the previous one published its cache
+                var tasks = Enumerable.Range(0, 200).Select(i => Task.Run(() =>
+                {
+                    using (var commands = store.Commands())
+                    {
+                        commands.Put($"parallel/{i}", null, new { Data = i }, new Dictionary<string, object>
+                        {
+                            { Constants.Documents.Metadata.Collection, $"Parallel{i % 10}" }
+                        });
+                    }
+                })).ToArray();
+
+                await Task.WhenAll(tasks);
+
+                AssertCacheMatchesStorage(database);
+            }
+        }
+
+        private static Dictionary<string, object> CollectionMetadata(int i)
+        {
+            return new Dictionary<string, object>
+            {
+                { Constants.Documents.Metadata.Collection, $"Docs{i}" }
+            };
+        }
+
+        private static void AssertCacheMatchesStorage(DocumentDatabase database)
+        {
+            var storage = database.DocumentsStorage;
+
+            using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext readContext))
+            using (storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext writeContext))
+            using (readContext.OpenReadTransaction())
+            using (writeContext.OpenWriteTransaction())
+            {
+                // write transactions never use the cache, so they provide the values read directly from storage
+                var readTx = readContext.Transaction.InnerTransaction;
+                var writeTx = writeContext.Transaction.InnerTransaction;
+
+                Assert.False(readTx.IsWriteTransaction);
+                Assert.True(writeTx.IsWriteTransaction);
+
+                Assert.Equal(DocumentsStorage.ReadLastDocumentEtag(writeTx), DocumentsStorage.ReadLastDocumentEtag(readTx));
+                Assert.Equal(DocumentsStorage.ReadLastTombstoneEtag(writeTx), DocumentsStorage.ReadLastTombstoneEtag(readTx));
+                Assert.Equal(storage.ReadLastEtag(writeTx), storage.ReadLastEtag(readTx));
+
+                var collections = storage.GetCollections(writeContext).Select(x => x.Name).ToList();
+                Assert.NotEmpty(collections);
+
+                foreach (var collection in collections)
+                {
+                    Assert.Equal(storage.GetLastDocumentEtag(writeTx, collection), storage.GetLastDocumentEtag(readTx, collection));
+                    Assert.Equal(storage.GetLastTombstoneEtag(writeTx, collection), storage.GetLastTombstoneEtag(readTx, collection));
+                    Assert.Equal(storage.GetLastDocumentChangeVector(writeTx, writeContext, collection), storage.GetLastDocumentChangeVector(readTx, readContext, collection));
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/DocumentsTransactionCacheTests.cs
+++ b/test/SlowTests/Server/Documents/DocumentsTransactionCacheTests.cs
@@ -140,7 +140,7 @@ namespace SlowTests.Server.Documents
                 {
                     Assert.Equal(storage.GetLastDocumentEtag(writeTx, collection), storage.GetLastDocumentEtag(readTx, collection));
                     Assert.Equal(storage.GetLastTombstoneEtag(writeTx, collection), storage.GetLastTombstoneEtag(readTx, collection));
-                    Assert.Equal(storage.GetLastDocumentChangeVector(writeTx, writeContext, collection), storage.GetLastDocumentChangeVector(readTx, readContext, collection));
+                    Assert.Equal(storage.GetLastDocumentChangeVector(writeTx, collection), storage.GetLastDocumentChangeVector(readTx, collection));
                 }
             }
         }

--- a/test/SlowTests/Voron/Storage/RavenDB-27178.cs
+++ b/test/SlowTests/Voron/Storage/RavenDB-27178.cs
@@ -1,0 +1,58 @@
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Storage
+{
+    public class RavenDB_27178 : FastTests.Voron.StorageTest
+    {
+        public RavenDB_27178(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void AsyncCommitTransactionInheritsImmutableExternalStateFromCommittingTransaction()
+        {
+            // DocumentsStorage stores its per-commit cache in ImmutableExternalState during
+            // LastChanceToReadFromWriteTransactionBeforeCommit (i.e. in CommitStage1). when a write commit
+            // starts the next transaction asynchronously, that transaction must inherit the state the
+            // committing transaction just computed - which is ahead of what the environment has published,
+            // since the environment only publishes when the async commit completes.
+            var state = new object();
+
+            var tx1 = Env.WriteTransaction();
+            try
+            {
+                // nothing has set it yet on a freshly opened write transaction
+                Assert.Null(tx1.LowLevelTransaction.ImmutableExternalState);
+
+                // dirty the transaction so the async commit really goes through the journal path
+                var tree = tx1.CreateTree("foo");
+                tree.Add("a", StreamFor("1"));
+
+                // runs in CommitStage1, triggered by BeginAsyncCommitAndStartNewTransaction below
+                tx1.LowLevelTransaction.LastChanceToReadFromWriteTransactionBeforeCommit +=
+                    llt => llt.ImmutableExternalState = state;
+
+                using (var tx2 = tx1.BeginAsyncCommitAndStartNewTransaction(tx1.LowLevelTransaction.PersistentContext))
+                {
+                    // tx2 was cloned right after CommitStage1 ran the handler above, so it carries the freshly
+                    // computed state - not null, and not a stale value published by the environment
+                    Assert.Same(state, tx2.LowLevelTransaction.ImmutableExternalState);
+
+                    using (tx1)
+                    {
+                        tx1.EndAsyncCommit();
+                    }
+                    tx1 = null;
+
+                    tx2.Commit();
+                }
+            }
+            finally
+            {
+                tx1?.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27178/ComputeTransactionCacheBeforeCommit-reads-the-last-document-of-every-collection-on-every-write-transaction-commit

### Additional description

#### What

`DocumentsStorage.ComputeTransactionCache_BeforeCommit` runs on **every write-transaction commit** and rebuilt the entire `DocumentTransactionCache` from scratch: the 8 scalar last-etags (cheap) plus a loop over **every collection** that reads each collection's last document and last tombstone. With documents compression (or encryption) enabled, reading the last document **decompresses/decrypts** it just to extract its etag and change vector — so a database with hundreds of collections paid a full decompress/decrypt sweep of all collections on every commit, on the transaction-merger thread.

This change computes the cache **incrementally**: carry the previous cache forward and recompute only the collections the committing transaction actually touched.

#### How

- **Carry-forward + FullyComputed seed.** The first commit after startup does the full scan once (seeding). Every subsequent commit copies the previous cache's per-collection entries into a fresh cache and recomputes only the modified collections. Entries are immutable (a change produces a new instance), and each commit builds a **new** dictionary and publishes it via an atomic reference swap, so in-flight read transactions keep a stable snapshot.
- **Modified-collection detection with no string parsing.** A `Dictionary<Slice, CollectionName>` maps each collection's Documents and Tombstones table-name slices to its `CollectionName`. The committing transaction's opened tables (`Transaction.Tables`) are a superset of the modified collections; each is resolved with a single slice lookup (a non-collection table is simply a miss). The reverse map is grown copy-on-write alongside `_collectionsCache`.
- **Collections created in the same transaction** aren't in the shared reverse map yet (it's grown on a post-commit hook), so they're taken from the transaction's own created-set (`DocumentsTransaction.CollectionsCreatedInTransaction`), reached via `Transaction.Owner` (now set for every documents transaction, previously sharded-only).
- **Async-commit correctness.** Under the transaction merger, the next transaction is created before the committing one publishes its cache, so the freshly computed cache is propagated through `ImmutableExternalState` on the async write-transaction clone; `SetTransactionCache` keeps an already-inherited cache on write transactions.
- Collections are never removed at runtime, so carried-over entries can't dangle; readers already fall back to a live table read for any collection absent from the cache.

Also removed the unused `JsonOperationContext` parameter from `TableValueToChangeVector` and `GetLastDocumentChangeVector` (dead argument), which lets the incremental path skip allocating a context entirely.

##### Benchmark

300 collections × 100 documents each (~73 KB complex documents; documents-compression ratio ≈ 2.91×), one operation = 5× load/modify/save, persistent storage. Baseline = full scan of every collection on each write commit; optimized = incremental recompute of only the modified collections.

##### 300 collections

##### Time (per operation)
| Mode | Baseline | Optimized | Speedup |
|---|---:|---:|---:|
| Plain (uncompressed) | 71.12 ms | 46.27 ms | 1.54× |
| Compressed | 177.48 ms | 34.57 ms | 5.13× |
| Encrypted | 426.17 ms | 35.94 ms | 11.9× |

##### Managed memory (allocated per operation)
| Mode | Baseline | Optimized | Reduction |
|---|---:|---:|---:|
| Plain (uncompressed) | 38.8 MB | 23.1 MB | −40% |
| Compressed | 39.9 MB | 22.7 MB | −43% |
| Encrypted | 41.7 MB | 23.1 MB | −45% |

##### Peak native memory (server `UnmanagedAllocations` under sustained load)
| Mode | Baseline | Optimized | Reduction |
|---|---:|---:|---:|
| Plain (uncompressed) | 53.9 MB | 39.7 MB | −26% |
| Compressed | 116.1 MB | 56.5 MB | −51% |
| Encrypted | 227.5 MB | 164.9 MB | −28% |

##### GC (collections per 1,000 ops)
| Mode | Baseline (Gen0 / Gen1) | Optimized (Gen0 / Gen1) |
|---|---|---|
| Plain (uncompressed) | 2167 / 1167 | 1300 / 100 |
| Compressed | 2333 / 1333 | 1214 / 0 |
| Encrypted | 2000 / 1000 | 1286 / 143 |

##### 20 collections

##### Time (per operation)
| Mode | Baseline | Optimized | Speedup |
|---|---:|---:|---:|
| Plain (uncompressed) | 32.65 ms | 31.60 ms | 1.03× |
| Compressed | 40.99 ms | 32.79 ms | 1.25× |
| Encrypted | 43.82 ms | 34.12 ms | 1.28× |

The optimized path only re-reads the collection(s) the transaction modified, so it is insensitive to the number of collections and to compression/encryption (~31–46 ms in both runs). The baseline rescans every collection on each commit, so its cost - and therefore the speedup - grows with the collection count: marginal at 20 collections, up to ~12× at 300, and the gain widens as the per-collection read gets more expensive (raw read < decompress < decrypt).


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
