### PR TITLE
RavenDB-27240 Build native JsArray instances when projecting stored array fields from Lucene documents

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Hl7.Fhir.R4" Version="5.12.2" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageVersion Include="Jint" Version="4.15.1" />
+    <PackageVersion Include="Jint" Version="4.15.3" />
     <PackageVersion Include="JunitXml.TestLogger" Version="8.0.0" />
     <PackageVersion Include="Lambda2Js.Signed" Version="3.1.4" />
     <PackageVersion Include="Lextm.SharpSnmpLib.Engine" Version="11.3.102" />

--- a/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
+++ b/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
@@ -305,12 +305,16 @@ namespace Raven.Server.Documents.Patch
                             arrayItems[i] = TranslateToJs(parent, field.Name, BlittableJsonToken.StartObject, itemAsBlittable);
                         }
 
-                        value = FromObject(parent.Engine, arrayItems);
+                        value = new JsArray(parent.Engine, arrayItems);
                         return true;
                     }
 
                     var values = parent.IndexRetriever.LuceneDocument.GetValues(property, parent.IndexRetriever.State);
-                    value = FromObject(parent.Engine, values);
+                    var jsValues = new JsValue[values.Length];
+                    for (int i = 0; i < values.Length; i++)
+                        jsValues[i] = values[i];
+
+                    value = new JsArray(parent.Engine, jsValues);
                     return true;
                 }
 


### PR DESCRIPTION
Jint 4.14.0 changed Options.Interop.ArrayConversion to default to ArrayConversionMode.LiveView, so CLR arrays crossing into script became ArrayWrapper<T> live views instead of native JsArray copies. IsArray() returns false for those wrappers, so load(<stored array field>) hit the "must be called with a single string or array argument" guard in ScriptRunner.LoadDocument.

Only the Lucene branch of BlittableObjectInstance was affected - TryGetValueFromCorax already builds JsArray explicitly.

Same fix as the one applied to OLAP ETL partitionBy in 1cba151cf8a.

Fixes RavenDB_16818.Should_Be_Able_To_Project_Arrays_From_Stored_Index_Fields_Correctly and RavenDB_13412.CanProjectIdFromJsLoadedDocumentInMapReduceQuery.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27240

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
