### PR TITLE
RavenDB-27189 Refactor the "Connect to your source database" view

### DIFF
--- a/.github/workflows/quill-web-checks.yml
+++ b/.github/workflows/quill-web-checks.yml
@@ -62,6 +62,10 @@ jobs:
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm format:check
 
+      - name: Unit tests
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: pnpm test:unit
+
   storybook-tests:
     name: Storybook smoke tests
     runs-on: ubuntu-latest

--- a/src/Raven.Quill.Web/package.json
+++ b/src/Raven.Quill.Web/package.json
@@ -16,7 +16,8 @@
         "preview": "vite preview",
         "storybook": "storybook dev -p 6006",
         "build-storybook": "storybook build",
-        "test:storybook": "vitest run --project=storybook"
+        "test:storybook": "vitest run --project=storybook",
+        "test:unit": "vitest run --project=unit"
     },
     "dependencies": {
         "@base-ui/react": "^1.5.0",

--- a/src/Raven.Quill.Web/src/components/form/form-textarea.tsx
+++ b/src/Raven.Quill.Web/src/components/form/form-textarea.tsx
@@ -9,6 +9,7 @@ type FormTextareaProps<TFieldValues extends FieldValues, TName extends FieldPath
     UseControllerProps<TFieldValues, TName> & {
         description?: ReactNode;
         label?: ReactNode;
+        labelClassName?: string;
         textareaClassName?: string;
     };
 
@@ -20,6 +21,7 @@ export function FormTextarea<TFieldValues extends FieldValues, TName extends Fie
     disabled,
     id,
     label,
+    labelClassName,
     name,
     textareaClassName,
     ...restProps
@@ -38,7 +40,9 @@ export function FormTextarea<TFieldValues extends FieldValues, TName extends Fie
 
     return (
         <Field className={className} data-invalid={invalid}>
-            <FieldLabel htmlFor={inputId}>{label}</FieldLabel>
+            <FieldLabel htmlFor={inputId} className={labelClassName}>
+                {label}
+            </FieldLabel>
             <Textarea
                 id={inputId}
                 onBlur={onBlur}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
@@ -49,7 +49,16 @@ function buildSeed(discovery: DiscoverResponse): AppFormData {
             appName: "AcmeShop",
             slug: "acme-shop",
             provider: "Npgsql",
-            connectionString: "Host=localhost;Port=5432;Database=acme_shop;Username=admin;Password=secret",
+            mode: "fields",
+            fields: {
+                host: "localhost",
+                port: 5432,
+                database: "acme_shop",
+                username: "admin",
+                password: "secret",
+                isSecured: false,
+            },
+            connectionString: "",
         },
         verifySchema: {
             tables: discovery.tables
@@ -79,6 +88,7 @@ function AppWizardAtStep({
     discovery = sampleDiscovery,
     isMappingApplied = true,
     hasSelectedTables = true,
+    seedOverride,
 }: {
     initialStep: AppStepId;
     discovery?: DiscoverResponse;
@@ -86,11 +96,13 @@ function AppWizardAtStep({
     isMappingApplied?: boolean;
     /** When false, the verify step starts with nothing selected, as it does on a fresh discovery. */
     hasSelectedTables?: boolean;
+    seedOverride?: (seed: AppFormData) => AppFormData;
 }) {
     const [seed] = useState(() => {
-        const values = buildSeed(discovery);
+        const built = buildSeed(discovery);
+        const values = hasSelectedTables ? built : { ...built, verifySchema: { tables: [] } };
 
-        return hasSelectedTables ? values : { ...values, verifySchema: { tables: [] } };
+        return seedOverride ? seedOverride(values) : values;
     });
 
     useState(() =>
@@ -149,6 +161,22 @@ export const ChooseDataSource: Story = {
 
 export const ConnectSource: Story = {
     render: () => <AppWizardAtStep initialStep="externalConnection" />,
+};
+
+export const ConnectSourceConnectionString: Story = {
+    render: () => (
+        <AppWizardAtStep
+            initialStep="externalConnection"
+            seedOverride={(seed) => ({
+                ...seed,
+                externalConnection: {
+                    ...seed.externalConnection,
+                    mode: "raw",
+                    connectionString: "Host=localhost;Port=5432;Database=acme_shop;Username=admin;Password=secret",
+                },
+            })}
+        />
+    ),
 };
 
 const connectFailureHandlers = {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.tsx
@@ -23,6 +23,7 @@ import {
     DialogTitle,
 } from "@/components/shadcn/ui/dialog";
 import { CdcPerformanceSection } from "@/pages/apps/cdc-performance-section";
+import { DEFAULT_PORT_BY_PROVIDER, DEFAULT_PROVIDER } from "@/pages/setup/add-app-wizard/connection-string";
 import { cancelAbandonedSuggestions } from "@/pages/setup/add-app-wizard/steps/map-tables/suggest-map-tables-query";
 import { VERIFY_CDC_QUERY_KEY } from "@/pages/setup/add-app-wizard/steps/verify/verify-cdc-query";
 
@@ -158,7 +159,16 @@ function getDefaultValues(): AppFormData {
         externalConnection: {
             appName: "",
             slug: "",
-            provider: "Npgsql",
+            provider: DEFAULT_PROVIDER,
+            mode: "fields",
+            fields: {
+                host: "",
+                port: DEFAULT_PORT_BY_PROVIDER[DEFAULT_PROVIDER],
+                database: "",
+                username: "",
+                password: "",
+                isSecured: true,
+            },
             connectionString: "",
         },
         verifySchema: {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
@@ -156,6 +156,30 @@ export const tablesSchema = z
         });
     });
 
+export const connectionModeSchema = z.union([z.literal("fields"), z.literal("raw")]);
+
+const connectionFieldsShape = {
+    host: z.string(),
+    port: z.number().nullable(),
+    database: z.string(),
+    username: z.string(),
+    password: z.string(),
+    isSecured: z.boolean(),
+};
+
+const filledConnectionFieldsSchema = z.object({
+    ...connectionFieldsShape,
+    host: z.string().trim().min(1, "Host is required"),
+    port: z
+        .number()
+        .int("Port must be a whole number")
+        .min(1, "Port must be between 1 and 65535")
+        .max(65535, "Port must be between 1 and 65535")
+        .nullable(),
+    database: z.string().trim().min(1, "Database name is required"),
+    username: z.string().trim().min(1, "Username is required"),
+});
+
 /** `takenSlugs` are the slugs of the already existing apps; the new app must not reuse one. */
 export const createExternalConnectionSchema = (takenSlugs: string[] = []) => {
     const normalizedTakenSlugs = new Set(takenSlugs.map((slug) => toSlug(slug)));
@@ -165,7 +189,9 @@ export const createExternalConnectionSchema = (takenSlugs: string[] = []) => {
             appName: z.string().trim().min(1, "Application name is required"),
             slug: slugSchema,
             provider: providerSchema,
-            connectionString: z.string().trim().min(1, "Connection string is required."),
+            mode: connectionModeSchema,
+            fields: z.object(connectionFieldsShape),
+            connectionString: z.string(),
         })
         .superRefine((values, ctx) => {
             const overrideSlug = values.slug.trim();
@@ -179,6 +205,28 @@ export const createExternalConnectionSchema = (takenSlugs: string[] = []) => {
                     path: [overrideSlug === "" ? "appName" : "slug"],
                     message: `Slug "${slug}" is already used by another app`,
                 });
+            }
+
+            if (values.mode === "raw") {
+                if (values.connectionString.trim() === "") {
+                    ctx.addIssue({
+                        code: "custom",
+                        path: ["connectionString"],
+                        message: "Connection string is required",
+                    });
+                }
+
+                return;
+            }
+
+            const fields = filledConnectionFieldsSchema.safeParse(values.fields);
+
+            if (fields.success) {
+                return;
+            }
+
+            for (const issue of fields.error.issues) {
+                ctx.addIssue({ code: "custom", path: ["fields", ...issue.path], message: issue.message });
             }
         });
 };

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/config-io.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/config-io.ts
@@ -5,6 +5,7 @@ import type {
     CdcSinkTableConfig,
 } from "@/api/generated/server-api";
 import { type AppFormData, providerSchema, slugSchema } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+import { resolveConnectionString } from "@/pages/setup/add-app-wizard/connection-string";
 import { mapFormTablesToDto } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-dto";
 
 /** The portable wizard configuration: connection details, the public URL slug, plus the CDC Sink table
@@ -34,7 +35,7 @@ const wizardConfigSchema = z.object({
 export function buildConfigExport(values: AppFormData): WizardConfig {
     return {
         provider: values.externalConnection.provider,
-        connectionString: values.externalConnection.connectionString,
+        connectionString: resolveConnectionString(values.externalConnection),
         slug: values.externalConnection.slug,
         tables: mapFormTablesToDto(values.mapTables.tables),
     };

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.test.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+    buildConnectionString,
+    getPortAfterProviderChange,
+    parseConnectionString,
+    resolveConnectionString,
+    type ConnectionValues,
+} from "@/pages/setup/add-app-wizard/connection-string";
+
+function values(overrides: Partial<ConnectionValues> = {}): ConnectionValues {
+    return {
+        host: "localhost",
+        port: 5432,
+        database: "acme_shop",
+        username: "admin",
+        password: "secret",
+        isSecured: false,
+        ...overrides,
+    };
+}
+
+describe("buildConnectionString", () => {
+    it("builds a PostgreSQL connection string", () => {
+        expect(buildConnectionString("Npgsql", values())).toBe(
+            "Host=localhost;Port=5432;Database=acme_shop;Username=admin;Password=secret;SSL Mode=Disable",
+        );
+    });
+
+    it("builds a MySQL connection string with the User ID keyword", () => {
+        expect(buildConnectionString("MySqlConnectorFactory", values({ port: 3306 }))).toBe(
+            "Server=localhost;Port=3306;Database=acme_shop;User ID=admin;Password=secret;SslMode=None",
+        );
+    });
+
+    it("folds the SQL Server port into the server value", () => {
+        expect(buildConnectionString("SqlClient", values({ port: 1433 }))).toBe(
+            "Server=localhost,1433;Database=acme_shop;User ID=admin;Password=secret;Encrypt=False",
+        );
+    });
+
+    it("asks for an encrypted transport with the keyword each provider expects", () => {
+        expect(buildConnectionString("Npgsql", values({ isSecured: true }))).toContain("SSL Mode=Require");
+        expect(buildConnectionString("SqlClient", values({ isSecured: true }))).toContain("Encrypt=True");
+        expect(buildConnectionString("MySqlConnectorFactory", values({ isSecured: true }))).toContain(
+            "SslMode=Required",
+        );
+    });
+
+    it("omits the port and password when not provided", () => {
+        expect(buildConnectionString("Npgsql", values({ port: null, password: "" }))).toBe(
+            "Host=localhost;Database=acme_shop;Username=admin;SSL Mode=Disable",
+        );
+        expect(buildConnectionString("SqlClient", values({ port: null }))).toBe(
+            "Server=localhost;Database=acme_shop;User ID=admin;Password=secret;Encrypt=False",
+        );
+    });
+
+    it("leaves out empty values instead of emitting a bare keyword", () => {
+        expect(buildConnectionString("Npgsql", values({ host: "", database: "", username: "", password: "" }))).toBe(
+            "Port=5432;SSL Mode=Disable",
+        );
+    });
+
+    it("quotes values containing separators or quotes", () => {
+        expect(buildConnectionString("Npgsql", values({ password: "p;a='s" }))).toContain("Password='p;a=''s'");
+    });
+
+    it("quotes values with surrounding whitespace", () => {
+        expect(buildConnectionString("Npgsql", values({ password: " secret " }))).toContain("Password=' secret '");
+    });
+});
+
+describe("parseConnectionString", () => {
+    it("parses a PostgreSQL connection string", () => {
+        expect(
+            parseConnectionString(
+                "Host=localhost;Port=5432;Database=acme_shop;Username=admin;Password=secret;SSL Mode=Disable",
+            ),
+        ).toEqual({ values: values(), droppedKeywords: [] });
+    });
+
+    it("parses keyword aliases case-insensitively", () => {
+        expect(
+            parseConnectionString(
+                "server=db.example.com;PORT=3306;Initial Catalog=shop;Uid=root;Pwd=secret;sslmode=none",
+            ).values,
+        ).toEqual(values({ host: "db.example.com", port: 3306, database: "shop", username: "root" }));
+    });
+
+    it("extracts the SQL Server port from the server value", () => {
+        expect(
+            parseConnectionString("Server=db.example.com,1433;Database=shop;User ID=sa;Password=secret;Encrypt=False")
+                .values,
+        ).toEqual(values({ host: "db.example.com", port: 1433, database: "shop", username: "sa" }));
+    });
+
+    it("splits the host and port whichever provider's dialect wrote them", () => {
+        const parsed = parseConnectionString(
+            "Server=localhost,5432;Database=acme_shop;User ID=admin;Password=secret;Encrypt=True",
+        );
+
+        expect(parsed.values).toEqual(values({ isSecured: true }));
+        expect(parsed.droppedKeywords).toEqual([]);
+    });
+
+    it("leaves a multi-host value alone", () => {
+        expect(
+            parseConnectionString("Host=primary.example.com,replica.example.com;Database=shop").values,
+        ).toMatchObject({ host: "primary.example.com,replica.example.com", port: null });
+    });
+
+    it("reads the secured flag from each provider's SSL keyword", () => {
+        expect(parseConnectionString("Host=h;SSL Mode=Require").values.isSecured).toBe(true);
+        expect(parseConnectionString("Host=h;SSL Mode=Disable").values.isSecured).toBe(false);
+        expect(parseConnectionString("Server=h;Encrypt=True").values.isSecured).toBe(true);
+        expect(parseConnectionString("Server=h;Encrypt=False").values.isSecured).toBe(false);
+        expect(parseConnectionString("Server=h;SslMode=Required").values.isSecured).toBe(true);
+        expect(parseConnectionString("Server=h;SslMode=None").values.isSecured).toBe(false);
+    });
+
+    it("treats a missing SSL keyword as secured", () => {
+        expect(parseConnectionString("Host=h;Database=d;Username=u;Password=p").values.isSecured).toBe(true);
+    });
+
+    it("keeps a SQL Server named instance intact when there is no port", () => {
+        expect(parseConnectionString("Server=host\\SQLEXPRESS;Database=shop;User ID=sa;Password=x").values.host).toBe(
+            "host\\SQLEXPRESS",
+        );
+    });
+
+    it("names the keywords no input represents", () => {
+        expect(
+            parseConnectionString(
+                "Server=localhost;Database=shop;User ID=sa;Password=x;TrustServerCertificate=True;Connect Timeout=30",
+            ).droppedKeywords,
+        ).toEqual(["TrustServerCertificate", "Connect Timeout"]);
+    });
+
+    it("drops nothing from a string the values fully express", () => {
+        expect(
+            parseConnectionString("Host=h;Port=5432;Database=d;Username=u;Password=p;SSL Mode=Require").droppedKeywords,
+        ).toEqual([]);
+    });
+
+    it("unquotes values containing separators", () => {
+        expect(
+            parseConnectionString("Host=localhost;Database=shop;Username=admin;Password='p;a=''s'").values.password,
+        ).toBe("p;a='s");
+    });
+
+    it("round-trips through build for every provider", () => {
+        const original = values({ password: "we;ird'pa=ss", isSecured: true });
+
+        for (const provider of ["Npgsql", "SqlClient", "MySqlConnectorFactory"] as const) {
+            expect(parseConnectionString(buildConnectionString(provider, original))).toEqual({
+                values: original,
+                droppedKeywords: [],
+            });
+        }
+    });
+});
+
+describe("resolveConnectionString", () => {
+    it("composes the fields while the fields editor is active", () => {
+        expect(
+            resolveConnectionString({
+                provider: "Npgsql",
+                mode: "fields",
+                fields: values(),
+                connectionString: "Host=ignored",
+            }),
+        ).toBe("Host=localhost;Port=5432;Database=acme_shop;Username=admin;Password=secret;SSL Mode=Disable");
+    });
+
+    it("uses the pasted string verbatim while the raw editor is active", () => {
+        expect(
+            resolveConnectionString({
+                provider: "SqlClient",
+                mode: "raw",
+                fields: values(),
+                connectionString: "  Server=host\\SQLEXPRESS;Integrated Security=true  ",
+            }),
+        ).toBe("Server=host\\SQLEXPRESS;Integrated Security=true");
+    });
+});
+
+describe("getPortAfterProviderChange", () => {
+    it("follows the new provider when the port is still the previous default", () => {
+        expect(getPortAfterProviderChange(5432, "Npgsql", "SqlClient")).toBe(1433);
+        expect(getPortAfterProviderChange(1433, "SqlClient", "MySqlConnectorFactory")).toBe(3306);
+        expect(getPortAfterProviderChange(3306, "MySqlConnectorFactory", "Npgsql")).toBe(5432);
+    });
+
+    it("fills the new provider's default when the port is empty", () => {
+        expect(getPortAfterProviderChange(null, "Npgsql", "MySqlConnectorFactory")).toBe(3306);
+    });
+
+    it("keeps a port the operator chose", () => {
+        expect(getPortAfterProviderChange(6543, "Npgsql", "SqlClient")).toBe(6543);
+    });
+});

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.ts
@@ -1,0 +1,228 @@
+import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+
+type ExternalConnection = AppFormData["externalConnection"];
+type Provider = ExternalConnection["provider"];
+
+export type ConnectionValues = {
+    host: string;
+    port: number | null;
+    database: string;
+    username: string;
+    password: string;
+    isSecured: boolean;
+};
+
+export type ParsedConnectionString = {
+    values: ConnectionValues;
+    droppedKeywords: string[];
+};
+
+export const DEFAULT_PROVIDER: Provider = "Npgsql";
+
+export const DEFAULT_PORT_BY_PROVIDER: Record<Provider, number> = {
+    Npgsql: 5432,
+    SqlClient: 1433,
+    MySqlConnectorFactory: 3306,
+};
+
+export function getPortAfterProviderChange(
+    port: number | null,
+    previousProvider: Provider,
+    nextProvider: Provider,
+): number {
+    const isPortOwnedByOperator = port !== null && port !== DEFAULT_PORT_BY_PROVIDER[previousProvider];
+
+    return isPortOwnedByOperator ? port : DEFAULT_PORT_BY_PROVIDER[nextProvider];
+}
+
+const KEYWORDS_BY_PROVIDER: Record<
+    Provider,
+    { host: string; port: string | null; database: string; username: string; password: string }
+> = {
+    Npgsql: { host: "Host", port: "Port", database: "Database", username: "Username", password: "Password" },
+    SqlClient: { host: "Server", port: null, database: "Database", username: "User ID", password: "Password" },
+    MySqlConnectorFactory: {
+        host: "Server",
+        port: "Port",
+        database: "Database",
+        username: "User ID",
+        password: "Password",
+    },
+};
+
+const SSL_BY_PROVIDER: Record<Provider, { keyword: string; secured: string; insecure: string }> = {
+    Npgsql: { keyword: "SSL Mode", secured: "Require", insecure: "Disable" },
+    SqlClient: { keyword: "Encrypt", secured: "True", insecure: "False" },
+    MySqlConnectorFactory: { keyword: "SslMode", secured: "Required", insecure: "None" },
+};
+
+export function buildConnectionString(provider: Provider, values: ConnectionValues): string {
+    const keywords = KEYWORDS_BY_PROVIDER[provider];
+    const host = values.host.trim();
+    const hostValue = provider === "SqlClient" && values.port != null ? `${host},${values.port}` : host;
+    const pairs: string[] = [];
+
+    if (hostValue !== "") {
+        pairs.push(`${keywords.host}=${escapeValue(hostValue)}`);
+    }
+
+    if (keywords.port && values.port != null) {
+        pairs.push(`${keywords.port}=${values.port}`);
+    }
+
+    for (const [keyword, value] of [
+        [keywords.database, values.database.trim()],
+        [keywords.username, values.username.trim()],
+        [keywords.password, values.password],
+    ]) {
+        if (value !== "") {
+            pairs.push(`${keyword}=${escapeValue(value)}`);
+        }
+    }
+
+    const ssl = SSL_BY_PROVIDER[provider];
+    pairs.push(`${ssl.keyword}=${values.isSecured ? ssl.secured : ssl.insecure}`);
+
+    return pairs.join(";");
+}
+
+export function resolveConnectionString(
+    connection: Pick<ExternalConnection, "provider" | "mode" | "fields" | "connectionString">,
+): string {
+    return connection.mode === "raw"
+        ? connection.connectionString.trim()
+        : buildConnectionString(connection.provider, connection.fields);
+}
+
+function escapeValue(value: string): string {
+    if (value !== "" && !/[;'"=]/.test(value) && value === value.trim()) {
+        return value;
+    }
+
+    return `'${value.replaceAll("'", "''")}'`;
+}
+
+const FIELD_BY_KEYWORD: Record<string, keyof ConnectionValues> = {
+    host: "host",
+    server: "host",
+    "data source": "host",
+    address: "host",
+    addr: "host",
+    "network address": "host",
+    port: "port",
+    database: "database",
+    "initial catalog": "database",
+    username: "username",
+    "user name": "username",
+    "user id": "username",
+    user: "username",
+    uid: "username",
+    password: "password",
+    pwd: "password",
+    "ssl mode": "isSecured",
+    sslmode: "isSecured",
+    encrypt: "isSecured",
+};
+
+const INSECURE_SSL_VALUES = new Set(["disable", "disabled", "none", "false", "0", "no"]);
+
+export function parseConnectionString(connectionString: string): ParsedConnectionString {
+    const values: ConnectionValues = {
+        host: "",
+        port: null,
+        database: "",
+        username: "",
+        password: "",
+        isSecured: true,
+    };
+    const droppedKeywords: string[] = [];
+
+    for (const segment of splitSegments(connectionString)) {
+        const separatorIndex = segment.indexOf("=");
+
+        if (separatorIndex < 0) {
+            droppedKeywords.push(segment);
+            continue;
+        }
+
+        const keyword = segment.slice(0, separatorIndex).trim();
+        const value = unquote(segment.slice(separatorIndex + 1).trim());
+        const field = FIELD_BY_KEYWORD[keyword.toLowerCase()];
+
+        if (!field) {
+            droppedKeywords.push(keyword);
+        } else if (field === "port") {
+            values.port = parsePort(value);
+        } else if (field === "isSecured") {
+            values.isSecured = !INSECURE_SSL_VALUES.has(value.trim().toLowerCase());
+        } else if (field === "host") {
+            const { host, port } = splitHostAndPort(value);
+            values.host = host;
+            values.port = port ?? values.port;
+        } else {
+            values[field] = value;
+        }
+    }
+
+    return { values, droppedKeywords };
+}
+
+function splitHostAndPort(value: string): { host: string; port: number | null } {
+    const commaIndex = value.lastIndexOf(",");
+
+    if (commaIndex < 0) {
+        return { host: value, port: null };
+    }
+
+    const port = parsePort(value.slice(commaIndex + 1).trim());
+
+    return port === null ? { host: value, port: null } : { host: value.slice(0, commaIndex).trim(), port };
+}
+
+function parsePort(value: string): number | null {
+    return /^\d+$/.test(value) ? Number(value) : null;
+}
+
+function splitSegments(connectionString: string): string[] {
+    const segments: string[] = [];
+    let current = "";
+    let quote: string | null = null;
+
+    for (let i = 0; i < connectionString.length; i++) {
+        const char = connectionString[i];
+
+        if (quote !== null) {
+            if (char === quote && connectionString[i + 1] === quote) {
+                current += char + char;
+                i++;
+            } else {
+                if (char === quote) {
+                    quote = null;
+                }
+                current += char;
+            }
+        } else if (char === "'" || char === '"') {
+            quote = char;
+            current += char;
+        } else if (char === ";") {
+            segments.push(current);
+            current = "";
+        } else {
+            current += char;
+        }
+    }
+
+    segments.push(current);
+
+    return segments.map((segment) => segment.trim()).filter(Boolean);
+}
+
+function unquote(value: string): string {
+    const first = value[0];
+
+    if ((first === "'" || first === '"') && value.length >= 2 && value.endsWith(first)) {
+        return value.slice(1, -1).replaceAll(first + first, first);
+    }
+
+    return value;
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
@@ -1,7 +1,6 @@
 import { useController, useFormContext, useFormState } from "react-hook-form";
 import { SELECTED_CARD_CLASSES } from "@/components/form/form-radio-cards";
 import { FormInput } from "@/components/form/form-input";
-import { FormTextarea } from "@/components/form/form-textarea";
 import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
 import { Field, FieldDescription, FieldLabel } from "@/components/shadcn/ui/field";
 import { cn } from "@/lib/utils";
@@ -9,9 +8,11 @@ import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-sto
 import { type AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { ImportedConfigAlert } from "@/pages/setup/add-app-wizard/imported-config-alert";
 import { PROVIDER_OPTIONS } from "@/pages/setup/add-app-wizard/steps/connect/connect-source-options";
+import { ConnectionEditor } from "@/pages/setup/add-app-wizard/steps/connect/connection-editor";
 import { ImportConfigDialog } from "@/pages/setup/add-app-wizard/steps/connect/import-config-dialog";
 import { TestConnectionButton } from "@/pages/setup/add-app-wizard/steps/connect/test-connection-button";
 import { toSlug } from "@/pages/setup/add-app-wizard/slugify";
+import { useConnectionSync } from "@/pages/setup/add-app-wizard/steps/connect/use-connection-sync";
 import { InputGroupAddon } from "@/components/shadcn/ui/input-group";
 import { Button } from "@/components/shadcn/ui/button";
 import { RefreshCw } from "lucide-react";
@@ -26,9 +27,10 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
     const isSlugTouched = Boolean(touchedFields.externalConnection?.slug);
 
     const {
-        field: { value, onChange },
+        field: { value },
         fieldState: { error, invalid },
     } = useController({ control, name: "externalConnection.provider" });
+    const { changeProvider } = useConnectionSync();
 
     const isConnectionDisabled = isBusy || isLocked;
 
@@ -92,7 +94,7 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
                                 key={option.value}
                                 type="button"
                                 aria-pressed={isSelected}
-                                onClick={() => onChange(option.value)}
+                                onClick={() => changeProvider(option.value)}
                                 disabled={isConnectionDisabled}
                                 className={cn(
                                     "flex min-h-28 flex-col items-center justify-center gap-3 rounded-lg border bg-background p-4 transition-colors",
@@ -111,14 +113,7 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
                 </div>
                 {error?.message && <FieldDescription className="text-destructive">{error.message}</FieldDescription>}
             </Field>
-            <FormTextarea
-                control={control}
-                name="externalConnection.connectionString"
-                label="Connection string"
-                placeholder="Host=localhost;Port=5432;Database=my_db;Username=admin;Password=pass"
-                textareaClassName="font-mono text-xs"
-                disabled={isConnectionDisabled}
-            />
+            <ConnectionEditor isDisabled={isConnectionDisabled} />
             <TestConnectionButton disabled={isConnectionDisabled} />
         </div>
     );

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connection-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connection-editor.tsx
@@ -1,0 +1,115 @@
+import { useFormContext, useWatch } from "react-hook-form";
+import { FormInput } from "@/components/form/form-input";
+import { FormSwitch } from "@/components/form/form-switch";
+import { FormTextarea } from "@/components/form/form-textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/ui/tabs";
+import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+import { DEFAULT_PORT_BY_PROVIDER } from "@/pages/setup/add-app-wizard/connection-string";
+import { useConnectionSync } from "@/pages/setup/add-app-wizard/steps/connect/use-connection-sync";
+
+type Provider = AppFormData["externalConnection"]["provider"];
+
+const CONNECTION_STRING_PLACEHOLDER_BY_PROVIDER: Record<Provider, string> = {
+    Npgsql: "Host=localhost;Port=5432;Database=my_db;Username=admin;Password=pass",
+    SqlClient: "Server=localhost,1433;Database=my_db;User ID=sa;Password=pass",
+    MySqlConnectorFactory: "Server=localhost;Port=3306;Database=my_db;User ID=admin;Password=pass",
+};
+
+export function ConnectionEditor({ isDisabled }: { isDisabled: boolean }) {
+    const { control } = useFormContext<AppFormData>();
+    const mode = useWatch({ control, name: "externalConnection.mode" });
+    const { changeMode } = useConnectionSync();
+
+    return (
+        <Tabs value={mode} onValueChange={(next) => changeMode(next as AppFormData["externalConnection"]["mode"])}>
+            <TabsList>
+                <TabsTrigger value="fields" disabled={isDisabled}>
+                    Connection details
+                </TabsTrigger>
+                <TabsTrigger value="raw" disabled={isDisabled}>
+                    Connection string
+                </TabsTrigger>
+            </TabsList>
+            <TabsContent value="fields" className="grid gap-5 pt-2">
+                <ConnectionFieldsEditor isDisabled={isDisabled} />
+            </TabsContent>
+            <TabsContent value="raw" className="grid gap-5 pt-2">
+                <ConnectionStringEditor isDisabled={isDisabled} />
+            </TabsContent>
+        </Tabs>
+    );
+}
+
+function ConnectionFieldsEditor({ isDisabled }: { isDisabled: boolean }) {
+    const { control } = useFormContext<AppFormData>();
+    const provider = useWatch({ control, name: "externalConnection.provider" });
+
+    return (
+        <>
+            <div className="grid gap-5 sm:grid-cols-[minmax(0,1fr)_9rem]">
+                <FormInput
+                    control={control}
+                    name="externalConnection.fields.host"
+                    label="Host"
+                    placeholder="e.g. db.example.com"
+                    disabled={isDisabled}
+                />
+                <FormInput
+                    control={control}
+                    name="externalConnection.fields.port"
+                    label="Port"
+                    type="number"
+                    placeholder={String(DEFAULT_PORT_BY_PROVIDER[provider])}
+                    disabled={isDisabled}
+                />
+            </div>
+            <FormInput
+                control={control}
+                name="externalConnection.fields.database"
+                label="Database"
+                placeholder="e.g. acme_shop"
+                disabled={isDisabled}
+            />
+            <div className="grid gap-5 sm:grid-cols-2">
+                <FormInput
+                    control={control}
+                    name="externalConnection.fields.username"
+                    label="Username"
+                    placeholder="e.g. admin"
+                    disabled={isDisabled}
+                />
+                <FormInput
+                    control={control}
+                    name="externalConnection.fields.password"
+                    label="Password"
+                    type="password"
+                    disabled={isDisabled}
+                />
+            </div>
+            <FormSwitch
+                control={control}
+                name="externalConnection.fields.isSecured"
+                label="Secured connection (SSL/TLS)"
+                disabled={isDisabled}
+            />
+        </>
+    );
+}
+
+function ConnectionStringEditor({ isDisabled }: { isDisabled: boolean }) {
+    const { control } = useFormContext<AppFormData>();
+    const provider = useWatch({ control, name: "externalConnection.provider" });
+
+    return (
+        <FormTextarea
+            control={control}
+            name="externalConnection.connectionString"
+            label="Connection string"
+            labelClassName="sr-only"
+            placeholder={CONNECTION_STRING_PLACEHOLDER_BY_PROVIDER[provider]}
+            textareaClassName="font-mono text-xs"
+            description="Switching to the connection details reads them from this string and keeps only the settings they can show."
+            disabled={isDisabled}
+        />
+    );
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/test-connection-button.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/test-connection-button.tsx
@@ -14,11 +14,7 @@ import {
     testConnection,
 } from "@/pages/setup/add-app-wizard/steps/connect/use-connect-source-step";
 
-const CONNECTION_FIELDS = [
-    "externalConnection.provider",
-    "externalConnection.connectionString",
-    "externalConnection.slug",
-] as const satisfies FieldPath<AppFormData>[];
+const CONNECTION_FIELD = "externalConnection" as const satisfies FieldPath<AppFormData>;
 
 export function TestConnectionButton({ disabled }: { disabled: boolean }) {
     const { control, getValues, trigger } = useFormContext<AppFormData>();
@@ -26,8 +22,7 @@ export function TestConnectionButton({ disabled }: { disabled: boolean }) {
 
     // The key must be derived from the watched values (not getValues), otherwise React Compiler
     // memoizes it against the stable getValues reference and it never reflects form changes.
-    const [provider, connectionString, slug] = useWatch({ control, name: CONNECTION_FIELDS });
-    const connectKey = computeConnectKey({ provider, connectionString, slug });
+    const connectKey = computeConnectKey(useWatch({ control, name: CONNECTION_FIELD }));
     const isVerified = isConnectionVerified(connectionAttempt, connectKey);
     const error = getConnectionError(connectionAttempt, connectKey);
 
@@ -37,7 +32,7 @@ export function TestConnectionButton({ disabled }: { disabled: boolean }) {
     });
 
     const handleTest = async () => {
-        if (await trigger([...CONNECTION_FIELDS])) {
+        if (await trigger(CONNECTION_FIELD)) {
             mutate();
         }
     };

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connect-source-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connect-source-step.ts
@@ -3,17 +3,21 @@ import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-valida
 import type { WizardProgress } from "@/components/form/wizard/form-wizard";
 import { toError, toWizardStepError, WizardHandledError } from "@/components/form/wizard/wizard-step-error";
 import { useSetupWizardStore, type ConnectionAttempt } from "@/pages/setup/add-app-wizard/app-wizard-store";
+import { resolveConnectionString } from "@/pages/setup/add-app-wizard/connection-string";
 import { getTableKey, isTableSupported } from "@/pages/setup/add-app-wizard/discover-utils";
 import { discoverTables } from "@/pages/setup/add-app-wizard/steps/verify/use-discover-tables";
 import { useFormContext } from "react-hook-form";
 
-export type ConnectSourceInput = Pick<AppFormData["externalConnection"], "provider" | "connectionString" | "slug">;
+export type ConnectSourceInput = Pick<
+    AppFormData["externalConnection"],
+    "provider" | "mode" | "fields" | "connectionString" | "slug"
+>;
 
 /** Identifies the source database, and with it the discovered schema and any mapping built from it. */
-export function computeSourceKey(connection: Pick<ConnectSourceInput, "provider" | "connectionString">): string {
+export function computeSourceKey(connection: Omit<ConnectSourceInput, "slug">): string {
     return JSON.stringify({
         provider: connection.provider,
-        connectionString: connection.connectionString,
+        connectionString: resolveConnectionString(connection),
     });
 }
 
@@ -46,7 +50,7 @@ export async function testConnection(connection: ConnectSourceInput): Promise<vo
 
     try {
         const connectResult = await api.services.setup.connect({
-            connectionString: connection.connectionString,
+            connectionString: resolveConnectionString(connection),
             provider: connection.provider,
             slug: connection.slug,
         });

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connection-sync.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connection-sync.ts
@@ -1,0 +1,69 @@
+import { useFormContext } from "react-hook-form";
+import { toast } from "sonner";
+import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+import {
+    buildConnectionString,
+    getPortAfterProviderChange,
+    parseConnectionString,
+    type ConnectionValues,
+} from "@/pages/setup/add-app-wizard/connection-string";
+
+type ExternalConnection = AppFormData["externalConnection"];
+
+export function useConnectionSync() {
+    const { getValues, setValue } = useFormContext<AppFormData>();
+
+    const changeMode = (mode: ExternalConnection["mode"]) => {
+        const connection = getValues("externalConnection");
+
+        if (mode === "raw") {
+            setValue(
+                "externalConnection.connectionString",
+                buildConnectionString(connection.provider, connection.fields),
+            );
+        } else {
+            const { values, droppedKeywords } = parseConnectionString(connection.connectionString);
+
+            setValue("externalConnection.fields", values);
+            warnAboutDroppedKeywords(droppedKeywords);
+        }
+
+        setValue("externalConnection.mode", mode, { shouldValidate: true });
+    };
+
+    const changeProvider = (provider: ExternalConnection["provider"]) => {
+        const connection = getValues("externalConnection");
+        const { values, droppedKeywords } = readActiveEditor(connection);
+        const fields: ConnectionValues = {
+            ...values,
+            port: getPortAfterProviderChange(values.port, connection.provider, provider),
+        };
+
+        setValue("externalConnection.fields", fields, { shouldValidate: true });
+
+        if (connection.mode === "raw") {
+            setValue("externalConnection.connectionString", buildConnectionString(provider, fields));
+            warnAboutDroppedKeywords(droppedKeywords);
+        }
+
+        setValue("externalConnection.provider", provider, { shouldDirty: true, shouldValidate: true });
+    };
+
+    return { changeMode, changeProvider };
+}
+
+function readActiveEditor(connection: ExternalConnection) {
+    return connection.mode === "raw"
+        ? parseConnectionString(connection.connectionString)
+        : { values: connection.fields, droppedKeywords: [] };
+}
+
+function warnAboutDroppedKeywords(droppedKeywords: string[]) {
+    if (droppedKeywords.length === 0) {
+        return;
+    }
+
+    toast.warning("Some connection string keywords were dropped", {
+        description: `The connection details cannot express ${droppedKeywords.join(", ")}.`,
+    });
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
@@ -12,6 +12,7 @@ import {
     parseConfigFile,
     type WizardConfig,
 } from "@/pages/setup/add-app-wizard/config-io";
+import { parseConnectionString } from "@/pages/setup/add-app-wizard/connection-string";
 import { isTableSupported } from "@/pages/setup/add-app-wizard/discover-utils";
 import { wrapDtoTablesToFormShape } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-dto";
 import {
@@ -111,8 +112,11 @@ export function useImportConfig() {
                 sourceTableName: table.sourceTableName ?? "",
             }));
 
+            const { values: fields, droppedKeywords } = parseConnectionString(config.connectionString);
+
             setValue("externalConnection.provider", config.provider);
-            setValue("externalConnection.mode", "raw");
+            setValue("externalConnection.mode", droppedKeywords.length === 0 ? "fields" : "raw");
+            setValue("externalConnection.fields", fields);
             setValue("externalConnection.connectionString", config.connectionString);
             setValue("externalConnection.slug", slug, { shouldValidate: true, shouldTouch: true });
             setValue("verifySchema.tables", verifySchemaTables);

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
@@ -51,6 +51,13 @@ export function useImportConfig() {
             const config = await parseConfigFile(file);
             // An older configuration carries no slug; keep whatever the operator already typed.
             const slug = config.slug || getValues("externalConnection").slug;
+            const connection = {
+                ...getValues("externalConnection"),
+                provider: config.provider,
+                mode: "raw" as const,
+                connectionString: config.connectionString,
+                slug,
+            };
 
             setProgressLabel(IMPORT_PHASES.connecting);
             const connectResult = await api.services.setup.connect({
@@ -67,11 +74,7 @@ export function useImportConfig() {
             // in custom schemas can still be verified.
             setProgressLabel(IMPORT_PHASES.discovering);
             const schemas = collectConfigSchemas(config.tables);
-            const discoverResult = await discoverTables(
-                { provider: config.provider, connectionString: config.connectionString },
-                schemas,
-                slug,
-            );
+            const discoverResult = await discoverTables(connection, schemas, slug);
 
             if (!discoverResult.success) {
                 throw toWizardStepError(discoverResult.errors, "Could not discover tables.");
@@ -109,6 +112,7 @@ export function useImportConfig() {
             }));
 
             setValue("externalConnection.provider", config.provider);
+            setValue("externalConnection.mode", "raw");
             setValue("externalConnection.connectionString", config.connectionString);
             setValue("externalConnection.slug", slug, { shouldValidate: true, shouldTouch: true });
             setValue("verifySchema.tables", verifySchemaTables);
@@ -121,16 +125,14 @@ export function useImportConfig() {
             store.setDiscoverResult(discoverResult, schemas);
             store.resetMapTablesUiState();
 
-            const connectKey = computeConnectKey({
-                provider: config.provider,
-                connectionString: config.connectionString,
-                slug,
-            });
+            const connection = getValues("externalConnection");
+            const connectKey = computeConnectKey(connection);
+
             store.setConnectKey(connectKey);
             store.setConnectionAttempt({ key: connectKey, error: null });
             store.setAppliedMapKey(
                 computeMapKey({
-                    sourceKey: computeSourceKey(config),
+                    sourceKey: computeSourceKey(connection),
                     source: "manual",
                     aiPrompt: "",
                     selectedTables: verifySchemaTables,

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-discover-tables.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-discover-tables.ts
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { api } from "@/api/api";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+import { resolveConnectionString } from "@/pages/setup/add-app-wizard/connection-string";
 
 /** Trims entries, drops empties, and dedupes the user-entered schema list. */
 export function normalizeDiscoverSchemas(schemas: string[] | undefined): string[] {
@@ -12,13 +13,13 @@ export function normalizeDiscoverSchemas(schemas: string[] | undefined): string[
 
 /** Discovers source tables. An empty schema list means the connection's default schema. */
 export function discoverTables(
-    connection: Pick<AppFormData["externalConnection"], "provider" | "connectionString">,
+    connection: Pick<AppFormData["externalConnection"], "provider" | "mode" | "fields" | "connectionString">,
     schemas: string[],
     slug: string,
 ) {
     return api.services.setup.discover({
         provider: connection.provider,
-        connectionString: connection.connectionString,
+        connectionString: resolveConnectionString(connection),
         schemas: schemas.length > 0 ? schemas : null,
         slug,
     });

--- a/src/Raven.Quill.Web/vitest.config.ts
+++ b/src/Raven.Quill.Web/vitest.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
         projects: [
             {
                 extends: "vite.config.ts",
+                test: {
+                    name: "unit",
+                    environment: "node",
+                    include: ["src/**/*.test.ts"],
+                },
+            },
+            {
+                extends: "vite.config.ts",
                 plugins: [storybookTest({ configDir: path.join(dirname, ".storybook") })],
                 test: {
                     name: "storybook",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27189/Quill-Replace-connection-string-with-separate-input-for-each-value

### Additional description

<img width="1685" height="1178" alt="image" src="https://github.com/user-attachments/assets/4ba9cfaf-1108-47b3-b222-83eae8e8c3c0" />
<img width="1667" height="1116" alt="image" src="https://github.com/user-attachments/assets/81f6c59f-5864-4714-9a6a-ddbf71002a20" />
<img width="1728" height="1172" alt="image" src="https://github.com/user-attachments/assets/2a2e7cc3-2a23-423c-b185-d223d8189196" />

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
