### PR TITLE
RavenDB-27227 Fix Corax 2.0 collapsing a vanished when() to the wrong identity

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/BuildResolver.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/BuildResolver.cs
@@ -151,10 +151,12 @@ ref struct BuildResolver(PlanTemplate template, PlanParameters planParams, Query
         // A clause that collapses (WHEN(false), a statically-true exists()/NOT exists(), an empty IN, a contradictory BETWEEN, etc) is replaced IN PLACE by a MatchAll / MatchNothing sentinel. 
         var execList = new List<ClauseExecution>(template.Clauses.Count);
         QueryExecution queryExecution = new();
+        // no filter left means match everything, so the top level takes the AND identity whatever IsOr says
+        bool enclosingIsOr = template.IsOr && WholeWhereVanishes() == false;
         foreach (var cached in template.Clauses)
         {
             var exec = QueryPlanBuilder.CreateExecution(cached);
-            ApplyFate(exec, cached);
+            ApplyFate(exec, cached, enclosingIsOr);
             if (exec.IsSentinel == false)
             {
                 QueryPlanBuilder.PopulateClauseValues(exec, planParams.SlotBindings, planParams.QueryParameters, _writer, builderParameters, SentinelBits());
@@ -195,23 +197,60 @@ ref struct BuildResolver(PlanTemplate template, PlanParameters planParams, Query
         }
     }
 
-    private void ApplyFate(ClauseExecution exec, ClauseInfo clause)
+    private void ApplyFate(ClauseExecution exec, ClauseInfo clause, bool enclosingIsOr)
     {
         if (template.WhenCount is 0)
             return;
 
-        ApplyFateRecursive(exec, clause, template.IsOr);
+        ApplyFateRecursive(exec, clause, enclosingIsOr);
+    }
+
+    // A clause stops filtering when its own guard is off - or, for a group, when every clause under it has gone,
+    // which leaves the group itself empty.
+    private bool VanishesFromGuards(ClauseInfo clause)
+    {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+
+        if (clause.WhenCondition is { } predicate && predicate(planParams.QueryParameters) == false)
+            return true;
+
+        if (clause.SubClauses is not { Count: > 0 } subClauses)
+            return false;
+
+        foreach (var sub in subClauses)
+        {
+            if (VanishesFromGuards(sub) == false)
+                return false;
+        }
+
+        return true;
+    }
+
+    // True when the guards leave no filter at all, so the query matches the whole index. The top-level clauses then
+    // have no surviving sibling to be joined with, and MatchNothing - the OR identity - would answer the wrong
+    // question: it is the identity for joining, not for a WHERE that has ceased to exist.
+    private bool WholeWhereVanishes()
+    {
+        if (template.WhenCount is 0 || template.Clauses.Count is 0)
+            return false;
+
+        foreach (var clause in template.Clauses)
+        {
+            if (VanishesFromGuards(clause) == false)
+                return false;
+        }
+
+        return true;
     }
 
     private void ApplyFateRecursive(ClauseExecution exec, ClauseInfo clause, bool enclosingIsOr)
     {
         RuntimeHelpers.EnsureSufficientExecutionStack();
 
-        if (clause.WhenCondition is { } predicate && predicate(planParams.QueryParameters) == false)
+        if (VanishesFromGuards(clause))
         {
-            // WHEN(false): the guard is off, so the whole guarded clause (its negation included) does not filter.
-            // It collapses to the identity of its enclosing boolean operator: MatchAll under AND, MatchNothing
-            // under OR. Once the (sub)clause is a sentinel its children are irrelevant, so stop descending.
+            // The clause does not filter, so it collapses to the identity of its enclosing boolean operator:
+            // MatchAll under AND, MatchNothing under OR. Its children are then irrelevant, so stop descending.
             if (enclosingIsOr)
                 exec.MarkAsSentinel(ClauseType.MatchNothing, 0);
             else

--- a/test/SlowTests.Issues/Issues/RavenDB_27227.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27227.cs
@@ -1,0 +1,107 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    // A false when() guard drops its predicate, so what is left has to be the identity of the ENCLOSING operator -
+    // and a WHERE that has ceased to exist filters nothing at all.
+    public class RavenDB_27227 : RavenTestBase
+    {
+        public RavenDB_27227(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Doc
+        {
+            public string Z { get; set; }
+            public string A { get; set; }
+            public string C { get; set; }
+        }
+
+        private class Docs_ByFlags : AbstractIndexCreationTask<Doc>
+        {
+            public Docs_ByFlags()
+            {
+                Map = docs => from d in docs
+                              select new { d.Z, d.A, d.C };
+            }
+        }
+
+        private const int AllDocs = 4;
+        private const int ZDocs = 3;
+
+        private static int Count(IDocumentSession session, string where, bool guard = false) =>
+            session.Advanced.RawQuery<Doc>($"from index 'Docs/ByFlags' where {where}")
+                .AddParameter("f", guard).ToList().Count;
+
+        private IDocumentStore Seed(Options options)
+        {
+            var store = GetDocumentStore(options);
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc { Z = "y", A = "y" });
+                session.Store(new Doc { Z = "y", C = "y" });
+                session.Store(new Doc { Z = "y" });
+                session.Store(new Doc { A = "y" });
+                session.SaveChanges();
+            }
+
+            new Docs_ByFlags().Execute(store);
+            Indexes.WaitForIndexing(store);
+            return store;
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void RootLevelGuardOffLeavesNoFilter(Options options)
+        {
+            using var store = Seed(options);
+            using var session = store.OpenSession();
+
+            // the when() is the whole WHERE, so an off guard leaves nothing to filter on - the inner connective
+            // must not decide the answer
+            Assert.Equal(AllDocs, Count(session, "when($f = true, A = \"y\" or C = \"y\")"));
+            Assert.Equal(AllDocs, Count(session, "when($f = true, A = \"y\" and C = \"y\")"));
+            Assert.Equal(AllDocs, Count(session, "when($f = true, A = \"y\")"));
+
+            // guard on - the predicate applies again
+            Assert.Equal(3, Count(session, "when($f = true, A = \"y\" or C = \"y\")", guard: true));
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void GroupEmptiedByGuardsTakesItsParentsIdentity(Options options)
+        {
+            using var store = Seed(options);
+            using var session = store.OpenSession();
+
+            // every clause inside the parentheses is dropped, so the group is empty and only Z is left to filter on
+            Assert.Equal(ZDocs, Count(session, "Z = \"y\" and (when($f = true, A = \"y\") or when($f = true, C = \"y\"))"));
+            Assert.Equal(ZDocs, Count(session, "Z = \"y\" or (when($f = true, A = \"y\") and when($f = true, C = \"y\"))"));
+
+            // an absent clause takes its negation with it
+            Assert.Equal(ZDocs, Count(session, "Z = \"y\" and not (when($f = true, A = \"y\") or when($f = true, C = \"y\"))"));
+
+            // guard on - the group filters again
+            Assert.Equal(2, Count(session, "Z = \"y\" and (when($f = true, A = \"y\") or when($f = true, C = \"y\"))", guard: true));
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void GuardOffBesideASurvivingSiblingKeepsTheSibling(Options options)
+        {
+            using var store = Seed(options);
+            using var session = store.OpenSession();
+
+            // a live sibling remains, so the dropped clause takes the joining identity - these already worked and
+            // must keep working
+            Assert.Equal(ZDocs, Count(session, "Z = \"y\" and when($f = true, A = \"y\" or C = \"y\")"));
+            Assert.Equal(ZDocs, Count(session, "Z = \"y\" or when($f = true, A = \"y\" and C = \"y\")"));
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27227

### Additional description

A false `when()` guard removes its predicate, and what is left has to be the identity of the operator that **encloses** the removed clause. Two cases got the identity of the removed clause's own connective instead. Measured on 4 documents, 3 of them with `Z`, guard off:

| query | Corax 2.0 before | Lucene | correct |
|---|---|---|---|
| `where when($f, A or C)` | **0** | 4 | 4 |
| `where Z and (when($f, A) or when($f, C))` | **0** | 3 | 3 |
| `where Z or (when($f, A) and when($f, C))` | **4** | 3 | 3 |
| `where when($f, A and C)` | 4 | 4 | 4 |
| `where Z and when($f, A or C)` | 3 | 3 | 3 |
| `where Z or when($f, A and C)` | 3 | 3 | 3 |

Row 1 is the reported case: the `when()` is the whole WHERE, so there is no enclosing operator and no sibling to join with — the query simply has no filter. But [`ApplyFate`](https://github.com/ravendb/ravendb/blob/e2a5ff176405ad1328d23cbfae3334a7c0fc8d49/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/BuildResolver.cs#L203) passed `template.IsOr`, which for a lone `when()` is [the connective *inside* it](https://github.com/ravendb/ravendb/blob/e2a5ff176405ad1328d23cbfae3334a7c0fc8d49/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs#L80), so the OR identity `MatchNothing` was chosen and the result was empty.

Rows 2–3 are the same defect one level down, and reachable on plain RQL through parentheses: a group whose every clause is guarded off is itself empty, yet [`ApplyFateRecursive`](https://github.com/ravendb/ravendb/blob/e2a5ff176405ad1328d23cbfae3334a7c0fc8d49/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/BuildResolver.cs#L206-L228) only ever tested a clause's *own* guard, so the children collapsed to the group's inner identity and the emptied group kept filtering.

**Fix:** replace the single-level guard test with a recursive one — a clause is gone when its guard is off, or when every clause under it is gone — and treat "everything is gone" at the top level as no filter, which is the AND identity regardless of `IsOr`. Rows 4–6 keep working unchanged: a guarded clause beside a surviving sibling still takes the joining identity.

Two structural notes for review:
- `enclosingIsOr = template.IsOr && WholeWhereVanishes() == false` short-circuits, so the top-level part only ever changes an OR-rooted template. Since [`GroupCollapse`](https://github.com/ravendb/ravendb/blob/e2a5ff176405ad1328d23cbfae3334a7c0fc8d49/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/PlanWalker.cs#L121-L124) lifts spatial/vector clauses out of `template.Clauses` only when `IsOr` is false, the two sets do not intersect and `FastTests/Corax/RavenDB_25281_WhenSpatialVector` cannot be affected.
- Marking a group as a sentinel routes it to the sentinel arm of the emitter, because the OrGroup/AndGroup dispatch case is guarded by the clause still having a group `ClauseType`; `EmitSentinelInto` already handles every (sentinel, MergeKind) pair.

### Verification

`SlowTests.Issues.RavenDB_27227`, 3 methods × {Corax, Lucene}. At the same base commit without the fix: `RootLevelGuardOffLeavesNoFilter` and `GroupEmptiedByGuardsTakesItsParentsIdentity` fail on Corax, all three pass on Lucene. With the fix 6/6 pass. The third method, `GuardOffBesideASurvivingSiblingKeepsTheSibling`, passes with **and** without the fix — it is the regression control for the shapes that already worked.

`test/FastTests --filter Corax`: 1177 passed / 0 failed with and without the fix.

Negation over a vanished guarded expression was measured to agree between the engines (the `not` goes away with the absent clause, matching [`LuceneQueryBuilder`](https://github.com/ravendb/ravendb/blob/e2a5ff176405ad1328d23cbfae3334a7c0fc8d49/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs#L335-L336)) and is pinned by an assertion.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed