### PR TITLE
RavenDB-27166 Mark the environment as catastrophically failed when a rollback would restore freed scratch pages

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -78,6 +78,7 @@ namespace Voron.Impl
         private readonly WriteAheadJournal _journal;
         public ImmutableDictionary<long, PageFromScratchBuffer> ModifiedPagesInTransaction;
         private ImmutableDictionary<long, PageFromScratchBuffer> _scratchBuffersSnapshotToRollbackTo;
+        private bool _rollbackWouldRestoreFreedScratchPages;
         internal sealed class WriteTransactionPool
         {
 #if DEBUG
@@ -1320,17 +1321,6 @@ namespace Voron.Impl
             if (Committed || RolledBack || Flags != (TransactionFlags.ReadWrite))
                 return;
 
-            if (AppliedJournalStateAfterFlush)
-            {
-                // RavenDB-27166: this transaction applied a piggybacked journal flush-state update in CommitStage1,
-                // freeing the flushed scratch pages, and then failed to commit. The rollback below restores the
-                // tx-start scratch snapshot, which still maps those freed entries - state that cannot be trusted -
-                // so mark the environment as catastrophically failed to force an unload and a clean recovery
-                // instead of serving stale scratch mappings.
-                _env.Options.SetCatastrophicFailure(ExceptionDispatchInfo.Capture(
-                    new InvalidOperationException("Transaction rolled back after applying a piggybacked journal flush-state update; the in-memory scratch state cannot be safely restored (RavenDB-27166)")));
-            }
-
             OnRollBack?.Invoke(this);
 
             _freeSpaceHandling.OnRollback();
@@ -1350,6 +1340,15 @@ namespace Voron.Impl
             }
 
             RolledBack = true;
+
+            if (_rollbackWouldRestoreFreedScratchPages)
+            {
+                Debug.Assert(AppliedJournalStateAfterFlush, "Scratch pages of older transactions are freed only by the journal flush-state update");
+
+                // the restored scratch state cannot be trusted - force an environment unload and a clean recovery
+                _env.Options.SetCatastrophicFailure(ExceptionDispatchInfo.Capture(
+                    new InvalidOperationException("Rollback of a transaction that applied the journal flush-state update has restored mappings to already freed scratch pages. The in-memory scratch state cannot be trusted, the environment must be reloaded to recover a consistent state.")));
+            }
         }
 
         public void RetrieveCommitStats(out CommitStats stats)
@@ -1641,6 +1640,9 @@ namespace Voron.Impl
 
         public void ForgetAboutScratchPage(PageFromScratchBuffer value)
         {
+            if (_rollbackWouldRestoreFreedScratchPages == false) // once set, no need to keep checking
+                _rollbackWouldRestoreFreedScratchPages = RollbackWouldRestoreFreedScratchPage(value);
+
             if (_scratchPagesInUse.TryGetValue(value.PageNumberInDataFile, out var existing) == false)
             {
                 // page may have been freed, that is expected
@@ -1652,6 +1654,15 @@ namespace Voron.Impl
                 return; // transaction scratch page is different
 
             _scratchPagesInUse.Remove(value.PageNumberInDataFile);
+        }
+
+        private bool RollbackWouldRestoreFreedScratchPage(PageFromScratchBuffer value)
+        {
+            // checking if Rollback()'s snapshot restore would really bring back a mapping onto a freed scratch position (via _scratchBuffersSnapshotToRollbackTo)
+
+            return value.AllocatedInTransaction != Id && // the free is done on behalf of an older committed transaction - only a piggybacked journal flush-state update does that
+                _scratchBuffersSnapshotToRollbackTo.TryGetValue(value.PageNumberInDataFile, out var mappedScratchPageAtTxStart) &&
+                mappedScratchPageAtTxStart.AllocatedInTransaction == value.AllocatedInTransaction; // not a newer version that superseded it before this tx started
         }
 
         public void RecordSparseRangeCandidate(long sectionPageNumber)

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1320,6 +1320,17 @@ namespace Voron.Impl
             if (Committed || RolledBack || Flags != (TransactionFlags.ReadWrite))
                 return;
 
+            if (AppliedJournalStateAfterFlush)
+            {
+                // RavenDB-27166: this transaction applied a piggybacked journal flush-state update in CommitStage1,
+                // freeing the flushed scratch pages, and then failed to commit. The rollback below restores the
+                // tx-start scratch snapshot, which still maps those freed entries - state that cannot be trusted -
+                // so mark the environment as catastrophically failed to force an unload and a clean recovery
+                // instead of serving stale scratch mappings.
+                _env.Options.SetCatastrophicFailure(ExceptionDispatchInfo.Capture(
+                    new InvalidOperationException("Transaction rolled back after applying a piggybacked journal flush-state update; the in-memory scratch state cannot be safely restored (RavenDB-27166)")));
+            }
+
             OnRollBack?.Invoke(this);
 
             _freeSpaceHandling.OnRollback();

--- a/test/SlowTests/Voron/Issues/RavenDB_23264.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_23264.cs
@@ -28,6 +28,10 @@ public class RavenDB_23264 : StorageTest
         // is invoked by a piggybacking write tx that then fails to commit, the flush thread's
         // retry succeeds because the free loop is idempotent (entries are nulled after freeing).
 
+        // file-based so RestartDatabase builds fresh options, the way a real database reload does - the
+        // catastrophic-failure mark set by the RavenDB-27166 fix lives on the options instance
+        RequireFileBasedPager();
+
         long p1, p2, p3;
 
         // Step 1: Create initial pages and commit
@@ -120,10 +124,55 @@ public class RavenDB_23264 : StorageTest
         // Without the fix: double-free → crash.
         flushThread.Join(TimeSpan.FromSeconds(30));
 
+        // Clean up
+        Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
+
+        // Step 12 (RavenDB-27166): the rollback of a transaction that applied the flush action marks the
+        // environment as catastrophically failed - the retry is refused by design and recovery happens on
+        // restart, with no committed data lost (the failed transaction never reached the journal).
+        if (Env.Options.IsCatastrophicFailureSet)
+        {
+            Assert.NotNull(flushException);
+
+            RestartDatabase();
+
+            using (var rtx = Env.ReadTransaction())
+            {
+                foreach (var pageNumber in new[] { p1, p2, p3 })
+                {
+                    var page = rtx.LowLevelTransaction.GetPage(pageNumber);
+                    Assert.Equal(pageNumber, page.PageNumber);
+                }
+            }
+
+            return;
+        }
+
         // Step 12: Verify no exception from flush thread
         Assert.Null(flushException);
 
-        // Clean up
-        Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
+        // Step 13 (RavenDB-27166): the retry did not double-free, but the environment is not healthy either.
+        // txBlocker's rollback restored its tx-start scratch snapshot, resurrecting the entries the flush action
+        // had already freed via tx.ForgetAboutScratchPage. The retry cannot repair that: the free buffer entries
+        // were nulled by the first (partial) execution, so ForgetAboutScratchPage never runs for them again.
+        // The scratch positions are back on the free list while the environment still maps p1/p2/p3 onto them,
+        // so reusing the scratch makes those pages resolve to whatever now occupies their old positions.
+        for (int c = 0; c < 10; c++)
+        {
+            using var txw = Env.WriteTransaction();
+            var tree = txw.CreateTree("churn");
+            for (int i = 0; i < 100; i++)
+                tree.Add($"churn-{c}-{i}", new string((char)('0' + i % 10), 512));
+            txw.Commit();
+        }
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            foreach (var pageNumber in new[] { p1, p2, p3 })
+            {
+                var page = rtx.LowLevelTransaction.GetPage(pageNumber);
+                Assert.Equal(pageNumber, page.PageNumber);
+            }
+        }
     }
 }

--- a/test/SlowTests/Voron/Issues/RavenDB_23264.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_23264.cs
@@ -22,11 +22,13 @@ public class RavenDB_23264 : StorageTest
     }
     
     [RavenFact(RavenTestCategory.Voron)]
-    public void Piggybacking_tx_failure_after_flush_action_should_not_cause_double_free_on_retry()
+    public void Piggybacking_tx_failure_after_flush_action_should_poison_the_environment_and_recover_on_restart()
     {
-        // RavenDB-23264: This test validates that if the _updateJournalStateAfterFlush action
-        // is invoked by a piggybacking write tx that then fails to commit, the flush thread's
-        // retry succeeds because the free loop is idempotent (entries are nulled after freeing).
+        // RavenDB-23264: the _updateJournalStateAfterFlush action invoked by a piggybacking write tx that then
+        // fails to commit must not double-free on the flush thread's retry (the free loop nulls entries after
+        // freeing them). RavenDB-27166 then revoked the retry contract entirely: such a rollback would restore
+        // the freed scratch entries, so it marks the environment as catastrophically failed and the recovery
+        // happens on restart.
 
         // file-based so RestartDatabase builds fresh options, the way a real database reload does - the
         // catastrophic-failure mark set by the RavenDB-27166 fix lives on the options instance
@@ -118,53 +120,19 @@ public class RavenDB_23264 : StorageTest
         // OnTransactionCompleted will NOT clear the action because Committed = false.
         txBlocker.Dispose();
 
-        // Step 11: Flush thread wakes up, creates its own tx, Commit() →
-        // CommitStage1 → OnTransactionCommitted → action invoked AGAIN.
-        // With the fix (idempotent free loop): entries are null → skip → success.
-        // Without the fix: double-free → crash.
+        // Step 11 (RavenDB-27166): the flush thread wakes up, but txBlocker's rollback marked the environment
+        // as catastrophically failed - its retry transaction is refused and the flush surfaces the failure.
         flushThread.Join(TimeSpan.FromSeconds(30));
 
         // Clean up
         Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
 
-        // Step 12 (RavenDB-27166): the rollback of a transaction that applied the flush action marks the
-        // environment as catastrophically failed - the retry is refused by design and recovery happens on
-        // restart, with no committed data lost (the failed transaction never reached the journal).
-        if (Env.Options.IsCatastrophicFailureSet)
-        {
-            Assert.NotNull(flushException);
+        Assert.True(Env.Options.IsCatastrophicFailureSet, "the rollback did not mark the environment as catastrophically failed");
+        Assert.NotNull(flushException);
 
-            RestartDatabase();
-
-            using (var rtx = Env.ReadTransaction())
-            {
-                foreach (var pageNumber in new[] { p1, p2, p3 })
-                {
-                    var page = rtx.LowLevelTransaction.GetPage(pageNumber);
-                    Assert.Equal(pageNumber, page.PageNumber);
-                }
-            }
-
-            return;
-        }
-
-        // Step 12: Verify no exception from flush thread
-        Assert.Null(flushException);
-
-        // Step 13 (RavenDB-27166): the retry did not double-free, but the environment is not healthy either.
-        // txBlocker's rollback restored its tx-start scratch snapshot, resurrecting the entries the flush action
-        // had already freed via tx.ForgetAboutScratchPage. The retry cannot repair that: the free buffer entries
-        // were nulled by the first (partial) execution, so ForgetAboutScratchPage never runs for them again.
-        // The scratch positions are back on the free list while the environment still maps p1/p2/p3 onto them,
-        // so reusing the scratch makes those pages resolve to whatever now occupies their old positions.
-        for (int c = 0; c < 10; c++)
-        {
-            using var txw = Env.WriteTransaction();
-            var tree = txw.CreateTree("churn");
-            for (int i = 0; i < 100; i++)
-                tree.Add($"churn-{c}-{i}", new string((char)('0' + i % 10), 512));
-            txw.Commit();
-        }
+        // Step 12: no committed data was lost (the failed transaction never reached the journal) - the forced
+        // restart recovers a consistent state
+        RestartDatabase();
 
         using (var rtx = Env.ReadTransaction())
         {

--- a/test/SlowTests/Voron/Issues/RavenDB_27166.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27166.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+// RavenDB-27166: a write transaction that piggybacks a pending journal flush-state update (freeing the flushed
+// scratch pages, including tx.ForgetAboutScratchPage) and then fails to commit rolls back to its tx-start scratch
+// snapshot, resurrecting those freed entries. The flush thread's retry cannot repair it - the free buffer entries
+// were nulled (RavenDB-23264), so ForgetAboutScratchPage never runs again - so the environment keeps a scratch
+// mapping onto positions that are back on the free list. Once later writes reuse those positions, reads of the
+// original pages follow the stale mapping to the wrong page: a DEBUG build trips ScratchBufferFile.VerifyMatch,
+// while a release build silently loses every committed value. A restart recovers all of it (the data file and
+// journal are intact), so the corruption is purely in the environment's in-memory scratch state.
+public class RavenDB_27166 : StorageTest
+{
+    public RavenDB_27166(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        base.Configure(options);
+
+        options.ManualFlushing = true;
+        options.ManualSyncing = true;
+    }
+
+    // This is RavenDB_23264's scenario (a piggybacking tx applies the flush action, fails to commit, and the flush
+    // thread retries without double-freeing), continued past the retry: the environment must not serve corrupted
+    // data afterwards.
+    [RavenFact(RavenTestCategory.Voron)]
+    public void PiggybackedFlushFailure_MustNotLeaveEnvironmentServingCorruptedData()
+    {
+        var values = new Dictionary<string, string>();
+
+        using (var txw = Env.WriteTransaction())
+        {
+            var tree = txw.CreateTree("tree");
+            for (int i = 0; i < 200; i++)
+            {
+                var key = $"key-{i:D4}";
+                var value = i + "-" + new string((char)('a' + i % 26), 256);
+                tree.Add(key, value);
+                values[key] = value;
+            }
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        // modify the same pages again so the old scratch entries land in the next flush's free buffer
+        using (var txw = Env.WriteTransaction())
+        {
+            var tree = txw.CreateTree("tree");
+            for (int i = 0; i < 200; i += 2)
+            {
+                var key = $"key-{i:D4}";
+                var value = "v2-" + i + "-" + new string((char)('A' + i % 26), 256);
+                tree.Add(key, value);
+                values[key] = value;
+            }
+            txw.Commit();
+        }
+
+        // hold the write lock so the flush thread has to park _updateJournalStateAfterFlush
+        var txBlocker = Env.WriteTransaction();
+
+        // throw after the journal write succeeded but before Committed is set, so the transaction rolls back having
+        // already applied the flush action
+        txBlocker.LowLevelTransaction.BeforeCommitFinalization += _ => throw new InvalidOperationException("Simulated failure after flush action completed");
+
+        var actionSetEvent = new ManualResetEventSlim(false);
+        Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush += () => actionSetEvent.Set();
+
+        Exception flushException = null;
+        var flushThread = new Thread(() =>
+        {
+            try
+            {
+                Env.FlushLogToDataFile();
+            }
+            catch (Exception e)
+            {
+                flushException = e;
+            }
+        });
+        flushThread.Start();
+        try
+        {
+            Assert.True(actionSetEvent.Wait(TimeSpan.FromSeconds(30)), "Timed out waiting for flush to set _updateJournalStateAfterFlush");
+
+            Assert.Throws<InvalidOperationException>(() => txBlocker.Commit());
+            txBlocker.Dispose(); // -> Rollback -> restores the tx-start scratch snapshot
+
+            Assert.True(flushThread.Join(TimeSpan.FromSeconds(30)), "flush thread did not complete");
+        }
+        finally
+        {
+            Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
+        }
+
+        // if the environment was poisoned, the failure was reported and the database will be unloaded and recovered -
+        // that is an acceptable outcome, the unacceptable one is staying up while serving corrupted data
+        if (Env.Options.IsCatastrophicFailureSet)
+            return;
+
+        // reuse the scratch: the positions the flush action freed are on the free list, so new allocations take them
+        // while the resurrected entries still map the old pages onto them
+        for (int c = 0; c < 10; c++)
+        {
+            using var txw = Env.WriteTransaction();
+            var tree = txw.CreateTree("churn");
+            for (int i = 0; i < 100; i++)
+                tree.Add($"churn-{c}-{i}", new string((char)('0' + i % 10), 512));
+            txw.Commit();
+        }
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            var tree = rtx.ReadTree("tree");
+            Assert.NotNull(tree);
+            foreach (var (key, expected) in values)
+            {
+                var read = tree.Read(key);
+                Assert.True(read != null, $"'{key}' is unreadable after the failed piggybacking commit");
+                Assert.Equal(expected, read.Reader.ToStringValue());
+            }
+        }
+
+        // sanity: the data was never lost on disk - a restart recovers everything, which is why the in-memory
+        // corruption above is what has to be prevented
+        RestartDatabase();
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            var tree = rtx.ReadTree("tree");
+            Assert.NotNull(tree);
+            foreach (var (key, expected) in values)
+                Assert.Equal(expected, tree.Read(key).Reader.ToStringValue());
+        }
+    }
+
+    private const string V0 = "v0-baseline";
+    private const string V1 = "v1-committed-must-survive";
+    private const string V2 = "v2-rolled-back";
+
+    // The failing tx itself modified "p", whose prior committed version (V1) is NOT covered by the parked flush
+    // (a read transaction pins the flush horizon below it). After the rollback the committed V1 must still be
+    // readable - it exists only in scratch, the data file does not have it.
+    [RavenFact(RavenTestCategory.Voron)]
+    public void FailedPiggybackingTx_ModifiedPage_PriorVersionNotCoveredByFlush_MustKeepItReadable()
+    {
+        // "p" = V0, flushed to the data file
+        using (var txw = Env.WriteTransaction())
+        {
+            txw.CreateTree("tree").Add("p", V0);
+            txw.Commit();
+        }
+        Env.FlushLogToDataFile();
+
+        // filler commit - the work the parked flush will cover
+        using (var txw = Env.WriteTransaction())
+        {
+            var filler = txw.CreateTree("filler");
+            for (int i = 0; i < 64; i++)
+                filler.Add($"f-{i}", new string('f', 256));
+            txw.Commit();
+        }
+
+        // bump the tx id so the read tx below pins the flush horizon above the filler but below "p" = V1
+        using (var txw = Env.WriteTransaction())
+        {
+            txw.CreateTree("filler").Add("bump", "bump");
+            txw.Commit();
+        }
+
+        using (var _ = Env.ReadTransaction()) // pins the flush horizon
+        {
+            // committed but not covered by the parked flush - lives only in scratch
+            using (var txw = Env.WriteTransaction())
+            {
+                txw.CreateTree("tree").Add("p", V1);
+                txw.Commit();
+            }
+
+            RunPiggybackingTxThatModifiesPageAndFails();
+        }
+
+        // poisoning the environment is the other acceptable outcome: the failure is reported and recovery
+        // restores a consistent state (the doomed write never reached the journal)
+        if (Env.Options.IsCatastrophicFailureSet)
+            return;
+
+        // the failed pre-write commit leaves its entry in the merge buffer (separate issue) - clear it so this
+        // test isolates the scratch mapping
+        Env.Journal.SharedJournalState.Reset();
+
+        using (var txw = Env.WriteTransaction()) // publish the post-rollback state
+        {
+            txw.CreateTree("sanity").Add("s", "s");
+            txw.Commit();
+        }
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            var read = rtx.ReadTree("tree").Read("p");
+            Assert.True(read != null, "'p' is unreadable after the failed piggybacking commit");
+            Assert.Equal(V1, read.Reader.ToStringValue()); // the committed-but-unflushed version must survive
+        }
+    }
+
+    // The failing tx itself modified "p", whose prior committed version (V1) IS covered by the parked flush:
+    // the flush wrote V1 to the data file and freed its scratch entry (the map already pointed to the failing
+    // tx's entry, so nothing was removed from the map at that point). After the rollback "p" must not be mapped
+    // onto the freed scratch position.
+    [RavenFact(RavenTestCategory.Voron)]
+    public void FailedPiggybackingTx_ModifiedPage_PriorVersionCoveredByFlush_MustNotResurrectFreedScratch()
+    {
+        // "p" = V0, flushed to the data file
+        using (var txw = Env.WriteTransaction())
+        {
+            txw.CreateTree("tree").Add("p", V0);
+            txw.Commit();
+        }
+        Env.FlushLogToDataFile();
+
+        // "p" = V1, committed - covered by the parked flush below (no read tx pins the horizon)
+        using (var txw = Env.WriteTransaction())
+        {
+            txw.CreateTree("tree").Add("p", V1);
+            txw.Commit();
+        }
+
+        RunPiggybackingTxThatModifiesPageAndFails();
+
+        // poisoning the environment is the other acceptable outcome, as above
+        if (Env.Options.IsCatastrophicFailureSet)
+            return;
+
+        Env.Journal.SharedJournalState.Reset(); // failed pre-write commit leaves its entry in the merge buffer - separate issue
+
+        // reuse the scratch so a resurrected mapping onto freed positions turns into wrong-page reads
+        for (int c = 0; c < 10; c++)
+        {
+            using var txw = Env.WriteTransaction();
+            var churn = txw.CreateTree("churn");
+            for (int i = 0; i < 100; i++)
+                churn.Add($"churn-{c}-{i}", new string((char)('0' + i % 10), 512));
+            txw.Commit();
+        }
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            var read = rtx.ReadTree("tree").Read("p");
+            Assert.True(read != null, "'p' is unreadable after the failed piggybacking commit");
+            Assert.Equal(V1, read.Reader.ToStringValue()); // flushed to the data file by the parked flush
+        }
+    }
+
+    // Opens a write tx that updates "p" to V2, lets the parked flush install its journal-state update so the tx
+    // piggybacks it in CommitStage1, and fails the commit just before the journal write. The tx rolls back.
+    private void RunPiggybackingTxThatModifiesPageAndFails()
+    {
+        var armed = 1;
+        Env.ForTestingPurposesOnly().ModifyNewLowLevelTransaction = t =>
+        {
+            if (Interlocked.Exchange(ref armed, 0) == 1)
+                t.ActionToCallJustBeforeWritingToJournal = () => throw new InvalidOperationException("RavenDB-27166 simulated pre-write commit failure");
+        };
+
+        var txBlocker = Env.WriteTransaction();
+        Env.ForTestingPurposesOnly().ModifyNewLowLevelTransaction = null;
+        try
+        {
+            txBlocker.CreateTree("tree").Add("p", V2);
+
+            var actionSetEvent = new ManualResetEventSlim(false);
+            Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush += () => actionSetEvent.Set();
+
+            Exception flushException = null;
+            var flushThread = new Thread(() =>
+            {
+                try
+                {
+                    Env.FlushLogToDataFile();
+                }
+                catch (Exception e)
+                {
+                    flushException = e;
+                }
+            });
+            flushThread.Start();
+            try
+            {
+                Assert.True(actionSetEvent.Wait(TimeSpan.FromSeconds(30)), "Timed out waiting for flush to set _updateJournalStateAfterFlush");
+
+                Assert.Throws<InvalidOperationException>(() => txBlocker.Commit());
+            }
+            finally
+            {
+                txBlocker.Dispose(); // -> Rollback
+
+                Assert.True(flushThread.Join(TimeSpan.FromSeconds(30)), "flush thread did not complete");
+                Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
+            }
+            // on an environment that stayed up the flush retry must have completed cleanly; a poisoned
+            // environment faults the retry by design and the calling test stops there
+            if (Env.Options.IsCatastrophicFailureSet == false)
+                Assert.Null(flushException);
+        }
+        finally
+        {
+            Env.ForTestingPurposesOnly().ModifyNewLowLevelTransaction = null;
+        }
+    }
+}

--- a/test/SlowTests/Voron/Issues/RavenDB_27166.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27166.cs
@@ -33,8 +33,17 @@ public class RavenDB_27166 : StorageTest
     // This is RavenDB_23264's scenario (a piggybacking tx applies the flush action, fails to commit, and the flush
     // thread retries without double-freeing), continued past the retry: the environment must not serve corrupted
     // data afterwards.
-    [RavenFact(RavenTestCategory.Voron)]
-    public void PiggybackedFlushFailure_MustNotLeaveEnvironmentServingCorruptedData()
+    //
+    // rollBackAnotherTxBeforeTheFlushRetry keeps the flush thread parked after the rollback and lets one more write
+    // transaction roll back first. That matters because a rollback restores env.CurrentStateRecord.ScratchPagesTable
+    // (LowLevelTransaction.cs:294) and a failed transaction never republishes it (StorageEnvironment.cs:876), so the
+    // published table still maps the entries the flush action freed. Repairing only the live scratch builder holds
+    // until that table is restored again, which is what this variant does - ScratchBufferPool.Cleanup opens a write
+    // transaction and disposes it without committing, so a rolling-back write transaction is not a contrived event.
+    [RavenTheory(RavenTestCategory.Voron)]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void PiggybackedFlushFailure_MustNotLeaveEnvironmentServingCorruptedData(bool rollBackAnotherTxBeforeTheFlushRetry)
     {
         var values = new Dictionary<string, string>();
 
@@ -75,7 +84,15 @@ public class RavenDB_27166 : StorageTest
         txBlocker.LowLevelTransaction.BeforeCommitFinalization += _ => throw new InvalidOperationException("Simulated failure after flush action completed");
 
         var actionSetEvent = new ManualResetEventSlim(false);
-        Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush += () => actionSetEvent.Set();
+
+        // the action is installed before this hook runs and the flush thread has not tried for the write lock yet,
+        // so parking it here keeps the piggyback available while holding the retry back
+        var flushRetryGate = new ManualResetEventSlim(initialState: rollBackAnotherTxBeforeTheFlushRetry == false);
+        Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush += () =>
+        {
+            actionSetEvent.Set();
+            flushRetryGate.Wait(TimeSpan.FromSeconds(30));
+        };
 
         Exception flushException = null;
         var flushThread = new Thread(() =>
@@ -97,10 +114,23 @@ public class RavenDB_27166 : StorageTest
             Assert.Throws<InvalidOperationException>(() => txBlocker.Commit());
             txBlocker.Dispose(); // -> Rollback -> restores the tx-start scratch snapshot
 
+            // nothing has republished the scratch table yet, so this rollback restores the same stale published table -
+            // and this transaction freed nothing on behalf of the flush, so it has nothing to re-apply
+            if (rollBackAnotherTxBeforeTheFlushRetry && Env.Options.IsCatastrophicFailureSet == false)
+            {
+                using (Env.WriteTransaction())
+                {
+                    // no Commit, exactly like ScratchBufferPool.Cleanup
+                }
+            }
+
+            flushRetryGate.Set();
+
             Assert.True(flushThread.Join(TimeSpan.FromSeconds(30)), "flush thread did not complete");
         }
         finally
         {
+            flushRetryGate.Set();
             Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
         }
 

--- a/test/SlowTests/Voron/Issues/RavenDB_27166.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27166.cs
@@ -10,12 +10,12 @@ namespace SlowTests.Voron.Issues;
 
 // RavenDB-27166: a write transaction that piggybacks a pending journal flush-state update (freeing the flushed
 // scratch pages, including tx.ForgetAboutScratchPage) and then fails to commit rolls back to its tx-start scratch
-// snapshot, resurrecting those freed entries. The flush thread's retry cannot repair it - the free buffer entries
-// were nulled (RavenDB-23264), so ForgetAboutScratchPage never runs again - so the environment keeps a scratch
-// mapping onto positions that are back on the free list. Once later writes reuse those positions, reads of the
-// original pages follow the stale mapping to the wrong page: a DEBUG build trips ScratchBufferFile.VerifyMatch,
-// while a release build silently loses every committed value. A restart recovers all of it (the data file and
-// journal are intact), so the corruption is purely in the environment's in-memory scratch state.
+// snapshot, restoring those freed entries. The flush thread's retry cannot repair it - the free buffer entries
+// were nulled (RavenDB-23264), so ForgetAboutScratchPage never runs again - so the environment would keep a scratch
+// mapping onto positions that are back on the free list, and reads would follow the stale mapping to the wrong page
+// once those positions get reused. The data file and journal are intact, so such a rollback marks the environment
+// as catastrophically failed (the restored in-memory scratch state cannot be trusted) and a restart recovers all
+// the committed data.
 public class RavenDB_27166 : StorageTest
 {
     public RavenDB_27166(ITestOutputHelper output) : base(output)
@@ -30,21 +30,13 @@ public class RavenDB_27166 : StorageTest
         options.ManualSyncing = true;
     }
 
-    // This is RavenDB_23264's scenario (a piggybacking tx applies the flush action, fails to commit, and the flush
-    // thread retries without double-freeing), continued past the retry: the environment must not serve corrupted
-    // data afterwards.
-    //
-    // rollBackAnotherTxBeforeTheFlushRetry keeps the flush thread parked after the rollback and lets one more write
-    // transaction roll back first. That matters because a rollback restores env.CurrentStateRecord.ScratchPagesTable
-    // (LowLevelTransaction.cs:294) and a failed transaction never republishes it (StorageEnvironment.cs:876), so the
-    // published table still maps the entries the flush action freed. Repairing only the live scratch builder holds
-    // until that table is restored again, which is what this variant does - ScratchBufferPool.Cleanup opens a write
-    // transaction and disposes it without committing, so a rolling-back write transaction is not a contrived event.
-    [RavenTheory(RavenTestCategory.Voron)]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void PiggybackedFlushFailure_MustNotLeaveEnvironmentServingCorruptedData(bool rollBackAnotherTxBeforeTheFlushRetry)
+    // This is RavenDB_23264's scenario (a piggybacking tx applies the flush action and fails to commit), continued
+    // past the rollback: the environment must be poisoned and a restart must bring back every committed value.
+    [RavenFact(RavenTestCategory.Voron)]
+    public void PiggybackedFlushFailure_MustNotLeaveEnvironmentServingCorruptedData()
     {
+        RequireFileBasedPager(); // the restart below must build fresh options - the catastrophic-failure mark lives on the options instance
+
         var values = new Dictionary<string, string>();
 
         using (var txw = Env.WriteTransaction())
@@ -84,15 +76,7 @@ public class RavenDB_27166 : StorageTest
         txBlocker.LowLevelTransaction.BeforeCommitFinalization += _ => throw new InvalidOperationException("Simulated failure after flush action completed");
 
         var actionSetEvent = new ManualResetEventSlim(false);
-
-        // the action is installed before this hook runs and the flush thread has not tried for the write lock yet,
-        // so parking it here keeps the piggyback available while holding the retry back
-        var flushRetryGate = new ManualResetEventSlim(initialState: rollBackAnotherTxBeforeTheFlushRetry == false);
-        Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush += () =>
-        {
-            actionSetEvent.Set();
-            flushRetryGate.Wait(TimeSpan.FromSeconds(30));
-        };
+        Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush += () => actionSetEvent.Set();
 
         Exception flushException = null;
         var flushThread = new Thread(() =>
@@ -112,58 +96,19 @@ public class RavenDB_27166 : StorageTest
             Assert.True(actionSetEvent.Wait(TimeSpan.FromSeconds(30)), "Timed out waiting for flush to set _updateJournalStateAfterFlush");
 
             Assert.Throws<InvalidOperationException>(() => txBlocker.Commit());
-            txBlocker.Dispose(); // -> Rollback -> restores the tx-start scratch snapshot
-
-            // nothing has republished the scratch table yet, so this rollback restores the same stale published table -
-            // and this transaction freed nothing on behalf of the flush, so it has nothing to re-apply
-            if (rollBackAnotherTxBeforeTheFlushRetry && Env.Options.IsCatastrophicFailureSet == false)
-            {
-                using (Env.WriteTransaction())
-                {
-                    // no Commit, exactly like ScratchBufferPool.Cleanup
-                }
-            }
-
-            flushRetryGate.Set();
+            txBlocker.Dispose(); // -> Rollback -> would restore the freed scratch entries -> poisons the environment
 
             Assert.True(flushThread.Join(TimeSpan.FromSeconds(30)), "flush thread did not complete");
         }
         finally
         {
-            flushRetryGate.Set();
             Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
         }
 
-        // if the environment was poisoned, the failure was reported and the database will be unloaded and recovered -
-        // that is an acceptable outcome, the unacceptable one is staying up while serving corrupted data
-        if (Env.Options.IsCatastrophicFailureSet)
-            return;
+        Assert.True(Env.Options.IsCatastrophicFailureSet, "the rollback did not mark the environment as catastrophically failed");
+        Assert.NotNull(flushException); // the flush retry is refused on the poisoned environment
 
-        // reuse the scratch: the positions the flush action freed are on the free list, so new allocations take them
-        // while the resurrected entries still map the old pages onto them
-        for (int c = 0; c < 10; c++)
-        {
-            using var txw = Env.WriteTransaction();
-            var tree = txw.CreateTree("churn");
-            for (int i = 0; i < 100; i++)
-                tree.Add($"churn-{c}-{i}", new string((char)('0' + i % 10), 512));
-            txw.Commit();
-        }
-
-        using (var rtx = Env.ReadTransaction())
-        {
-            var tree = rtx.ReadTree("tree");
-            Assert.NotNull(tree);
-            foreach (var (key, expected) in values)
-            {
-                var read = tree.Read(key);
-                Assert.True(read != null, $"'{key}' is unreadable after the failed piggybacking commit");
-                Assert.Equal(expected, read.Reader.ToStringValue());
-            }
-        }
-
-        // sanity: the data was never lost on disk - a restart recovers everything, which is why the in-memory
-        // corruption above is what has to be prevented
+        // the data was never lost on disk - the forced restart recovers every committed value
         RestartDatabase();
 
         using (var rtx = Env.ReadTransaction())
@@ -180,11 +125,13 @@ public class RavenDB_27166 : StorageTest
     private const string V2 = "v2-rolled-back";
 
     // The failing tx itself modified "p", whose prior committed version (V1) is NOT covered by the parked flush
-    // (a read transaction pins the flush horizon below it). After the rollback the committed V1 must still be
-    // readable - it exists only in scratch, the data file does not have it.
+    // (a read transaction pins the flush horizon below it). V1 exists only in scratch and the journal - the data
+    // file does not have it - so the recovery after the poisoning rollback must bring it back.
     [RavenFact(RavenTestCategory.Voron)]
     public void FailedPiggybackingTx_ModifiedPage_PriorVersionNotCoveredByFlush_MustKeepItReadable()
     {
+        RequireFileBasedPager(); // the restart below must build fresh options - the catastrophic-failure mark lives on the options instance
+
         // "p" = V0, flushed to the data file
         using (var txw = Env.WriteTransaction())
         {
@@ -221,36 +168,24 @@ public class RavenDB_27166 : StorageTest
             RunPiggybackingTxThatModifiesPageAndFails();
         }
 
-        // poisoning the environment is the other acceptable outcome: the failure is reported and recovery
-        // restores a consistent state (the doomed write never reached the journal)
-        if (Env.Options.IsCatastrophicFailureSet)
-            return;
-
-        // the failed pre-write commit leaves its entry in the merge buffer (separate issue) - clear it so this
-        // test isolates the scratch mapping
-        Env.Journal.SharedJournalState.Reset();
-
-        using (var txw = Env.WriteTransaction()) // publish the post-rollback state
-        {
-            txw.CreateTree("sanity").Add("s", "s");
-            txw.Commit();
-        }
+        RestartDatabase();
 
         using (var rtx = Env.ReadTransaction())
         {
             var read = rtx.ReadTree("tree").Read("p");
-            Assert.True(read != null, "'p' is unreadable after the failed piggybacking commit");
-            Assert.Equal(V1, read.Reader.ToStringValue()); // the committed-but-unflushed version must survive
+            Assert.True(read != null, "'p' is unreadable after recovery");
+            Assert.Equal(V1, read.Reader.ToStringValue()); // the committed-but-unflushed version must survive; the doomed V2 never reached the journal
         }
     }
 
     // The failing tx itself modified "p", whose prior committed version (V1) IS covered by the parked flush:
-    // the flush wrote V1 to the data file and freed its scratch entry (the map already pointed to the failing
-    // tx's entry, so nothing was removed from the map at that point). After the rollback "p" must not be mapped
-    // onto the freed scratch position.
+    // the flush wrote V1 to the data file and freed its scratch entry. After the poisoning rollback the forced
+    // restart must bring "p" back as V1.
     [RavenFact(RavenTestCategory.Voron)]
-    public void FailedPiggybackingTx_ModifiedPage_PriorVersionCoveredByFlush_MustNotResurrectFreedScratch()
+    public void FailedPiggybackingTx_ModifiedPage_PriorVersionCoveredByFlush_MustKeepItReadable()
     {
+        RequireFileBasedPager(); // the restart below must build fresh options - the catastrophic-failure mark lives on the options instance
+
         // "p" = V0, flushed to the data file
         using (var txw = Env.WriteTransaction())
         {
@@ -268,32 +203,19 @@ public class RavenDB_27166 : StorageTest
 
         RunPiggybackingTxThatModifiesPageAndFails();
 
-        // poisoning the environment is the other acceptable outcome, as above
-        if (Env.Options.IsCatastrophicFailureSet)
-            return;
-
-        Env.Journal.SharedJournalState.Reset(); // failed pre-write commit leaves its entry in the merge buffer - separate issue
-
-        // reuse the scratch so a resurrected mapping onto freed positions turns into wrong-page reads
-        for (int c = 0; c < 10; c++)
-        {
-            using var txw = Env.WriteTransaction();
-            var churn = txw.CreateTree("churn");
-            for (int i = 0; i < 100; i++)
-                churn.Add($"churn-{c}-{i}", new string((char)('0' + i % 10), 512));
-            txw.Commit();
-        }
+        RestartDatabase();
 
         using (var rtx = Env.ReadTransaction())
         {
             var read = rtx.ReadTree("tree").Read("p");
-            Assert.True(read != null, "'p' is unreadable after the failed piggybacking commit");
-            Assert.Equal(V1, read.Reader.ToStringValue()); // flushed to the data file by the parked flush
+            Assert.True(read != null, "'p' is unreadable after recovery");
+            Assert.Equal(V1, read.Reader.ToStringValue()); // written to the data file by the parked flush
         }
     }
 
     // Opens a write tx that updates "p" to V2, lets the parked flush install its journal-state update so the tx
-    // piggybacks it in CommitStage1, and fails the commit just before the journal write. The tx rolls back.
+    // piggybacks it in CommitStage1, and fails the commit just before the journal write. The rollback would restore
+    // the scratch entries the flush action freed, so it must poison the environment.
     private void RunPiggybackingTxThatModifiesPageAndFails()
     {
         var armed = 1;
@@ -333,15 +255,14 @@ public class RavenDB_27166 : StorageTest
             }
             finally
             {
-                txBlocker.Dispose(); // -> Rollback
+                txBlocker.Dispose(); // -> Rollback -> poisons the environment
 
                 Assert.True(flushThread.Join(TimeSpan.FromSeconds(30)), "flush thread did not complete");
                 Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
             }
-            // on an environment that stayed up the flush retry must have completed cleanly; a poisoned
-            // environment faults the retry by design and the calling test stops there
-            if (Env.Options.IsCatastrophicFailureSet == false)
-                Assert.Null(flushException);
+
+            Assert.True(Env.Options.IsCatastrophicFailureSet, "the rollback did not mark the environment as catastrophically failed");
+            Assert.NotNull(flushException); // the flush retry is refused on the poisoned environment
         }
         finally
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issueRavenDB-27166

### Additional description

### The bug

After a journal flush writes pages to the data file, Voron frees the scratch pages that held them. When the flusher cannot take the write lock, it hands that work to the next committing write transaction, which runs it as part of its own commit (piggybacking).

Each ingredient is harmless alone, the bug is their intersection: a transaction that **piggybacked the flush-state update and then failed to commit**. Its rollback restores the page-to-scratch mappings from the transaction start, and that snapshot still contains the entries the update just freed. The environment ends up mapping pages onto scratch positions that are back on the free list, so once those get reused, reads return the wrong page (an assertion failure in Debug, silently wrong data in Release). The disk is untouched - the corruption is purely in-memory, and a restart recovers everything.

Worse, the failure is invisible: the flusher's retry finds nothing left to free (RavenDB-23264 made the retry idempotent), reports success, and the environment keeps running on the corrupted state.

### The fix

The rollback now marks the environment as catastrophically failed, forcing a database unload and a clean recovery - no committed data is lost.

This is not a new policy. When the very same flush-state update fails on the flusher's own thread (`ApplyJournalStateAfterFlush` called from `ApplyLogsToDataFile`), the environment is already poisoned today via `GlobalFlushingBehavior` - the code even states "any error from here on out is a catastrophic failure, and will be handled by recovering from scratch". Piggybacking merely relocated that same failure into a user transaction's commit, where it surfaced as an ordinary commit failure and left the environment running. The async-commit path already poisons on any failure in this window too, so the transaction merger (documents) was covered - the sync path (indexes) was not, which is why indexes were the exposed population.

The trigger is exact: we poison only when the rollback would really restore a freed mapping - the freed entry belongs to an older committed transaction and the transaction-start snapshot still maps that exact entry. A transaction that applied the update but freed nothing (empty retry, failure before the free loop, entries already superseded) rolls back without consequences, as before.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
