### PR TITLE
RavenDB-27199 Quill - UI/UX polish before the release

### DIFF
--- a/src/Raven.Quill.Web/src/components/ai-connection-string/ai-connection-string-form.tsx
+++ b/src/Raven.Quill.Web/src/components/ai-connection-string/ai-connection-string-form.tsx
@@ -17,6 +17,11 @@ import {
     getProviderOptions,
     mapFormDataToDto,
 } from "@/components/ai-connection-string/ai-connection-string-utils";
+import { TestAiConnectionStringButton } from "@/components/ai-connection-string/test-ai-connection-string-button";
+import {
+    ConnectionTestFailedError,
+    useAiConnectionTest,
+} from "@/components/ai-connection-string/use-ai-connection-test";
 import { AzureOpenAiFields } from "@/components/ai-connection-string/provider-fields/azure-open-ai-fields";
 import { EmbeddedFields } from "@/components/ai-connection-string/provider-fields/embedded-fields";
 import { GoogleFields } from "@/components/ai-connection-string/provider-fields/google-fields";
@@ -79,13 +84,13 @@ export function AiConnectionStringForm({
 
     const provider = useWatch({ control: form.control, name: "provider" });
 
+    const connectionTest = useAiConnectionTest(modelType, form);
+
     const saveMutation = useMutation({
         mutationFn: async (values: ConnectionStringFormData) => {
+            await connectionTest.ensureVerified(values);
+
             const dto = mapFormDataToDto(values, modelType);
-            const test = await api.services.aiConnectionStrings.test(dto);
-            if (!test.success) {
-                throw new Error(test.error ?? "The selected model can't be used by an agent.");
-            }
             const result = await api.services.aiConnectionStrings.create(
                 existingIdentifier ? { ...dto, identifier: existingIdentifier } : dto,
             );
@@ -128,7 +133,15 @@ export function AiConnectionStringForm({
                     />
                     <ProviderFields provider={provider} modelType={modelType} />
 
-                    {saveMutation.isError && (
+                    <TestAiConnectionStringButton
+                        isVerified={connectionTest.isVerified}
+                        isPending={connectionTest.isPending}
+                        error={connectionTest.error}
+                        disabled={saveMutation.isPending}
+                        onTest={connectionTest.test}
+                    />
+
+                    {saveMutation.error && !(saveMutation.error instanceof ConnectionTestFailedError) && (
                         <Alert variant="destructive">
                             {saveMutation.error instanceof Error
                                 ? saveMutation.error.message

--- a/src/Raven.Quill.Web/src/components/ai-connection-string/ai-connection-string-utils.ts
+++ b/src/Raven.Quill.Web/src/components/ai-connection-string/ai-connection-string-utils.ts
@@ -121,6 +121,13 @@ const connectionStringObject = z.object({
 
 export type ConnectionStringFormData = z.infer<typeof connectionStringObject>;
 
+export type ProviderSettings = ConnectionStringFormData[ProviderKey];
+
+/** Identifies what the test endpoint verifies: the provider and its settings, never the name. */
+export function computeConnectionTestKey(provider: ProviderKey, settings: ProviderSettings): string {
+    return JSON.stringify({ provider, settings });
+}
+
 // Required text fields per provider (validated only for the active provider).
 const REQUIRED_FIELDS: Record<ProviderKey, { field: string; message: string }[]> = {
     openAiSettings: [

--- a/src/Raven.Quill.Web/src/components/ai-connection-string/test-ai-connection-string-button.tsx
+++ b/src/Raven.Quill.Web/src/components/ai-connection-string/test-ai-connection-string-button.tsx
@@ -1,0 +1,43 @@
+import { CircleCheck, PlugZap } from "lucide-react";
+import { Alert } from "@/components/shadcn/ui/alert";
+import { Button } from "@/components/shadcn/ui/button";
+import { Spinner } from "@/components/shadcn/ui/spinner";
+import { cn } from "@/lib/utils";
+
+type TestAiConnectionStringButtonProps = {
+    isVerified: boolean;
+    isPending: boolean;
+    error: string | null;
+    disabled?: boolean;
+    onTest: () => void | Promise<void>;
+};
+
+export function TestAiConnectionStringButton({
+    isVerified,
+    isPending,
+    error,
+    disabled,
+    onTest,
+}: TestAiConnectionStringButtonProps) {
+    return (
+        <div className="grid gap-3">
+            <div className="flex">
+                <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => void onTest()}
+                    disabled={disabled || isPending || isVerified}
+                    className={cn(isVerified && "border-success/40 text-success disabled:opacity-100")}
+                >
+                    {isPending ? <Spinner /> : isVerified ? <CircleCheck /> : <PlugZap />}
+                    {isVerified ? "Connection verified" : "Test connection"}
+                </Button>
+            </div>
+            {error && (
+                <Alert variant="destructive" className="whitespace-pre-wrap">
+                    {error}
+                </Alert>
+            )}
+        </div>
+    );
+}

--- a/src/Raven.Quill.Web/src/components/ai-connection-string/use-ai-connection-test.ts
+++ b/src/Raven.Quill.Web/src/components/ai-connection-string/use-ai-connection-test.ts
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useWatch, type UseFormReturn } from "react-hook-form";
+import { api } from "@/api/api";
+import type { AiModelType } from "@/api/generated/server-api";
+import {
+    computeConnectionTestKey,
+    mapFormDataToDto,
+    type ConnectionStringFormData,
+} from "@/components/ai-connection-string/ai-connection-string-utils";
+
+const DEFAULT_TEST_ERROR = "The connection could not be verified.";
+
+type TestAttempt = {
+    key: string;
+    error: string | null;
+};
+
+/** A failed test that the connection test UI already reports, so callers must not report it again. */
+export class ConnectionTestFailedError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "ConnectionTestFailedError";
+    }
+}
+
+function getTestKey(values: ConnectionStringFormData): string {
+    return computeConnectionTestKey(values.provider, values[values.provider]);
+}
+
+async function getTestError(values: ConnectionStringFormData, modelType: AiModelType): Promise<string | null> {
+    try {
+        const result = await api.services.aiConnectionStrings.test(mapFormDataToDto(values, modelType));
+        return result.success ? null : (result.error ?? DEFAULT_TEST_ERROR);
+    } catch (error) {
+        return error instanceof Error ? error.message : DEFAULT_TEST_ERROR;
+    }
+}
+
+export function useAiConnectionTest(modelType: AiModelType, form: UseFormReturn<ConnectionStringFormData>) {
+    const { control, getValues, trigger } = form;
+    const [attempt, setAttempt] = useState<TestAttempt | null>(null);
+
+    // The key must be derived from the watched values (not getValues), otherwise React Compiler
+    // memoizes it against the stable getValues reference and it never reflects form changes.
+    const provider = useWatch({ control, name: "provider" });
+    const settings = useWatch({ control, name: provider });
+    const testKey = computeConnectionTestKey(provider, settings);
+
+    // Keying the attempt drops the outcome as soon as the operator edits anything it was based on.
+    const isVerified = attempt?.key === testKey && attempt.error === null;
+
+    const testMutation = useMutation({
+        mutationFn: async (values: ConnectionStringFormData) => {
+            const error = await getTestError(values, modelType);
+            setAttempt({ key: getTestKey(values), error });
+            return error;
+        },
+    });
+
+    return {
+        isVerified,
+        isPending: testMutation.isPending,
+        error: attempt?.key === testKey ? attempt.error : null,
+        test: async () => {
+            if (await trigger(provider)) {
+                await testMutation.mutateAsync(getValues());
+            }
+        },
+        /** Saving requires a verified connection; an already verified one is not tested twice. */
+        ensureVerified: async (values: ConnectionStringFormData) => {
+            if (isVerified) {
+                return;
+            }
+
+            const error = await testMutation.mutateAsync(values);
+            if (error) {
+                throw new ConnectionTestFailedError(error);
+            }
+        },
+    };
+}

--- a/src/Raven.Quill.Web/src/components/form/wizard/form-wizard.tsx
+++ b/src/Raven.Quill.Web/src/components/form/wizard/form-wizard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
     useFormContext,
     useWatch,
@@ -11,6 +11,7 @@ import { ArrowLeft, ArrowRight, Check } from "lucide-react";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { WizardErrorAlert } from "@/components/form/wizard/wizard-error-alert";
+import { toError, WizardHandledError } from "@/components/form/wizard/wizard-step-error";
 import { cn } from "@/lib/utils";
 
 export type WizardProgress = {
@@ -90,7 +91,7 @@ export function FormWizard<StepId extends string, Values extends FieldValues>({
     cancel,
     completion = { type: "submit" },
 }: FormWizardProps<StepId, Values>) {
-    const { trigger, control, getValues, formState } = useFormContext<Values>();
+    const { trigger, control, getValues, formState, subscribe } = useFormContext<Values>();
 
     if (flow.length === 0) {
         throw new Error("FormWizard requires at least one step in the flow.");
@@ -103,6 +104,10 @@ export function FormWizard<StepId extends string, Values extends FieldValues>({
     const [progressLabel, setProgressLabel] = useState<string | null>(null);
     const [advanceError, setAdvanceError] = useState<Error | null>(null);
     const isAdvancingRef = useRef(false);
+
+    // A failure describes the values it ran against, so any edit makes it stale. Steps that edit values
+    // while advancing are unaffected: runAction sets the error after its action returned.
+    useEffect(() => subscribe({ formState: { values: true }, callback: () => setAdvanceError(null) }), [subscribe]);
 
     const currentIndexInFlow = flow.indexOf(currentStepId);
     const currentIndex = currentIndexInFlow >= 0 ? currentIndexInFlow : Math.min(lastKnownIndex, flow.length - 1);
@@ -158,7 +163,9 @@ export function FormWizard<StepId extends string, Values extends FieldValues>({
         try {
             await action({ report: setProgressLabel });
         } catch (error) {
-            setAdvanceError(error instanceof Error ? error : new Error(String(error)));
+            if (!(error instanceof WizardHandledError)) {
+                setAdvanceError(toError(error));
+            }
         } finally {
             isAdvancingRef.current = false;
             setIsAdvancing(false);

--- a/src/Raven.Quill.Web/src/components/form/wizard/wizard-error-alert.tsx
+++ b/src/Raven.Quill.Web/src/components/form/wizard/wizard-error-alert.tsx
@@ -1,12 +1,13 @@
 import { Alert } from "@/components/shadcn/ui/alert";
 import { WizardErrorDetails } from "@/components/form/wizard/wizard-error-details";
 import { WizardStepError } from "@/components/form/wizard/wizard-step-error";
+import { cn } from "@/lib/utils";
 
-export function WizardErrorAlert({ error }: { error: Error }) {
+export function WizardErrorAlert({ error, className }: { error: Error; className?: string }) {
     const details = error instanceof WizardStepError ? error.details : undefined;
 
     return (
-        <Alert variant="destructive" className="grid gap-2">
+        <Alert variant="destructive" className={cn("grid gap-2", className)}>
             <span className="whitespace-pre-wrap">{error.message}</span>
             {details && <WizardErrorDetails details={details} />}
         </Alert>

--- a/src/Raven.Quill.Web/src/components/form/wizard/wizard-step-error.ts
+++ b/src/Raven.Quill.Web/src/components/form/wizard/wizard-step-error.ts
@@ -10,6 +10,18 @@ export class WizardStepError extends Error {
     }
 }
 
+/** Thrown by a step whose own body already renders the failure, so the wizard skips its error alert. */
+export class WizardHandledError extends Error {
+    constructor(cause: unknown) {
+        super("The step already reported this failure.", { cause });
+        this.name = "WizardHandledError";
+    }
+}
+
+export function toError(value: unknown): Error {
+    return value instanceof Error ? value : new Error(String(value));
+}
+
 export function toWizardStepError(errors: WizardError[] | undefined, fallbackMessage: string): WizardStepError {
     const list = errors ?? [];
     const message = list.map((error) => error.message).join("\n") || fallbackMessage;

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
@@ -1,0 +1,326 @@
+import { useId, useLayoutEffect, useRef, useState, type ComponentProps, type ReactNode, type UIEvent } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { ChevronRight, CircleAlert, CircleCheck, Loader2, type LucideIcon } from "lucide-react";
+import { Badge } from "@/components/shadcn/ui/badge";
+import { Label } from "@/components/shadcn/ui/label";
+import { Switch } from "@/components/shadcn/ui/switch";
+import { formatCompact } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { CdcLiveBatch, CdcLiveBatchState } from "@/pages/apps/use-cdc-live-performance";
+
+// The h-10 header button plus the 1px row separator, so an unmeasured collapsed row already
+// estimates to its real height and the total size barely moves once measuring catches up.
+const COLLAPSED_ROW_HEIGHT_IN_PX = 41;
+const LIST_HEIGHT_IN_PX = 420;
+const OVERSCAN = 12;
+// Slack around the bottom edge so a resting scroll position still counts as "at the latest".
+const AT_LATEST_THRESHOLD_IN_PX = 24;
+// How far the view has to travel back up before it reads as the user leaving the live tail.
+const SCROLL_UP_SLACK_IN_PX = 8;
+
+export function CdcBatchLog({ batches }: { batches: CdcLiveBatch[] }) {
+    if (batches.length === 0) {
+        return (
+            <div className="rounded-lg border">
+                <p className="py-12 text-center text-sm text-muted-foreground">No batches yet.</p>
+            </div>
+        );
+    }
+
+    return <CdcBatchList batches={batches} />;
+}
+
+function CdcBatchList({ batches }: { batches: CdcLiveBatch[] }) {
+    // The virtualizer returns fresh functions on every render, so memoizing this component would
+    // freeze the visible window on its first value. The rows below stay compiled.
+    "use no memo";
+    const followId = useId();
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const contentRef = useRef<HTMLDivElement>(null);
+    const [expandedKeys, setExpandedKeys] = useState<ReadonlySet<string>>(() => new Set());
+    const [isFollowingLatest, setIsFollowingLatest] = useState(true);
+    // Furthest offset reached without the user pulling back, so appended rows - which grow the
+    // list without ever moving scrollTop - cannot be mistaken for a scroll away from the tail.
+    const highWaterOffsetRef = useRef(0);
+
+    // eslint-disable-next-line react-hooks/incompatible-library -- handled by "use no memo" above
+    const virtualizer = useVirtualizer({
+        count: batches.length,
+        estimateSize: () => COLLAPSED_ROW_HEIGHT_IN_PX,
+        getScrollElement: () => scrollRef.current,
+        getItemKey: (index) => batches[index]?.key ?? index,
+        overscan: OVERSCAN,
+    });
+
+    // The feed keeps appending, so pin the viewport to the newest batch while following is on.
+    // Rows report their real height only once they have rendered, so the list still grows a
+    // little after an append lands - watching the sizer re-pins on that late growth too, which
+    // a `batches.length` effect alone would miss and leave the newest row half cut off.
+    useLayoutEffect(() => {
+        const scrollElement = scrollRef.current;
+        const contentElement = contentRef.current;
+        if (!isFollowingLatest || !scrollElement || !contentElement) {
+            return;
+        }
+
+        const pinToBottom = () => {
+            scrollElement.scrollTop = scrollElement.scrollHeight;
+            highWaterOffsetRef.current = scrollElement.scrollTop;
+        };
+
+        pinToBottom();
+
+        const observer = new ResizeObserver(pinToBottom);
+        observer.observe(contentElement);
+
+        return () => observer.disconnect();
+    }, [isFollowingLatest]);
+
+    // Scrolling up parks the view where the user left it, scrolling back to the bottom resumes.
+    const handleScroll = (event: UIEvent<HTMLDivElement>) => {
+        const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
+
+        if (scrollTop < highWaterOffsetRef.current - SCROLL_UP_SLACK_IN_PX) {
+            setIsFollowingLatest(false);
+        } else if (scrollHeight - scrollTop - clientHeight <= AT_LATEST_THRESHOLD_IN_PX) {
+            setIsFollowingLatest(true);
+        }
+
+        // Only downward travel moves the mark, so a slow drag upwards still adds up to a pause.
+        highWaterOffsetRef.current = Math.max(highWaterOffsetRef.current, scrollTop);
+    };
+
+    const toggleExpanded = (key: string) => {
+        setExpandedKeys((previous) => {
+            const next = new Set(previous);
+            if (!next.delete(key)) {
+                next.add(key);
+            }
+
+            return next;
+        });
+    };
+
+    return (
+        <div className="overflow-hidden rounded-lg border">
+            <div className="flex items-center justify-between gap-3 border-b bg-muted/40 px-3 py-2">
+                <p className="text-xs text-muted-foreground tabular-nums">{formatCompact(batches.length)} batches</p>
+                <div className="flex items-center gap-2">
+                    <Label htmlFor={followId} className="text-xs font-normal text-muted-foreground">
+                        Follow latest
+                    </Label>
+                    <Switch id={followId} checked={isFollowingLatest} onCheckedChange={setIsFollowingLatest} />
+                </div>
+            </div>
+            <div
+                ref={scrollRef}
+                onScroll={handleScroll}
+                className="overflow-y-auto overscroll-contain"
+                style={{ height: LIST_HEIGHT_IN_PX }}
+            >
+                <div ref={contentRef} className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+                    {virtualizer.getVirtualItems().map((virtualRow) => {
+                        const batch = batches[virtualRow.index];
+
+                        if (!batch) {
+                            return null;
+                        }
+
+                        return (
+                            <div
+                                key={batch.key}
+                                data-index={virtualRow.index}
+                                ref={(node) => virtualizer.measureElement(node)}
+                                // Positioned via top instead of translateY: Chromium never shrinks
+                                // scrollable overflow contributed by transformed children, so rows
+                                // that transiently render lower leave a permanent phantom scrollbar.
+                                className="absolute inset-x-0"
+                                style={{ top: virtualRow.start }}
+                            >
+                                <CdcBatchRow
+                                    batch={batch}
+                                    isExpanded={expandedKeys.has(batch.key)}
+                                    // A `last:` selector would follow the rendered window, not the feed.
+                                    isLast={virtualRow.index === batches.length - 1}
+                                    onToggle={() => toggleExpanded(batch.key)}
+                                />
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+const BATCH_STATES: Record<
+    CdcLiveBatchState,
+    {
+        label: string;
+        badgeVariant: ComponentProps<typeof Badge>["variant"];
+        icon: LucideIcon;
+        iconClassName?: string;
+        accentClassName: string;
+    }
+> = {
+    success: {
+        label: "Success",
+        badgeVariant: "success",
+        icon: CircleCheck,
+        accentClassName: "border-l-success",
+    },
+    pending: {
+        label: "Pending",
+        badgeVariant: "secondary",
+        icon: Loader2,
+        iconClassName: "animate-spin",
+        accentClassName: "border-l-muted-foreground",
+    },
+    error: {
+        label: "Error",
+        badgeVariant: "destructive",
+        icon: CircleAlert,
+        accentClassName: "border-l-destructive",
+    },
+};
+
+function CdcBatchRow({
+    batch,
+    isExpanded,
+    isLast,
+    onToggle,
+}: {
+    batch: CdcLiveBatch;
+    isExpanded: boolean;
+    isLast: boolean;
+    onToggle: () => void;
+}) {
+    const state = BATCH_STATES[batch.state];
+    const StateIcon = state.icon;
+    const errorCount = batch.scriptErrors + batch.readErrors;
+
+    return (
+        <div className={cn("border-l-2", !isLast && "border-b", state.accentClassName, isExpanded && "bg-muted/30")}>
+            <button
+                type="button"
+                onClick={onToggle}
+                aria-expanded={isExpanded}
+                className="flex h-10 w-full items-center gap-2 px-3 text-left transition-colors hover:bg-muted/50 focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none sm:gap-3"
+            >
+                <ChevronRight
+                    aria-hidden={true}
+                    className={cn(
+                        "size-3.5 shrink-0 text-muted-foreground transition-transform",
+                        isExpanded && "rotate-90",
+                    )}
+                />
+                <Badge variant={state.badgeVariant} className="w-20 shrink-0 justify-start">
+                    <StateIcon aria-hidden={true} className={state.iconClassName} />
+                    {state.label}
+                </Badge>
+                <span className="shrink-0 font-mono text-xs text-muted-foreground tabular-nums">
+                    {formatBatchTime(batch.started)}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                    {describeBatch(batch, errorCount)}
+                </span>
+                {/* The narrow layout keeps state, time and summary; the duration stays in the details below. */}
+                <span className="hidden shrink-0 font-mono text-xs text-muted-foreground tabular-nums sm:inline">
+                    {formatBatchDuration(batch.durationInMs)}
+                </span>
+            </button>
+            {isExpanded && (
+                <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1.5 px-3 pb-3 pl-10">
+                    <CdcBatchDetail label="Started" value={formatBatchDateTime(batch.started)} />
+                    <CdcBatchDetail
+                        label="Completed"
+                        value={batch.ended ? formatBatchDateTime(batch.ended) : "Still in progress"}
+                    />
+                    <CdcBatchDetail label="Duration" value={formatBatchDuration(batch.durationInMs)} />
+                    <CdcBatchDetail label="Messages processed" value={batch.processed.toLocaleString()} />
+                    {batch.scriptErrors > 0 && (
+                        <CdcBatchDetail
+                            label="Script errors"
+                            value={batch.scriptErrors.toLocaleString()}
+                            isDestructive
+                        />
+                    )}
+                    {batch.readErrors > 0 && (
+                        <CdcBatchDetail label="Read errors" value={batch.readErrors.toLocaleString()} isDestructive />
+                    )}
+                </dl>
+            )}
+        </div>
+    );
+}
+
+function CdcBatchDetail({
+    label,
+    value,
+    isDestructive = false,
+}: {
+    label: string;
+    value: ReactNode;
+    isDestructive?: boolean;
+}) {
+    return (
+        <>
+            <dt className="text-xs text-muted-foreground">{label}</dt>
+            <dd
+                className={cn(
+                    "font-mono text-xs break-words tabular-nums",
+                    isDestructive ? "text-destructive" : "text-foreground",
+                )}
+            >
+                {value}
+            </dd>
+        </>
+    );
+}
+
+function describeBatch(batch: CdcLiveBatch, errorCount: number): string {
+    const messages = `${formatCompact(batch.processed)} ${batch.processed === 1 ? "message" : "messages"}`;
+
+    if (batch.state === "error") {
+        return `${formatCompact(errorCount)} ${errorCount === 1 ? "error" : "errors"}, ${messages} processed`;
+    }
+
+    return batch.state === "pending" ? `Processing ${messages}` : `Processed ${messages}`;
+}
+
+const TIME_WITH_MS_OPTIONS: Intl.DateTimeFormatOptions = {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    fractionalSecondDigits: 3,
+    hour12: false,
+};
+
+const batchTimeFormatter = new Intl.DateTimeFormat("en-GB", TIME_WITH_MS_OPTIONS);
+const batchDateTimeFormatter = new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    ...TIME_WITH_MS_OPTIONS,
+});
+
+function formatBatchTime(value: string): string {
+    return format(batchTimeFormatter, value);
+}
+
+function formatBatchDateTime(value: string): string {
+    return format(batchDateTimeFormatter, value);
+}
+
+function format(formatter: Intl.DateTimeFormat, value: string): string {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? value : formatter.format(date);
+}
+
+const SECOND_IN_MS = 1000;
+
+function formatBatchDuration(durationInMs: number): string {
+    return durationInMs < SECOND_IN_MS
+        ? `${Math.round(durationInMs)} ms`
+        : `${(durationInMs / SECOND_IN_MS).toFixed(2)} s`;
+}

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-performance-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-performance-section.tsx
@@ -1,22 +1,15 @@
-import { useState, type ComponentProps } from "react";
+import { type ComponentProps } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
-import { ZERO_SAFE_Y_DOMAIN } from "@/lib/chart-domain";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
-import { ChartContainer, ChartTooltip, type ChartConfig } from "@/components/shadcn/ui/chart";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/shadcn/ui/select";
-import { formatCompact } from "@/lib/format";
-import { formatDateTime } from "@/lib/utils";
+import { CdcBatchLog } from "@/pages/apps/cdc-batch-log";
 import { DashboardStatCards, type DashboardStatCard } from "@/pages/dashboard/dashboard-stat-cards";
 import { CdcErrorsSheet } from "@/pages/apps/cdc-errors-sheet";
 import { SectionCard } from "@/pages/apps/section-card";
 import {
-    MAX_TRACKED_BATCHES,
     useCdcLivePerformance,
-    type CdcLiveBatch,
     type CdcLivePerformance,
     type CdcLiveStatus,
 } from "@/pages/apps/use-cdc-live-performance";
@@ -83,13 +76,7 @@ function CdcStatusBadge({ status }: { status: CdcLiveStatus }) {
     return <Badge variant={badge.variant}>{badge.label}</Badge>;
 }
 
-const CHART_LIMIT_OPTIONS = [50, 100, 250, MAX_TRACKED_BATCHES];
-const DEFAULT_CHART_LIMIT = 100;
-
 function CdcPerformanceContent({ performance }: { performance: CdcLivePerformance }) {
-    const [chartLimit, setChartLimit] = useState(DEFAULT_CHART_LIMIT);
-    const visibleBatches = performance.recentBatches.slice(-chartLimit);
-
     const cards: DashboardStatCard[] = [
         { label: "Recent writes", value: performance.recentWrites, isLoading: false },
         { label: "Errors", value: performance.errorCount, isLoading: false },
@@ -98,116 +85,7 @@ function CdcPerformanceContent({ performance }: { performance: CdcLivePerformanc
     return (
         <div className="space-y-4">
             <DashboardStatCards cards={cards} />
-            <div className="flex items-center justify-between gap-2">
-                <p className="text-sm text-muted-foreground">
-                    Showing {visibleBatches.length} of {performance.totalBatches} batches
-                </p>
-                <Select value={String(chartLimit)} onValueChange={(value) => setChartLimit(Number(value))}>
-                    <SelectTrigger size="sm" aria-label="Batches shown in chart" className="w-auto">
-                        <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent align="end">
-                        {CHART_LIMIT_OPTIONS.map((option) => (
-                            <SelectItem key={option} value={String(option)}>
-                                Up to {option} batches
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
-            </div>
-            <CdcBatchesChart batches={visibleBatches} />
-        </div>
-    );
-}
-
-// recharts 3.x drops `Cell` fills inside `Bar`, so per-batch coloring is done with
-// stacked series where each batch populates exactly one of them.
-const batchesChartConfig = {
-    okProcessed: { label: "Processed", color: "var(--success)" },
-    inProgressProcessed: { label: "In progress", color: "var(--text-muted)" },
-    errorProcessed: { label: "Processed (errors)", color: "var(--destructive)" },
-} satisfies ChartConfig;
-
-const batchTimeFormatter = new Intl.DateTimeFormat("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
-
-function formatBatchTick(started: string) {
-    const date = new Date(started);
-    return Number.isNaN(date.getTime()) ? started : batchTimeFormatter.format(date);
-}
-
-function CdcBatchesChart({ batches }: { batches: CdcLiveBatch[] }) {
-    if (batches.length === 0) {
-        return <p className="py-8 text-center text-sm text-muted-foreground">No recent batches.</p>;
-    }
-
-    const points = batches.map((batch) => {
-        const isInProgress = batch.ended === null;
-        return {
-            ...batch,
-            okProcessed: batch.errors === 0 && !isInProgress ? batch.processed : null,
-            inProgressProcessed: batch.errors === 0 && isInProgress ? batch.processed : null,
-            errorProcessed: batch.errors > 0 ? batch.processed : null,
-        };
-    });
-
-    return (
-        <ChartContainer config={batchesChartConfig} className="aspect-auto h-56 w-full">
-            <BarChart
-                accessibilityLayer
-                data={points}
-                maxBarSize={24}
-                margin={{ top: 8, right: 0, bottom: 0, left: 0 }}
-            >
-                <CartesianGrid vertical={false} />
-                <XAxis
-                    dataKey="started"
-                    tickLine={false}
-                    axisLine={false}
-                    tickMargin={8}
-                    tickFormatter={formatBatchTick}
-                />
-                <YAxis hide domain={ZERO_SAFE_Y_DOMAIN} />
-                <ChartTooltip cursor={false} content={<CdcBatchTooltip />} />
-                <Bar dataKey="okProcessed" stackId="batch" fill="var(--color-okProcessed)" radius={[4, 4, 0, 0]} />
-                <Bar
-                    dataKey="inProgressProcessed"
-                    stackId="batch"
-                    fill="var(--color-inProgressProcessed)"
-                    radius={[4, 4, 0, 0]}
-                />
-                <Bar
-                    dataKey="errorProcessed"
-                    stackId="batch"
-                    fill="var(--color-errorProcessed)"
-                    radius={[4, 4, 0, 0]}
-                />
-            </BarChart>
-        </ChartContainer>
-    );
-}
-
-function CdcBatchTooltip({ active, payload }: { active?: boolean; payload?: ReadonlyArray<{ payload?: unknown }> }) {
-    const batch = payload?.[0]?.payload as CdcLiveBatch | undefined;
-    if (!active || !batch) {
-        return null;
-    }
-
-    return (
-        <div className="grid min-w-40 gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
-            <CdcBatchTooltipRow label="Started" value={formatDateTime(batch.started)} />
-            <CdcBatchTooltipRow label="Ended" value={batch.ended ? formatDateTime(batch.ended) : "In progress"} />
-            <CdcBatchTooltipRow label="Processed" value={formatCompact(batch.processed)} />
-            <CdcBatchTooltipRow label="Duration" value={`${Math.round(batch.durationInMs)} ms`} />
-            {batch.errors > 0 && <CdcBatchTooltipRow label="Errors" value={String(batch.errors)} />}
-        </div>
-    );
-}
-
-function CdcBatchTooltipRow({ label, value }: { label: string; value: string }) {
-    return (
-        <div className="flex items-center justify-between gap-4 leading-none">
-            <span className="text-muted-foreground">{label}</span>
-            <span className="font-mono font-medium text-foreground tabular-nums">{value}</span>
+            <CdcBatchLog batches={performance.batches} />
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
@@ -11,12 +11,15 @@ import { appRoutes } from "@/lib/app-routes";
 import { CHANNEL_TYPE_LABELS } from "@/lib/channel-type-labels";
 import { formatDateTime } from "@/lib/utils";
 import { AddChannelMenu } from "@/pages/apps/channels/add-channel-menu";
+import type { FixedAgent } from "@/pages/apps/channels/web-widget-channel-form";
 import { GenerateEmbedLinkDialog } from "@/pages/apps/channels/generate-embed-link-dialog";
 import { DeleteChannelDialog } from "@/pages/apps/channels/delete-channel-dialog";
 import { EditChannelSheet } from "@/pages/apps/channels/edit-channel-sheet";
 import { SectionCard, SectionTable } from "@/pages/apps/section-card";
 
-export function ChannelsSection({ slug }: { slug: string }) {
+// When `agent` is set the section is scoped to that single agent: only its channels are listed,
+// the agent name column is dropped, and new channels are routed to it (e.g. the capability wizard).
+export function ChannelsSection({ slug, agent: fixedAgent }: { slug: string; agent?: FixedAgent }) {
     const agentsQuery = useQuery(api.queries.agents.list(slug));
     const channelsQuery = useQuery(api.queries.channels.list(slug));
     // Active-link counts are supplementary — kept out of the ApiState gate so a
@@ -37,8 +40,15 @@ export function ChannelsSection({ slug }: { slug: string }) {
         }
     };
 
+    const channels = fixedAgent
+        ? (channelsQuery.data ?? []).filter((channel) => channel.agentId === fixedAgent.agentId)
+        : channelsQuery.data;
+
     return (
-        <SectionCard title="Channels" action={<AddChannelMenu slug={slug} />}>
+        <SectionCard
+            title={fixedAgent ? `Channels for “${fixedAgent.name}”` : "Channels"}
+            action={<AddChannelMenu slug={slug} agent={fixedAgent} />}
+        >
             <ApiState
                 isLoading={channelsQuery.isPending || agentsQuery.isPending}
                 isError={channelsQuery.isError || agentsQuery.isError}
@@ -46,13 +56,21 @@ export function ChannelsSection({ slug }: { slug: string }) {
                 onRetry={onRetry}
                 loadingLabel="Loading channels..."
             >
-                {channelsQuery.data && (
+                {channels && (
                     <SectionTable
-                        headers={["Channel name", "Agent name", "Status", "Type", "Active links", "Created", ""]}
-                        isEmpty={channelsQuery.data.length === 0}
+                        headers={[
+                            "Channel name",
+                            ...(fixedAgent ? [] : ["Agent name"]),
+                            "Status",
+                            "Type",
+                            "Active links",
+                            "Created",
+                            "",
+                        ]}
+                        isEmpty={channels.length === 0}
                         emptyMessage="No channels yet."
                     >
-                        {channelsQuery.data.map((channel) => {
+                        {channels.map((channel) => {
                             const agent = agentsQuery.data?.find((x) => x.agentId === channel.agentId);
                             return (
                                 <TableRow key={channel.channelId}>
@@ -65,7 +83,7 @@ export function ChannelsSection({ slug }: { slug: string }) {
                                             {channel.displayName}
                                         </Link>
                                     </TableCell>
-                                    <TableCell className="font-medium">{agent?.name}</TableCell>
+                                    {!fixedAgent && <TableCell className="font-medium">{agent?.name}</TableCell>}
                                     <TableCell>
                                         <StatusIndicator
                                             tone={channel.enabled ? "positive" : "muted"}
@@ -87,13 +105,15 @@ export function ChannelsSection({ slug }: { slug: string }) {
                                     </TableCell>
                                     <TableCell className="text-right">
                                         <div className="flex items-center justify-end gap-1">
-                                            <Link
-                                                to={appRoutes.app(slug, `channels/${channel.channelId}`)}
-                                                title="Open details"
-                                                className="mx-1"
-                                            >
-                                                <Eye className="size-3.5" aria-hidden="true" />
-                                            </Link>
+                                            {!fixedAgent && (
+                                                <Link
+                                                    to={appRoutes.app(slug, `channels/${channel.channelId}`)}
+                                                    title="Open details"
+                                                    className="mx-1"
+                                                >
+                                                    <Eye className="size-3.5" aria-hidden="true" />
+                                                </Link>
+                                            )}
                                             {channel.type === "IFrame" && (
                                                 <GenerateEmbedLinkDialog
                                                     slug={slug}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/add-channel-menu.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/add-channel-menu.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { CodeXml, MessageCircle, Plus, Send, type LucideIcon } from "lucide-react";
+import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import {
     DropdownMenu,
@@ -80,7 +81,14 @@ export function AddChannelMenu({
                         >
                             <option.icon className="mt-0.5 size-4 text-muted-foreground" aria-hidden="true" />
                             <div className="flex flex-col gap-0.5">
-                                <span className="leading-none font-medium">{option.label}</span>
+                                <span className="flex items-center gap-2">
+                                    <span className="leading-none font-medium">{option.label}</span>
+                                    {!option.enabled && (
+                                        <Badge variant="secondary" className="text-muted-foreground">
+                                            Coming soon
+                                        </Badge>
+                                    )}
+                                </span>
                                 <span className="text-xs text-muted-foreground">{option.description}</span>
                             </div>
                         </DropdownMenuItem>

--- a/src/Raven.Quill.Web/src/pages/apps/use-cdc-live-performance.ts
+++ b/src/Raven.Quill.Web/src/pages/apps/use-cdc-live-performance.ts
@@ -185,23 +185,31 @@ function shape(batches: Map<string, TrackedBatch>, nowMs: number): CdcLivePerfor
         status,
         recentWrites,
         errorCount,
-        batches: orderedBatches.map(({ key, taskName, raw }) => ({
-            key,
-            id: raw.Id,
-            taskName,
-            state: toBatchState(raw),
-            started: raw.Started,
-            ended: raw.Completed ?? null,
-            durationInMs: raw.DurationInMs,
-            processed: raw.NumberOfProcessedMessages,
-            scriptErrors: raw.ScriptProcessingErrorCount,
-            readErrors: raw.ReadErrorCount,
-        })),
+        // A batch that moved nothing is noise in the log. An errored batch usually processed
+        // nothing precisely because it failed, so that one still has to be visible.
+        batches: orderedBatches
+            .filter(({ raw }) => raw.NumberOfProcessedMessages > 0 || hasErrors(raw))
+            .map(({ key, taskName, raw }) => ({
+                key,
+                id: raw.Id,
+                taskName,
+                state: toBatchState(raw),
+                started: raw.Started,
+                ended: raw.Completed ?? null,
+                durationInMs: raw.DurationInMs,
+                processed: raw.NumberOfProcessedMessages,
+                scriptErrors: raw.ScriptProcessingErrorCount,
+                readErrors: raw.ReadErrorCount,
+            })),
     };
 }
 
+function hasErrors(raw: CdcLiveRawBatch): boolean {
+    return raw.ScriptProcessingErrorCount + raw.ReadErrorCount > 0;
+}
+
 function toBatchState(raw: CdcLiveRawBatch): CdcLiveBatchState {
-    if (raw.ScriptProcessingErrorCount + raw.ReadErrorCount > 0) {
+    if (hasErrors(raw)) {
         return "error";
     }
 

--- a/src/Raven.Quill.Web/src/pages/apps/use-cdc-live-performance.ts
+++ b/src/Raven.Quill.Web/src/pages/apps/use-cdc-live-performance.ts
@@ -20,13 +20,19 @@ export type CdcLiveRawFrame = {
     }[];
 };
 
+export type CdcLiveBatchState = "success" | "pending" | "error";
+
 export type CdcLiveBatch = {
     key: string;
+    id: number;
+    taskName: string;
+    state: CdcLiveBatchState;
     started: string;
     ended: string | null;
     durationInMs: number;
     processed: number;
-    errors: number;
+    scriptErrors: number;
+    readErrors: number;
 };
 
 export type CdcLiveStatus = "active" | "error" | "idle";
@@ -35,9 +41,13 @@ export type CdcLivePerformance = {
     status: CdcLiveStatus;
     recentWrites: number;
     errorCount: number;
-    // Batches observed since the connection opened, including ones pruned from recentBatches.
-    totalBatches: number;
-    recentBatches: CdcLiveBatch[];
+    batches: CdcLiveBatch[];
+};
+
+type TrackedBatch = {
+    key: string;
+    taskName: string;
+    raw: CdcLiveRawBatch;
 };
 
 type CdcLiveConnection = "connecting" | "error" | "open";
@@ -63,10 +73,9 @@ export function useCdcLivePerformance(slug: string) {
     }
 
     useEffect(() => {
-        const batches = new Map<string, CdcLiveRawBatch>();
+        const batches = new Map<string, TrackedBatch>();
         const socket = new WebSocket(buildProgressUrl(slug));
         let isDisposed = false;
-        let totalBatches = 0;
 
         socket.onmessage = (event) => {
             if (isDisposed || typeof event.data !== "string") {
@@ -75,7 +84,7 @@ export function useCdcLivePerformance(slug: string) {
 
             const frame = parseFrame(event.data);
             if (frame) {
-                totalBatches += mergeFrame(batches, frame);
+                mergeFrame(batches, frame);
             }
 
             // Heartbeats (no frame) still land here every few seconds, keeping lag and
@@ -83,7 +92,7 @@ export function useCdcLivePerformance(slug: string) {
             setState({
                 connectionId,
                 connection: "open",
-                performance: shape(batches, totalBatches, Date.now()),
+                performance: shape(batches, Date.now()),
             });
         };
 
@@ -128,36 +137,16 @@ function parseFrame(data: string): CdcLiveRawFrame | null {
 }
 
 // The feed resends an in-progress batch (same Id) until it completes, so merge by
-// task/process/batch identity instead of appending. Returns the number of batches not
-// seen before, so the caller can keep a running total across pruning.
-function mergeFrame(batches: Map<string, CdcLiveRawBatch>, frame: CdcLiveRawFrame): number {
-    let newBatches = 0;
+// task/process/batch identity instead of appending.
+function mergeFrame(batches: Map<string, TrackedBatch>, frame: CdcLiveRawFrame) {
     for (const task of frame.Results ?? []) {
+        const taskName = task.TaskName ?? "";
         (task.Stats ?? []).forEach((process, processIndex) => {
-            for (const batch of process.Performance ?? []) {
-                const key = `${task.TaskName ?? ""}/${processIndex}/${batch.Id}`;
-                if (!batches.has(key)) {
-                    newBatches += 1;
-                }
-                batches.set(key, batch);
+            for (const raw of process.Performance ?? []) {
+                const key = `${taskName}/${processIndex}/${raw.Id}`;
+                batches.set(key, { key, taskName, raw });
             }
         });
-    }
-
-    pruneOldest(batches);
-    return newBatches;
-}
-
-export const MAX_TRACKED_BATCHES = 500;
-
-function pruneOldest(batches: Map<string, CdcLiveRawBatch>) {
-    if (batches.size <= MAX_TRACKED_BATCHES) {
-        return;
-    }
-
-    const oldestFirst = [...batches.entries()].sort(([, a], [, b]) => Date.parse(a.Started) - Date.parse(b.Started));
-    for (const [key] of oldestFirst.slice(0, batches.size - MAX_TRACKED_BATCHES)) {
-        batches.delete(key);
     }
 }
 
@@ -165,9 +154,9 @@ function pruneOldest(batches: Map<string, CdcLiveRawBatch>) {
 // does not carry (task disabled flag, persisted last-activity timestamp).
 const ACTIVE_WINDOW_MS = 60_000;
 
-function shape(batches: Map<string, CdcLiveRawBatch>, totalBatches: number, nowMs: number): CdcLivePerformance {
-    const orderedBatches = [...batches.entries()]
-        .map(([key, raw]) => ({ key, raw, startedMs: Date.parse(raw.Started) }))
+function shape(batches: Map<string, TrackedBatch>, nowMs: number): CdcLivePerformance {
+    const orderedBatches = [...batches.values()]
+        .map((tracked) => ({ ...tracked, startedMs: Date.parse(tracked.raw.Started) }))
         .sort((a, b) => a.startedMs - b.startedMs);
 
     let recentWrites = 0;
@@ -196,14 +185,25 @@ function shape(batches: Map<string, CdcLiveRawBatch>, totalBatches: number, nowM
         status,
         recentWrites,
         errorCount,
-        totalBatches,
-        recentBatches: orderedBatches.map(({ key, raw }) => ({
+        batches: orderedBatches.map(({ key, taskName, raw }) => ({
             key,
+            id: raw.Id,
+            taskName,
+            state: toBatchState(raw),
             started: raw.Started,
             ended: raw.Completed ?? null,
             durationInMs: raw.DurationInMs,
             processed: raw.NumberOfProcessedMessages,
-            errors: raw.ScriptProcessingErrorCount + raw.ReadErrorCount,
+            scriptErrors: raw.ScriptProcessingErrorCount,
+            readErrors: raw.ReadErrorCount,
         })),
     };
+}
+
+function toBatchState(raw: CdcLiveRawBatch): CdcLiveBatchState {
+    if (raw.ScriptProcessingErrorCount + raw.ReadErrorCount > 0) {
+        return "error";
+    }
+
+    return raw.Completed ? "success" : "pending";
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FormProvider, useForm } from "react-hook-form";
@@ -18,6 +19,7 @@ import { getAppFlow, useAppSteps } from "./app-wizard-flow";
 import { useSetupWizardStore } from "./app-wizard-store";
 import { isTableSupported } from "./discover-utils";
 import { appSchema, type AppFormData, type AppStepId } from "./app-wizard-validation";
+import { computeSourceKey } from "./steps/connect/use-connect-source-step";
 import { computeMapKey } from "./steps/map/use-map-schema-step";
 import { scaffoldRootTable } from "./steps/map-tables/map-tables-utils";
 
@@ -76,13 +78,20 @@ function AppWizardAtStep({
     initialStep,
     discovery = sampleDiscovery,
     isMappingApplied = true,
+    hasSelectedTables = true,
 }: {
     initialStep: AppStepId;
     discovery?: DiscoverResponse;
     /** When false, the map-tables step treats its seeded tables as stale and asks the AI again. */
     isMappingApplied?: boolean;
+    /** When false, the verify step starts with nothing selected, as it does on a fresh discovery. */
+    hasSelectedTables?: boolean;
 }) {
-    const [seed] = useState(() => buildSeed(discovery));
+    const [seed] = useState(() => {
+        const values = buildSeed(discovery);
+
+        return hasSelectedTables ? values : { ...values, verifySchema: { tables: [] } };
+    });
 
     useState(() =>
         useSetupWizardStore.setState({
@@ -92,6 +101,7 @@ function AppWizardAtStep({
             connectKey: null,
             appliedMapKey: isMappingApplied
                 ? computeMapKey({
+                      sourceKey: computeSourceKey(seed.externalConnection),
                       source: seed.map.source,
                       aiPrompt: seed.map.aiPrompt,
                       selectedTables: seed.verifySchema.tables,
@@ -166,6 +176,26 @@ const connectFailureHandlers = {
 export const ConnectSourceError: Story = {
     parameters: { msw: { handlers: connectFailureHandlers } },
     render: () => <AppWizardAtStep initialStep="externalConnection" />,
+    // A failure belongs to the connection it was made with: editing any part of that connection
+    // drops it, and exactly one alert shows at a time.
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const findAlerts = () => canvas.queryAllByText(/could not connect to the source database/i);
+
+        await userEvent.click(canvas.getByRole("button", { name: /test connection/i }));
+        await waitFor(() => expect(findAlerts()).toHaveLength(1));
+
+        await userEvent.click(canvas.getByRole("button", { name: /sql server/i }));
+        await waitFor(() => expect(findAlerts()).toHaveLength(0));
+
+        await userEvent.click(canvas.getByRole("button", { name: /test connection/i }));
+        await waitFor(() => expect(findAlerts()).toHaveLength(1));
+
+        // Back on the provider that failed first, the alert stays gone and nothing claims success.
+        await userEvent.click(canvas.getByRole("button", { name: /postgresql/i }));
+        await waitFor(() => expect(findAlerts()).toHaveLength(0));
+        expect(canvas.getByRole("button", { name: /test connection/i })).toBeEnabled();
+    },
 };
 
 // Verified tables (one with table-level warnings), tables that need configuration (CDC
@@ -181,11 +211,37 @@ export const VerifySchemaDiscoveryFailed: Story = {
     render: () => <AppWizardAtStep initialStep="verifySchema" discovery={failedDiscovery} />,
 };
 
+// The array-level "at least one table" error must clear as soon as a table is selected.
+export const VerifySchemaWithoutSelection: Story = {
+    render: () => <AppWizardAtStep initialStep="verifySchema" hasSelectedTables={false} />,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await userEvent.click(canvas.getByRole("button", { name: /next/i }));
+        await waitFor(() => expect(canvas.getByText("At least one table is required")).toBeInTheDocument());
+
+        await userEvent.click(canvas.getAllByRole("checkbox", { name: "Select row" })[0]);
+        await waitFor(() => expect(canvas.queryByText("At least one table is required")).not.toBeInTheDocument());
+    },
+};
+
 export const VerifySchemaCdcVerificationFailed: Story = {
     parameters: {
         msw: { handlers: { setup: [setupMocks.verifyCdc(failedCdcVerification), ...defaultApiMocks.setup] } },
     },
     render: () => <AppWizardAtStep initialStep="verifySchema" />,
+    // The dry run's blockers keep the wizard on this step and stay on screen until the selection changes.
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const findAlert = () => canvas.queryByText(/must have the REPLICATION role attribute/i);
+
+        await userEvent.click(canvas.getByRole("button", { name: /next/i }));
+        await waitFor(() => expect(findAlert()).toBeInTheDocument());
+        expect(canvas.getByRole("heading", { name: /verify your schema/i })).toBeInTheDocument();
+
+        await userEvent.click(canvas.getAllByRole("checkbox", { name: "Select row" })[0]);
+        await waitFor(() => expect(findAlert()).not.toBeInTheDocument());
+    },
 };
 
 export const MapSchema: Story = {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/shadcn/ui/dialog";
 import { CdcPerformanceSection } from "@/pages/apps/cdc-performance-section";
 import { cancelAbandonedSuggestions } from "@/pages/setup/add-app-wizard/steps/map-tables/suggest-map-tables-query";
+import { VERIFY_CDC_QUERY_KEY } from "@/pages/setup/add-app-wizard/steps/verify/verify-cdc-query";
 
 type CreatedApp = { slug: string; name: string };
 
@@ -46,10 +47,14 @@ export function AddAppWizard() {
     });
 
     useEffect(() => {
+        // The dry run is cached for as long as its inputs hold, which must not outlive the session:
+        // a reopened wizard would light up "Schema verified" for a run the operator never saw.
+        queryClient.removeQueries({ queryKey: VERIFY_CDC_QUERY_KEY });
         resetStore();
 
         return () => {
             cancelAbandonedSuggestions(queryClient);
+            queryClient.removeQueries({ queryKey: VERIFY_CDC_QUERY_KEY });
             resetStore();
         };
     }, [queryClient, resetStore]);

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-flow.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-flow.tsx
@@ -21,13 +21,14 @@ import { useMapSchemaStep } from "@/pages/setup/add-app-wizard/steps/map/use-map
 import { useFocusMapTablesError } from "@/pages/setup/add-app-wizard/steps/map-tables/use-focus-map-tables-error";
 import { useMapTablesStep } from "@/pages/setup/add-app-wizard/steps/map-tables/use-map-tables-step";
 import { useIsMapTablesNextDisabled } from "@/pages/setup/add-app-wizard/steps/map-tables/use-suggested-map-tables";
-import { useVerifyCdcStep } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step";
+import { useIsVerifyCdcRunning, useVerifyCdcStep } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step";
 import { useVerifySchemaStep } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-schema-step";
 
 export const useAppSteps = (): WizardSteps<AppStepId, AppFormData> => {
     const connectSourceBeforeNext = useConnectSourceStep();
     const verifySchemaBeforeNext = useVerifySchemaStep();
     const verifyCdcBeforeNext = useVerifyCdcStep();
+    const isVerifyCdcRunning = useIsVerifyCdcRunning();
     const mapSchemaBeforeNext = useMapSchemaStep();
     const mapTablesBeforeNext = useMapTablesStep();
     const focusMapTablesError = useFocusMapTablesError();
@@ -74,6 +75,8 @@ export const useAppSteps = (): WizardSteps<AppStepId, AppFormData> => {
                 await verifyCdcBeforeNext(progress);
                 verifySchemaBeforeNext();
             },
+            // Advancing mid-run would carry a selection the dry run has not answered for yet.
+            isNextDisabled: isVerifyCdcRunning,
         },
         map: {
             title: "How would you like to map your schema?",

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-store.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-store.ts
@@ -7,6 +7,9 @@ import {
 
 export type ImportState = "none" | "locked" | "unlocked";
 
+/** Outcome of a connect attempt together with the connect key it ran with. */
+export type ConnectionAttempt = { key: string; error: Error | null };
+
 export type SetupWizardState = {
     reset: () => void;
     discoverResult: DiscoverResponse | null;
@@ -15,18 +18,27 @@ export type SetupWizardState = {
     importState: ImportState;
     lockImportedConfig: () => void;
     unlockImportedConfig: () => void;
+    /**
+     * Last connect attempt made via "Test connection" (or a previous Next). Both the verified state and
+     * the failure alert are derived from it, so neither survives an edit to the connection inputs.
+     */
+    connectionAttempt: ConnectionAttempt | null;
+    setConnectionAttempt: (attempt: ConnectionAttempt) => void;
+    /**
+     * The keys below record what the wizard already did for a given set of inputs, so a step can skip
+     * work when nothing it depends on changed. Everything the server keeps per app - the discovery, the
+     * CDC dry run, the stored map configuration - is keyed by connectKey, because that is the state
+     * document those calls wrote into. The mapping the operator edits in the form is keyed by the source
+     * alone, so renaming the app keeps it.
+     */
     connectKey: string | null;
     setConnectKey: (key: string) => void;
-    /** Connection already verified via "Test connection" (or a previous Next), so Next can skip the connect call. */
-    testedConnectKey: string | null;
-    setTestedConnectKey: (key: string) => void;
     verifiedCdcKey: string | null;
     setVerifiedCdcKey: (key: string) => void;
     appliedMapKey: string | null;
     setAppliedMapKey: (key: string) => void;
     mapTablesKey: string | null;
     setMapTablesKey: (key: string) => void;
-    invalidateMapping: () => void;
     mapActiveTable: MapActiveTable | null;
     setMapActiveTable: (table: MapActiveTable | null) => void;
     /** Bumped by focusMapTable so the explorer scrolls the focused table into view. */
@@ -53,7 +65,7 @@ const initialState: Pick<
     | "discoverSchemas"
     | "importState"
     | "connectKey"
-    | "testedConnectKey"
+    | "connectionAttempt"
     | "verifiedCdcKey"
     | "appliedMapKey"
     | "mapTablesKey"
@@ -68,7 +80,7 @@ const initialState: Pick<
     discoverSchemas: [],
     importState: "none",
     connectKey: null,
-    testedConnectKey: null,
+    connectionAttempt: null,
     verifiedCdcKey: null,
     appliedMapKey: null,
     mapTablesKey: null,
@@ -91,11 +103,10 @@ export const useSetupWizardStore = create<SetupWizardState>((set) => ({
     lockImportedConfig: () => set({ importState: "locked" }),
     unlockImportedConfig: () => set({ importState: "unlocked" }),
     setConnectKey: (key) => set({ connectKey: key }),
-    setTestedConnectKey: (key) => set({ testedConnectKey: key }),
+    setConnectionAttempt: (attempt) => set({ connectionAttempt: attempt }),
     setVerifiedCdcKey: (key) => set({ verifiedCdcKey: key }),
     setAppliedMapKey: (key) => set({ appliedMapKey: key }),
     setMapTablesKey: (key) => set({ mapTablesKey: key }),
-    invalidateMapping: () => set({ appliedMapKey: null, mapTablesKey: null }),
     setMapActiveTable: (table) => set({ mapActiveTable: table }),
     focusMapTable: (table) =>
         set((state) => ({

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-store.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-store.ts
@@ -33,8 +33,6 @@ export type SetupWizardState = {
      */
     connectKey: string | null;
     setConnectKey: (key: string) => void;
-    verifiedCdcKey: string | null;
-    setVerifiedCdcKey: (key: string) => void;
     appliedMapKey: string | null;
     setAppliedMapKey: (key: string) => void;
     mapTablesKey: string | null;
@@ -66,7 +64,6 @@ const initialState: Pick<
     | "importState"
     | "connectKey"
     | "connectionAttempt"
-    | "verifiedCdcKey"
     | "appliedMapKey"
     | "mapTablesKey"
     | "mapActiveTable"
@@ -81,7 +78,6 @@ const initialState: Pick<
     importState: "none",
     connectKey: null,
     connectionAttempt: null,
-    verifiedCdcKey: null,
     appliedMapKey: null,
     mapTablesKey: null,
     mapActiveTable: null,
@@ -104,7 +100,6 @@ export const useSetupWizardStore = create<SetupWizardState>((set) => ({
     unlockImportedConfig: () => set({ importState: "unlocked" }),
     setConnectKey: (key) => set({ connectKey: key }),
     setConnectionAttempt: (attempt) => set({ connectionAttempt: attempt }),
-    setVerifiedCdcKey: (key) => set({ verifiedCdcKey: key }),
     setAppliedMapKey: (key) => set({ appliedMapKey: key }),
     setMapTablesKey: (key) => set({ mapTablesKey: key }),
     setMapActiveTable: (table) => set({ mapActiveTable: table }),

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
@@ -9,7 +9,7 @@ const RELATION_TYPES = ["Array", "Map", "Value"] as const satisfies readonly Cdc
 // Optional override; when empty the server derives the slug from the app name. Mirrors the
 // server's normalization checks so obvious problems surface before provisioning (reserved
 // names are only known server-side and come back as a 400).
-const slugSchema = z
+export const slugSchema = z
     .string()
     .trim()
     .superRefine((value, ctx) => {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/config-io.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/config-io.ts
@@ -4,14 +4,16 @@ import type {
     CdcSinkLinkedTableConfig,
     CdcSinkTableConfig,
 } from "@/api/generated/server-api";
-import { type AppFormData, providerSchema } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+import { type AppFormData, providerSchema, slugSchema } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { mapFormTablesToDto } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-dto";
 
-/** The portable wizard configuration: connection details plus the CDC Sink table mapping, in the
- * canonical DTO shape (matching `/setup/map`). The application name is intentionally excluded. */
+/** The portable wizard configuration: connection details, the public URL slug, plus the CDC Sink table
+ * mapping, in the canonical DTO shape (matching `/setup/map`). The application name is intentionally
+ * excluded. */
 export type WizardConfig = {
     provider: AppFormData["externalConnection"]["provider"];
     connectionString: string;
+    slug: string;
     tables: CdcSinkTableConfig[];
 };
 
@@ -25,6 +27,7 @@ export type SourceTableRef = {
 const wizardConfigSchema = z.object({
     provider: providerSchema,
     connectionString: z.string().trim().min(1, "The configuration is missing a connection string."),
+    slug: slugSchema.default(""),
     tables: z.array(z.looseObject({})).min(1, "The configuration does not define any tables."),
 });
 
@@ -32,6 +35,7 @@ export function buildConfigExport(values: AppFormData): WizardConfig {
     return {
         provider: values.externalConnection.provider,
         connectionString: values.externalConnection.connectionString,
+        slug: values.externalConnection.slug,
         tables: mapFormTablesToDto(values.mapTables.tables),
     };
 }
@@ -75,6 +79,7 @@ export async function parseConfigFile(file: File): Promise<WizardConfig> {
     return {
         provider: result.data.provider,
         connectionString: result.data.connectionString,
+        slug: result.data.slug,
         tables: result.data.tables as CdcSinkTableConfig[],
     };
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/test-connection-button.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/test-connection-button.tsx
@@ -7,7 +7,12 @@ import { Spinner } from "@/components/shadcn/ui/spinner";
 import { cn } from "@/lib/utils";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
-import { computeConnectKey, connectToSource } from "@/pages/setup/add-app-wizard/steps/connect/use-connect-source-step";
+import {
+    computeConnectKey,
+    getConnectionError,
+    isConnectionVerified,
+    testConnection,
+} from "@/pages/setup/add-app-wizard/steps/connect/use-connect-source-step";
 
 const CONNECTION_FIELDS = [
     "externalConnection.provider",
@@ -17,21 +22,18 @@ const CONNECTION_FIELDS = [
 
 export function TestConnectionButton({ disabled }: { disabled: boolean }) {
     const { control, getValues, trigger } = useFormContext<AppFormData>();
-    const testedConnectKey = useSetupWizardStore((state) => state.testedConnectKey);
-    const setTestedConnectKey = useSetupWizardStore((state) => state.setTestedConnectKey);
+    const connectionAttempt = useSetupWizardStore((state) => state.connectionAttempt);
 
     // The key must be derived from the watched values (not getValues), otherwise React Compiler
     // memoizes it against the stable getValues reference and it never reflects form changes.
     const [provider, connectionString, slug] = useWatch({ control, name: CONNECTION_FIELDS });
-    const isTested = computeConnectKey({ provider, connectionString, slug }) === testedConnectKey;
+    const connectKey = computeConnectKey({ provider, connectionString, slug });
+    const isVerified = isConnectionVerified(connectionAttempt, connectKey);
+    const error = getConnectionError(connectionAttempt, connectKey);
 
-    const { mutate, isPending, error } = useMutation({
-        mutationFn: async () => {
-            const connection = getValues("externalConnection");
-            await connectToSource(connection);
-            return computeConnectKey(connection);
-        },
-        onSuccess: setTestedConnectKey,
+    // testConnection stores its outcome, so the mutation only drives the pending state.
+    const { mutate, isPending } = useMutation({
+        mutationFn: () => testConnection(getValues("externalConnection")),
     });
 
     const handleTest = async () => {
@@ -47,14 +49,14 @@ export function TestConnectionButton({ disabled }: { disabled: boolean }) {
                     type="button"
                     variant="outline"
                     onClick={handleTest}
-                    disabled={disabled || isPending || isTested}
-                    className={cn(isTested && "border-success/40 text-success disabled:opacity-100")}
+                    disabled={disabled || isPending || isVerified}
+                    className={cn(isVerified && "border-success/40 text-success disabled:opacity-100")}
                 >
-                    {isPending ? <Spinner /> : isTested ? <CircleCheck /> : <PlugZap />}
-                    {isTested ? "Connection verified" : "Test connection"}
+                    {isPending ? <Spinner /> : isVerified ? <CircleCheck /> : <PlugZap />}
+                    {isVerified ? "Connection verified" : "Test connection"}
                 </Button>
             </div>
-            {error && !isTested && <WizardErrorAlert error={error} />}
+            {error && <WizardErrorAlert error={error} />}
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connect-source-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connect-source-step.ts
@@ -1,34 +1,65 @@
 import { api } from "@/api/api";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import type { WizardProgress } from "@/components/form/wizard/form-wizard";
-import { toWizardStepError } from "@/components/form/wizard/wizard-step-error";
-import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
+import { toError, toWizardStepError, WizardHandledError } from "@/components/form/wizard/wizard-step-error";
+import { useSetupWizardStore, type ConnectionAttempt } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import { getTableKey, isTableSupported } from "@/pages/setup/add-app-wizard/discover-utils";
 import { discoverTables } from "@/pages/setup/add-app-wizard/steps/verify/use-discover-tables";
 import { useFormContext } from "react-hook-form";
 
-export function computeConnectKey(
-    connection: Pick<AppFormData["externalConnection"], "provider" | "connectionString" | "slug">,
-): string {
+export type ConnectSourceInput = Pick<AppFormData["externalConnection"], "provider" | "connectionString" | "slug">;
+
+/** Identifies the source database, and with it the discovered schema and any mapping built from it. */
+export function computeSourceKey(connection: Pick<ConnectSourceInput, "provider" | "connectionString">): string {
     return JSON.stringify({
         provider: connection.provider,
         connectionString: connection.connectionString,
+    });
+}
+
+/**
+ * Identifies what the server holds for this wizard. Its state document is keyed by slug, so a new slug
+ * means an empty document: everything the wizard had the server do must run again under that slug.
+ */
+export function computeConnectKey(connection: ConnectSourceInput): string {
+    return JSON.stringify({
+        sourceKey: computeSourceKey(connection),
         slug: connection.slug,
     });
 }
 
-export async function connectToSource(
-    connection: Pick<AppFormData["externalConnection"], "provider" | "connectionString" | "slug">,
-): Promise<void> {
-    const connectResult = await api.services.setup.connect({
-        connectionString: connection.connectionString,
-        provider: connection.provider,
-        slug: connection.slug,
-    });
+export function isConnectionVerified(attempt: ConnectionAttempt | null, connectKey: string): boolean {
+    return attempt?.key === connectKey && attempt.error === null;
+}
 
-    if (!connectResult.success) {
-        throw toWizardStepError(connectResult.errors, "Connection failed.");
+export function getConnectionError(attempt: ConnectionAttempt | null, connectKey: string): Error | null {
+    return attempt?.key === connectKey ? attempt.error : null;
+}
+
+/**
+ * Records the outcome for the inputs it ran with, so the connect step renders the single result the
+ * operator sees. Failures surface as WizardHandledError to keep the wizard from alerting about them again.
+ */
+export async function testConnection(connection: ConnectSourceInput): Promise<void> {
+    const key = computeConnectKey(connection);
+    const { setConnectionAttempt } = useSetupWizardStore.getState();
+
+    try {
+        const connectResult = await api.services.setup.connect({
+            connectionString: connection.connectionString,
+            provider: connection.provider,
+            slug: connection.slug,
+        });
+
+        if (!connectResult.success) {
+            throw toWizardStepError(connectResult.errors, "Connection failed.");
+        }
+    } catch (error) {
+        setConnectionAttempt({ key, error: toError(error) });
+        throw new WizardHandledError(error);
     }
+
+    setConnectionAttempt({ key, error: null });
 }
 
 export function useConnectSourceStep() {
@@ -44,10 +75,9 @@ export function useConnectSourceStep() {
             return;
         }
 
-        if (connectKey !== store.testedConnectKey) {
+        if (!isConnectionVerified(store.connectionAttempt, connectKey)) {
             progress.report("Testing connection...");
-            await connectToSource(formValues);
-            store.setTestedConnectKey(connectKey);
+            await testConnection(formValues);
         }
 
         progress.report("Discovering tables...");
@@ -69,6 +99,5 @@ export function useConnectSourceStep() {
         );
 
         store.setConnectKey(connectKey);
-        store.invalidateMapping();
     };
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
@@ -19,7 +19,10 @@ import {
     getSourceTableLabel,
 } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
 import { discoverTables } from "@/pages/setup/add-app-wizard/steps/verify/use-discover-tables";
-import { computeConnectKey } from "@/pages/setup/add-app-wizard/steps/connect/use-connect-source-step";
+import {
+    computeConnectKey,
+    computeSourceKey,
+} from "@/pages/setup/add-app-wizard/steps/connect/use-connect-source-step";
 import { toWizardStepError } from "@/components/form/wizard/wizard-step-error";
 import { computeMapKey } from "@/pages/setup/add-app-wizard/steps/map/use-map-schema-step";
 
@@ -121,9 +124,14 @@ export function useImportConfig() {
                 slug: getValues("externalConnection").slug,
             });
             store.setConnectKey(connectKey);
-            store.setTestedConnectKey(connectKey);
+            store.setConnectionAttempt({ key: connectKey, error: null });
             store.setAppliedMapKey(
-                computeMapKey({ source: "manual", aiPrompt: "", selectedTables: verifySchemaTables }),
+                computeMapKey({
+                    sourceKey: computeSourceKey(config),
+                    source: "manual",
+                    aiPrompt: "",
+                    selectedTables: verifySchemaTables,
+                }),
             );
             store.lockImportedConfig();
         },

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
@@ -35,6 +35,7 @@ const IMPORT_PHASES = {
 
 type ImportResult = {
     config: WizardConfig;
+    slug: string;
     formTables: AppFormData["mapTables"]["tables"];
     discoverResult: DiscoverResponse;
     schemas: string[];
@@ -48,7 +49,8 @@ export function useImportConfig() {
         mutationFn: async (file) => {
             setProgressLabel(IMPORT_PHASES.reading);
             const config = await parseConfigFile(file);
-            const slug = getValues("externalConnection").slug;
+            // An older configuration carries no slug; keep whatever the operator already typed.
+            const slug = config.slug || getValues("externalConnection").slug;
 
             setProgressLabel(IMPORT_PHASES.connecting);
             const connectResult = await api.services.setup.connect({
@@ -91,14 +93,14 @@ export function useImportConfig() {
 
             try {
                 const formTables = tablesSchema.parse(wrapDtoTablesToFormShape(config.tables));
-                return { config, formTables, discoverResult, schemas };
+                return { config, slug, formTables, discoverResult, schemas };
             } catch {
                 throw new Error(
                     "The configuration's table mapping is invalid or was exported from an incompatible version.",
                 );
             }
         },
-        onSuccess: ({ config, formTables, discoverResult, schemas }) => {
+        onSuccess: ({ config, slug, formTables, discoverResult, schemas }) => {
             toast.success("Configuration imported");
 
             const verifySchemaTables = config.tables.map((table) => ({
@@ -108,6 +110,7 @@ export function useImportConfig() {
 
             setValue("externalConnection.provider", config.provider);
             setValue("externalConnection.connectionString", config.connectionString);
+            setValue("externalConnection.slug", slug, { shouldValidate: true, shouldTouch: true });
             setValue("verifySchema.tables", verifySchemaTables);
             setValue("map.source", "manual");
             setValue("map.aiPrompt", "");
@@ -121,7 +124,7 @@ export function useImportConfig() {
             const connectKey = computeConnectKey({
                 provider: config.provider,
                 connectionString: config.connectionString,
-                slug: getValues("externalConnection").slug,
+                slug,
             });
             store.setConnectKey(connectKey);
             store.setConnectionAttempt({ key: connectKey, error: null });

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-map-tables-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-map-tables-step.ts
@@ -6,10 +6,13 @@ import { useApplyMapTables } from "@/pages/setup/add-app-wizard/steps/map-tables
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import type { WizardProgress } from "@/components/form/wizard/form-wizard";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
+import { computeConnectKey } from "@/pages/setup/add-app-wizard/steps/connect/use-connect-source-step";
 import { useFormContext } from "react-hook-form";
 
-function computeMapTablesKey(tables: AppFormData["mapTables"]["tables"]): string {
-    return JSON.stringify(mapFormTablesToDto(tables));
+// The server stores the mapping on the state document of the slug it was posted for, so the call has
+// to run again for a new slug (or a new source) even when the tables themselves did not change.
+function computeMapTablesKey(connectKey: string, tables: AppFormData["mapTables"]["tables"]): string {
+    return JSON.stringify({ connectKey, tables: mapFormTablesToDto(tables) });
 }
 
 export function useMapTablesStep() {
@@ -27,8 +30,9 @@ export function useMapTablesStep() {
             store.closeMapTablesRawView();
         }
 
+        const connection = getValues("externalConnection");
         const formTables = getValues("mapTables.tables");
-        const mapTablesKey = computeMapTablesKey(formTables);
+        const mapTablesKey = computeMapTablesKey(computeConnectKey(connection), formTables);
 
         if (mapTablesKey === store.mapTablesKey) {
             return;
@@ -37,7 +41,7 @@ export function useMapTablesStep() {
         progress.report("Applying mapping...");
         await api.services.setup.map({
             tables: mapFormTablesToDto(formTables),
-            slug: getValues("externalConnection").slug,
+            slug: connection.slug,
         });
 
         const firstTable = formTables[0];

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-suggested-map-tables.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-suggested-map-tables.ts
@@ -4,6 +4,7 @@ import { useFormContext, useWatch } from "react-hook-form";
 import { getFetchStartedAt } from "@/lib/query-fetch-start";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+import { computeSourceKey } from "@/pages/setup/add-app-wizard/steps/connect/use-connect-source-step";
 import { computeMapKey } from "@/pages/setup/add-app-wizard/steps/map/use-map-schema-step";
 import { suggestMapTablesQueryForValues } from "@/pages/setup/add-app-wizard/steps/map-tables/suggest-map-tables-query";
 import { useApplyMapTables } from "@/pages/setup/add-app-wizard/steps/map-tables/use-apply-map-tables";
@@ -35,7 +36,12 @@ export function useSuggestedMapTables(): SuggestedMapTables {
 
     const { source, aiPrompt } = getValues("map");
     const selectedTables = getValues("verifySchema.tables");
-    const mapKey = computeMapKey({ source, aiPrompt, selectedTables });
+    const mapKey = computeMapKey({
+        sourceKey: computeSourceKey(getValues("externalConnection")),
+        source,
+        aiPrompt,
+        selectedTables,
+    });
     const isApplied = appliedMapKey === mapKey && getValues("mapTables.tables").length > 0;
     const isSuggestionNeeded = source === "ai-suggested" && !isApplied;
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map/use-map-schema-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map/use-map-schema-step.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import { type AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { getTableKey } from "@/pages/setup/add-app-wizard/discover-utils";
+import { computeSourceKey } from "@/pages/setup/add-app-wizard/steps/connect/use-connect-source-step";
 import { scaffoldTables } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
 import {
     cancelAbandonedSuggestions,
@@ -10,11 +11,13 @@ import {
 import { useFormContext } from "react-hook-form";
 
 export function computeMapKey(map: {
+    sourceKey: string;
     source: AppFormData["map"]["source"];
     aiPrompt: string;
     selectedTables: AppFormData["verifySchema"]["tables"];
 }): string {
     return JSON.stringify({
+        sourceKey: map.sourceKey,
         source: map.source,
         aiPrompt: map.source === "ai-suggested" ? map.aiPrompt.trim() : "",
         selectedTables: map.selectedTables.map(getTableKey).sort(),
@@ -46,7 +49,12 @@ export function useMapSchemaStep() {
         }
 
         const selectedTables = values.verifySchema.tables;
-        const appliedMapKey = computeMapKey({ source, aiPrompt, selectedTables });
+        const appliedMapKey = computeMapKey({
+            sourceKey: computeSourceKey(values.externalConnection),
+            source,
+            aiPrompt,
+            selectedTables,
+        });
 
         // Same inputs as the last generation - keep the (possibly edited) tables.
         if (appliedMapKey === store.appliedMapKey && getValues("mapTables.tables").length > 0) {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step.ts
@@ -8,6 +8,7 @@ import {
     verifyCdcQuery,
     type VerifyCdcInput,
 } from "@/pages/setup/add-app-wizard/steps/verify/verify-cdc-query";
+import type { WizardProgress } from "@/components/form/wizard/form-wizard";
 
 /** The dry-run inputs the form and the store currently hold. */
 function useVerifyCdcInput(): VerifyCdcInput {
@@ -56,11 +57,12 @@ export function useVerifyCdcStep() {
     const queryClient = useQueryClient();
     const { getValues } = useFormContext<AppFormData>();
 
-    return async () => {
+    return async (progress: WizardProgress) => {
         const { connectKey } = useSetupWizardStore.getState();
         const { slug } = getValues("externalConnection");
 
         try {
+            progress.report("Verifying schema...");
             // Serves the cached pass when this selection was already verified, here or from the button.
             await queryClient.fetchQuery(
                 verifyCdcQuery({ connectKey, slug, selectedTables: getValues("verifySchema.tables") }),

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step.ts
@@ -1,58 +1,73 @@
-import { useFormContext } from "react-hook-form";
-import { toast } from "sonner";
-import { api } from "@/api/api";
-import type { WizardProgress } from "@/components/form/wizard/form-wizard";
-import { toWizardStepError } from "@/components/form/wizard/wizard-step-error";
+import { useIsFetching, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useFormContext, useWatch } from "react-hook-form";
+import { WizardHandledError } from "@/components/form/wizard/wizard-step-error";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
-import { getTableKey } from "@/pages/setup/add-app-wizard/discover-utils";
+import {
+    VERIFY_CDC_QUERY_KEY,
+    verifyCdcQuery,
+    type VerifyCdcInput,
+} from "@/pages/setup/add-app-wizard/steps/verify/verify-cdc-query";
 
-export function computeVerifyCdcKey(verify: {
-    connectKey: string | null;
-    selectedTables: AppFormData["verifySchema"]["tables"];
-}): string {
-    return JSON.stringify({
-        connectKey: verify.connectKey,
-        selectedTables: verify.selectedTables.map(getTableKey).sort(),
-    });
+/** The dry-run inputs the form and the store currently hold. */
+function useVerifyCdcInput(): VerifyCdcInput {
+    const { control } = useFormContext<AppFormData>();
+    const connectKey = useSetupWizardStore((state) => state.connectKey);
+
+    // Watched rather than read through getValues, otherwise React Compiler memoizes the input against
+    // the stable getValues reference and it never follows the selection.
+    const [slug, selectedTables] = useWatch({ control, name: ["externalConnection.slug", "verifySchema.tables"] });
+
+    return { connectKey, slug, selectedTables };
+}
+
+/**
+ * Whether a dry run is in flight, for any selection - including one still finishing for a selection the
+ * operator has since changed. It freezes everything that would invalidate the run under way: the table
+ * selection, the schema list it was discovered from, and Next. Deliberately reads nothing but the fetch
+ * state, so the wizard shell can hold Next back without re-rendering on every checkbox.
+ */
+export function useIsVerifyCdcRunning(): boolean {
+    return useIsFetching({ queryKey: VERIFY_CDC_QUERY_KEY }) > 0;
+}
+
+/**
+ * The dry run for the current selection. The query is only observed here, never enabled: the call
+ * provisions capture infrastructure on the source, so it runs when the operator asks for it or when
+ * Next needs it, and both read their state from this one cache entry.
+ */
+export function useVerifyCdcState() {
+    const queryClient = useQueryClient();
+    const input = useVerifyCdcInput();
+    const { isFetching, isSuccess, error } = useQuery({ ...verifyCdcQuery(input), enabled: false });
+    const isRunning = useIsVerifyCdcRunning();
+
+    return {
+        isVerifying: isFetching,
+        isVerified: isSuccess,
+        isRunning,
+        error,
+        // The rejection is the query's own error, which the step already renders from the cache.
+        verify: () => void queryClient.fetchQuery(verifyCdcQuery(input)).catch(() => {}),
+    };
 }
 
 export function useVerifyCdcStep() {
+    const queryClient = useQueryClient();
     const { getValues } = useFormContext<AppFormData>();
 
-    return async (progress: WizardProgress) => {
-        const store = useSetupWizardStore.getState();
-        const selectedTables = getValues("verifySchema.tables");
-        const verifyCdcKey = computeVerifyCdcKey({ connectKey: store.connectKey, selectedTables });
+    return async () => {
+        const { connectKey } = useSetupWizardStore.getState();
+        const { slug } = getValues("externalConnection");
 
-        if (verifyCdcKey === store.verifiedCdcKey) {
-            return;
-        }
-
-        progress.report("Verifying CDC access...");
-
-        const result = await api.services.setup.verifyCdc({
-            tables: selectedTables.map((table) => ({
-                sourceTableSchema: table.sourceTableSchema,
-                sourceTableName: table.sourceTableName,
-            })),
-            slug: getValues("externalConnection").slug,
-        });
-
-        if (!result.success) {
-            const warningErrors = result.warnings.map((warning) => ({ message: warning }));
-            throw toWizardStepError(
-                [...result.errors, ...warningErrors],
-                "CDC verification failed for the selected tables.",
+        try {
+            // Serves the cached pass when this selection was already verified, here or from the button.
+            await queryClient.fetchQuery(
+                verifyCdcQuery({ connectKey, slug, selectedTables: getValues("verifySchema.tables") }),
             );
+        } catch (error) {
+            // The step renders the failure from the query, so the wizard must not alert about it again.
+            throw new WizardHandledError(error);
         }
-
-        if (result.warnings.length > 0) {
-            toast.warning("CDC verification passed with warnings", {
-                description: result.warnings.join("\n"),
-            });
-        }
-
-        store.setVerifiedCdcKey(verifyCdcKey);
     };
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verified-tables-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verified-tables-table.tsx
@@ -8,6 +8,7 @@ import type { DiscoverTableResponse } from "@/api/generated/server-api";
 import { TooltipProvider } from "@/components/shadcn/ui/tooltip";
 import { VirtualDataTable } from "@/components/table/virtual-data-table";
 import { getTableKey } from "@/pages/setup/add-app-wizard/discover-utils";
+import { VerifySchemaButton } from "@/pages/setup/add-app-wizard/steps/verify/verify-schema-button";
 import { VERIFIED_COLUMNS } from "@/pages/setup/add-app-wizard/steps/verify/verify-schema-columns";
 
 type VerifiedTablesTableProps = {
@@ -17,8 +18,10 @@ type VerifiedTablesTableProps = {
     search: string;
     rowSelection: RowSelectionState;
     onRowSelectionChange: (selection: RowSelectionState) => void;
-    /** When an imported configuration is locked, the selection is read-only. */
+    /** The selection is read-only: an imported configuration is locked, or a dry run is in flight. */
     disabled?: boolean;
+    /** The wizard is running a step action, so the overlay must not start a second verification. */
+    isBusy?: boolean;
 };
 
 export function VerifiedTablesTable({
@@ -28,6 +31,7 @@ export function VerifiedTablesTable({
     rowSelection,
     onRowSelectionChange,
     disabled,
+    isBusy = false,
 }: VerifiedTablesTableProps) {
     // react-table needs a stable filter-state reference between renders; a fresh identity on
     // every render makes it recompute row models and queue state resets, ending in a re-render
@@ -64,24 +68,28 @@ export function VerifiedTablesTable({
                 className="mb-4"
                 getRowState={(rowId) => (rowSelection[rowId] ? "selected" : "")}
                 overlay={
-                    <div className="absolute bottom-0 left-1/2 flex -translate-x-1/2 translate-y-1/2 items-center gap-2.5 rounded-full border bg-card px-4 py-2 text-sm shadow-md">
-                        <span className="whitespace-nowrap text-muted-foreground">
-                            {selectedCount} out of {totalTableCount} tables selected
-                        </span>
-                        {!disabled && selectedCount > 0 && (
-                            <>
-                                <div className="h-4 w-px bg-border" />
-                                <button
-                                    type="button"
-                                    className="flex items-center gap-1.5 whitespace-nowrap text-foreground transition-colors hover:text-muted-foreground"
-                                    onClick={() => onRowSelectionChange({})}
-                                >
-                                    <XIcon className="size-3.5" aria-hidden="true" />
-                                    Deselect all
-                                </button>
-                            </>
-                        )}
-                    </div>
+                    selectedCount > 0 && (
+                        <div className="absolute bottom-0 left-1/2 flex -translate-x-1/2 translate-y-1/2 items-center gap-2.5 rounded-full border bg-card px-4 py-2 text-sm shadow-md">
+                            <span className="whitespace-nowrap text-muted-foreground">
+                                {selectedCount} out of {totalTableCount} tables selected
+                            </span>
+                            {!disabled && (
+                                <>
+                                    <div className="h-4 w-px bg-border" />
+                                    <button
+                                        type="button"
+                                        className="flex items-center gap-1.5 whitespace-nowrap text-foreground transition-colors hover:text-muted-foreground"
+                                        onClick={() => onRowSelectionChange({})}
+                                    >
+                                        <XIcon className="size-3.5" aria-hidden="true" />
+                                        Deselect all
+                                    </button>
+                                </>
+                            )}
+                            <div className="h-4 w-px bg-border" />
+                            <VerifySchemaButton disabled={isBusy} />
+                        </div>
+                    )
                 }
             />
         </TooltipProvider>

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-cdc-query.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-cdc-query.ts
@@ -1,0 +1,62 @@
+import { queryOptions } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api } from "@/api/api";
+import { toWizardStepError } from "@/components/form/wizard/wizard-step-error";
+import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+import { getTableKey } from "@/pages/setup/add-app-wizard/discover-utils";
+
+export const VERIFY_CDC_QUERY_KEY = ["setup", "verifyCdc"];
+
+type SelectedTables = AppFormData["verifySchema"]["tables"];
+
+export type VerifyCdcInput = {
+    /** Everything the server keeps for this app lives under the connect key, the dry run included. */
+    connectKey: string | null;
+    slug: string;
+    selectedTables: SelectedTables;
+};
+
+/**
+ * The CDC dry run for one table selection. A query rather than a mutation because the outcome belongs
+ * to the inputs it ran against: the cache entry is what lets "Verify schema" and Next share a single
+ * spinner and a single error, and what keeps Next from repeating a run the operator already passed.
+ */
+export function verifyCdcQuery({ connectKey, slug, selectedTables }: VerifyCdcInput) {
+    return queryOptions({
+        // The connect key already embeds the source and the slug, so the selection is all that is left
+        // to key on.
+        queryKey: [...VERIFY_CDC_QUERY_KEY, connectKey, selectedTables.map(getTableKey).sort()],
+        queryFn: () => verifyCdc(slug, selectedTables),
+        // A dry run against an unchanged selection cannot go stale on its own, and a failed one is
+        // retried by the operator rather than automatically.
+        staleTime: Infinity,
+        retry: false,
+    });
+}
+
+async function verifyCdc(slug: string, selectedTables: SelectedTables) {
+    const result = await api.services.setup.verifyCdc({
+        tables: selectedTables.map((table) => ({
+            sourceTableSchema: table.sourceTableSchema,
+            sourceTableName: table.sourceTableName,
+        })),
+        slug,
+    });
+
+    if (!result.success) {
+        const warningErrors = result.warnings.map((warning) => ({ message: warning }));
+        throw toWizardStepError(
+            [...result.errors, ...warningErrors],
+            "CDC verification failed for the selected tables.",
+        );
+    }
+
+    // Toasting from the fetcher stays a one-off: the entry never goes stale and is never retried.
+    if (result.warnings.length > 0) {
+        toast.warning("CDC verification passed with warnings", {
+            description: result.warnings.join("\n"),
+        });
+    }
+
+    return result;
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-button.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-button.tsx
@@ -1,0 +1,33 @@
+import { CircleCheckIcon, ShieldCheckIcon } from "lucide-react";
+import { Spinner } from "@/components/shadcn/ui/spinner";
+import { cn } from "@/lib/utils";
+import { useVerifyCdcState } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step";
+
+/**
+ * Runs the CDC dry run that Next runs, so the operator can settle the selection before leaving the step.
+ * Lives in the selection overlay: verifying is only meaningful once at least one table is selected.
+ */
+export function VerifySchemaButton({ disabled }: { disabled: boolean }) {
+    const { isVerifying, isVerified, isRunning, verify } = useVerifyCdcState();
+
+    return (
+        <button
+            type="button"
+            onClick={verify}
+            disabled={disabled || isVerified || isRunning}
+            className={cn(
+                "flex items-center gap-1.5 whitespace-nowrap transition-colors disabled:pointer-events-none",
+                isVerified ? "text-success" : "text-foreground hover:text-muted-foreground",
+            )}
+        >
+            {isVerifying ? (
+                <Spinner className="size-3.5" />
+            ) : isVerified ? (
+                <CircleCheckIcon className="size-3.5" aria-hidden="true" />
+            ) : (
+                <ShieldCheckIcon className="size-3.5" aria-hidden="true" />
+            )}
+            {isVerifying ? "Verifying schema..." : isVerified ? "Schema verified" : "Verify schema"}
+        </button>
+    );
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-step.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import type { RowSelectionState } from "@tanstack/react-table";
-import { useFormContext } from "react-hook-form";
+import { useFormContext, useFormState } from "react-hook-form";
 import { CheckIcon, PlusIcon, SearchIcon, TriangleAlertIcon } from "lucide-react";
 import type { DiscoverResponse, DiscoverTableResponse } from "@/api/generated/server-api";
 import { Alert } from "@/components/shadcn/ui/alert";
@@ -26,7 +26,10 @@ import {
 type VerifyTab = "verified" | "needs-configuration";
 
 export function VerifySchemaStep() {
-    const { setValue, getValues, formState } = useFormContext<AppFormData>();
+    const { control, setValue, getValues } = useFormContext<AppFormData>();
+    // formState off the context does not re-render this step; only its own subscription does.
+    const { errors } = useFormState({ control, name: "verifySchema.tables" });
+    const tablesError = errors.verifySchema?.tables;
     const discoverResult = useSetupWizardStore((state) => state.discoverResult);
     const discoverSchemas = useSetupWizardStore((state) => state.discoverSchemas);
     const isLocked = useSetupWizardStore((state) => state.importState) === "locked";
@@ -176,9 +179,7 @@ export function VerifySchemaStep() {
                 <NoTablesFound schemas={discoverSchemas} onCustomizeSchemas={() => setIsSchemasSheetOpen(true)} />
             ) : null}
 
-            {formState.errors?.verifySchema?.tables && (
-                <Alert variant="destructive">{formState.errors.verifySchema.tables.message}</Alert>
-            )}
+            {tablesError && <Alert variant="destructive">{tablesError.message}</Alert>}
 
             <DefineSchemasSheet
                 isOpen={isSchemasSheetOpen}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-step.tsx
@@ -3,6 +3,8 @@ import type { RowSelectionState } from "@tanstack/react-table";
 import { useFormContext, useFormState } from "react-hook-form";
 import { CheckIcon, PlusIcon, SearchIcon, TriangleAlertIcon } from "lucide-react";
 import type { DiscoverResponse, DiscoverTableResponse } from "@/api/generated/server-api";
+import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
+import { WizardErrorAlert } from "@/components/form/wizard/wizard-error-alert";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
@@ -15,6 +17,7 @@ import { ImportedConfigAlert } from "@/pages/setup/add-app-wizard/imported-confi
 import { DefineSchemasSheet } from "@/pages/setup/add-app-wizard/steps/verify/define-schemas-sheet";
 import { NeedsConfigTablesTable } from "@/pages/setup/add-app-wizard/steps/verify/needs-config-tables-table";
 import { useDiscoverTablesMutation } from "@/pages/setup/add-app-wizard/steps/verify/use-discover-tables";
+import { useVerifyCdcState } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step";
 import { VerifiedTablesTable } from "@/pages/setup/add-app-wizard/steps/verify/verified-tables-table";
 import { WizardErrorList } from "@/components/form/wizard/wizard-error-list";
 import {
@@ -25,11 +28,12 @@ import {
 
 type VerifyTab = "verified" | "needs-configuration";
 
-export function VerifySchemaStep() {
+export function VerifySchemaStep({ isBusy }: WizardBodyComponentProps) {
     const { control, setValue, getValues } = useFormContext<AppFormData>();
     // formState off the context does not re-render this step; only its own subscription does.
     const { errors } = useFormState({ control, name: "verifySchema.tables" });
     const tablesError = errors.verifySchema?.tables;
+    const { error: cdcError, isRunning: isVerifyCdcRunning } = useVerifyCdcState();
     const discoverResult = useSetupWizardStore((state) => state.discoverResult);
     const discoverSchemas = useSetupWizardStore((state) => state.discoverSchemas);
     const isLocked = useSetupWizardStore((state) => state.importState) === "locked";
@@ -100,9 +104,11 @@ export function VerifySchemaStep() {
 
     return (
         <div className="flex min-h-0 flex-1 flex-col gap-4">
-            <ImportedConfigAlert />
-            <WizardErrorList errors={discoverResult?.errors} />
-            <MessageList messages={discoverResult?.warnings} tone="warning" />
+            <div className="grid shrink-0 gap-4">
+                <ImportedConfigAlert />
+                <WizardErrorList errors={discoverResult?.errors} />
+                <MessageList messages={discoverResult?.warnings} tone="warning" />
+            </div>
 
             {discoverMutation.isPending ? (
                 <DiscoverLoadingSkeleton />
@@ -125,7 +131,7 @@ export function VerifySchemaStep() {
                             variant="outline"
                             className="ml-auto"
                             onClick={() => setIsSchemasSheetOpen(true)}
-                            disabled={isLocked}
+                            disabled={isLocked || isVerifyCdcRunning}
                         >
                             <PlusIcon aria-hidden="true" />
                             Customize schemas
@@ -169,7 +175,8 @@ export function VerifySchemaStep() {
                             search={search}
                             rowSelection={rowSelection}
                             onRowSelectionChange={handleRowSelectionChange}
-                            disabled={isLocked}
+                            disabled={isLocked || isVerifyCdcRunning}
+                            isBusy={isBusy}
                         />
                     ) : (
                         <NeedsConfigTablesTable tables={needsConfigTables} search={search} />
@@ -179,7 +186,14 @@ export function VerifySchemaStep() {
                 <NoTablesFound schemas={discoverSchemas} onCustomizeSchemas={() => setIsSchemasSheetOpen(true)} />
             ) : null}
 
-            {tablesError && <Alert variant="destructive">{tablesError.message}</Alert>}
+            {/* shrink-0: the table below claims the column's free space, and Alert scrolls its own
+                overflow, so a shrinkable alert collapses into an unreadable sliver. */}
+            {tablesError && (
+                <Alert variant="destructive" className="shrink-0">
+                    {tablesError.message}
+                </Alert>
+            )}
+            {cdcError && <WizardErrorAlert error={cdcError} className="shrink-0" />}
 
             <DefineSchemasSheet
                 isOpen={isSchemasSheetOpen}

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/channels/channels-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/channels/channels-step.tsx
@@ -1,14 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router";
-import { MessageSquarePlus } from "lucide-react";
-import { api } from "@/api/api";
 import { Alert } from "@/components/shadcn/ui/alert";
-import { ApiState } from "@/components/data/api-state";
-import { StatusIndicator } from "@/components/data/status-indicator";
-import { TableCell, TableRow } from "@/components/shadcn/ui/table";
-import { CHANNEL_TYPE_LABELS } from "@/lib/channel-type-labels";
-import { AddChannelMenu } from "@/pages/apps/channels/add-channel-menu";
-import { SectionCard, SectionTable } from "@/pages/apps/section-card";
+import { ChannelsSection } from "@/pages/apps/channels-section";
 import { useCapabilityWizardStore } from "@/pages/setup/add-capability-wizard/capability-wizard-store";
 
 // The wizard's final, optional step. Reached only after the agent is provisioned; lets the
@@ -16,10 +8,6 @@ import { useCapabilityWizardStore } from "@/pages/setup/add-capability-wizard/ca
 export function ChannelsStep() {
     const { slug = "" } = useParams();
     const createdAgent = useCapabilityWizardStore((state) => state.createdAgent);
-    const channelsQuery = useQuery({
-        ...api.queries.channels.list(slug),
-        enabled: Boolean(createdAgent),
-    });
 
     // The flow only advances here after provisioning succeeds, so createdAgent is set; guard
     // defensively in case the step is rendered out of order.
@@ -27,56 +15,5 @@ export function ChannelsStep() {
         return <Alert>Create the agent first to add channels.</Alert>;
     }
 
-    const channels = (channelsQuery.data ?? []).filter((channel) => channel.agentId === createdAgent.agentId);
-
-    return (
-        <div className="max-w-3xl">
-            <ApiState
-                isLoading={channelsQuery.isPending}
-                isError={channelsQuery.isError}
-                errorTitle="Could not load channels"
-                onRetry={() => void channelsQuery.refetch()}
-                loadingLabel="Loading channels..."
-            >
-                {channels.length === 0 ? (
-                    <div className="flex flex-col items-center gap-4 rounded-lg border border-dashed px-6 py-12 text-center">
-                        <span className="flex size-11 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                            <MessageSquarePlus className="size-5" aria-hidden="true" />
-                        </span>
-                        <div className="grid gap-1">
-                            <p className="text-sm font-medium">No channels connected yet</p>
-                            <p className="text-sm text-muted-foreground">
-                                Connect one so people can start chatting with “{createdAgent.name}”.
-                            </p>
-                        </div>
-                        <AddChannelMenu slug={slug} agent={createdAgent} />
-                    </div>
-                ) : (
-                    <SectionCard
-                        title={`Channels for “${createdAgent.name}”`}
-                        action={<AddChannelMenu slug={slug} agent={createdAgent} />}
-                    >
-                        <SectionTable
-                            headers={["Channel name", "Status", "Type"]}
-                            isEmpty={false}
-                            emptyMessage="No channels yet."
-                        >
-                            {channels.map((channel) => (
-                                <TableRow key={channel.channelId}>
-                                    <TableCell className="font-medium">{channel.displayName}</TableCell>
-                                    <TableCell>
-                                        <StatusIndicator
-                                            tone={channel.enabled ? "positive" : "muted"}
-                                            label={channel.enabled ? "Connected" : "Disabled"}
-                                        />
-                                    </TableCell>
-                                    <TableCell>{channel.type ? CHANNEL_TYPE_LABELS[channel.type] : "—"}</TableCell>
-                                </TableRow>
-                            ))}
-                        </SectionTable>
-                    </SectionCard>
-                )}
-            </ApiState>
-        </div>
-    );
+    return <ChannelsSection slug={slug} agent={createdAgent} />;
 }

--- a/src/Raven.Quill/Endpoints/WizardEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/WizardEndpoints.cs
@@ -107,13 +107,25 @@ public static class WizardEndpoints
         var wizardId = WizardState.DocumentIdFor(body.Slug);
         using (var session = store.OpenAsyncSession())
         {
-            var state = new WizardState
+            var state = await session.LoadAsync<WizardState>(wizardId, ct) ?? new WizardState();
+
+            // Re-testing the same source must keep the discovery and mapping already made against it:
+            // the wizard skips those calls when its inputs did not change and expects them to still be
+            // here. A different source, on the other hand, invalidates both.
+            var isSameSource = state.Provider == factoryName && state.SourceConnectionString == connectionString;
+            if (!isSameSource)
             {
-                Provider = factoryName,
-                SourceConnectionString = connectionString,
-                LastVerifyResult = result,
-                LastVerifyAt = DateTime.UtcNow,
-            };
+                state.LastDiscoveredSchema = null;
+                state.LastDiscoverAt = null;
+                state.LastMapConfiguration = null;
+                state.LastMapAt = null;
+            }
+
+            state.Provider = factoryName;
+            state.SourceConnectionString = connectionString;
+            state.LastVerifyResult = result;
+            state.LastVerifyAt = DateTime.UtcNow;
+
             await session.StoreAsync(state, wizardId, ct);
             await session.SaveChangesAsync(ct);
         }


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27199/Quill-UI-UX-polish-before-the-release

### Additional description

- Fix test connection bugs
- Add slug to import/export config
- Add test button to AI connection string
- Reuse the channels section in the channel step, with a "coming soon" badge
- Add verify schema button
- Use a virtual list in the performance section

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
