### PR TITLE
RavenDB-27191 Validate CDC join columns and keep column resolution atomic

### DIFF
--- a/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/CdcSink/CdcSinkConfiguration.cs
@@ -95,7 +95,7 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
             ValidatePrimaryKeyColumnsExist(table.CollectionName, table.PrimaryKeyColumns, table.Columns, errors);
             ValidateColumnsAndPropertyNames(table.CollectionName, table.Columns, table.EmbeddedTables, table.LinkedTables, errors);
             ValidateEmbeddedTables(table.EmbeddedTables, table.CollectionName, errors);
-            ValidateLinkedTables(table.LinkedTables, table.CollectionName, errors);
+            ValidateLinkedTables(table.LinkedTables, table.CollectionName, table.Columns, errors);
         }
 
         return errors.Count == 0;
@@ -209,15 +209,18 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
             if (embedded.Columns == null || embedded.Columns.Count == 0)
                 errors.Add($"Embedded table '{embedded.SourceTableName}' under '{parentName}' must have at least one column mapping");
 
+            ValidateJoinColumnsAreSourceColumns($"Embedded table '{embedded.SourceTableName}' under '{parentName}'",
+                embedded.JoinColumns, embedded.Columns, errors);
+
             ValidatePrimaryKeyColumnsExist(embedded.SourceTableName, embedded.PrimaryKeyColumns, embedded.Columns, errors);
             ValidateColumnsAndPropertyNames(embedded.SourceTableName, embedded.Columns, embedded.EmbeddedTables, embedded.LinkedTables, errors);
 
             ValidateEmbeddedTables(embedded.EmbeddedTables, embedded.SourceTableName, errors);
-            ValidateLinkedTables(embedded.LinkedTables, embedded.SourceTableName, errors);
+            ValidateLinkedTables(embedded.LinkedTables, embedded.SourceTableName, embedded.Columns, errors);
         }
     }
 
-    private static void ValidateLinkedTables(List<CdcSinkLinkedTableConfig> linkedTables, string parentName, List<string> errors)
+    private static void ValidateLinkedTables(List<CdcSinkLinkedTableConfig> linkedTables, string parentName, List<CdcColumnMapping> parentColumns, List<string> errors)
     {
         if (linkedTables == null)
             return;
@@ -240,6 +243,40 @@ public class CdcSinkConfiguration : IDynamicJson, IDatabaseTask
             if (linked.JoinColumns == null || linked.JoinColumns.Count == 0)
                 errors.Add($"Linked table '{linked.SourceTableName}' under '{parentName}' must have join columns");
 
+            ValidateJoinColumnsAreSourceColumns($"Linked table '{linked.SourceTableName}' under '{parentName}'",
+                linked.JoinColumns, parentColumns, errors);
+        }
+    }
+    
+    private static void ValidateJoinColumnsAreSourceColumns(string description, List<string> joinColumns, List<CdcColumnMapping> columns, List<string> errors)
+    {
+        if (joinColumns == null || columns == null)
+            return;
+
+        foreach (var joinColumn in joinColumns)
+        {
+            if (string.IsNullOrWhiteSpace(joinColumn))
+            {
+                errors.Add($"{description}: join column names cannot be empty");
+                continue;
+            }
+
+            string renamedFrom = null;
+            foreach (var col in columns)
+            {
+                if (string.Equals(col.Column, joinColumn, StringComparison.OrdinalIgnoreCase))
+                {
+                    renamedFrom = null;
+                    break;
+                }
+
+                if (renamedFrom == null && string.Equals(col.Name, joinColumn, StringComparison.OrdinalIgnoreCase))
+                    renamedFrom = col.Column;
+            }
+
+            if (renamedFrom != null)
+                errors.Add($"{description}: join column '{joinColumn}' is a mapped property name, not a source column. " +
+                    $"Join columns must name source columns - use '{renamedFrom}' instead.");
         }
     }
 

