### PR TITLE
RavenDB-27076 Restore no-op for calls to undefined functions after the Jint 4.6+ reference change

### DIFF
--- a/src/Raven.Server/Documents/Patch/JintNullPropagationReferenceResolver.cs
+++ b/src/Raven.Server/Documents/Patch/JintNullPropagationReferenceResolver.cs
@@ -101,6 +101,7 @@ namespace Raven.Server.Documents.Patch
                 var baseValue = reference.Base;
 
                 if (baseValue.IsUndefined() ||
+                    reference.IsUnresolvableReference ||
                     baseValue.IsArray() && baseValue.AsArray().Length == 0)
                 {
                     JsValue referencedName = reference.ReferencedName;

--- a/test/FastTests/Issues/RavenDB_27076.cs
+++ b/test/FastTests/Issues/RavenDB_27076.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_27076 : RavenTestBase
+    {
+        public RavenDB_27076(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public async Task CallingUndefinedFunctionInPatch_IsNoOp()
+        {
+            using var store = GetDocumentStore();
+
+            using (var s = store.OpenAsyncSession())
+            {
+                await s.StoreAsync(new User { Name = "Joe" }, "users/1");
+                await s.SaveChangesAsync();
+            }
+
+            await store.Operations.SendAsync(new PatchOperation("users/1", null,
+                new PatchRequest { Script = "this.Called = someUndefinedFn(this.Name); this.Touched = true;" }));
+
+            using (var s = store.OpenAsyncSession())
+            {
+                var u = await s.LoadAsync<User>("users/1");
+                Assert.NotNull(u);
+                Assert.True(u.Touched);
+            }
+        }
+
+        private sealed class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public object Called { get; set; }
+            public bool Touched { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27076

### Additional description

`SnowflakeEtlTests.VarcharAndNVarcharFunctionsArentAvailable` broke after the Jint bump to 4.15.x.
This is a follow-up to the upstream fix, not a Snowflake issue.

Jint 4.6 (sebastienros/jint#2266) changed the base of an unresolvable reference from `undefined` to
a sentinel. The upstream fix sebastienros/jint#2750 (shipped in 4.15.x) restored consulting the
reference resolver for the call's `this` binding, which removed the `InvalidCastException`. But
`JintNullPropagationReferenceResolver.TryGetCallable` had the same assumption: it checked
`baseValue.IsUndefined()`, and the sentinel is not undefined, so calling a function that is not
defined in the script scope stopped reaching the no-op fallback and threw `... is not a function`
instead of degrading to a no-op.

This adds the matching one-liner: treat an unresolvable reference base like undefined, so the call
degrades to the no-op again, restoring the pre-bump behavior. Reads of an undefined name were
unaffected (they already returned null).

Verified locally on `v7.2` (Jint 4.15.1):
- Without this change a patch calling an undefined function throws; with it, it no-ops.
- Full FastTests green (4571 passed). The SlowTests that were red on Jenkins (TimeSeries JS
  projections, ScriptedPatching, and the rest of that set) are green again (60 passed).

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

  Restores the pre-Jint-4.6 behavior (calling an undefined function is a no-op). No public API change.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

  Any server-side JS script (patch / ETL / index / subscription): calling a function that is not defined in the script scope no-ops again (returns undefined, script continues), instead of throwing. This restores the pre-bump behavior. Reads of undefined names are unaffected.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
