### PR TITLE
RavenDB-27270 Fix checksum validation skipped for last 64 pages of data file

### DIFF
--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -154,7 +154,10 @@ namespace Voron
                 var remainingBits = _lastValidPageAfterLoad % (8 * sizeof(long));
 
                 _validPagesAfterLoad = new long[_lastValidPageAfterLoad / (8 * sizeof(long)) + (remainingBits == 0 ? 0 : 1)];
-                _validPagesAfterLoad[^1] |= unchecked(((long)ulong.MaxValue << (int)remainingBits));
+                // Pad only the high bits of the last word that do not cover real pages.
+                // When the page count is a multiple of 64 the last word holds only real pages.
+                if (remainingBits != 0)
+                    _validPagesAfterLoad[^1] |= unchecked(((long)ulong.MaxValue << (int)remainingBits));
 
                 _decompressionBuffers = new DecompressionBuffersPool(options);
 

--- a/test/SlowTests/Voron/Checksum.cs
+++ b/test/SlowTests/Voron/Checksum.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using FastTests.Utils;
 using FastTests.Voron;
 using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Voron.Impl.Paging;
+using Voron.Global;
 using Xunit.Abstractions;
 
 namespace SlowTests.Voron
@@ -109,5 +111,148 @@ namespace SlowTests.Voron
                 Assert.True(e is InvalidOperationException || e is InvalidDataException);
             }
         }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public unsafe void ValidatePageChecksumShouldDetectCorruptionInLast64PagesOfDataFile()
