### PR TITLE
RavenDB-26453 Remove deprecated unload event

### DIFF
--- a/src/Raven.Studio/typescript/common/changesContext.ts
+++ b/src/Raven.Studio/typescript/common/changesContext.ts
@@ -26,15 +26,6 @@ class changesContext {
     private globalDatabaseSubscriptions: changeSubscription[] = [];
 
     constructor() {
-        window.addEventListener("unload", () => {
-            this.disconnectFromDatabaseChangesApi("ChangingDatabase");
-            this.serverNotifications().dispose();
-
-            if (this.databaseNotifications()) {
-                this.databaseNotifications().dispose();
-            }
-        });
-
         this.databaseChangesApi.subscribe(newValue => {
             if (!newValue) {
                 this.hasChangesApiConnected = false;


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-26453/Remove-deprecated-unload-event

### Additional description

`unload` is [deprecated in Chrome](https://developer.chrome.com/docs/web-platform/deprecating-unload) and makes the page ineligible for bfcache. The handler is redundant, so it is removed rather than ported to `pagehide`.

Why it is safe to drop:

- `dispose()` only calls `webSocket.close()`. Nothing is sent to the server, and the
  browser closes the sockets itself when the document is destroyed.
- The rest of the handler nulls `ko` observables and publishes `EVENTS.Database.Disconnect`,
  which is consumed only by listeners in the document being torn down.
- It was already best-effort. `dispose()` defers the close behind
  `connectToWebSocketTask.done(...)`, so it never ran when the socket was still connecting,
  and the unguarded `serverNotifications().dispose()` threw when the server notification
  center had not connected yet.

Real teardown is unaffected: `changeDatabase` (database switch) and `disconnectIfCurrent`
(database deleted / disabled) still dispose as before, and per-view `changeSubscription`
cleanup still happens in `viewModelBase.detached()`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
