### PR TITLE
RavenDB-27081 Registered missing SNMP OIDs

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/5.1.11/TotalNumberOfActiveOngoingTasks.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/5.1.11/TotalNumberOfActiveOngoingTasks.cs
@@ -18,6 +18,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
             count += GetNumberOfActiveOlapEtls(rachisState, nodeTag, database);
             count += GetNumberOfActivePeriodicBackups(rachisState, nodeTag, database);
             count += GetNumberOfActiveQueueEtls(rachisState, nodeTag, database);
+            count += GetNumberOfActiveQueueSinks(rachisState, nodeTag, database);
             count += GetNumberOfActiveRavenEtls(rachisState, nodeTag, database);
             count += GetNumberOfActiveSinkPullReplications(rachisState, nodeTag, database);
             count += GetNumberOfActiveSqlEtls(rachisState, nodeTag, database);

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/5.1.11/TotalNumberOfActiveSnowflakeEtlTasks.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/5.1.11/TotalNumberOfActiveSnowflakeEtlTasks.cs
@@ -4,9 +4,9 @@ using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Monitoring.Snmp.Objects.Database;
 
-public class TotalNumberOfActiveSnowflakeTasks : ActiveOngoingTasksBase
+public class TotalNumberOfActiveSnowflakeEtlTasks : ActiveOngoingTasksBase
 {
-    public TotalNumberOfActiveSnowflakeTasks(ServerStore serverStore) : base(serverStore, SnmpOids.Databases.General.TotalNumberOfActiveSnowflakeEtlTasks)
+    public TotalNumberOfActiveSnowflakeEtlTasks(ServerStore serverStore) : base(serverStore, SnmpOids.Databases.General.TotalNumberOfActiveSnowflakeEtlTasks)
     {
     }
 

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -437,24 +437,34 @@ namespace Raven.Server.Monitoring.Snmp
             store.Add(new TotalNumberOfIndexingErrors(server.ServerStore));
 
             store.Add(new TotalNumberOfActiveBackupTasks(server.ServerStore));
+            store.Add(new TotalNumberOfActiveCdcSinkTasks(server.ServerStore));
             store.Add(new TotalNumberOfActiveElasticSearchEtlTasks(server.ServerStore));
+            store.Add(new TotalNumberOfActiveEmbeddingsGenerationTasks(server.ServerStore));
             store.Add(new TotalNumberOfActiveExternalReplicationTasks(server.ServerStore));
+            store.Add(new TotalNumberOfActiveGenAiTasks(server.ServerStore));
             store.Add(new TotalNumberOfActiveOlapEtlTasks(server.ServerStore));
             store.Add(new TotalNumberOfActiveOngoingTasks(server.ServerStore));
             store.Add(new TotalNumberOfActivePullReplicationAsSinkTasks(server.ServerStore));
             store.Add(new TotalNumberOfActiveQueueEtlTasks(server.ServerStore));
+            store.Add(new TotalNumberOfActiveQueueSinkTasks(server.ServerStore));
             store.Add(new TotalNumberOfActiveRavenEtlTasks(server.ServerStore));
+            store.Add(new TotalNumberOfActiveSnowflakeEtlTasks(server.ServerStore));
             store.Add(new TotalNumberOfActiveSqlEtlTasks(server.ServerStore));
             store.Add(new TotalNumberOfActiveSubscriptionTasks(server.ServerStore));
 
             store.Add(new TotalNumberOfBackupTasks(server.ServerStore));
+            store.Add(new TotalNumberOfCdcSinkTasks(server.ServerStore));
             store.Add(new TotalNumberOfElasticSearchEtlTasks(server.ServerStore));
+            store.Add(new TotalNumberOfEmbeddingsGenerationTasks(server.ServerStore));
             store.Add(new TotalNumberOfExternalReplicationTasks(server.ServerStore));
+            store.Add(new TotalNumberOfGenAiTasks(server.ServerStore));
             store.Add(new TotalNumberOfOlapEtlTasks(server.ServerStore));
             store.Add(new TotalNumberOfOngoingTasks(server.ServerStore));
             store.Add(new TotalNumberOfPullReplicationAsSinkTasks(server.ServerStore));
             store.Add(new TotalNumberOfQueueEtlTasks(server.ServerStore));
+            store.Add(new TotalNumberOfQueueSinkTasks(server.ServerStore));
             store.Add(new TotalNumberOfRavenEtlTasks(server.ServerStore));
+            store.Add(new TotalNumberOfSnowflakeEtlTasks(server.ServerStore));
             store.Add(new TotalNumberOfSqlEtlTasks(server.ServerStore));
             store.Add(new TotalNumberOfSubscriptionTasks(server.ServerStore));
 

--- a/test/SlowTests.Issues/Issues/RavenDB-27081.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27081.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Threading.Tasks;
 using FastTests;
@@ -32,8 +34,15 @@ public class RavenDB_27081 : RavenTestBase
         UseNewLocalServer(new Dictionary<string, string>
         {
             [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.Enabled)] = "true",
-            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.Port)] = ReservePort().Port.ToString()
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.Port)] = GetBindableSnmpPort().ToString()
         });
+    }
+
+    private static int GetBindableSnmpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Any, 0));
+        return ((IPEndPoint)probe.LocalEndPoint).Port;
     }
 
     [RavenFact(RavenTestCategory.Monitoring)]

--- a/test/SlowTests.Issues/Issues/RavenDB-27081.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27081.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using FastTests;
+using Lextm.SharpSnmpLib;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.Queue;
+using Raven.Client.Documents.Operations.QueueSink;
+using Raven.Server.Config;
+using Raven.Server.Monitoring.Snmp;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27081 : RavenTestBase
+{
+    public RavenDB_27081(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private static IEnumerable<(string Name, string Oid)> GeneralOids() =>
+        typeof(SnmpOids.Databases.General)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(x => x.FieldType == typeof(string))
+            .Select(x => (x.Name, (string)x.GetRawConstantValue()));
+
+    private void UseServerWithSnmp()
+    {
+        UseNewLocalServer(new Dictionary<string, string>
+        {
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.Enabled)] = "true",
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.Port)] = ReservePort().Port.ToString()
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Monitoring)]
+    public void EveryDeclaredGeneralOidIsRegistered()
+    {
+        UseServerWithSnmp();
+
+        var unregistered = GeneralOids()
+            .Where(x => Server.SnmpWatcher.GetData(SnmpOids.Root + x.Oid) == null)
+            .Select(x => $"{x.Name} ({SnmpOids.Root + x.Oid})")
+            .ToList();
+
+        Assert.True(unregistered.Count == 0,
+            $"These OIDs are declared in {nameof(SnmpOids)} but were never added to the SNMP object store, " +
+            $"so /monitoring/snmp returns 404 for them: {string.Join(", ", unregistered)}");
+    }
+
+    [RavenTheory(RavenTestCategory.Monitoring)]
+    [InlineData(SnmpOids.Databases.General.TotalNumberOfQueueSinkTasks)]
+    [InlineData(SnmpOids.Databases.General.TotalNumberOfActiveQueueSinkTasks)]
+    [InlineData(SnmpOids.Databases.General.TotalNumberOfSnowflakeEtlTasks)]
+    [InlineData(SnmpOids.Databases.General.TotalNumberOfActiveSnowflakeEtlTasks)]
+    [InlineData(SnmpOids.Databases.General.TotalNumberOfEmbeddingGenerationTasks)]
+    [InlineData(SnmpOids.Databases.General.TotalNumberOfActiveEmbeddingGenerationTasks)]
+    [InlineData(SnmpOids.Databases.General.TotalNumberOfGenAiTasks)]
+    [InlineData(SnmpOids.Databases.General.TotalNumberOfActiveGenAiTasks)]
+    [InlineData(SnmpOids.Databases.General.TotalNumberOfCdcSinkTasks)]
+    [InlineData(SnmpOids.Databases.General.TotalNumberOfActiveCdcSinkTasks)]
+    public void OngoingTaskCountOidsReportZeroInsteadOf404(string oid)
+    {
+        UseServerWithSnmp();
+
+        var data = Server.SnmpWatcher.GetData(SnmpOids.Root + oid);
+
+        Assert.NotNull(data);
+        Assert.Equal(0, Assert.IsType<Integer32>(data).ToInt32());
+    }
+
+    [RavenFact(RavenTestCategory.Monitoring | RavenTestCategory.Etl)]
+    public async Task QueueSinkTaskIsCountedByItsOwnOidAndByTheAggregate()
+    {
+        UseServerWithSnmp();
+
+        using (var store = GetDocumentStore())
+        {
+            var ongoingBefore = GetInt(SnmpOids.Databases.General.TotalNumberOfOngoingTasks);
+            var activeBefore = GetInt(SnmpOids.Databases.General.TotalNumberOfActiveOngoingTasks);
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<QueueConnectionString>(new QueueConnectionString
+            {
+                Name = "kafka-cs",
+                BrokerType = QueueBrokerType.Kafka,
+                KafkaConnectionSettings = new KafkaConnectionSettings { BootstrapServers = "localhost:9092" }
+            }));
+
+            await store.Maintenance.SendAsync(new AddQueueSinkOperation<QueueConnectionString>(new QueueSinkConfiguration
+            {
+                Name = "sink-1",
+                ConnectionStringName = "kafka-cs",
+                BrokerType = QueueBrokerType.Kafka,
+                Scripts =
+                [
+                    new QueueSinkScript { Name = "script-1", Queues = ["users"], Script = "put(this.Id, this)" }
+                ]
+            }));
+
+            Assert.Equal(1, WaitForValue(() => GetInt(SnmpOids.Databases.General.TotalNumberOfQueueSinkTasks), 1, interval: 500));
+            Assert.Equal(ongoingBefore + 1, WaitForValue(() => GetInt(SnmpOids.Databases.General.TotalNumberOfOngoingTasks), ongoingBefore + 1, interval: 500));
+
+            Assert.Equal(1, WaitForValue(() => GetInt(SnmpOids.Databases.General.TotalNumberOfActiveQueueSinkTasks), 1, interval: 500));
+            Assert.Equal(activeBefore + 1, WaitForValue(() => GetInt(SnmpOids.Databases.General.TotalNumberOfActiveOngoingTasks), activeBefore + 1, interval: 500));
+        }
+
+        int GetInt(string oid) => ((Integer32)Server.SnmpWatcher.GetData(SnmpOids.Root + oid)).ToInt32();
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27081/SNMP-OIDs-5.1.11.25-30-are-defined-but-never-registered

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
