### PR TITLE
RavenDB-27220 Reuse scratch pages freed by rolled back transactions

### DIFF
--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -199,16 +199,30 @@ namespace Voron.Impl.Scratch
                 _freePagesBySize[value.Size] = list;
             }
 
-            list.AddFirst(new PendingPage
+            var pending = new PendingPage
             {
                 Page = value.PositionInScratchBuffer,
                 ValidAfterTransactionId = asOfTxId,
                 AllocatedInTransaction = value.AllocatedInTransaction,
-            });
+            };
 
-            _txIdAfterWhichLatestFreePagesBecomeAvailable = asOfTxId;
+            // TryGettingFromAllocatedBuffer inspects the tail only, which is correct as long as the tail holds the
+            // lowest ValidAfterTransactionId in the list. Frees carrying a transaction id arrive in increasing order,
+            // so adding them at the head keeps the list descending. A page freed with -1 was never visible to any
+            // transaction (a rollback, or a page the current write tx allocated and dropped), so it belongs at the
+            // tail: it is usable right away, and putting it anywhere else would hide it behind a page that is still
+            // gated on an old read transaction.
+            if (asOfTxId == -1)
+                list.AddLast(pending);
+            else
+                list.AddFirst(pending);
 
-            return NumberOfAllocations == 0; 
+            // Only pages freed with a transaction id hold readers back, and a later free cannot make an earlier one
+            // available sooner, so this watermark only ever moves forward.
+            if (asOfTxId > _txIdAfterWhichLatestFreePagesBecomeAvailable)
+                _txIdAfterWhichLatestFreePagesBecomeAvailable = asOfTxId;
+
+            return NumberOfAllocations == 0;
         }
 
         public ref Pager.State GetStateRef() => ref _scratchPagerState;

--- a/test/FastTests/Voron/ScratchBuffer/ScratchSpaceReuseAfterRollback.cs
+++ b/test/FastTests/Voron/ScratchBuffer/ScratchSpaceReuseAfterRollback.cs
@@ -1,0 +1,77 @@
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace FastTests.Voron.ScratchBuffer
+{
+    public class ScratchSpaceReuseAfterRollback : StorageTest
+    {
+        public ScratchSpaceReuseAfterRollback(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.ManualFlushing = true;
+            base.Configure(options);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void Pages_freed_by_rolled_back_transactions_are_reused_and_scratch_space_stays_constant()
+        {
+            var overflowValue = new string('a', 20000); // stored as an overflow, allocated as a 4 pages block in the scratch space
+
+            using (var txw = Env.WriteTransaction())
+            {
+                txw.CreateTree("foo").Add("blocked", overflowValue);
+                txw.Commit();
+            }
+
+            using (var txw = Env.WriteTransaction())
+            {
+                // supersedes the pages written by the first transaction
+                txw.CreateTree("foo").Add("blocked", new string('b', 20000));
+                txw.Commit();
+            }
+
+            using (Env.ReadTransaction())
+            {
+                // frees the superseded pages - but with 'valid after the flush txid' markers, so as long as
+                // the read transaction above stays open, those free pages are not allowed to be reused
+                Env.FlushLogToDataFile();
+
+                var scratchFile = Env.ScratchBufferPool._current.File;
+
+                // warm-up: the first rolled back transaction allocates the working set once
+                RollbackTransactionAddingTempValue(overflowValue);
+
+                var before = scratchFile.LastUsedPage;
+
+                const int rolledBackTransactions = 50;
+
+                for (var i = 0; i < rolledBackTransactions + 1; i++)
+                {
+                    // no reader could ever see the pages of a rolled back transaction,
+                    // so every next transaction is expected to reuse them immediately
+                    RollbackTransactionAddingTempValue(overflowValue);
+                }
+
+                var after = scratchFile.LastUsedPage;
+
+                Assert.True(after == before,
+                    $"the scratch space grew from {before} to {after} pages ({(after - before) / rolledBackTransactions} pages per transaction) " +
+                    $"over {rolledBackTransactions} rolled back transactions, although each of them freed everything it allocated. ");
+            }
+        }
+
+        private void RollbackTransactionAddingTempValue(string value)
+        {
+            using (var txw = Env.WriteTransaction())
+            {
+                txw.CreateTree("foo").Add("temp", value);
+
+                // no Commit() - the pages this transaction allocated were never visible to anyone
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27220

### Additional description

v7.2 kept those pages in a separate `_freePagesBySizeAvailableImmediately` dictionary
that the lookup consulted first. It was dropped in 362d672c766 (RavenDB-22457) as "only
useful for rollback, and they are rare enough that we shouldn't worry about them", while
the `-1` marker and `ScratchBufferPool.FreeImmediately` stayed - so the marker survived
with nothing honouring it. Rarity does not bound the cost: the pages are unreclaimable
for as long as the reader is open, so the growth accumulates.

Fix, both halves restoring an invariant rather than adding a mechanism:

1. Pages freed with `-1` are added at the tail, so "the tail holds the lowest
   `ValidAfterTransactionId`" - the precondition the existing single probe already
   assumes - is true again. `-1` is below every real transaction id, so ungated pages are
   consumed first and the tail afterwards is the oldest real id, as before. Allocation
   stays O(1); deliberately not a scan of the list, which would put an O(n) walk on every
   page allocation.
2. `_txIdAfterWhichLatestFreePagesBecomeAvailable` only ever moves forward, as in v7.2. A
   `-1` free used to assign it unconditionally and reset it to `-1` (verified: 3 -> -1),
   which disarms the reader-protection term of `HasActivelyUsedBytes` and can report a
   file as unused while an old read transaction still maps freed-but-gated pages in it -
   whose consumers are destructive (`Reset()` -> `DiscardWholeFile`, dispose). I could not
   construct a state where this flipped the check's outcome, because the allocated-pages
   term still held, so this half is a latent defect rather than an observed failure; it is
   worth a second look during review.

### Type of change

- [x] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

Two statements in `ScratchBufferFile.Free`, but on the scratch page allocation path that
every write transaction goes through.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

In-memory scratch bookkeeping only - no on-disk format, API or wire change.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

`FastTests.Voron.ScratchBuffer.ScratchSpaceReuseAfterRollback` - the reporter's repro; it
fails on v8.0 (19 -> 274 pages) and passes with this change, with `LastUsedPage` constant
across 51 rolled back transactions. Full FastTests: 4991 passed, 0 failed, 23 skipped.
`Category=Voron`: 392 passed, 0 failed.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

Worth watching scratch file sizes under a workload that mixes long-running read
transactions with failed/rolled back write transactions - that is the shape that grew
without bound.

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Scratch buffer reuse: pages freed by rollbacks are now handed out again instead of
extending the file. Scratch files consequently stay smaller under the pattern above,
which also means fewer scratch growth/recycle events. `HasActivelyUsedBytes` now keeps
reporting a file as in use after a rollback when a gated reader exists, which is the
v7.2 behavior.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed