### PR TITLE
RavenDB-27218 Fix Corax 2.0 returning nothing for an equality on null resolved through a compound field

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
@@ -472,10 +472,15 @@ internal static partial class QueryPlanBuilder
     }
 
     
+    // the compound writer stores null and "" alike, as an empty component, so neither can be matched there
+    private static bool IsNullOrMissingValue(QueryExecution exec, PackedParam packed) =>
+        packed.IsNone || (packed.ValueType == PackedParam.TypeString && exec.StringValues[packed.Param1] is null or "");
+
     private static bool TryCreateCompoundExactMatch(ref InstantiateContext ctx, out string rejectReason)
     {
-        // The only thing still unknown is value-dependent — a bound parameter can resolve to "none" (null/missing), which has no composite-key encoding.
-        if (ctx.Exec.CompoundExactFirst.PackedParamValue.IsNone || ctx.Exec.CompoundExactSecond.PackedParamValue.IsNone)
+        // The only thing still unknown is value-dependent — a value can resolve to "none" (missing) or to null, neither of which has a composite-key encoding.
+        if (IsNullOrMissingValue(ctx.Exec, ctx.Exec.CompoundExactFirst.PackedParamValue) ||
+            IsNullOrMissingValue(ctx.Exec, ctx.Exec.CompoundExactSecond.PackedParamValue))
         {
             rejectReason = "the combined-key lookup needs both values, but one is null or missing";
             return false;
@@ -520,6 +525,14 @@ internal static partial class QueryPlanBuilder
         if (ctx.Exec.CompoundFieldDrivingClause is null || ctx.Exec.Plan.Template.CompoundFieldSortName is null)
         {
             rejectReason = "no compound field matches this query's filter-and-sort shape";
+            return false;
+        }
+
+        // Value-dependent, so it can only be checked here: the filter's value is encoded into the compound-field
+        // prefix we seek with, and null has no such encoding.
+        if (IsNullOrMissingValue(ctx.Exec, ctx.Exec.CompoundFieldDrivingClause.PackedParamValue))
+        {
+            rejectReason = "the compound-field scan needs the filter's value, but it is null or missing";
             return false;
         }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_27218.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27218.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27218 : RavenTestBase
+    {
+        public RavenDB_27218(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Movie
+        {
+            public string Genre { get; set; }
+            public DateTime? ReleaseDate { get; set; }
+        }
+
+        private class Movies_ByGenreAndReleaseDate : AbstractIndexCreationTask<Movie>
+        {
+            public Movies_ByGenreAndReleaseDate()
+            {
+                Map = movies => from m in movies
+                                select new
+                                {
+                                    m.Genre,
+                                    m.ReleaseDate
+                                };
+
+                CompoundField("Genre", "ReleaseDate");
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void EqualityOnNullMustMatchWhenACompoundFieldCoversBothClauses(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Movie { Genre = "Action", ReleaseDate = null });
+                session.Store(new Movie { Genre = "Action", ReleaseDate = null });
+                session.Store(new Movie { Genre = "Action", ReleaseDate = new DateTime(2020, 1, 1) });
+                session.Store(new Movie { Genre = "Drama", ReleaseDate = null });
+                session.SaveChanges();
+            }
+
+            new Movies_ByGenreAndReleaseDate().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                // Two equality clauses that are both covered by the compound field (Genre, ReleaseDate).
+                // The null value must still match the two Action documents that have no ReleaseDate.
+                var both = session.Advanced
+                    .RawQuery<Movie>("from index \"Movies/ByGenreAndReleaseDate\" where Genre = $g and ReleaseDate = null")
+                    .AddParameter("g", "Action")
+                    .ToList();
+
+                Assert.Equal(2, both.Count);
+
+                // Controls: each clause on its own already works.
+                var byGenre = session.Advanced
+                    .RawQuery<Movie>("from index \"Movies/ByGenreAndReleaseDate\" where Genre = $g")
+                    .AddParameter("g", "Action")
+                    .ToList();
+
+                Assert.Equal(3, byGenre.Count);
+
+                var byNull = session.Advanced
+                    .RawQuery<Movie>("from index \"Movies/ByGenreAndReleaseDate\" where ReleaseDate = null")
+                    .ToList();
+
+                Assert.Equal(3, byNull.Count);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void EqualityOnEmptyStringMustMatchWhenACompoundFieldCoversBothClauses(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Movie { Genre = "", ReleaseDate = new DateTime(2020, 1, 1) });
+                session.Store(new Movie { Genre = "", ReleaseDate = new DateTime(2020, 1, 1) });
+                session.Store(new Movie { Genre = "Action", ReleaseDate = new DateTime(2020, 1, 1) });
+                session.SaveChanges();
+            }
+
+            new Movies_ByGenreAndReleaseDate().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                // The compound writer folds an empty string into the same "no bytes" component as null, so an
+                // empty-string equality cannot be answered through the compound field either.
+                var results = session.Advanced
+                    .RawQuery<Movie>("from index \"Movies/ByGenreAndReleaseDate\" where Genre = $g and ReleaseDate = $d")
+                    .AddParameter("g", "")
+                    .AddParameter("d", new DateTime(2020, 1, 1))
+                    .ToList();
+
+                Assert.Equal(2, results.Count);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void EqualityOnNullMustMatchEvenWhenAPlanWasCachedForANonNullParameter(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Movie { Genre = "Action", ReleaseDate = null });
+                session.Store(new Movie { Genre = "Action", ReleaseDate = null });
+                session.Store(new Movie { Genre = "Action", ReleaseDate = new DateTime(2020, 1, 1) });
+                session.SaveChanges();
+            }
+
+            new Movies_ByGenreAndReleaseDate().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                const string rql = "from index \"Movies/ByGenreAndReleaseDate\" where Genre = $g and ReleaseDate = $d";
+
+                // Warm the plan with a non-null parameter first: null and a short string share one plan-cache
+                // entry, so whichever value runs first pins the execution strategy.
+                var warm = session.Advanced
+                    .RawQuery<Movie>(rql)
+                    .AddParameter("g", "Action")
+                    .AddParameter("d", new DateTime(2020, 1, 1))
+                    .ToList();
+
+                Assert.Equal(1, warm.Count);
+
+                // Same query shape, now with null - the two Action documents without a ReleaseDate must still match.
+                var withNull = session.Advanced
+                    .RawQuery<Movie>(rql)
+                    .AddParameter("g", "Action")
+                    .AddParameter("d", (object)null)
+                    .ToList();
+
+                Assert.Equal(2, withNull.Count);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void EqualityOnNullMustMatchWhenTheCompoundFieldDrivesASortedScan(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            // Every document has a ReleaseDate, so the sort field itself has no nulls - only the driving
+            // equality (Genre) is null.
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Movie { Genre = null, ReleaseDate = new DateTime(2020, 1, 1) });
+                session.Store(new Movie { Genre = null, ReleaseDate = new DateTime(2021, 1, 1) });
+                session.Store(new Movie { Genre = "Action", ReleaseDate = new DateTime(2022, 1, 1) });
+                session.SaveChanges();
+            }
+
+            new Movies_ByGenreAndReleaseDate().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var byNullGenre = session.Advanced
+                    .RawQuery<Movie>("from index \"Movies/ByGenreAndReleaseDate\" where Genre = null order by ReleaseDate")
+                    .ToList();
+
+                Assert.Equal(2, byNullGenre.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27218

### Additional description

`where A = <value> and B = null` returned 0 documents when the index declares a compound field over (A, B). Each clause on its own was correct, and so were Corax 1.0 and Lucene.

The two sides encode null differently. The writer stores null as **zero bytes** — [`CoraxDocumentConverterBase.cs#L638-L642`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs#L638-L642) (`// for nulls, we put no value and it will sort at the beginning`) — with the trailing byte holding `len(component1)`, see [`AnonymousCoraxDocumentConverter.cs#L118`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs#L118). So `Genre=null, ReleaseDate=X` is stored as `<X> 0x00`.

The query side goes through [`TryGetCompoundFieldEncoding`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs#L826) → `GetAnalyzedSlice` → [`TryAnalyzeSingleToken`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Corax/Querying/IndexSearcher.cs#L321-L325), where null becomes [`Constants.NullValueSlice`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Corax/Constants.cs#L17) — one byte `0x00`, `Size == 1` — and the key is assembled at [`Resolution.cs#L511`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs#L511) as `[0x00] <X> [0x01]`. The two encodings can never meet, hence the empty result.

The guard for this existed but tested the wrong thing — [`Resolution.cs#L478`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs#L478): `PackedParamValue.IsNone` is only true for the `PackedParam.None` sentinel, i.e. a *missing* value. A null literal is `TypeString` with a null entry in `StringValues`, so it sailed past.

Two things this PR covers beyond the report:

1. **The CompoundSortedScan path was broken the same way and had no value check at all.** `where Genre = null order by ReleaseDate` also returned 0: the driving equality's value is encoded into the prefix used for the seek, and [`StartWithQuery(validatePostfixLen: true)`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Corax/Querying/Matches/TermsProviders/TermProvider.StartWith.cs#L53) then demands `key[^1] == 1` while those documents carry `key[^1] == 0`.
2. **Empty string was broken identically.** The writer folds `null`, `""` and missing into the same zero-bytes branch ([the shared `case` group](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs#L638-L642)), so `where Genre = '' and ReleaseDate = $d` returned 0 as well. The guard now covers `null or ""`.

Why this is a rejection rather than a corrected encoding: `null` and `""` are byte-identical inside a compound term, so no query-side encoding can tell `= null` from `= ''` — each would return the other's documents. Separating them requires changing what the writer stores, i.e. an index format change. Falling back to the per-field path is correct today because that path *does* distinguish them — [`NullValueSpan`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Corax/Constants.cs#L17) `0x00` vs [`EmptyString`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Corax/Constants.cs#L19) `0x03`.

The check has to stay at instantiate time, since null-ness depends on the query parameters while the plan template is cached. Order inside the helper matters: `IsNone` is tested first, otherwise indexing `StringValues[0x7FFF]` would go out of range.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

Narrows when an optimization applies; on rejection the query takes the already-existing per-field path.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

Query-time only, no index format change. Affected queries now return the documents they should have returned all along.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

Four scenarios, each on Corax and Lucene (8 cases). Before the fix, on Corax: `CompoundKeyLookup` with null → 0 instead of 2; `CompoundSortedScan` with null → 0 instead of 2; empty string → 0 instead of 2. Lucene passed throughout. Also reproduced live on the imdb dataset: `where genre = "Action" and release_date = null` gave 0 on Corax 2.0 vs 2,535 on both Corax 1.0 and Lucene. The fix was additionally verified on a branch taken straight from the upstream tip, to confirm it does not depend on any other in-flight change.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Corax queries whose equality value is `null` or `""` on a field covered by a compound field no longer use `CompoundKeyLookup` / `CompoundSortedScan` and go through the per-field path instead — correct results, at the cost of that optimization for those specific values.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed