### PR TITLE
RavenDB-27226: wait for running queries when disposing an index

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -346,7 +346,7 @@ namespace Raven.Server.Documents.Indexes
 
             _disposeOnce = new DisposeOnce<SingleAttempt>(() =>
             {
-                using (DrainRunningQueries())
+                using (DrainRunningQueries(true))
                     DisposeIndex();
             });
         }
@@ -787,18 +787,20 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        internal IDisposable DrainRunningQueries()
+        internal IDisposable DrainRunningQueries(bool waitForRunningQueriesToEnd = false)
         {
             if (_isRunningQueriesWriteLockTaken.Value)
                 return null;
 
             IDisposable currentlyRunningQueriesWriteLock;
 
+            var timeout = waitForRunningQueriesToEnd ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(10);
+
             try
             {
-                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+                using (var cts = new CancellationTokenSource(timeout))
                     currentlyRunningQueriesWriteLock = _currentlyRunningQueriesLock.WriterLock(cts.Token);
-
+                
                 _isRunningQueriesWriteLockTaken.Value = true;
             }
             catch (OperationCanceledException)
@@ -5529,14 +5531,23 @@ namespace Raven.Server.Documents.Indexes
             if (_forTestingPurposes != null)
                 return _forTestingPurposes;
 
-            return _forTestingPurposes = new TestingStuff();
+            return _forTestingPurposes = new TestingStuff(this);
         }
 
         internal sealed class TestingStuff
         {
+            private readonly Index _index;
+
+            public TestingStuff(Index index)
+            {
+                _index = index;
+            }
+
             internal Action ActionToCallInFinallyOfExecuteIndexing;
 
             internal bool ShouldRenewTransaction;
+
+            internal IDisposable HoldRunningQueriesReadLock() => _index.CurrentlyInUse();
 
             internal Action BeforeClosingDocumentsReadTransactionForHandleReferences;
 

--- a/test/SlowTests/Issues/RavenDB_27226.cs
+++ b/test/SlowTests/Issues/RavenDB_27226.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27226 : RavenTestBase
+    {
+        public RavenDB_27226(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task DisposingIndex_WaitsForTheRunningQueriesToEnd_AndThenReleasesItsStorageEnvironment()
+        {
+            // the index must live on disk - the whole point is that its memory mapped files keep the
+            // index directory undeletable on Windows if the storage environment is not disposed
+            using (var store = GetDocumentStore(new Options { RunInMemory = false, Path = NewDataPath() }))
+            {
+                const string indexName = "Users/ByName";
+
+                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Maps = { "from user in docs.Users select new { user.Name }" },
+                    Type = IndexType.Map,
+                    Name = indexName
+                }));
+
+                Indexes.WaitForIndexing(store);
+
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                var index = database.IndexStore.GetIndex(indexName);
+
+                var indexPath = index._environment.Options.BasePath.FullPath;
+                Assert.True(Directory.Exists(indexPath), $"Expected the index directory '{indexPath}' to exist");
+
+                Task delete;
+
+                using (index.ForTestingPurposesOnly().HoldRunningQueriesReadLock())
+                {
+                    delete = Task.Run(() => database.IndexStore.DeleteIndexInternal(index));
+
+                    // longer than the 10 seconds DrainRunningQueries is willing to wait, so giving up on the
+                    // drain and disposing the index anyway would be caught here. a query is still reading from
+                    // the index, disposing it now would pull its readers and environment from underneath it
+                    Assert.False(delete.Wait(TimeSpan.FromSeconds(15)),
+                        $"Index '{index.Name}' was disposed while a query was still running on it");
+
+                    Assert.False(index._environment.Disposed,
+                        $"The storage environment of '{index.Name}' was disposed while a query was still running on it");
+                }
+
+                // the query is done, nothing is reading from the index anymore, so the dispose can complete
+                await delete.WaitAsync(TimeSpan.FromSeconds(30));
+
+                // without this the environment stays alive with its temp buffers mapped, the index is no longer
+                // reachable through IndexStore so nothing can ever dispose it, and on Windows neither the file nor
+                // the index directory can be deleted for the lifetime of the process
+                Assert.True(index._environment.Disposed,
+                    $"The storage environment of '{index.Name}' was not disposed, so its memory mapped files are leaked for the lifetime of the process");
+
+                Assert.False(Directory.Exists(indexPath), $"Expected the index directory '{indexPath}' to be deleted");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27226/Voron-temp-file-handle-leaked-when-an-in-flight-side-by-side-index-replacement-is-aborted-index-directory-becomes-undeletable

### Additional description

`DrainRunningQueries` gives up after 10 seconds and throws `TimeoutException`, and since that call sits inside the `DisposeOnce<SingleAttempt>` action, `DisposeIndex()` never runs and the storage environment is never disposed. `DisposeOnce<SingleAttempt>` caches the failure and `IndexStore.DeleteIndexInternal` has already removed the index from `_indexes`, so nothing can ever dispose it again — its memory mapped files stay open, and that makes the index directory undeletable for the lifetime of the process. The customer hit this on a side-by-side replacement index that was being queried while it was torn down.

The fix is that dispose no longer gives up on the drain. `DrainRunningQueries` takes a `waitForRunningQueriesToEnd` flag that swaps the 10 second cap for `Timeout.InfiniteTimeSpan`; only `Dispose` passes it, every other caller is unchanged.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
