### PR TITLE
RavenDB-26938 - Fix side-by-side index reset silently disappearing on database record change or server restart

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1629,7 +1629,7 @@ namespace Raven.Server.Documents.Indexes
                     var sp = Stopwatch.StartNew();
 
                     addToInitLog(LogMode.Information, $"Initializing side-by-side reset replacement index: `{replacementName}`");
-                    OpenIndex(path, replacementPath, exceptions, replacementName, startIndex, indexDefinition: null);
+                    OpenIndex(path, replacementPath, exceptions, replacementName, startIndex, definition);
 
                     if (Logger.IsInfoEnabled)
                         Logger.Info($"Initialized side-by-side reset replacement index: `{replacementName}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
@@ -1730,8 +1730,6 @@ namespace Raven.Server.Documents.Indexes
             {
                 index = Index.Open(indexPath, _documentDatabase, generateNewDatabaseId: false, out searchEngineType);
 
-                indexDefinition ??= index.GetIndexDefinition();
-
                 var differences = IndexDefinitionCompareDifferences.None;
 
                 if (indexDefinition is IndexDefinition def)
@@ -1789,9 +1787,6 @@ namespace Raven.Server.Documents.Indexes
                 exceptions?.Add(e);
 
                 if (alreadyFaulted)
-                    return;
-
-                if (indexDefinition == null)
                     return;
 
                 var configuration = new FaultyInMemoryIndexConfiguration(path, _documentDatabase.Configuration);

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1617,6 +1617,23 @@ namespace Raven.Server.Documents.Indexes
                     if (Logger.IsInfoEnabled)
                         Logger.Info($"Initialized static index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
                 }
+
+                // A side-by-side reset replacement (ReplacementOf/...) is created through a local-only path and is
+                // not persisted in the database record, so it isn't opened by the loop above. Open its directory here
+                // so an in-progress side-by-side reset survives a restart instead of being left as an orphaned directory.
+                var replacementName = Constants.Documents.Indexing.SideBySideIndexNamePrefix + name;
+                var replacementSafeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(replacementName);
+                var replacementPath = path.Combine(replacementSafeName).FullPath;
+                if (Directory.Exists(replacementPath))
+                {
+                    var sp = Stopwatch.StartNew();
+
+                    addToInitLog(LogMode.Information, $"Initializing side-by-side reset replacement index: `{replacementName}`");
+                    OpenIndex(path, replacementPath, exceptions, replacementName, startIndex, indexDefinition: null);
+
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Initialized side-by-side reset replacement index: `{replacementName}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
+                }
             }
 
             foreach (var kvp in record.AutoIndexes)
@@ -1634,7 +1651,7 @@ namespace Raven.Server.Documents.Indexes
                     var sp = Stopwatch.StartNew();
 
                     addToInitLog(LogMode.Information, $"Initializing auto index: `{name}`");
-                    OpenIndex(path, indexPath, exceptions, name, startIndex, definition);
+                     OpenIndex(path, indexPath, exceptions, name, startIndex, definition);
 
                     addToInitLog(LogMode.Information, $"Initialized auto index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
                 }
@@ -1713,6 +1730,8 @@ namespace Raven.Server.Documents.Indexes
             {
                 index = Index.Open(indexPath, _documentDatabase, generateNewDatabaseId: false, out searchEngineType);
 
+                indexDefinition ??= index.GetIndexDefinition();
+
                 var differences = IndexDefinitionCompareDifferences.None;
 
                 if (indexDefinition is IndexDefinition def)
@@ -1770,6 +1789,9 @@ namespace Raven.Server.Documents.Indexes
                 exceptions?.Add(e);
 
                 if (alreadyFaulted)
+                    return;
+
+                if (indexDefinition == null)
                     return;
 
                 var configuration = new FaultyInMemoryIndexConfiguration(path, _documentDatabase.Configuration);

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1617,23 +1617,6 @@ namespace Raven.Server.Documents.Indexes
                     if (Logger.IsInfoEnabled)
                         Logger.Info($"Initialized static index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
                 }
-
-                // A side-by-side reset replacement (ReplacementOf/...) is created through a local-only path and is
-                // not persisted in the database record, so it isn't opened by the loop above. Open its directory here
-                // so an in-progress side-by-side reset survives a restart instead of being left as an orphaned directory.
-                var replacementName = Constants.Documents.Indexing.SideBySideIndexNamePrefix + name;
-                var replacementSafeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(replacementName);
-                var replacementPath = path.Combine(replacementSafeName).FullPath;
-                if (Directory.Exists(replacementPath))
-                {
-                    var sp = Stopwatch.StartNew();
-
-                    addToInitLog(LogMode.Information, $"Initializing side-by-side reset replacement index: `{replacementName}`");
-                    OpenIndex(path, replacementPath, exceptions, replacementName, startIndex, definition);
-
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Initialized side-by-side reset replacement index: `{replacementName}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
-                }
             }
 
             foreach (var kvp in record.AutoIndexes)
@@ -1651,7 +1634,7 @@ namespace Raven.Server.Documents.Indexes
                     var sp = Stopwatch.StartNew();
 
                     addToInitLog(LogMode.Information, $"Initializing auto index: `{name}`");
-                     OpenIndex(path, indexPath, exceptions, name, startIndex, definition);
+                    OpenIndex(path, indexPath, exceptions, name, startIndex, definition);
 
                     addToInitLog(LogMode.Information, $"Initialized auto index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
                 }
@@ -1689,6 +1672,32 @@ namespace Raven.Server.Documents.Indexes
             addToInitLog(LogMode.Information, "Starting new indexes");
             startIndex = _documentDatabase.Configuration.Indexing.IndexStartupBehavior != IndexingConfiguration.IndexStartupBehaviorType.Pause;
             var startedIndexes = HandleDatabaseRecordChange(record, raftIndex, startIndex);
+
+            // A side-by-side reset replacement (ReplacementOf/...) is created through a local-only path and is not
+            // persisted in the database record, so it isn't opened from the record above. A definition-change
+            // side-by-side, on the other hand, was already recreated by HandleDatabaseRecordChange (its original
+            // differs from the record). So here we open only the replacement directories that are still orphaned -
+            // the in-progress side-by-side resets - so they survive the restart instead of being left on disk unused.
+            foreach (var kvp in record.Indexes)
+            {
+                if (_documentDatabase.DatabaseShutdown.IsCancellationRequested)
+                    return;
+
+                var name = kvp.Key;
+                var definition = kvp.Value;
+
+                var replacementName = Constants.Documents.Indexing.SideBySideIndexNamePrefix + name;
+                if (_indexes.TryGetByName(replacementName, out _))
+                    continue;
+
+                var replacementSafeName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(replacementName);
+                var replacementPath = path.Combine(replacementSafeName).FullPath;
+                if (Directory.Exists(replacementPath) == false)
+                    continue;
+
+                addToInitLog(LogMode.Information, $"Initializing side-by-side reset replacement index: `{replacementName}`");
+                OpenIndex(path, replacementPath, exceptions, replacementName, startIndex, definition);
+            }
 
             addToInitLog(LogMode.Information, $"Started {startedIndexes} new index{(startedIndexes > 1 ? "es" : string.Empty)}, took: {startIndexSp.ElapsedMilliseconds}ms");
             addToInitLog(LogMode.Information, $"IndexStore initialization is completed, took: {totalSp.ElapsedMilliseconds:#,#;;0}ms");

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -607,6 +607,10 @@ namespace Raven.Server.Documents.Indexes
 
                     if (replacementIndex != null)
                     {
+                        creationOptions = GetIndexCreationOptions(definition, replacementIndex.ToIndexInformationHolder(), _documentDatabase.Configuration, out _);
+                        if (creationOptions == IndexCreationOptions.Noop)
+                            return null;
+
                         if (replacementIndex is MapReduceIndex replacementMapReduceIndex && replacementMapReduceIndex.OutputReduceToCollection != null)
                         {
                             if (replacementMapReduceIndex.Definition.ReduceOutputIndex != null &&

--- a/test/SlowTests/Issues/RavenDB-26938.cs
+++ b/test/SlowTests/Issues/RavenDB-26938.cs
@@ -1,0 +1,79 @@
+using System.Linq;
+using Raven.Client;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26938 : ClusterTestBase
+{
+    public RavenDB_26938(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void SideBySideReplacementFromResetShouldSurviveDatabaseRecordChange()
+    {
+        using (var store = GetDocumentStore())
+        {
+            new DocIndex().Execute(store); // simple map index
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc { Id = "doc-1", StrVal = "value" });
+                session.SaveChanges();
+            }
+
+            Indexes.WaitForIndexing(store);
+
+            // stop indexing so the side-by-side replacement cannot complete and swap
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            store.Maintenance.Send(new ResetIndexOperation(nameof(DocIndex), IndexResetMode.SideBySide));
+
+            var replacementName = Constants.Documents.Indexing.SideBySideIndexNamePrefix + nameof(DocIndex);
+
+            var names = store.Maintenance.Send(new GetIndexNamesOperation(0, 100));
+            Assert.Contains(replacementName, names); // replacement exists
+
+            // any database record change; here: deploying an unrelated index
+            new OtherIndex().Execute(store);
+
+            names = store.Maintenance.Send(new GetIndexNamesOperation(0, 100));
+            Assert.Contains(replacementName, names); // the replacement should still be there
+        }
+    }
+
+    private class Doc
+    {
+        public string Id { get; set; }
+        public string StrVal { get; set; }
+    }
+
+    private class Other
+    {
+        public string Id { get; set; }
+        public string StrVal { get; set; }
+    }
+
+    private class DocIndex : AbstractIndexCreationTask<Doc>
+    {
+        public DocIndex()
+        {
+            Map = docs => from doc in docs
+                select new { doc.StrVal };
+        }
+    }
+
+    private class OtherIndex : AbstractIndexCreationTask<Other>
+    {
+        public OtherIndex()
+        {
+            Map = others => from other in others
+                select new { other.StrVal };
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-26938.cs
+++ b/test/SlowTests/Issues/RavenDB-26938.cs
@@ -1,7 +1,14 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -46,6 +53,69 @@ public class RavenDB_26938 : ClusterTestBase
             Assert.Contains(replacementName, names); // the replacement should still be there
         }
     }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task SideBySideReplacementFromResetShouldSurviveServerRestart()
+    {
+        using var server = GetNewServer(new ServerCreationOptions { RunInMemory = false });
+        using var store = GetDocumentStore(new Options { RunInMemory = false, Server = server });
+
+        new DocIndex().Execute(store); // simple map index
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Doc { Id = "doc-1", StrVal = "value" });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        // stop indexing so the side-by-side replacement cannot complete and swap while we set it up
+        store.Maintenance.Send(new StopIndexingOperation());
+
+        store.Maintenance.Send(new ResetIndexOperation(nameof(DocIndex), IndexResetMode.SideBySide));
+
+        var replacementName = Constants.Documents.Indexing.SideBySideIndexNamePrefix + nameof(DocIndex);
+
+        var names = store.Maintenance.Send(new GetIndexNamesOperation(0, 100));
+        Assert.Contains(replacementName, names); // replacement exists
+
+        // disable the replacement so it stays paused across the restart (StopIndexing is in-memory only and is lost
+        // on restart, which would let the replacement run and immediately swap into the original)
+        store.Maintenance.Send(new DisableIndexOperation(replacementName));
+
+        // restart the server, keeping the data on disk
+        var result = await DisposeServerAndWaitForFinishOfDisposalAsync(server);
+        using var newServer = GetNewServer(new ServerCreationOptions
+        {
+            DeletePrevious = false,
+            RunInMemory = false,
+            DataDirectory = result.DataDirectory,
+            CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url }
+        });
+
+        await WaitForIndexInitialization(newServer, store);
+
+        names = store.Maintenance.Send(new GetIndexNamesOperation(0, 100));
+        Assert.Contains(replacementName, names); // the replacement should still be there after restart
+    }
+
+    private async Task WaitForIndexInitialization(RavenServer server, IDocumentStore store)
+    {
+        if (server.ServerStore.Initialized == false)
+            await server.ServerStore.InitializationCompleted.WaitAsync();
+
+        long lastRaftIndex;
+        using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+        using (ctx.OpenReadTransaction())
+        {
+            lastRaftIndex = server.ServerStore.Engine.GetLastCommitIndex(ctx);
+        }
+
+        var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+        await database.RachisLogIndexNotifications.WaitForIndexNotification(lastRaftIndex, TimeSpan.FromSeconds(15));
+    }
+
 
     private class Doc
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26938/Side-by-side-index-reset-is-silently-cancelled-by-any-subsequent-database-record-change

### Additional description

#### Summary

A side-by-side index reset (`ResetIndexOperation(indexName, IndexResetMode.SideBySide)`) could silently vanish before the replacement finished rebuilding. The `ReplacementOf/<index>` was dropped with no error, notification, or alert, and the original index was never rebuilt — from the operator's point of view the reset just quietly evaporated.

Reported via GitHub discussion: https://github.com/ravendb/ravendb/discussions/23107

#### Symptom

After starting a side-by-side reset, **any** of the following before the replacement completes would drop the replacement:

- Deploying any index definition
- Changing any database setting
- A cluster topology update after a leader election
- A full server restart

Observed in production: an index was reset side-by-side, load triggered a leader election, and the in-progress replacement was removed. The result is indistinguishable from the index having been fully recomputed — but the rebuild never actually completed.

Tested with 7.2.4.

#### Root cause

A side-by-side reset creates the replacement through a **local-only** path (`ResetIndexSideBySideInternal` → `HandleStaticIndexChange(..., forceUpdate: true)`) and does **not** persist anything in the database record. Because the replacement's definition is identical to the record's definition, two things go wrong:

1. **On any database record change** (`StateChangedAsync` → `UpdateOnStateChange` → `IndexStore.HandleDatabaseRecordChange`), the original index compares as `IndexCreationOptions.Noop`, and the `Noop` cleanup in `HandleStaticIndexChange` deletes the in-progress replacement.
2. **On a full server restart**, `OpenIndexesFromRecord` iterates only `record.Indexes` / `record.AutoIndexes`. The reset replacement is not in the record, so its on-disk `ReplacementOf/...` directory is never re-opened and is left orphaned.

A *definition-change* side-by-side is unaffected: the record holds the new definition, so the original-vs-record comparison is never `Noop`, and the replacement is recreated by `HandleDatabaseRecordChange`.

#### Fix

All changes are in `IndexStore.cs`.

**1. Don't delete the reset replacement on an unrelated record change** (`HandleStaticIndexChange`)
In the `Noop` cleanup path, compare the existing replacement against the current definition. If that comparison is itself `Noop` (an identical, pending side-by-side reset), return without deleting it.

**2. Re-open the orphaned reset replacement on startup** (`OpenIndexesFromRecord`)
After `HandleDatabaseRecordChange` has been applied, iterate the record's static indexes and open any `ReplacementOf/<name>` directory that exists on disk but is **not already in `_indexes`**. `Index.Open` reads the replacement's name, type, and definition from its own storage.

The `_indexes` check is the discriminator between the two side-by-side kinds and avoids opening a directory twice:
- **Definition-change**: original ≠ record, so `HandleDatabaseRecordChange` already recreated the replacement → it's in `_indexes` → skipped.
- **Reset**: original == record → `Noop` → no replacement was recreated → not in `_indexes` → the orphan is opened.

Together these keep the replacement alive across record changes and restarts; indexing then resumes and completes the swap normally.

#### Tests

Added `SlowTests/Issues/RavenDB-26938.cs`:

- `SideBySideReplacementFromResetShouldSurviveDatabaseRecordChange` — resets side-by-side, then deploys an unrelated index (a record change), and asserts the replacement still exists.
- `SideBySideReplacementFromResetShouldSurviveServerRestart` — resets side-by-side, disables the replacement so it stays paused across the restart (`StopIndexing` is in-memory only), restarts the server against the same data, and asserts the replacement is re-opened rather than orphaned.

Also verified the existing `RavenDB_15163.FailureDuringIndexReplacementMustNotCauseProblemsWith` (definition-change replacement failure recovered on restart) still passes — an earlier iteration that opened the replacement unconditionally double-opened it and leaked a storage environment; the `_indexes` guard fixes that.

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