--- a/src/Raven.Quill/Endpoints/WizardEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/WizardEndpoints.cs
@@ -398,6 +398,13 @@ public static class WizardEndpoints
             return Results.UnprocessableEntity(new ApiErrorResponse(Errors: errors.ToArray()));
         }
 
+        ValidateJoinColumnsAgainstSchema(result.Configuration, state.LastDiscoveredSchema, errors);
+        if (errors.Count > 0)
+        {
+            logger.LogInformation("SuggestCdc: returned configuration has {Count} join column(s) the source schema does not have", errors.Count);
+            return Results.UnprocessableEntity(new ApiErrorResponse(Errors: errors.ToArray()));
+        }
+
         return Results.Ok(new SuggestCdcResponse(result.Configuration, result.Rationale, result.Status.ToString()));
     }
 
@@ -532,6 +539,55 @@ public static class WizardEndpoints
     /// Discovery enumerates whole schemas, so handing the AI everything it found would map tables the
     /// operator deliberately left out.
     /// </summary>
+    private static void ValidateJoinColumnsAgainstSchema(CdcSinkConfiguration configuration, CdcSinkSourceSchema schema, List<string> errors)
+    {
+        foreach (var table in configuration.Tables)
+            ValidateScope(table.SourceTableSchema, table.SourceTableName, table.CollectionName, table.EmbeddedTables, table.LinkedTables);
+
+        void ValidateScope(
+            string? tableSchema,
+            string tableName,
+            string description,
+            List<CdcSinkEmbeddedTableConfig>? embeddedTables,
+            List<CdcSinkLinkedTableConfig>? linkedTables)
+        {
+            var columns = SourceColumnsOf(tableSchema, tableName);
+
+            foreach (var linked in linkedTables ?? [])
+                CheckJoinColumns(linked.JoinColumns, columns, $"Linked table '{linked.SourceTableName}' under '{description}'");
+
+            foreach (var embedded in embeddedTables ?? [])
+            {
+                ValidateScope(embedded.SourceTableSchema, embedded.SourceTableName,
+                    $"{description}.{embedded.PropertyName}", embedded.EmbeddedTables, embedded.LinkedTables);
+
+                CheckJoinColumns(embedded.JoinColumns, SourceColumnsOf(embedded.SourceTableSchema, embedded.SourceTableName),
+                    $"Embedded table '{embedded.SourceTableName}' under '{description}'");
+            }
+        }
+
+        HashSet<string>? SourceColumnsOf(string? tableSchema, string tableName) => schema.Tables
+            .FirstOrDefault(table =>
+                string.Equals(table.SourceTableName, tableName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(table.SourceTableSchema ?? string.Empty, tableSchema ?? string.Empty, StringComparison.OrdinalIgnoreCase))
+            ?.Columns.Select(column => column.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        void CheckJoinColumns(List<string>? joinColumns, HashSet<string>? sourceColumns, string description)
+        {
+            if (sourceColumns is null)
+                return;
+
+            foreach (var joinColumn in joinColumns ?? [])
+            {
+                if (string.IsNullOrWhiteSpace(joinColumn) || sourceColumns.Contains(joinColumn))
+                    continue;
+
+                errors.Add($"{description}: join column '{joinColumn}' is not a column of the source table. " +
+                    $"Its columns are: {string.Join(", ", sourceColumns)}.");
+            }
+        }
+    }
+
     private static CdcSinkSourceSchema SelectTables(CdcSinkSourceSchema schema, SelectedSourceTable[] selectedTables)
     {
         var selectedKeys = selectedTables

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkProcess.cs
@@ -991,7 +991,18 @@ public abstract class CdcSinkProcess : IDisposable, ILowMemoryHandler, IAsyncDis
                     var columnNames = new string[reader.FieldCount];
                     for (int i = 0; i < reader.FieldCount; i++)
                         columnNames[i] = reader.GetName(i);
-                    processor.SetSourceColumnNames(columnNames);
+
+                    try
+                    {
+                        processor.SetSourceColumnNames(columnNames);
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        throw new CdcSinkFaultedException(
+                            $"Initial load cannot start for table '{tableInfo.FullName}': {e.Message} " +
+                            "Fix the table configuration; the task will restart.", e);
+                    }
+
                     columnNamesSet = true;
                 }
                 else

--- a/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
+++ b/src/Raven.Server/Documents/CdcSink/CdcSinkTableProcessor.cs
@@ -178,49 +178,47 @@ public class CdcSinkTableProcessor
 
     public void SetSourceColumnNames(string[] names)
     {
-        if (SourceColumnNames?.Length != names.Length)
-            _valuesPool.Clear();
-
-        SourceColumnNames = names;
-
         // Compute PrimaryKeyIndices
         var pkColumns = IsRoot ? RootConfig.PrimaryKeyColumns : EmbeddedConfig.PrimaryKeyColumns;
-        PrimaryKeyIndices = new int[pkColumns.Count];
+        var primaryKeyIndices = new int[pkColumns.Count];
         for (int i = 0; i < pkColumns.Count; i++)
-            PrimaryKeyIndices[i] = FindColumnIndex(names, pkColumns[i]);
+            primaryKeyIndices[i] = FindColumnIndex(names, pkColumns[i]);
 
         // Compute ColumnMappingIndices (one per non-attachment column)
-        ColumnMappingIndices = new int[Columns.Count - AttachmentColumns.Count];
+        var columnMappingIndices = new int[Columns.Count - AttachmentColumns.Count];
         int mapIdx = 0;
         for (int i = 0; i < Columns.Count; i++)
         {
             if (Columns[i].Type != CdcColumnType.Attachment)
-                ColumnMappingIndices[mapIdx++] = FindColumnIndex(names, Columns[i].Column);
+                columnMappingIndices[mapIdx++] = FindColumnIndex(names, Columns[i].Column);
         }
 
         // Compute AttachmentColumnIndices
-        AttachmentColumnIndices = new int[AttachmentColumns.Count];
+        var attachmentColumnIndices = new int[AttachmentColumns.Count];
         for (int i = 0; i < AttachmentColumns.Count; i++)
-            AttachmentColumnIndices[i] = FindColumnIndex(names, AttachmentColumns[i].Column);
+            attachmentColumnIndices[i] = FindColumnIndex(names, AttachmentColumns[i].Column);
 
         // Compute RootJoinIndices (for embedded tables)
+        int[] rootJoinIndices = null;
         if (RootJoinColumns != null)
         {
-            RootJoinIndices = new int[RootJoinColumns.Count];
+            rootJoinIndices = new int[RootJoinColumns.Count];
             for (int i = 0; i < RootJoinColumns.Count; i++)
-                RootJoinIndices[i] = FindColumnIndex(names, RootJoinColumns[i]);
+                rootJoinIndices[i] = FindColumnIndex(names, RootJoinColumns[i]);
         }
 
         // Compute LinkedTableJoinIndices
+        int[][] linkedTableJoinIndices = null;
         if (LinkedTables is { Count: > 0 })
         {
-            LinkedTableJoinIndices = new int[LinkedTables.Count][];
+            linkedTableJoinIndices = new int[LinkedTables.Count][];
             for (int lt = 0; lt < LinkedTables.Count; lt++)
             {
                 var linked = LinkedTables[lt];
-                LinkedTableJoinIndices[lt] = new int[linked.JoinColumns.Count];
+                var joinIndices = new int[linked.JoinColumns.Count];
                 for (int j = 0; j < linked.JoinColumns.Count; j++)
-                    LinkedTableJoinIndices[lt][j] = FindColumnIndex(names, linked.JoinColumns[j]);
+                    joinIndices[j] = FindColumnIndex(names, linked.JoinColumns[j]);
+                linkedTableJoinIndices[lt] = joinIndices;
             }
         }
 
@@ -228,8 +226,18 @@ public class CdcSinkTableProcessor
         // that must be present in binlog events for all mapped columns to be safely decoded.
         // Used by MySQL CDC for prefix comparison of TableMapEvent column types.
 
-        var maxLinkedIdx = ComputeMaxOrdinal(LinkedTableJoinIndices);
-        var maxColIdx = ComputeMaxOrdinal(PrimaryKeyIndices, ColumnMappingIndices, AttachmentColumnIndices, RootJoinIndices);
+        var maxLinkedIdx = ComputeMaxOrdinal(linkedTableJoinIndices);
+        var maxColIdx = ComputeMaxOrdinal(primaryKeyIndices, columnMappingIndices, attachmentColumnIndices, rootJoinIndices);
+
+        if (SourceColumnNames?.Length != names.Length)
+            _valuesPool.Clear();
+
+        SourceColumnNames = names;
+        PrimaryKeyIndices = primaryKeyIndices;
+        ColumnMappingIndices = columnMappingIndices;
+        AttachmentColumnIndices = attachmentColumnIndices;
+        RootJoinIndices = rootJoinIndices;
+        LinkedTableJoinIndices = linkedTableJoinIndices;
         RequiredPrefixLength = Math.Max(maxLinkedIdx, maxColIdx) + 1;
 
         static int ComputeMaxOrdinal(params ReadOnlySpan<int[]> arrays)

--- a/test/QuillTests/AiHelperSuggestCdcEndpointTests.cs
+++ b/test/QuillTests/AiHelperSuggestCdcEndpointTests.cs
@@ -145,6 +145,34 @@ public class AiHelperSuggestCdcEndpointTests(ITestOutputHelper output, QuillAiHe
     }
 
     [RavenFact(RavenTestCategory.Quill)]
+    public async Task Returns_422_when_a_join_column_names_a_mapped_property_instead_of_a_source_column()
+    {
+        var renamed = AiHelperSamples.BuildCdcConfig();
+        renamed.Tables[0].Columns.Add(new CdcColumnMapping { Column = "customer_id", Name = "CustomerId" });
+        renamed.Tables[0].LinkedTables[0].JoinColumns = ["CustomerId"];
+        Mock.CdcResponse = (200, AiHelperSamples.CdcEnvelope(renamed));
+        await SeedDiscoveredSchemaAsync(Host);
+
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => Host.SuggestCdcAsync(Request("x", "orders")));
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, ex.StatusCode);
+        Assert.Contains("is a mapped property name", ex.Message);
+        Assert.Contains("customer_id", ex.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Returns_422_when_a_join_column_is_not_a_column_of_the_source_table()
+    {
+        var hallucinated = AiHelperSamples.BuildCdcConfig();
+        hallucinated.Tables[0].LinkedTables[0].JoinColumns = ["buyer_ref"];
+        Mock.CdcResponse = (200, AiHelperSamples.CdcEnvelope(hallucinated));
+        await SeedDiscoveredSchemaAsync(Host);
+
+        var ex = await Assert.ThrowsAsync<QuillHttpException>(() => Host.SuggestCdcAsync(Request("x", "orders")));
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, ex.StatusCode);
+        Assert.Contains("buyer_ref", ex.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
     public async Task Maps_401_to_invalid_credentials()
     {
         Mock.CdcResponse = (401, "{}");
@@ -288,7 +316,11 @@ public class AiHelperSuggestCdcEndpointTests(ITestOutputHelper output, QuillAiHe
         SourceTableName = name,
         IsCdcEnabled = true,
         PrimaryKeyColumns = ["id"],
-        Columns = [new CdcSinkSourceColumn { Name = "id", NativeType = "int", IsPrimaryKey = true, IsCdcCapturable = true }],
+        Columns =
+        [
+            new CdcSinkSourceColumn { Name = "id", NativeType = "int", IsPrimaryKey = true, IsCdcCapturable = true },
+            new CdcSinkSourceColumn { Name = "customer_id", NativeType = "int", IsCdcCapturable = true },
+        ],
         ForeignKeys = [.. (foreignKeysTo ?? []).Select(referenced => new CdcSinkSourceForeignKey
         {
             Columns = [$"{referenced}_id"],

--- a/test/SlowTests.Issues/Issues/RavenDB-27191.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27191.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using FastTests;
+using Raven.Client.Documents.Operations.CdcSink;
+using Raven.Server.Documents.CdcSink;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27191(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    private static CdcSinkConfiguration CreateRenamedJunctionConfig(string customerJoinColumn) => new()
+    {
+        Name = "TestCdc",
+        ConnectionStringName = "TestSql",
+        Tables =
+        [
+            new CdcSinkTableConfig
+            {
+                CollectionName = "CustomersAddressesMapping",
+                SourceTableSchema = "public",
+                SourceTableName = "CustomerAddresses",
+                PrimaryKeyColumns = ["Customer_Id", "Address_Id"],
+                Columns =
+                [
+                    new CdcColumnMapping { Column = "Customer_Id", Name = "CustomerId" },
+                    new CdcColumnMapping { Column = "Address_Id", Name = "AddressId" },
+                ],
+                LinkedTables =
+                [
+                    new CdcSinkLinkedTableConfig
+                    {
+                        SourceTableSchema = "public",
+                        SourceTableName = "Customer",
+                        PropertyName = "Customer",
+                        JoinColumns = [customerJoinColumn],
+                        LinkedCollectionName = "Customers",
+                    },
+                    new CdcSinkLinkedTableConfig
+                    {
+                        SourceTableSchema = "public",
+                        SourceTableName = "Address",
+                        PropertyName = "Address",
+                        JoinColumns = ["Address_Id"],
+                        LinkedCollectionName = "Addresses",
+                    },
+                ],
+            },
+        ],
+    };
+
+    [RavenFact(RavenTestCategory.Sinks)]
+    public void UnresolvableJoinColumn_FailsTheSameWayOnEveryAttempt()
+    {
+        var documentProcessor = new CdcSinkDocumentProcessor(CreateRenamedJunctionConfig(customerJoinColumn: "CustomerId"));
+        var names = new[] { "Address_Id", "Customer_Id" };
+
+        var first = Assert.Throws<InvalidOperationException>(
+            () => documentProcessor.SetSourceColumnNames("public", "CustomerAddresses", names));
+        Assert.Contains("Column 'CustomerId' not found in source columns", first.Message);
+
+        var processor = documentProcessor.GetProcessor("public", "CustomerAddresses");
+        Assert.Null(processor.SourceColumnNames);
+        Assert.Null(processor.LinkedTableJoinIndices);
+
+        var second = Assert.Throws<InvalidOperationException>(
+            () => documentProcessor.SetSourceColumnNames("public", "CustomerAddresses", names));
+        Assert.Equal(first.Message, second.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Sinks)]
+    public void JoinColumnsNamingSourceColumns_ResolveBothReferences()
+    {
+        var documentProcessor = new CdcSinkDocumentProcessor(CreateRenamedJunctionConfig(customerJoinColumn: "Customer_Id"));
+        documentProcessor.SetSourceColumnNames("public", "CustomerAddresses", ["Address_Id", "Customer_Id"]);
+
+        var row = new CdcSinkRow
+        {
+            TableSchema = "public",
+            TableName = "CustomerAddresses",
+            Operation = CdcSinkOperation.Upsert,
+            Data = [42, 7]
+        };
+
+        var result = documentProcessor.ProcessRow(row, null);
+
+        Assert.NotNull(result);
+        Assert.Equal("CustomersAddressesMapping/7/42", result.DocumentId);
+        Assert.Equal("Customers/7", result.MappedData["Customer"].ToString());
+        Assert.Equal("Addresses/42", result.MappedData["Address"].ToString());
+    }
+
+    [RavenFact(RavenTestCategory.Sinks)]
+    public void Validate_RejectsLinkedJoinColumnNamingMappedProperty()
+    {
+        var configuration = CreateRenamedJunctionConfig(customerJoinColumn: "CustomerId");
+
+        Assert.False(configuration.Validate(out var errors, validateName: false, validateConnection: false));
+        var error = Assert.Single(errors);
+        Assert.Contains("Linked table 'Customer' under 'CustomersAddressesMapping'", error);
+        Assert.Contains("join column 'CustomerId' is a mapped property name", error);
+        Assert.Contains("use 'Customer_Id' instead", error);
+    }
+
+    [RavenFact(RavenTestCategory.Sinks)]
+    public void Validate_AcceptsJoinColumnNamingSourceColumn()
+    {
+        var configuration = CreateRenamedJunctionConfig(customerJoinColumn: "Customer_Id");
+
+        Assert.True(configuration.Validate(out var errors, validateName: false, validateConnection: false), string.Join("; ", errors));
+    }
+
+    [RavenFact(RavenTestCategory.Sinks)]
+    public void Validate_AcceptsJoinColumnThatIsNotMapped()
+    {
+        var configuration = CreateRenamedJunctionConfig(customerJoinColumn: "Customer_Id");
+        configuration.Tables[0].LinkedTables[1].JoinColumns = ["Unmapped_Address_Id"];
+
+        Assert.True(configuration.Validate(out var errors, validateName: false, validateConnection: false), string.Join("; ", errors));
+    }
+
+    [RavenFact(RavenTestCategory.Sinks)]
+    public void Validate_RejectsEmbeddedJoinColumnNamingMappedProperty()
+    {
+        var configuration = new CdcSinkConfiguration
+        {
+            Name = "TestCdc",
+            ConnectionStringName = "TestSql",
+            Tables =
+            [
+                new CdcSinkTableConfig
+                {
+                    CollectionName = "Orders",
+                    SourceTableSchema = "public",
+                    SourceTableName = "Order",
+                    PrimaryKeyColumns = ["Id"],
+                    Columns = [new CdcColumnMapping { Column = "Id", Name = "Id" }],
+                    EmbeddedTables =
+                    [
+                        new CdcSinkEmbeddedTableConfig
+                        {
+                            SourceTableSchema = "public",
+                            SourceTableName = "OrderItem",
+                            PropertyName = "Items",
+                            Type = CdcSinkRelationType.Array,
+                            PrimaryKeyColumns = ["Id"],
+                            JoinColumns = ["OrderId"],
+                            Columns =
+                            [
+                                new CdcColumnMapping { Column = "Id", Name = "Id" },
+                                new CdcColumnMapping { Column = "Order_Id", Name = "OrderId" },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        Assert.False(configuration.Validate(out var errors, validateName: false, validateConnection: false));
+        var error = Assert.Single(errors, e => e.Contains("join column 'OrderId'"));
+        Assert.Contains("Embedded table 'OrderItem' under 'Orders'", error);
+        Assert.Contains("use 'Order_Id' instead", error);
+    }
+
+    [RavenFact(RavenTestCategory.Sinks)]
+    public void Validate_RejectsEmptyJoinColumn()
+    {
+        var configuration = CreateRenamedJunctionConfig(customerJoinColumn: "  ");
+
+        Assert.False(configuration.Validate(out var errors, validateName: false, validateConnection: false));
+        Assert.Contains("Linked table 'Customer' under 'CustomersAddressesMapping': join column names cannot be empty", errors);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27191/CDC-initial-load-crashes-on-AI-Suggest-mapping-bad-joinColumns-source-vs-renamed-unhandled-NullReferenceException

### Additional description

Extra validation for CDC schema

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
