### PR TITLE
RavenDB-27187 Fix Corax 2.0 ignoring `ORDER BY ... AS STRING` when a filter on the sort field drives a direct scan

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
@@ -650,6 +650,24 @@ internal static partial class QueryPlanBuilder
             return false;
         }
 
+        // The driving clause picks which terms tree we walk, and with the sort elided that walk order is the
+        // final order - so the ordering type has to match the clause's term type.
+        var sortFieldType = ctx.OrderByFields[0].FieldType;
+        var drivingTermType = ctx.Exec.SortDrivingClause.TermValueType;
+        var orderMatchesScanOrder = drivingTermType switch
+        {
+            ParamValueType.Long => sortFieldType is MatchCompareFieldType.Integer,
+            ParamValueType.Double => sortFieldType is MatchCompareFieldType.Floating,
+            ParamValueType.String => sortFieldType is MatchCompareFieldType.Sequence,
+            _ => false
+        };
+
+        if (orderMatchesScanOrder == false)
+        {
+            rejectReason = $"the ORDER BY type ({sortFieldType}) doesn't match the term type of the filter driving the scan ({drivingTermType})";
+            return false;
+        }
+
         if (ctx.PlanParams.IndexSearcher.HasMultipleTermsInField(ctx.OrderByFields[0].Field))
         {
             rejectReason = "the sort field holds multiple values per document, so its filter can't be safely skipped during the walk";

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
@@ -664,7 +664,7 @@ internal static partial class QueryPlanBuilder
 
         if (orderMatchesScanOrder == false)
         {
-            rejectReason = $"the ORDER BY type ({sortFieldType}) doesn't match the term type of the filter driving the scan ({drivingTermType})";
+            rejectReason = "the ORDER BY type doesn't match the term type of the filter driving the scan";
             return false;
         }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_27187.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27187.cs
@@ -1,0 +1,135 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27187 : RavenTestBase
+    {
+        public RavenDB_27187(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Item
+        {
+            public int Num { get; set; }
+        }
+
+        private class Items_ByNum : AbstractIndexCreationTask<Item>
+        {
+            public Items_ByNum()
+            {
+                Map = items => from i in items
+                               select new
+                               {
+                                   i.Num
+                               };
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void OrderByAsStringMustBeHonoredWhenAFilterOnTheSameFieldDrivesTheQuery(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Item { Num = 2 });
+                session.Store(new Item { Num = 10 });
+                session.Store(new Item { Num = 100 });
+                session.SaveChanges();
+            }
+
+            new Items_ByNum().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                // Lexicographically "10" < "100" < "2", which is a different order than the numeric 2, 10, 100.
+                // The range filter is on the very field we order by, and that must not turn the requested string
+                // ordering into the numeric order of the scanned range.
+                var byString = session.Advanced
+                    .RawQuery<Item>("from index \"Items/ByNum\" where Num between $low and $high order by Num as string")
+                    .AddParameter("low", 1)
+                    .AddParameter("high", 1000)
+                    .ToList();
+
+                Assert.Equal(new[] { 10, 100, 2 }, byString.Select(x => x.Num));
+
+                // Control: without a filter competing for the sort field the string ordering already worked.
+                var noFilter = session.Advanced
+                    .RawQuery<Item>("from index \"Items/ByNum\" order by Num as string")
+                    .ToList();
+
+                Assert.Equal(new[] { 10, 100, 2 }, noFilter.Select(x => x.Num));
+
+                // Control: an explicitly numeric ordering must stay numeric.
+                var byLong = session.Advanced
+                    .RawQuery<Item>("from index \"Items/ByNum\" where Num between $low and $high order by Num as long")
+                    .AddParameter("low", 1)
+                    .AddParameter("high", 1000)
+                    .ToList();
+
+                Assert.Equal(new[] { 2, 10, 100 }, byLong.Select(x => x.Num));
+            }
+        }
+
+        private class DoubleItem
+        {
+            public double Num { get; set; }
+        }
+
+        private class DoubleItems_ByNum : AbstractIndexCreationTask<DoubleItem>
+        {
+            public DoubleItems_ByNum()
+            {
+                Map = items => from i in items
+                               select new
+                               {
+                                   i.Num
+                               };
+            }
+        }
+
+        private void StoreDoubleItems(Options options, out IDocumentStore store)
+        {
+            store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new DoubleItem { Num = 1.1 });
+                session.Store(new DoubleItem { Num = 1.8 });
+                session.Store(new DoubleItem { Num = 1.5 });
+                session.SaveChanges();
+            }
+
+            new DoubleItems_ByNum().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void OrderByAsDoubleMustBeHonoredWhenAnIntegerRangeOnTheSameFieldDrivesTheQuery(Options options)
+        {
+            StoreDoubleItems(options, out var store);
+            using (store)
+            using (var session = store.OpenSession())
+            {
+                // The range terms are integers while the ordering is by the double value: the integer tree groups
+                // 1.1/1.5/1.8 under a single term, so walking it says nothing about their double order.
+                var byRange = session.Advanced
+                    .RawQuery<DoubleItem>("from index \"DoubleItems/ByNum\" where Num between $low and $high order by Num as double")
+                    .AddParameter("low", 1)
+                    .AddParameter("high", 2)
+                    .ToList();
+
+                Assert.Equal(3, byRange.Count);
+                Assert.Equal(new[] { 1.1, 1.5, 1.8 }, byRange.Select(x => x.Num));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27187

### Additional description


`ORDER BY <field> AS STRING` was silently downgraded to numeric ordering whenever a filter on that same field drove the query. The result set was correct — only the order was wrong.

`TryCreateSimpleFieldDirectScan` has two paths. The full-scan path picks the terms tree from the *sort* type, so the walk order always matches what was requested. The driving-clause path picks the tree from the *filter* and never consulted `OrderByFields[0].FieldType` — yet the sort wrapper is elided there, so that walk order becomes the final order: a numeric range produced numeric order for a query asking for lexicographical order.

The gate now rejects the direct scan when the sort type doesn't match the driving clause's `TermValueType`, and the query falls back to the regular `SortingMatch` — the path that already produced correct results when the filter was on a different field. The match is **exact** (`Long`↔`Integer`, `Double`↔`Floating`, `String`↔`Sequence`): an integer filter cannot serve an `AS DOUBLE` ordering either, since the integer tree groups distinct doubles under a single term. This also closes the same hole for `AS ALPHANUMERIC`, which had no type check in this branch at all.

`TermValueType` is resolved to a concrete type even for parameterized queries, so the optimization is kept where it is still valid — `AS LONG` over a numeric range keeps using the direct scan.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
