### PR TITLE
RavenDB-27271 Fix incremental backup leaking a journal reference per backup

### DIFF
--- a/src/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/src/Voron/Impl/Backup/IncrementalBackup.cs
@@ -136,8 +136,6 @@ namespace Voron.Impl.Backup
 
                         var journalFile = GetJournalFile(env, journalNum, backupInfo, journalInfo);
 
-                        journalFile.AddRef();
-
                         usedJournals.Add(journalFile);
 
                         var startBackupAt = 0L;
@@ -217,6 +215,8 @@ namespace Voron.Impl.Backup
             return numberOfBackedUpPages;
         }
 
+        // The returned journal already holds one reference (taken on every return path);
+        // callers own that reference and must release it exactly once via Release(), without calling AddRef again.
         internal static JournalFile GetJournalFile(StorageEnvironment env, long journalNum, IncrementalBackupInfo backupInfo, JournalInfo journalInfo)
         {
             var journalFile = env.Journal.Files.FirstOrDefault(x => x.Number == journalNum); // first check journal files currently being in use

--- a/test/FastTests/Voron/Backups/IncrementalBackupReleasesJournalReferences.cs
+++ b/test/FastTests/Voron/Backups/IncrementalBackupReleasesJournalReferences.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Global;
+using Voron.Impl.Backup;
+using Voron.Impl.Journal;
+using Voron.Util.Settings;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron.Backups
+{
+    public class IncrementalBackupReleasesJournalReferences : StorageTest
+    {
+        public IncrementalBackupReleasesJournalReferences(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.MaxLogFileSize = 1000 * Constants.Storage.PageSize;
+            options.IncrementalBackupEnabled = true;
+            options.ManualFlushing = true;
+            options.ManualSyncing = true;
+        }
+
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.BackupExportImport)]
+        public void BackupReleasesJournalReference()
+        {
+            RequireFileBasedPager();
+
+            var random = new Random(1);
+            var buffer = new byte[512];
+            long firstCycleCurrentJournal = -1;
+
+            for (int cycle = 0; cycle < 2; cycle++)
+            {
+                var prefix = "cycle" + cycle + "/";
+
+                WriteRandomData(random, buffer, prefix);
+                Env.FlushLogToDataFile();
+                AssertSync();
+
+                if (cycle == 0)
+                {
+                    // the flush sealed journal 0 and removed it from the open set,
+                    // so GetJournalFile has to construct an ad-hoc JournalFile for it
+                    Assert.DoesNotContain(Env.Journal.Files, x => x.Number == 0);
+                    Assert.True(Env.Options.JournalExists(0));
+                }
+
+                // after the flush there may be no current journal; a write before the backup
+                // keeps one alive, otherwise the deletion guard's lastWrittenLogFile is -1
+                WriteRandomData(random, buffer, prefix + "current", count: 1);
+                Assert.NotNull(Env.Journal.CurrentFile);
+
+                if (cycle == 0)
+                {
+                    firstCycleCurrentJournal = Env.Journal.CurrentFile.Number;
+                }
+                else
+                {
+                    // the journal protected as current during the first backup is still on disk
+                    Assert.True(Env.Options.JournalExists(firstCycleCurrentJournal));
+                }
+
+                BackupMethods.Incremental.ToFile(Env,
+                    new VoronPathSetting(DataDir).Combine($"incremental-backup-{cycle}.zip").FullPath);
+
+                // the single reference GetJournalFile takes is released by the backup's finally,
+                // so a fully captured journal's refcount hits zero and its file is moved to the
+                // recyclable set; the second cycle proves references do not accumulate
+                if (cycle == 0)
+                {
+                    Assert.False(Env.Options.JournalExists(0));
+                }
+                else
+                {
+                    Assert.False(Env.Options.JournalExists(firstCycleCurrentJournal));
+                }
+            }
+        }
+
+        private void WriteRandomData(Random random, byte[] buffer, string prefix, int count = 20000)
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("items");
+                for (int i = 0; i < count; i++)
+                {
+                    random.NextBytes(buffer);
+                    tree.Add(prefix + i, new MemoryStream(buffer));
+                }
+                tx.Commit();
+            }
+        }
+
+        private void AssertSync()
+        {
+            using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator)
+            {
+                AfterGatherInformationAction = () => Env.FlushLogToDataFile()
+            })
+            {
+                Assert.True(operation.SyncDataFile());
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27271

### Additional description

`IncrementalBackup.Incremental_Backup` obtains each journal through the internal `GetJournalFile` helper, which takes one reference on **both** of its return paths: the in-use journal found in `env.Journal.Files`, and the ad-hoc `JournalFile` it constructs for a journal that is no longer open. The backup then took a second `AddRef()` of its own, while the `finally` block releases exactly once per journal. Every incremental backup therefore left one permanent reference per journal it touched.

The leftover reference kept each journal's refcount above zero. Two consequences followed: the read/write PAL handles of every ad-hoc `JournalFile` were never closed, and the `ShouldDelete` flag the `finally` block sets was only honored when the count reached zero, so journals fully captured by a backup were never unlinked. They accumulated on disk for the life of the process, and the disk-space reclamation that incremental backup is supposed to enable never happened. `FullBackup` takes exactly one reference per journal, which confirms the balanced intent.

The fix removes the duplicate `AddRef()` and documents the ownership contract on `GetJournalFile`: the returned journal already holds one reference (taken on every return path); callers own that reference and must release it exactly once via `Release()`, without calling `AddRef()` again. The deletion policy in the `finally` block is unchanged — a journal is only marked `ShouldDelete` when its number is below both `lastWrittenLogFile` and `lastSyncedJournal`, so the current journal and journals not yet synced to the data file remain protected.

The test runs two write-flush-backup cycles and checks the observable symptom: whether journal files leave the disk. The first cycle seals a journal before backing up, forcing the path where the backup constructs the journal ad hoc, and asserts the captured journal's file is deleted — without the fix it stays. The second cycle asserts the journal protected as current during the first backup was kept until captured (deletion guards intact) and is then deleted too (references do not accumulate across backups). It fails before the fix and passes after it.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