+        {
+            // 1 MB data file = 128 pages, an exact multiple of 64, so the last 64 pages
+            // share the final bitmap word that the constructor pads with "validated" bits.
+            var options = StorageEnvironmentOptions.ForPath(DataDir);
+            options.InitialFileSize = 1024 * 1024;
+            options.ManualFlushing = true;
+
+            using (var env = new StorageEnvironment(options))
+            {
+                Assert.Equal(0, env._lastValidPageAfterLoad % 64);
+
+                using (var tx = env.WriteTransaction())
+                {
+                    tx.CreateTree("test").Add("items/1", new byte[16]);
+                    tx.Commit();
+                }
+
+                env.FlushLogToDataFile();
+            }
+
+            // Corrupt page 100 (inside the last 64 pages). No transaction ever wrote
+            // it, so no journal can shadow it and the read must hit the data file.
+            // Keep its header well-formed (PageNumber = 100) so the corruption
+            // surfaces as a checksum mismatch.
+            using (var fileStream = OpenDataFile())
+            {
+                long pageOffset = 100 * Constants.Storage.PageSize;
+                fileStream.Position = pageOffset + (long)Marshal.OffsetOf<PageHeader>(nameof(PageHeader.PageNumber));
+                fileStream.Write(BitConverter.GetBytes(100L), 0, sizeof(long));
+                fileStream.Position = pageOffset + PageHeader.SizeOf + 43;
+                fileStream.Write(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }, 0, 8);
+            }
+
+            using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
+            {
+                using (var tx = env.ReadTransaction())
+                {
+                    var exception = Assert.Throws<InvalidDataException>(() => tx.LowLevelTransaction.GetPage(100));
+                    Assert.Contains("checksum", exception.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void ValidPagesBitmapShouldOnlyMarkUnusedBitsAsValidated()
+        {
+            // 512 KB = 64 pages: an exact multiple of 64, so the only bitmap word
+            // holds real pages exclusively and none of its bits may be pre-set.
+            using (var env = CreateEnvironment(Path.Combine(DataDir, "multipleOf64"), 512 * 1024))
+            {
+                Assert.Equal(64, env._lastValidPageAfterLoad);
+                var lastWord = env._validPagesAfterLoad[env._validPagesAfterLoad.Length - 1];
+                Assert.Equal(0L, lastWord);
+            }
+
+            // 512 KB + 16 pages = 80 pages: remainder 16, so only the 48 high bits
+            // of the last word (the ones beyond the last real page) may be pre-set.
+            using (var env = CreateEnvironment(Path.Combine(DataDir, "remainder16"), 512 * 1024 + 16 * Constants.Storage.PageSize))
+            {
+                Assert.Equal(80, env._lastValidPageAfterLoad);
+                var lastWord = env._validPagesAfterLoad[env._validPagesAfterLoad.Length - 1];
+                Assert.Equal(unchecked((long)ulong.MaxValue << 16), lastWord);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public unsafe void PageIsValidatedOnlyOnceThenCorruptionIsSkippedOnLaterReads()
+        {
+            // 1 MB file = 128 pages, so page 40 lives in the first bitmap word,
+            // which never carries padding bits.
+            var options = StorageEnvironmentOptions.ForPath(DataDir);
+            options.InitialFileSize = 1024 * 1024;
+
+            const long pageNumber = 40;
+            using (var env = new StorageEnvironment(options))
+            {
+                var index = pageNumber / (8 * sizeof(long));
+                var bitToSet = 1L << (int)(pageNumber % (8 * sizeof(long)));
+
+                // Craft a valid page directly in the data file: a well-formed header
+                // and a matching checksum. No transaction wrote it, so no journal can
+                // shadow it and reads below must hit the data file. The write goes
+                // through the OS page cache, which is coherent with the mapping the
+                // open environment holds.
+                using (var fileStream = OpenDataFile())
+                {
+                    var buffer = new byte[Constants.Storage.PageSize];
+                    fileStream.Position = pageNumber * Constants.Storage.PageSize;
+                    fileStream.ReadExactly(buffer, 0, buffer.Length);
+                    fixed (byte* ptr = buffer)
+                    {
+                        var header = (PageHeader*)ptr;
+                        header->PageNumber = pageNumber;
+                        header->Checksum = StorageEnvironment.CalculatePageChecksum(ptr, pageNumber, header->Flags, header->OverflowSize);
+                    }
+                    fileStream.Position = pageNumber * Constants.Storage.PageSize;
+                    fileStream.Write(buffer, 0, buffer.Length);
+                }
+
+                // The first read validates the page against the data file and sets its bit.
+                Assert.Equal(0, env._validPagesAfterLoad[index] & bitToSet);
+                using (var tx = env.ReadTransaction())
+                {
+                    tx.LowLevelTransaction.GetPage(pageNumber);
+                }
+                Assert.NotEqual(0, env._validPagesAfterLoad[index] & bitToSet);
+
+                // Corrupt the page bytes on disk; the page cache is coherent with the
+                // environment's mapping, so the corruption is visible to it immediately.
+                using (var fileStream = OpenDataFile())
+                {
+                    fileStream.Position = pageNumber * Constants.Storage.PageSize + PageHeader.SizeOf + 43;
+                    fileStream.Write(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }, 0, 8);
+                }
+
+                // The second read skips validation (the bit was set by the first read)
+                // and returns the corrupted bytes.
+                using (var tx = env.ReadTransaction())
+                {
+                    var page = tx.LowLevelTransaction.GetPage(pageNumber);
+                    for (byte i = 0; i < 8; i++)
+                    {
+                        Assert.Equal(i, page.DataPointer[43 + i]);
+                    }
+                }
+            }
+        }
+
+        private static StorageEnvironment CreateEnvironment(string path, long initialFileSize)
+        {
+            var options = StorageEnvironmentOptions.ForPath(path);
+            options.InitialFileSize = initialFileSize;
+            return new StorageEnvironment(options);
+        }
+
+        // Voron opens the data file with read/write/delete sharing on every platform, so a plain
+        // stream can write beside a live environment.
+        private FileStream OpenDataFile() =>
+            new FileStream(Path.Combine(DataDir, Constants.DatabaseFilename),
+                FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete);
     }
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27270

### Additional description

The `StorageEnvironment` constructor builds the "already validated" bitmap for pages that existed when the data file was opened. Its last line pads the unused high bits of the final word with `ulong.MaxValue << remainingBits`. When the allocated page count is an exact multiple of 64, `remainingBits == 0` and the shift pre-marks every bit of the last word of real pages as validated. Because a set bit makes the read gate skip checksum computation, the final 64 pages of any data file whose size is a multiple of 512 KB were never checksum-validated; corruption in that range was returned as valid data, with no error and no recovery attempt.

The fix guards the padding write so it only runs when a padding word exists (`remainingBits != 0`). When the page count is a multiple of 64, the last word holds only real pages and no bit is pre-set. When it is not, exactly the unused high bits of the padding word are marked, as before. The watermark, the `pageNumber >= _lastValidPageAfterLoad` guard, the meaning of the bitmap, and the `Interlocked.CompareExchange` publish in `UnlikelyValidatePage` are unchanged.

The tests prove: corruption in the last 64 pages of a multiple-of-64 file is reported instead of returned as valid data; on open no real page is pre-marked as validated, only unused padding positions; and a page is still validated exactly once, on first read — pinned so the bug cannot be fixed by re-validating every read. The first two fail before the fix and pass after it; the third passes on both sides by design.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
