### PR TITLE
RavenDB-27193 Bump Jint to 4.15.1 and build native JsArray instances in OLAP ETL partitionBy

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Hl7.Fhir.R4" Version="5.12.2" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageVersion Include="Jint" Version="4.14.0" />
+    <PackageVersion Include="Jint" Version="4.15.1" />
     <PackageVersion Include="JunitXml.TestLogger" Version="8.0.0" />
     <PackageVersion Include="Lambda2Js.Signed" Version="3.1.4" />
     <PackageVersion Include="Lextm.SharpSnmpLib.Engine" Version="11.3.102" />

--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/OlapDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/OlapDocumentTransformer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using Jint;
 using Jint.Native;
@@ -231,17 +232,15 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
             JsValue array;
             if (args.Length == 1 && args[0].IsArray() == false)
             {
-                array = JsValue.FromObject(DocumentScript.ScriptEngine, new[]
-                {
-                    JsValue.FromObject(DocumentScript.ScriptEngine, new[]
-                    {
-                        new JsString(DefaultPartitionColumnName), args[0]
-                    })
-                });
+                var defaultPartition = new JsArray(DocumentScript.ScriptEngine, [
+                    new JsString(DefaultPartitionColumnName), args[0]
+                ]);
+
+                array = new JsArray(DocumentScript.ScriptEngine, [defaultPartition]);
             }
             else
             {
-                array = JsValue.FromObject(DocumentScript.ScriptEngine, args);
+                array = new JsArray(DocumentScript.ScriptEngine, args.ToArray());
             }
 
             var o = new JsObject(DocumentScript.ScriptEngine);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27193/OLAP-ETL-partitionBy-breaks-after-Jint-4.14-upgrade

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
