### PR TITLE
RavenDB-27223 Ignore the key-id prefix when validating the dashboard API key

### DIFF
--- a/src/Raven.Quill/Auth/ApiKeyStore.cs
+++ b/src/Raven.Quill/Auth/ApiKeyStore.cs
@@ -27,8 +27,12 @@ public sealed class ApiKeyStore(
         if (string.IsNullOrEmpty(presentedKey))
             return false;
 
+        var secret = StripKeyIdPrefix(presentedKey);
+        if (secret.Length == 0)
+            return false;
+
         var keys = _keys ?? await EnsureSeededAsync(ct);
-        var presented = Encoding.UTF8.GetBytes(presentedKey);
+        var presented = Encoding.UTF8.GetBytes(secret);
 
         var match = false;
         // no early return on match: keep timing uniform
@@ -54,7 +58,7 @@ public sealed class ApiKeyStore(
             if (_keys is not null)
                 return _keys;
 
-            var envKey = options.Value.ApiKey;
+            var envKey = options.Value.ApiKey is { } configured ? StripKeyIdPrefix(configured) : null;
             Record[] records;
             if (string.IsNullOrWhiteSpace(envKey))
             {
@@ -105,6 +109,13 @@ public sealed class ApiKeyStore(
         {
             logger.LogWarning(ex, "Failed to persist the API key hash to the config database.");
         }
+    }
+
+    // keys may be minted as "<key-id>/<secret>" (e.g. "primary/..."); only the secret part is compared
+    private static string StripKeyIdPrefix(string key)
+    {
+        var separator = key.IndexOf('/');
+        return separator < 0 ? key : key[(separator + 1)..];
     }
 
     private static byte[] Combine(byte[] a, byte[] b)

--- a/test/QuillTests/AuthEndpointsTests.cs
+++ b/test/QuillTests/AuthEndpointsTests.cs
@@ -79,6 +79,46 @@ public class AuthEndpointsTests(ITestOutputHelper output) : QuillTestBase(output
     }
 
     [RavenFact(RavenTestCategory.Quill)]
+    public async Task Key_id_prefix_on_the_presented_key_is_ignored()
+    {
+        await using var host = await NewHostAsync();
+        host.Client.DefaultRequestHeaders.Remove(ApiKeyAuthenticationHandler.HeaderName);
+
+        var resp = await host.Client.PostAsJsonAsync(QuillRoutes.AuthLogin,
+            new { apiKey = "primary/" + ApplianceWebApplicationFactory.TestApiKey });
+        Assert.True(resp.IsSuccessStatusCode, await resp.Content.ReadAsStringAsync());
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Key_id_prefix_on_the_configured_key_is_ignored()
+    {
+        await using var host = await NewHostAsync(configure: opts =>
+            opts.ApiKey = "primary/" + ApplianceWebApplicationFactory.TestApiKey);
+        host.Client.DefaultRequestHeaders.Remove(ApiKeyAuthenticationHandler.HeaderName);
+
+        var bare = await host.Client.PostAsJsonAsync(QuillRoutes.AuthLogin,
+            new { apiKey = ApplianceWebApplicationFactory.TestApiKey });
+        Assert.True(bare.IsSuccessStatusCode, await bare.Content.ReadAsStringAsync());
+
+        var prefixed = await host.Client.PostAsJsonAsync(QuillRoutes.AuthLogin,
+            new { apiKey = "primary/" + ApplianceWebApplicationFactory.TestApiKey });
+        Assert.True(prefixed.IsSuccessStatusCode, await prefixed.Content.ReadAsStringAsync());
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Key_id_prefix_with_wrong_secret_is_401()
+    {
+        await using var host = await NewHostAsync();
+        host.Client.DefaultRequestHeaders.Remove(ApiKeyAuthenticationHandler.HeaderName);
+
+        var wrongSecret = await host.Client.PostAsJsonAsync(QuillRoutes.AuthLogin, new { apiKey = "primary/wrong-key" });
+        Assert.Equal(HttpStatusCode.Unauthorized, wrongSecret.StatusCode);
+
+        var emptySecret = await host.Client.PostAsJsonAsync(QuillRoutes.AuthLogin, new { apiKey = "primary/" });
+        Assert.Equal(HttpStatusCode.Unauthorized, emptySecret.StatusCode);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
     public async Task Login_is_rate_limited_after_repeated_attempts()
     {
         await using var host = await NewHostAsync();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27223

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
