### PR TITLE
RavenDB-27225 Fix Corax 2.0 wrapper operands inheriting the enclosing connective

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/PlanWalker.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/PlanWalker.cs
@@ -110,11 +110,29 @@ internal static class PlanWalker
         {
             foreach (var t in pending.InnerClauses)
             {
-                if (t.ClauseType == ClauseType.Vector)
-                    throw new NotSupportedException("Boosting the VectorSearchMatch is not supported yet.");
-                t.Bindings = [..t.Bindings ?? [], pending.Factor];
-                t.HasBoost = true;
+                Apply(t, pending.Factor);
             }
+        }
+
+        // a group has no Bindings of its own - carry the factor down to the leaves
+        static void Apply(ClauseInfo clause, ParameterBinding factor)
+        {
+            RuntimeHelpers.EnsureSufficientExecutionStack();
+            if (clause.ClauseType == ClauseType.Vector)
+                throw new NotSupportedException("Boosting the VectorSearchMatch is not supported yet.");
+
+            if (clause.SubClauses is { Count: > 0 } subClauses)
+            {
+                foreach (var sub in subClauses)
+                {
+                    Apply(sub, factor);
+                }
+
+                return;
+            }
+
+            clause.Bindings = [..clause.Bindings ?? [], factor];
+            clause.HasBoost = true;
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
@@ -373,8 +373,11 @@ internal static partial class QueryPlanBuilder
         {
             case OperatorType.And:
             {
+                bool? savedEnclosing = walkerCtx.EnclosingIsOr;
+                walkerCtx.EnclosingIsOr = false;
                 BooleanOp left = be.Left is BinaryExpression { Operator: OperatorType.Or } ? HandleGroup(be.Left, ClauseType.OrGroup) : ParseExpression(be.Left, walkerCtx);
                 BooleanOp right = be.Right is BinaryExpression { Operator: OperatorType.Or } ? HandleGroup(be.Right, ClauseType.OrGroup) : ParseExpression(be.Right, walkerCtx);
+                walkerCtx.EnclosingIsOr = savedEnclosing;
 
                 return (left, right) switch
                 {
@@ -387,8 +390,11 @@ internal static partial class QueryPlanBuilder
 
             case OperatorType.Or:
             {
+                bool? savedEnclosing = walkerCtx.EnclosingIsOr;
+                walkerCtx.EnclosingIsOr = true;
                 BooleanOp left = be.Left is BinaryExpression { Operator: OperatorType.And } ? HandleGroup(be.Left, ClauseType.AndGroup) : ParseExpression(be.Left, walkerCtx);
                 BooleanOp right = be.Right is BinaryExpression { Operator: OperatorType.And } ? HandleGroup(be.Right, ClauseType.AndGroup) : ParseExpression(be.Right, walkerCtx);
+                walkerCtx.EnclosingIsOr = savedEnclosing;
 
                 return (left, right) switch
                 {
@@ -725,6 +731,34 @@ internal static partial class QueryPlanBuilder
         return BooleanOp.Leaf;
     }
 
+    // Group a wrapper's operands like HandleGroup groups a parenthesised sub-expression - only when their
+    // connective disagrees with the enclosing one, so a same-connective operand stays visible to
+    // ComputeTemplateOptimizations.
+    private static void GroupWrapperOperands(ResolutionContext walkerCtx, int beforeCount, BooleanOp innerOp)
+    {
+        if (innerOp is not (BooleanOp.And or BooleanOp.Or))
+            return;
+
+        // null enclosing = wrapper is the whole WHERE, so it can't disagree with itself
+        if (walkerCtx.EnclosingIsOr is not { } enclosingIsOr || enclosingIsOr == (innerOp is BooleanOp.Or))
+            return;
+
+        int count = walkerCtx.Clauses.Count - beforeCount;
+        if (count < 2)
+            return;
+
+        List<ClauseInfo> inner = walkerCtx.Clauses.GetRange(beforeCount, count);
+        walkerCtx.Clauses.RemoveRange(beforeCount, count);
+
+        // sub-clause OriginalIndex stays parent-relative, not 0-based like HandleGroup's - unread today
+        walkerCtx.Clauses.Add(new ClauseInfo
+        {
+            ClauseType = innerOp is BooleanOp.Or ? ClauseType.OrGroup : ClauseType.AndGroup,
+            OriginalIndex = beforeCount,
+            SubClauses = inner
+        });
+    }
+
     private static BooleanOp ParseExact(MethodExpression method, ResolutionContext walkerCtx)
     {
         // exact(expr) → recurse, then mark all new clauses as exact.
@@ -735,12 +769,24 @@ internal static partial class QueryPlanBuilder
             innerOp = ParseExpression(method.Arguments[0], walkerCtx);
         }
 
+        // descend - an operand may already be a group, and only leaves carry a field name
         for (int c = beforeCount; c < walkerCtx.Clauses.Count; c++)
         {
-            walkerCtx.Clauses[c].IsExact = true;
+            MarkExact(walkerCtx.Clauses[c]);
         }
 
+        GroupWrapperOperands(walkerCtx, beforeCount, innerOp);
         return innerOp;
+
+        static void MarkExact(ClauseInfo clause)
+        {
+            RuntimeHelpers.EnsureSufficientExecutionStack();
+            clause.IsExact = true;
+            foreach (ClauseInfo sub in clause.SubClauses ?? [])
+            {
+                MarkExact(sub);
+            }
+        }
     }
 
     private static BooleanOp ParseBoost(MethodExpression method, ResolutionContext walkerCtx)
@@ -753,15 +799,16 @@ internal static partial class QueryPlanBuilder
         }
 
         BooleanOp innerOp = ParseExpression(method.Arguments[0], walkerCtx);
-        if (method.Arguments.Count is 1 ||
-            walkerCtx.Clauses.Count == beforeCount ||
-            CreateBinding(method.Arguments[1], walkerCtx) is not { } boostBinding)
+        if (method.Arguments.Count > 1 &&
+            walkerCtx.Clauses.Count > beforeCount &&
+            CreateBinding(method.Arguments[1], walkerCtx) is { } boostBinding)
         {
-            return innerOp;
+            // copy - survives the regrouping below
+            List<ClauseInfo> inner = walkerCtx.Clauses.GetRange(beforeCount, walkerCtx.Clauses.Count - beforeCount);
+            walkerCtx.RecordPendingBoost(inner, boostBinding);
         }
 
-        List<ClauseInfo> inner = walkerCtx.Clauses.Slice(beforeCount, walkerCtx.Clauses.Count - beforeCount);
-        walkerCtx.RecordPendingBoost(inner, boostBinding);
+        GroupWrapperOperands(walkerCtx, beforeCount, innerOp);
         return innerOp;
     }
 
@@ -770,6 +817,10 @@ internal static partial class QueryPlanBuilder
         QueryExpression conditionExpr = method.Arguments[0];
         int beforeCount = walkerCtx.Clauses.Count;
         BooleanOp innerOp = ParseExpression(method.Arguments[1], walkerCtx);
+
+        // group first - the guard must land on what the parent combines, not the ungrouped operands
+        GroupWrapperOperands(walkerCtx, beforeCount, innerOp);
+
         var whenCondition = new WhenConditionEvaluator(conditionExpr, walkerCtx.Metadata).Evaluate;
         for (int wi = beforeCount; wi < walkerCtx.Clauses.Count; wi++)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
@@ -554,15 +554,21 @@ internal static partial class QueryPlanBuilder
     // not (Name != $p0 and Name != $p1) -> (Name = $p0 or Name = $p1), not(A = 1 or B = 2) -> A !=1 AND B != 2, etc
     private static BooleanOp ParseNegated(NegatedExpression negated, ResolutionContext walkerCtx)
     {
-        return negated.Expression switch
+        int beforeCount = walkerCtx.Clauses.Count;
+        BooleanOp innerOp = negated.Expression switch
         {
             NegatedExpression or BinaryExpression
                 {
                     Operator: OperatorType.And or OperatorType.Or or OperatorType.Equal or OperatorType.NotEqual
-                } => 
+                } =>
                     ParseExpression(NegationNormalForm(negated.Expression), walkerCtx),
             _ => ParseNegatedLeaf(negated.Expression, walkerCtx)
         };
+
+        // De Morgan flips the connective, so a NegatedExpression is an OR to the parent even when it reads as an AND -
+        // and ParseBinaryExpression decides grouping from the *syntactic* child, which is neither.
+        GroupWrapperOperands(walkerCtx, beforeCount, innerOp);
+        return innerOp;
     }
 
     private static QueryExpression NegationNormalForm(QueryExpression expr)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/ResolutionContext.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/ResolutionContext.cs
@@ -18,6 +18,8 @@ internal sealed class ResolutionContext
     public readonly QueryBuilderParameters BuilderParams;
     public int WhenCount;
     public bool IsOr;
+    // connective of the expression being parsed; null at the root
+    public bool? EnclosingIsOr;
     public List<ClauseInfo> SpatialClauses;
     public List<ClauseInfo> VectorClauses;
     public List<ClauseInfo> Clauses;

--- a/test/SlowTests.Issues/Issues/RavenDB_27225.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27225.cs
@@ -1,0 +1,234 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    // boost()/exact() are wrappers - they must never change which documents match.
+    public class RavenDB_27225 : RavenTestBase
+    {
+        public RavenDB_27225(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Doc
+        {
+            public string A { get; set; }
+            public string B { get; set; }
+            public string C { get; set; }
+            public string E { get; set; }
+        }
+
+        private class Docs_ByFlags : AbstractIndexCreationTask<Doc>
+        {
+            public Docs_ByFlags()
+            {
+                Map = docs => from d in docs
+                              select new { d.A, d.B, d.C, d.E };
+            }
+        }
+
+        private static int Count(IDocumentSession session, string where, bool flag = true) =>
+            session.Advanced.RawQuery<Doc>($"from index 'Docs/ByFlags' where {where}").AddParameter("flag", flag).ToList().Count;
+
+        private void Seed(Options options, out Raven.Client.Documents.IDocumentStore store)
+        {
+            store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc { E = "y", A = "y" });            // E and A
+                session.Store(new Doc { E = "y", C = "y" });            // E and C
+                session.Store(new Doc { E = "y", A = "y", C = "y" });    // E, A and C
+                session.Store(new Doc { A = "y", B = "y" });            // A and B
+                session.Store(new Doc { C = "y" });                     // C
+                session.Store(new Doc { A = "y" });                     // A only
+                session.SaveChanges();
+            }
+
+            new Docs_ByFlags().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void BoostedDisjunctionUnderAndMustNotLoseRows(Options options)
+        {
+            Seed(options, out var store);
+            using (store)
+            using (var session = store.OpenSession())
+            {
+                // control: the same predicate without the wrapper
+                Assert.Equal(3, Count(session, "E = \"y\" and (A = \"y\" or C = \"y\")"));
+
+                // boost is pure scoring, so the count has to be identical
+                Assert.Equal(3, Count(session, "E = \"y\" and boost(A = \"y\" or C = \"y\", 3)"));
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void BoostedConjunctionUnderOrMustNotAddRows(Options options)
+        {
+            Seed(options, out var store);
+            using (store)
+            using (var session = store.OpenSession())
+            {
+                Assert.Equal(4, Count(session, "(A = \"y\" and B = \"y\") or C = \"y\""));
+
+                Assert.Equal(4, Count(session, "boost(A = \"y\" and B = \"y\", 2) or C = \"y\""));
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void ExactWrapperMustNotLeakItsConnectiveEither(Options options)
+        {
+            Seed(options, out var store);
+            using (store)
+            using (var session = store.OpenSession())
+            {
+                // exact() is the same kind of wrapper as boost(); the fields here are not analysed, so it
+                // cannot change matching on its own.
+                Assert.Equal(3, Count(session, "E = \"y\" and exact(A = \"y\" or C = \"y\")"));
+                Assert.Equal(4, Count(session, "exact(A = \"y\" and B = \"y\") or C = \"y\""));
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void WhenWrapperMustNotLeakItsConnectiveEither(Options options)
+        {
+            Seed(options, out var store);
+            using (store)
+            using (var session = store.OpenSession())
+            {
+                // a satisfied when() condition keeps the predicate as-is, so the counts are the unwrapped ones
+                Assert.Equal(3, Count(session, "E = \"y\" and when($flag = true, A = \"y\" or C = \"y\")"));
+                Assert.Equal(4, Count(session, "when($flag = true, A = \"y\" and B = \"y\") or C = \"y\""));
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void WhenGuardOffUnderOrMustNotMatchEverything(Options options)
+        {
+            Seed(options, out var store);
+            using (store)
+            using (var session = store.OpenSession())
+            {
+                // an off guard drops the predicate, so what is left is the other side of the connective - and the
+                // grouped operands must collapse to the identity of the ENCLOSING operator, not of their own
+                const string underOr = "C = \"y\" or when($flag = true, A = \"y\" and B = \"y\")";
+                Assert.Equal(3, Count(session, underOr, flag: false));   // must not become the whole index
+                Assert.Equal(4, Count(session, underOr, flag: true));
+
+                const string underAnd = "E = \"y\" and when($flag = true, A = \"y\" or C = \"y\")";
+                Assert.Equal(3, Count(session, underAnd, flag: false));  // must not become nothing
+                Assert.Equal(3, Count(session, underAnd, flag: true));
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void ExactMustReachOperandsThatAreAlreadyGrouped(Options options)
+        {
+            using var store = GetDocumentStore(options);
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc { A = "y", B = "YY" });
+                session.Store(new Doc { A = "y", B = "yy" });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                // auto index: exact() picks the non-analyzed field variant, so only the exact casing may match. The
+                // parenthesised operand arrives as a group, and exact() has to reach the leaves under it - marking
+                // only the group leaves them resolving against the analyzed (lowercased) field, which also matches "yy".
+                var results = session.Advanced
+                    .RawQuery<Doc>("from Docs where exact(A = $a and (B = $b or C = $b))")
+                    .AddParameter("a", "y")
+                    .AddParameter("b", "YY")
+                    .ToList();
+
+                Assert.Equal(1, results.Count);
+                Assert.Equal("YY", results[0].B);
+            }
+        }
+
+        private class Tagged
+        {
+            public string Id { get; set; }
+            public string[] Tags { get; set; }
+        }
+
+        private class Tagged_ByTags : AbstractIndexCreationTask<Tagged>
+        {
+            public Tagged_ByTags()
+            {
+                Map = docs => from d in docs
+                              select new { d.Tags };
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void BoostFactorMustSurviveAnOperandThatIsGrouped(Options options)
+        {
+            const int perGroup = 3;
+            using var store = GetDocumentStore(options);
+            using (var session = store.OpenSession())
+            {
+                for (int i = 1; i <= perGroup; i++)
+                {
+                    session.Store(new Tagged { Tags = ["drama", "dx"] }, $"tagged/hi/{i}");
+                    session.Store(new Tagged { Tags = ["action", "ax"] }, $"tagged/lo/{i}");
+                }
+
+                session.SaveChanges();
+            }
+
+            new Tagged_ByTags().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            // Both arms are conjunctions under an OR, so both arrive as groups. The factor rides on the clause's own
+            // bindings and a group evaluates none, so it has to reach the leaves - otherwise both arms weigh the same
+            // and flipping the weights cannot flip the order.
+            const string q = "from index 'Tagged/ByTags' " +
+                             "where boost(exact(Tags = $h1 and Tags = $h2), $wHi) or boost(exact(Tags = $l1 and Tags = $l2), $wLo) " +
+                             "order by score()";
+
+            using (var session = store.OpenSession())
+            {
+                var hiBoosted = session.Advanced.RawQuery<Tagged>(q)
+                    .AddParameter("h1", "drama").AddParameter("h2", "dx")
+                    .AddParameter("l1", "action").AddParameter("l2", "ax")
+                    .AddParameter("wHi", 10).AddParameter("wLo", 2)
+                    .ToList();
+                AssertGroupLeads(hiBoosted, "tagged/hi/", "tagged/lo/", perGroup);
+
+                var loBoosted = session.Advanced.RawQuery<Tagged>(q)
+                    .AddParameter("h1", "drama").AddParameter("h2", "dx")
+                    .AddParameter("l1", "action").AddParameter("l2", "ax")
+                    .AddParameter("wHi", 2).AddParameter("wLo", 10)
+                    .ToList();
+                AssertGroupLeads(loBoosted, "tagged/lo/", "tagged/hi/", perGroup);
+            }
+        }
+
+        private static void AssertGroupLeads(System.Collections.Generic.List<Tagged> results, string leading, string trailing, int perGroup)
+        {
+            Assert.Equal(2 * perGroup, results.Count);
+
+            int lastLeading = results.FindLastIndex(r => r.Id.StartsWith(leading));
+            int firstTrailing = results.FindIndex(r => r.Id.StartsWith(trailing));
+            Assert.True(lastLeading >= 0 && firstTrailing >= 0, "both groups must be present");
+            Assert.True(lastLeading < firstTrailing,
+                $"expected every '{leading}' doc ahead of every '{trailing}' doc, got: {string.Join(", ", results.Select(r => r.Id))}");
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_27225.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27225.cs
@@ -160,6 +160,50 @@ namespace SlowTests.Issues
             }
         }
 
+        // not(...) is the fourth spelling of the same problem: De Morgan flips the connective, so the operands of a
+        // negated AND join the parent as an OR - and the parent decides grouping from the syntactic child, a
+        // NegatedExpression, which is neither an AND nor an OR. Every assertion below also runs on Lucene, which is
+        // the oracle for the expected counts.
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void NegatedConjunctionUnderAndMustFlipTheConnective(Options options)
+        {
+            Seed(options, out var store);
+            using (store)
+            using (var session = store.OpenSession())
+            {
+                // not(A and C) drops only the doc that has both, leaving the other two E docs
+                Assert.Equal(2, Count(session, "E = \"y\" and not (A = \"y\" and C = \"y\")"));
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void NegatedDisjunctionUnderOrMustFlipTheConnective(Options options)
+        {
+            Seed(options, out var store);
+            using (store)
+            using (var session = store.OpenSession())
+            {
+                // not(A or C) keeps only docs with neither, and no doc qualifies - so only the B doc is left
+                Assert.Equal(1, Count(session, "B = \"y\" or not (A = \"y\" or C = \"y\")"));
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void NegationWithNothingToDisagreeWithStaysCorrect(Options options)
+        {
+            Seed(options, out var store);
+            using (store)
+            using (var session = store.OpenSession())
+            {
+                // the negation is the whole predicate, so its own connective is the root's - nothing to group
+                Assert.Equal(5, Count(session, "true and not (A = \"y\" and C = \"y\")"));
+                Assert.Equal(2, Count(session, "true and not (A = \"y\" or B = \"y\")"));
+            }
+        }
+
         private class Tagged
         {
             public string Id { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27225

### Additional description

`boost()`, `exact()` and `when()` appended their operands to the **parent's** clause list as flat siblings, so the operands were combined with the parent's connective instead of their own: `E = 'y' and boost(A = 'y' or C = 'y', 3)` ran the inner OR as an AND and dropped rows, `boost(A and B, 2) or C` ran the inner AND as an OR and added them.

**Fix:** collapse a wrapper's operands into one group clause on the same condition
[`ParseBinaryExpression`](https://github.com/ravendb/ravendb/blob/e2a5ff176405ad1328d23cbfae3334a7c0fc8d49/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs#L369-L370)
already uses for a nested sub-expression — when their connective disagrees with the enclosing one. A same-connective operand stays flat, which keeps it visible to
[`ComputeTemplateOptimizations`](https://github.com/ravendb/ravendb/blob/e2a5ff176405ad1328d23cbfae3334a7c0fc8d49/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs#L165);
grouping unconditionally would cost `exact(A = $a and B = $b)` its `CompoundKeyLookup` and `FieldSortedScan` strategies.

Grouping moves where each wrapper's own mark has to sit:
- `when()` stamps the guard **after** grouping — an off guard collapses to the identity of the
  *enclosing* operator, so the condition must sit on what the parent actually combines;
- `exact()` marks `IsExact` down the subtree — only leaves carry a field name. Also fixes the
  pre-existing `exact(A = $a and (B = $b or C = $b))` on an auto index;
- `BoostPropagate` carries the factor down to the leaves — a group evaluates no `Bindings`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
