### PR TITLE
RavenDB-27184 Fix Corax 2.0 discarding NOT when its operand is resolved statically

### DIFF
--- a/src/Corax/Querying/Planning/ClauseExecution.cs
+++ b/src/Corax/Querying/Planning/ClauseExecution.cs
@@ -56,6 +56,16 @@ public sealed class ClauseExecution : IComparable<ClauseExecution>
         Cardinality = cardinality;
     }
 
+    // Unlike a false WHEN(), which removes the clause along with its negation, this one *resolved* the operand -
+    // so the negation still has to apply, and we fold it into the sentinel: not(nothing) is everything.
+    public void MarkAsResolvedSentinel(ClauseType sentinel, long numberOfEntries)
+    {
+        if (IsNegated)
+            sentinel = sentinel is ClauseType.MatchNothing ? ClauseType.MatchAll : ClauseType.MatchNothing;
+
+        MarkAsSentinel(sentinel, sentinel is ClauseType.MatchAll ? numberOfEntries : 0);
+    }
+
     /// <summary>Negated clauses sort last; ties broken by ascending cardinality.</summary>
     public int CompareTo(ClauseExecution other)
     {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/BuildResolver.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/BuildResolver.cs
@@ -158,9 +158,9 @@ ref struct BuildResolver(PlanTemplate template, PlanParameters planParams, Query
             if (exec.IsSentinel == false)
             {
                 QueryPlanBuilder.PopulateClauseValues(exec, planParams.SlotBindings, planParams.QueryParameters, _writer, builderParameters, SentinelBits());
-                QueryPlanBuilder.PropagateBetweenContradiction(exec, _writer); // a contradictory BETWEEN collapses to MatchNothing
+                QueryPlanBuilder.PropagateBetweenContradiction(exec, _writer, _indexSearcher.NumberOfEntries); // a contradictory BETWEEN collapses to MatchNothing
                 if (IsEmptyIn(exec))
-                    exec.MarkAsSentinel(ClauseType.MatchNothing, 0); // an empty IN matches nothing
+                    exec.MarkAsResolvedSentinel(ClauseType.MatchNothing, _indexSearcher.NumberOfEntries); // an empty IN matches nothing
 
                 if (exec.Cardinality < 0)
                     exec.Cardinality = CardinalityEstimator.Estimate(exec, _indexSearcher, _writer, walkerCtx);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
@@ -286,7 +286,7 @@ internal static partial class QueryPlanBuilder
     }
 
     /// <summary> Foo BETWEEN $x AND $y - where $x > $y - returns nothing</summary>
-    internal static void PropagateBetweenContradiction(ClauseExecution exec, ValueWriter writer)
+    internal static void PropagateBetweenContradiction(ClauseExecution exec, ValueWriter writer, long numberOfEntries)
     {
         var p = exec.PackedParamValue;
         if (exec.Clause.ClauseType != ClauseType.Between || p.Param2 is PackedParam.NoParamValue)
@@ -301,7 +301,7 @@ internal static partial class QueryPlanBuilder
         if (!contradictory)
             return;
 
-        exec.MarkAsSentinel(ClauseType.MatchNothing, 0);
+        exec.MarkAsResolvedSentinel(ClauseType.MatchNothing, numberOfEntries);
     }
 
     private static IQueryMatch InstantiateBitmapPipeline(

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
@@ -69,10 +69,13 @@ internal static partial class QueryPlanBuilder
         BooleanOp rootOp = ParseExpression(where, walkerCtx);
         PlanWalker.ThrowIfErrors(walkerCtx);
 
+        // A statically false WHERE matches nothing, so it needs a clause to say so - an empty clause list means
+        // "no filter", i.e. match everything, which is the opposite answer.
+        if (rootOp == BooleanOp.False)
+            return new PlanTemplate { Clauses = [new ClauseInfo { ClauseType = ClauseType.MatchNothing }], ValueOrdinalCount = walkerCtx.SlotBindings.Count };
+
         if (rootOp == BooleanOp.True || walkerCtx.Clauses.Count == 0)
             return new PlanTemplate { Clauses = [], ValueOrdinalCount = walkerCtx.SlotBindings.Count };
-
-        Debug.Assert(rootOp != BooleanOp.False, "No RQL expression currently reduces to BooleanOp.False at template time. ");
 
         walkerCtx.IsOr = rootOp == BooleanOp.Or;
 
@@ -373,7 +376,7 @@ internal static partial class QueryPlanBuilder
                 {
                     (BooleanOp.True, _) => right,
                     (_, BooleanOp.True) => left,
-                    (BooleanOp.False, BooleanOp.False) => BooleanOp.False,
+                    (BooleanOp.False, _) or (_, BooleanOp.False) => BooleanOp.False, // false annihilates an AND
                     _ => BooleanOp.And
                 };
             }
@@ -574,7 +577,7 @@ internal static partial class QueryPlanBuilder
     {
         List<ClauseInfo> saved = walkerCtx.Clauses;
         walkerCtx.Clauses = [];
-        ParseExpression(inner, walkerCtx);
+        BooleanOp innerOp = ParseExpression(inner, walkerCtx);
         List<ClauseInfo> innerClauses = walkerCtx.Clauses;
         walkerCtx.Clauses = saved;
         foreach (ClauseInfo clause in innerClauses)
@@ -582,6 +585,19 @@ internal static partial class QueryPlanBuilder
             clause.IsNegated = !clause.IsNegated;
             walkerCtx.Clauses.Add(clause);
         }
+
+        // A constant operand leaves no clauses to flip, so the negation has to be carried by the result itself -
+        // otherwise the `not` is silently dropped and the operand's own answer is returned.
+        if (innerClauses.Count == 0)
+        {
+            return innerOp switch
+            {
+                BooleanOp.True => BooleanOp.False,
+                BooleanOp.False => BooleanOp.True,
+                _ => BooleanOp.Leaf
+            };
+        }
+
         return BooleanOp.Leaf;
     }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_27184.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27184.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27184 : RavenTestBase
+    {
+        public RavenDB_27184(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Movie
+        {
+            public string Id { get; set; }
+            public long Runtime { get; set; }
+        }
+
+        private class Movies_Showcase : AbstractIndexCreationTask<Movie>
+        {
+            public Movies_Showcase()
+            {
+                Map = movies => from m in movies
+                                select new { m.Runtime };
+            }
+        }
+
+        private IDocumentStore Seed(Options options)
+        {
+            var store = GetDocumentStore(options);
+            store.ExecuteIndex(new Movies_Showcase());
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Movie { Id = "movies/1", Runtime = 25 });
+                session.Store(new Movie { Id = "movies/2", Runtime = 120 });
+                session.Store(new Movie { Id = "movies/3", Runtime = 320 });
+                session.SaveChanges();
+            }
+
+            Indexes.WaitForIndexing(store);
+            return store;
+        }
+
+        private static int Count(IDocumentSession session, string where) =>
+            session.Advanced.RawQuery<Movie>($"from index 'Movies/Showcase' {where}").ToList().Count;
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void NotOfAStaticallyFalseOperandMustMatchEverything(Options options)
+        {
+            using var store = Seed(options);
+            using var session = store.OpenSession();
+
+            // inverted bounds, so the clause is folded to 'always false' instead of being scanned;
+            // its negation has to match every document
+            Assert.Equal(3, Count(session, "where true and not (Runtime between 300 and 30)"));
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void NotOfAStaticallyTrueOperandMustMatchNothing(Options options)
+        {
+            using var store = Seed(options);
+            using var session = store.OpenSession();
+
+            // the same fold the other way round: 'always true', whose negation must match nothing
+            Assert.Equal(0, Count(session, "where true and (true and not true)"));
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void AStaticallyFalseOperandMustAnnihilateTheAnd(Options options)
+        {
+            using var store = Seed(options);
+            using var session = store.OpenSession();
+
+            // `not true` is false, and false AND anything is false - the other side must not leak through
+            Assert.Equal(0, Count(session, "where true and (Runtime = 120 and not true)"));
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void NotOfAScannedOperandMustMatchEverything(Options options)
+        {
+            using var store = Seed(options);
+            using var session = store.OpenSession();
+
+            // control - valid bounds, so the clause is scanned rather than folded. It matches nothing
+            // and the negation is applied correctly, which is what still passes today.
+            Assert.Equal(3, Count(session, "where true and not (Runtime between 999999 and 1000000)"));
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27184

### Additional description

When a NOT's operand was resolved statically - folded to always-true / always-false without scanning the index - the negation was dropped and the operand's own answer was returned. Symmetric: `NOT(always-false)` returned nothing instead of everything, `NOT(always-true)` returned everything instead of nothing.

There turned out to be **two independent mechanisms**, not one, and the ticket's "Negated / AllNegated are never set" is slightly off: `IsNegated` *is* set correctly and then **actively cleared**.

**1. The flag is erased for resolved operands.** [`MarkAsSentinel`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Corax/Querying/Planning/ClauseExecution.cs#L52-L57) clears `IsNegated` with the comment *"the sentinel already subsumes it"*. That holds for exactly one of its three callers - a false `WHEN()`, which removes the clause *along with* its negation ([BuildResolver.cs#L216-L218](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/BuildResolver.cs#L216-L218)). For a *resolved* operand the negation still has to apply, so clearing it is wrong: [contradictory BETWEEN](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs#L304) and [empty IN](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/BuildResolver.cs#L163) - the latter is the same bug and wasn't in the report.

New `MarkAsResolvedSentinel` folds the negation into the sentinel itself (`not(nothing)` is everything), which keeps the existing "sentinels are never negated" invariant and needs **no emitter change** - [`EmitSentinelInto`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/PlanEmitter.cs#L202-L222) already has the right arms, including `(MatchAll, Fill)` → `FillAllEntries`; they were simply unreachable while the flag was being cleared.

**2. A constant operand leaves no clauses to flip.** Negation is implemented by flipping `IsNegated` on the clauses the operand produced ([`ParseNegatedLeaf`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs#L573-L586)), and `true` produces none - so the loop body never runs and the `not` evaporates, while the result is mislabelled `BooleanOp.Leaf`. It now returns `False`/`True` for a constant operand.

That exposed the third part: there was **no representation for a statically false WHERE**. An empty clause list means "no filter", i.e. match everything - the opposite answer - which is what [`ParseTemplate`](https://github.com/ayende/ravendb/blob/d595804d5e43e8f80e98fe991c6ef16a7783ecc8/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs#L72-L73) returned. It now emits a single `MatchNothing` clause, and the `Debug.Assert(rootOp != BooleanOp.False, ...)` that documented this very limitation is gone.

Also fixed while there: `false` now annihilates an AND. Previously `(False, Leaf)` fell through to `_ => BooleanOp.And`, so `where true and (Runtime = 120 and not true)` returned the matching documents instead of nothing.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

It touches the planner front end: `BooleanOp.False` is now actually produced (it never was before, per the removed assert) and a new template shape exists (a clause list holding a lone sentinel). Behaviour only changes for queries that were returning the wrong set.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

Query-time only, no index format change.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

Four cases, each on Corax and Lucene (8 in total), split into separate test methods so the scanned control cannot be hidden behind an earlier failing assert. Before the fix, on Corax: `not (Runtime between 300 and 30)` → 0 instead of 3; `true and (true and not true)` → 3 instead of 0. The scanned control passed throughout. Because this removes a planner invariant, I also ran the full Corax suite: **1177 passed, 0 failed, 4 skipped** (`FastTests`, `~Corax` filter). Everything was verified on a branch taken straight from the upstream tip.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Corax queries whose NOT wraps a statically resolved operand now return the complement instead of the operand's own result. Same for `not (x in ())`, and for an AND containing a statically false operand, which now correctly matches nothing.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed