### PR TITLE
RavenDB-27259 GenAI connection string test button doesn't work

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
@@ -235,6 +235,10 @@ export type Connection =
     | AzureServiceBusConnection
     | AiConnection;
 
+export type ConnectionsByType = {
+    [K in StudioConnectionType]: Extract<Connection, { type: K }>[];
+};
+
 export type ConnectionStringDto = Partial<
     | ElasticSearchConnectionStringDto
     | OlapConnectionStringDto

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
@@ -1,5 +1,4 @@
 import {
-    Connection,
     ConnectionStringUsage,
     ElasticSearchAuthenticationMethod,
     ElasticSearchConnection,
@@ -13,7 +12,7 @@ import {
     AmazonSqsConnection,
     AzureServiceBusConnection,
     AiConnection,
-    StudioConnectionType,
+    ConnectionsByType,
     WithExcludedDatabases,
     ServerWideConnectionStringDto,
 } from "../connectionStringsTypes";
@@ -465,9 +464,7 @@ export function mapAiConnectionsFromDto(connections: Record<string, AiConnection
     return Object.values(connections).map((d) => mapAiFromSingleDto(d, mapUsedByFromDto(d)));
 }
 
-export function mapAllConnectionsFromDto(connectionStringsDto: GetConnectionStringsResult): {
-    [key in StudioConnectionType]: Connection[];
-} {
+export function mapAllConnectionsFromDto(connectionStringsDto: GetConnectionStringsResult): ConnectionsByType {
     return {
         Raven: mapRavenConnectionsFromDto(connectionStringsDto.RavenConnectionStrings),
         Sql: mapSqlConnectionsFromDto(connectionStringsDto.SqlConnectionStrings),
@@ -483,10 +480,8 @@ export function mapAllConnectionsFromDto(connectionStringsDto: GetConnectionStri
     };
 }
 
-export function mapServerWideConnectionsFromDto(results: ServerWideConnectionStringDto[]): {
-    [key in StudioConnectionType]: Connection[];
-} {
-    const mapped: Record<StudioConnectionType, Connection[]> = {
+export function mapServerWideConnectionsFromDto(results: ServerWideConnectionStringDto[]): ConnectionsByType {
+    const mapped: ConnectionsByType = {
         Raven: [],
         Sql: [],
         Snowflake: [],

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
@@ -17,8 +17,13 @@ import {
 } from "../connectionStringsTypes";
 import assertUnreachable from "components/utils/assertUnreachable";
 import ApiKeyAuthentication = Raven.Client.Documents.Operations.ETL.ElasticSearch.ApiKeyAuthentication;
+import AiConnectionStringDto = Raven.Client.Documents.Operations.AI.AiConnectionString;
+import RavenConnectionStringDto = Raven.Client.Documents.Operations.ETL.RavenConnectionString;
+import SqlConnectionStringDto = Raven.Client.Documents.Operations.ETL.SQL.SqlConnectionString;
+import SnowflakeConnectionStringDto = Raven.Client.Documents.Operations.ETL.Snowflake.SnowflakeConnectionString;
+import OlapConnectionStringDto = Raven.Client.Documents.Operations.ETL.OLAP.OlapConnectionString;
 
-export function mapRavenConnectionStringToDto(connection: RavenConnection): ConnectionStringDto {
+export function mapRavenConnectionStringToDto(connection: RavenConnection): RavenConnectionStringDto {
     return {
         Type: "Raven",
         Name: connection.name,
@@ -27,7 +32,7 @@ export function mapRavenConnectionStringToDto(connection: RavenConnection): Conn
     };
 }
 
-export function mapSqlConnectionStringToDto(connection: SqlConnection): ConnectionStringDto {
+export function mapSqlConnectionStringToDto(connection: SqlConnection): SqlConnectionStringDto {
     return {
         Type: "Sql",
         Name: connection.name,
@@ -36,7 +41,7 @@ export function mapSqlConnectionStringToDto(connection: SqlConnection): Connecti
     };
 }
 
-export function mapSnowflakeConnectionStringToDto(connection: SnowflakeConnection): ConnectionStringDto {
+export function mapSnowflakeConnectionStringToDto(connection: SnowflakeConnection): SnowflakeConnectionStringDto {
     return {
         Type: "Snowflake",
         Name: connection.name,
@@ -44,7 +49,7 @@ export function mapSnowflakeConnectionStringToDto(connection: SnowflakeConnectio
     };
 }
 
-export function mapOlapConnectionStringToDto(connection: OlapConnection): ConnectionStringDto {
+export function mapOlapConnectionStringToDto(connection: OlapConnection): OlapConnectionStringDto {
     return {
         Type: "Olap",
         Name: connection.name,
@@ -254,7 +259,7 @@ export function mapAzureServiceBusConnectionStringToDto(connection: AzureService
     };
 }
 
-export function mapAiConnectionStringToDto(connection: AiConnection): ConnectionStringDto {
+export function mapAiConnectionStringToDto(connection: AiConnection): AiConnectionStringDto {
     return {
         Type: "Ai",
         Name: connection.name,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
@@ -1,7 +1,7 @@
 import { PayloadAction, createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { services } from "components/hooks/useServices";
 import { loadStatus } from "components/models/common";
-import { Connection, StudioConnectionType } from "../connectionStringsTypes";
+import { Connection, ConnectionsByType, StudioConnectionType } from "../connectionStringsTypes";
 import { RootState } from "components/store";
 import { ConnectionStringsUrlParameters } from "../ConnectionStrings";
 import {
@@ -20,7 +20,7 @@ export type ConnectionStringsViewContext =
 
 interface ConnectionStringsState {
     loadStatus: loadStatus;
-    connections: { [key in StudioConnectionType]: Connection[] };
+    connections: ConnectionsByType;
     urlParameters: ConnectionStringsUrlParameters;
     initialEditConnection: Connection;
     viewContext: ConnectionStringsViewContext;
@@ -49,6 +49,12 @@ const initialState: ConnectionStringsState = {
     viewContext: "connectionStrings",
 };
 
+// A write keyed by a `Connection`'s own discriminant cannot be correlated with the matching
+// `ConnectionsByType` slot, so writes go through a widened view. Reads stay narrow.
+function widenByType(connections: ConnectionsByType): Record<StudioConnectionType, Connection[]> {
+    return connections;
+}
+
 export const connectionStringsSlice = createSlice({
     name: "connectionStrings",
     initialState,
@@ -73,17 +79,18 @@ export const connectionStringsSlice = createSlice({
                 ...connection,
                 usedBy: connection.usedBy ?? [],
             };
-            state.connections[connection.type].push(newConnection);
+            widenByType(state.connections)[connection.type].push(newConnection);
         },
         connectionEdited: (state, { payload }: PayloadAction<{ oldName: string; newConnection: Connection }>) => {
+            const connections = widenByType(state.connections);
             const type = payload.newConnection.type;
 
-            state.connections[type] = state.connections[type].map((x) =>
-                x.name === payload.oldName ? payload.newConnection : x
-            );
+            connections[type] = connections[type].map((x) => (x.name === payload.oldName ? payload.newConnection : x));
         },
         connectionDeleted: (state, { payload }: PayloadAction<Connection>) => {
-            state.connections[payload.type] = state.connections[payload.type].filter((x) => x.name !== payload.name);
+            const connections = widenByType(state.connections);
+
+            connections[payload.type] = connections[payload.type].filter((x) => x.name !== payload.name);
         },
         viewContextSet: (state, { payload: viewContext }: PayloadAction<ConnectionStringsViewContext>) => {
             state.viewContext = viewContext;
@@ -189,7 +196,10 @@ export const connectionStringsActions = {
 export const connectionStringSelectors = {
     loadStatus: (store: RootState) => store.connectionStrings.loadStatus,
     connections: (store: RootState) => store.connectionStrings.connections,
-    connectionsByType: (type: StudioConnectionType) => (store: RootState) => store.connectionStrings.connections[type],
+    connectionsByType:
+        <T extends StudioConnectionType>(type: T) =>
+        (store: RootState): ConnectionsByType[T] =>
+            store.connectionStrings.connections[type],
     initialEditConnection: (store: RootState) => store.connectionStrings.initialEditConnection,
     isEmpty: (store: RootState) => _.isEqual(store.connectionStrings.connections, initialState.connections),
     viewContext: (store: RootState) => store.connectionStrings.viewContext,

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskTestPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editCdcSinkTask/sections/tables/tableEditor/EditCdcSinkTaskTestPanel.tsx
@@ -25,10 +25,9 @@ import * as yup from "yup";
 import ExpandableListContainer from "components/common/ExpandableListContainer";
 import FormStringValueList from "components/common/formFields/FormStringValueList";
 import { connectionStringSelectors } from "components/pages/database/settings/connectionStrings/store/connectionStringsSlice";
-import { mapConnectionStringToDto } from "components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto";
+import { mapSqlConnectionStringToDto } from "components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto";
 
 type TestCdcSinkRowSelector = Raven.Client.Documents.Operations.CdcSink.Test.TestCdcSinkRowSelector;
-type SqlConnectionString = Raven.Client.Documents.Operations.ETL.SQL.SqlConnectionString;
 
 interface EditCdcSinkTaskTestPanelProps {
     editForm: UseFormReturn<EditCdcSinkTaskFormData>;
@@ -50,10 +49,8 @@ export default function EditCdcSinkTaskTestPanel({ editForm, path }: EditCdcSink
         config.Name ||= "Test-CDC";
 
         const connection = sqlConnections.find((x) => x.name === formValues.connectionStringName);
-        const connectionDto = mapConnectionStringToDto(connection) as SqlConnectionString;
-
         return await tasksService.testCdcSink(databaseName, {
-            Connection: connectionDto,
+            Connection: mapSqlConnectionStringToDto(connection),
             Configuration: config,
             Operation: formData.isSimulateOnDelete ? "Delete" : "Upsert",
             MaxRows: formData.rowSelector === "First" ? formData.maxRows : 1,

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/steps/EditGenAiTaskStepBasic.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/steps/EditGenAiTaskStepBasic.tsx
@@ -14,6 +14,10 @@ import EditGenAiTaskCancelButton from "../EditGenAiTaskCancelButton";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import { aiConnectionStringUtils } from "components/pages/database/settings/connectionStrings/editForms/aiConnectionStringUtils";
+import { connectionStringSelectors } from "components/pages/database/settings/connectionStrings/store/connectionStringsSlice";
+import { mapConnectionStringToDto } from "components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto";
+
+type AiConnectionString = Raven.Client.Documents.Operations.AI.AiConnectionString;
 
 export function EditGenAiTaskStepBasic() {
     const hasGenAi = useAppSelector(licenseSelectors.statusValue("HasGenAi"));
@@ -54,11 +58,13 @@ export function EditGenAiTaskStepBasicFooter() {
     const formValues = useWatch({ control });
 
     const connectionStringTest = useAppSelector(editGenAiTaskSelectors.connectionStringTest);
-    const aiConnectionStrings = useAppSelector(editGenAiTaskSelectors.aiConnectionStrings);
+    const aiConnections = useAppSelector(connectionStringSelectors.connectionsByType("Ai"));
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
 
-    const handleTest = async () => {
-        const connectionString = aiConnectionStrings[formValues.connectionStringName];
+    const selectedConnection = aiConnections.find((x) => x.name === formValues.connectionStringName);
+
+    const handleTest = () => {
+        const connectionString = mapConnectionStringToDto(selectedConnection) as AiConnectionString;
 
         dispatch(
             editGenAiTaskActions.testConnectionString({
@@ -93,12 +99,19 @@ export function EditGenAiTaskStepBasicFooter() {
 
             {hasGenAi && (
                 <div className="hstack gap-2">
-                    <PopoverWithHoverWrapper message="Test the connection to the specified connection string.">
+                    <PopoverWithHoverWrapper
+                        message={
+                            selectedConnection
+                                ? "Test the connection to the specified connection string."
+                                : "Select a connection string to test."
+                        }
+                    >
                         <ButtonWithSpinner
                             variant="info"
                             className="rounded-pill"
                             onClick={handleTest}
                             isSpinning={connectionStringTest.status === "loading"}
+                            disabled={!selectedConnection}
                             icon="test"
                         >
                             Test connection

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/steps/EditGenAiTaskStepBasic.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/steps/EditGenAiTaskStepBasic.tsx
@@ -15,9 +15,7 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import { aiConnectionStringUtils } from "components/pages/database/settings/connectionStrings/editForms/aiConnectionStringUtils";
 import { connectionStringSelectors } from "components/pages/database/settings/connectionStrings/store/connectionStringsSlice";
-import { mapConnectionStringToDto } from "components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto";
-
-type AiConnectionString = Raven.Client.Documents.Operations.AI.AiConnectionString;
+import { mapAiConnectionStringToDto } from "components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto";
 
 export function EditGenAiTaskStepBasic() {
     const hasGenAi = useAppSelector(licenseSelectors.statusValue("HasGenAi"));
@@ -64,7 +62,7 @@ export function EditGenAiTaskStepBasicFooter() {
     const selectedConnection = aiConnections.find((x) => x.name === formValues.connectionStringName);
 
     const handleTest = () => {
-        const connectionString = mapConnectionStringToDto(selectedConnection) as AiConnectionString;
+        const connectionString = mapAiConnectionStringToDto(selectedConnection);
 
         dispatch(
             editGenAiTaskActions.testConnectionString({

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/store/editGenAiTaskSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/store/editGenAiTaskSlice.ts
@@ -30,7 +30,6 @@ interface EditGenAiTaskState {
     globalTestResult: Raven.Server.Documents.ETL.Providers.AI.GenAi.Test.GenAiTestScriptResult;
     isPlaygroundCollapsed: boolean;
     isPlaygroundEditMode: boolean;
-    aiConnectionStrings: Record<string, Raven.Client.Documents.Operations.AI.AiConnectionString>;
     isTestOpen: boolean;
     isDocumentInfoVisible: boolean;
     isContextInfoVisible: boolean;
@@ -53,7 +52,6 @@ const initialState: EditGenAiTaskState = {
     globalTestResult: null,
     isPlaygroundCollapsed: false,
     isPlaygroundEditMode: false,
-    aiConnectionStrings: {},
     isTestOpen: false,
     isDocumentInfoVisible: true,
     isContextInfoVisible: true,
@@ -90,12 +88,6 @@ export const editGenAiTaskSlice = createSlice({
         },
         isPlaygroundEditModeSet: (state, action: PayloadAction<boolean>) => {
             state.isPlaygroundEditMode = action.payload;
-        },
-        aiConnectionStringsSet: (
-            state,
-            action: PayloadAction<Record<string, Raven.Client.Documents.Operations.AI.AiConnectionString>>
-        ) => {
-            state.aiConnectionStrings = action.payload;
         },
         isTestOpenSet: (state, action: PayloadAction<boolean>) => {
             state.isTestOpen = action.payload;
@@ -296,7 +288,6 @@ export const editGenAiTaskSelectors = {
     isPlaygroundCollapsed: (state: RootState) => state.editGenAiTask.isPlaygroundCollapsed,
     isPlaygroundEditMode: (state: RootState) => state.editGenAiTask.isPlaygroundEditMode,
     globalTestResult: (state: RootState) => state.editGenAiTask.globalTestResult,
-    aiConnectionStrings: (state: RootState) => state.editGenAiTask.aiConnectionStrings,
     isDocumentInfoVisible: (state: RootState) => state.editGenAiTask.isDocumentInfoVisible,
     isContextInfoVisible: (state: RootState) => state.editGenAiTask.isContextInfoVisible,
     isModelInputInfoVisible: (state: RootState) => state.editGenAiTask.isModelInputInfoVisible,

--- a/src/Raven.Studio/typings/_studio/connectionStringUsage.d.ts
+++ b/src/Raven.Studio/typings/_studio/connectionStringUsage.d.ts
@@ -34,7 +34,8 @@ declare module Raven.Client.Documents.Operations.ConnectionStrings {
     }
 
     // Merged (declaration merging) with the generated ConnectionString interface.
+    // Optional: the server sends it on reads, the Studio never sends it back on writes.
     interface ConnectionString {
-        UsedBy: Array<ConnectionStringUsage>;
+        UsedBy?: Array<ConnectionStringUsage>;
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27259

### Additional description

#### Problem

"Test connection" in the GenAI task editor threw `TypeError: Cannot read properties of undefined (reading 'AzureOpenAiSettings')`. `editGenAiTaskSlice` had its own `aiConnectionStrings` record that nothing ever populated, so the lookup by name always returned `undefined`.

#### Fix

Read the connection from `connectionStringsSlice` instead - the store that already backs the dropdown. Disabled the button while no connection string is selected. Removed the dead state, reducer and selector.

This was the only affected place. Other AI test buttons build settings from live form values, and the Knockout embeddings page uses its own loaded list with a guard.

#### Type cleanup

Tightened the types that made this possible:

- `ConnectionsByType` keeps per-type narrowing in the store, so `connectionsByType("Ai")` now returns `AiConnection[]`.
- `mapAiConnectionStringToDto` plus the Raven / Sql / Snowflake / Olap mappers return their exact DTO types.
- `ConnectionString.UsedBy` is optional - it is sent on reads only.

Removes both `as` casts on this path, including the one in `EditCdcSinkTaskTestPanel`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed