### PR TITLE
RavenDB-27221 Overview write usage should be per app

### DIFF
--- a/src/Raven.Quill/Infrastructure/AppProvisioner.cs
+++ b/src/Raven.Quill/Infrastructure/AppProvisioner.cs
@@ -1,5 +1,6 @@
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide.Operations;
 using Raven.Quill.Wizard;
 
 namespace Raven.Quill.Infrastructure;
@@ -9,11 +10,14 @@ internal static class AppProvisioner
     public static async Task<App> CreateAppAsync(
         IDocumentStore store, string slug, string appName, string cdcTaskName, CancellationToken ct)
     {
+        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(slug), ct);
+
         await AppDatabaseFeatures.ConfigureAsync(store, slug, ct);
 
         var app = new App
         {
             Slug = slug,
+            TopologyId = record.Topology.DatabaseTopologyIdBase64,
             AppName = appName,
             Database = slug,
             CdcTaskName = cdcTaskName,

--- a/src/Raven.Quill/Metrics/MetricsReadService.cs
+++ b/src/Raven.Quill/Metrics/MetricsReadService.cs
@@ -2,13 +2,11 @@ using System.Text.Json;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations;
-using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.ServerWide.Operations;
-using Raven.Client.ServerWide.Operations.ConnectionStrings;
 using Raven.Quill.Agents;
 using Raven.Quill.Cdc;
 using Raven.Quill.Channels;
@@ -40,30 +38,42 @@ internal static class MetricsReadService
     {
         var period = new UsagePeriod(year, month, day);
 
-        var results = await Task.WhenAll(apps.Select(app => GetAppUsageAsync(store, app, period, ct)));
+        var results = await Task.WhenAll(apps.Select(async app =>
+        {
+            var usage = await GetAppUsageAsync(store, app, period, ct);
+            return (Usage: usage, TopologyId: app.TopologyId);
+        }));
         
         var buckets = period.Buckets();
         var conversations = new long[buckets.Count];
         var messages = new long[buckets.Count];
         var tokens = new long[buckets.Count];
+        var writes = new long[buckets.Count];
+        
+        var stats = await provider.GetUsageAsync(year, month, day, ct);
+        var statsPerApp = stats.PerApplication.GroupBy(p => p.TopologyId)
+            .ToDictionary(g => g.Key, g => g.ToList());
 
         foreach (var result in results)
         {
+            var usage = result.Usage;
             for (int i = 0; i < buckets.Count; i++)
             {
-                conversations[i] += result.Conversations[i];
-                messages[i] += result.Messages[i];
-                tokens[i] += result.Tokens[i];
+                conversations[i] += usage.Conversations[i];
+                messages[i] += usage.Messages[i];
+                tokens[i] += usage.Tokens[i];
             }
-        }
 
-        var writes = new long[buckets.Count];
-        var stats = await provider.GetUsageAsync(year, month, day, ct);
-        foreach (var p in stats?.ByPeriod ?? [])
-        {
-            var i = period.IndexOf(Utc(p.From));
-            if (i < 0) continue;
-            writes[i] += p.Usage;
+            if (statsPerApp.TryGetValue(result.TopologyId, out var appWriteUsage) == false)
+                continue;
+
+            foreach (var p in appWriteUsage ?? [])
+            {
+                var i = period.IndexOf(Utc(p.From));
+                if (i < 0)
+                    continue;
+                writes[i] += p.Usage;
+            }
         }
 
         var points = new List<UsagePoint>(buckets.Count);

--- a/src/Raven.Quill/Wizard/App.cs
+++ b/src/Raven.Quill/Wizard/App.cs
@@ -3,7 +3,9 @@ namespace Raven.Quill.Wizard;
 internal sealed class App
 {
     public string? Id { get; set; }
-
+    
+    public string TopologyId { get; set; } = "";
+    
     public string Slug { get; set; } = "";
 
     public string AppName { get; set; } = "";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27221

### Additional description

 Overview write usage should be per app

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
