### PR TITLE
RavenDB-27258 Fix writer exclusion in ThreadHoppingReaderWriterLock and document its real contract

### DIFF
--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -96,7 +96,9 @@ namespace Voron
         internal readonly SemaphoreSlim _transactionWriter = new SemaphoreSlim(1, 1);
         internal NativeMemory.ThreadStats _currentWriteTransactionHolder;
         private readonly AsyncManualResetEvent _writeTransactionRunning = new AsyncManualResetEvent();
+#pragma warning disable CS0618 // the journal flush is the one remaining user of this lock
         internal readonly ThreadHoppingReaderWriterLock FlushInProgressLock = new ThreadHoppingReaderWriterLock();
+#pragma warning restore CS0618
         private readonly ReaderWriterLockSlim _txCreation = new ReaderWriterLockSlim();
         private readonly CountdownEvent _envDispose = new CountdownEvent(1);
 

--- a/src/Voron/Util/ThreadHoppingReaderWriterLock.cs
+++ b/src/Voron/Util/ThreadHoppingReaderWriterLock.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
@@ -6,14 +6,40 @@ namespace Voron.Util
 {
 
     /// <summary>
-    /// Assumptions:
-    /// * Only single writer 
-    /// * Write operations can be very long ( involves I/O )
-    /// * Many readers
-    /// * Writer waiting should stop additional readers from entering
-    /// * Entering & exiting the read lock can happen in different threads (no thread affinity)
-    /// * Write lock is always on the same thread
+    /// Do not use this type in new code. The name says reader/writer lock, and the behaviour is
+    /// not one. It is kept because the journal flush depends on the behaviour described below.
+    /// The transaction lock rework in 8.0 replaces it, and it is removed there.
+    ///
+    /// A gate that blocks new readers while a writer is active. This is not a mutual-exclusion
+    /// reader/writer lock: EnterWriteLock returns without waiting for readers that are already in.
+    ///
+    /// The read side and the write side have different thread rules. Only the read side can
+    /// move between threads:
+    /// * Read side: the lock counts the readers. It does not record which threads they are.
+    ///   A read lock can be entered on one thread and exited on a different thread, for
+    ///   example before and after an await.
+    /// * Write side: the writer stays on one thread. The lock records the thread id of the
+    ///   writer, IsWriteLockHeld is true only on that thread, and ExitWriteLock must run on
+    ///   the thread that called EnterWriteLock, or it throws. Caution: an await between the
+    ///   two calls can move the code to a different thread. A writer that must move between
+    ///   threads needs a different ownership token than a thread id.
+    ///
+    /// Rules for callers:
+    /// * Only one writer can be active at a time. EnterWriteLock waits for the active writer
+    ///   to exit, and throws a TimeoutException when the timeout expires.
+    /// * A thread must not call EnterWriteLock while it holds the write lock. The call throws.
+    ///   This check reads the thread id, so it can only see a caller that stayed on the
+    ///   entering thread. The timeout is what bounds every other case.
+    /// * There is no drain. EnterWriteLock does not wait for the readers that are already
+    ///   inside, and it does not stop them. It blocks new readers and returns immediately,
+    ///   while the earlier readers keep running. Code that runs under the write lock runs
+    ///   at the same time as those readers and must be safe to do so.
+    /// * Each successful TryEnterReadLock must be paired with exactly one ExitReadLock.
+    ///   The number of concurrent readers must stay below 2^23.
+    /// * Where writer/reader mutual exclusion is necessary, callers must supply it with a
+    ///   different mechanism.
     /// </summary>
+    [Obsolete("Do not use in new code. The journal flush depends on this type, it is replaced by the transaction lock rework in 8.0.")]
     public sealed class ThreadHoppingReaderWriterLock
     {
         private const uint ReaderMask = 0x00FFFFFF;

--- a/test/FastTests/Voron/ReaderWriterLockTests.cs
+++ b/test/FastTests/Voron/ReaderWriterLockTests.cs
@@ -9,6 +9,7 @@ using Tests.Infrastructure;
 
 namespace FastTests.Voron
 {
+#pragma warning disable CS0618 // this test covers the obsolete lock while the journal flush still uses it
     public class ReaderWriterLockTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
         [RavenFact(RavenTestCategory.Core)]
@@ -69,4 +70,5 @@ namespace FastTests.Voron
             Assert.True(resultReader1.ElapsedInMs < 1000, $"elapsed: {resultReader1.ElapsedInMs}");
         }
     }
+#pragma warning restore CS0618
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27258

### Related pull request

The class is removed on `v8.0` in https://github.com/ravendb/ravendb/pull/23327

### Additional description

`EnterWriteLock` waited for the other writer only while the reader count was zero. If a reader was inside, a second writer left the loop without winning the CAS. Both threads then believed they held the write lock. The second one threw when it exited, and the writer marker it added on entry stayed in the counter. That marker blocks every reader on that storage environment until the process restarts.

This pull request makes the following changes:

* `EnterWriteLock` takes the lock with a CAS on the owner thread, and waits for the other writer whether or not there are readers. The wait has a limit, 30 seconds by default, and `Timeout.InfiniteTimeSpan` removes it. When the limit expires the call throws a `TimeoutException` that names the thread which holds the lock. A thread that takes the lock while it already holds it throws immediately.
* `ExitReadLock` no longer signals the writer, because writers do not wait for readers.
* `TryEnterReadLock(TimeSpan)` clamps the value instead of overflowing the cast to milliseconds.
* The class header now states the contract that the code follows, and the type is marked `[Obsolete]` because 8.0 removes it. See pull request #23327.

Readers are still not drained, and that is deliberate. RavenDB-6660 built the flush piggyback on writer and reader coexistence. The flusher takes the write lock while a write transaction still holds the read lock, and hands that transaction the journal state update to run at its own commit. A drain would hold every flush behind the longest write transaction, which is the delay RavenDB-6660 removed. The dead drain loop from 2016 and its comment are deleted. The behaviour that remains is documented instead of changed.

There are no caller changes, and `EnterWriteLock` keeps its name. The code does what the flush needs, and the class is being retired, so a rename buys churn and nothing else. On a branch where the type is on its way out, the useful work is to stop new callers from appearing. That is the job of the header notice and the `[Obsolete]` attribute.

The tests are in `test/FastTests/Voron/ReaderWriterLockTests.cs`. `SecondWriterWaitsForFirst` checks that the second writer waits while the first one holds the lock, and continues after it exits. `WriterTimesOutWhenAnotherThreadHoldsTheWriteLock` checks that the wait has a limit, and that the attempt which times out leaves the lock usable. `TakingWriteLockTwiceOnSameThreadThrows` covers the same thread case. `WriterDoesNotWaitForActiveReaders` holds the gate behaviour that the flush piggyback depends on. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed

