### PR TITLE
RavenDB-27272 Bound overflow page extent against allocated file size on read

### DIFF
--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -538,6 +538,28 @@ namespace Voron.Impl.Paging
                 GetSourceName());
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void ThrowIfOverflowExtentExceedsAllocatedPages(long pageNumber, PageHeader* pageHeader)
+        {
+            // OverflowSize is only defined on overflow pages, other page types hold their own fields at that offset
+            if ((pageHeader->Flags & PageFlags.Overflow) != PageFlags.Overflow)
+                return;
+
+            // the persisted size is untrusted, its extent must fit the allocated file
+            int overflowSize = pageHeader->OverflowSize;
+            if (overflowSize < 0 || pageNumber + VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(overflowSize) > NumberOfAllocatedPages)
+                ThrowOverflowExtentExceedsAllocatedPages(pageNumber, overflowSize);
+        }
+
+        [DoesNotReturn]
+        private void ThrowOverflowExtentExceedsAllocatedPages(long pageNumber, int overflowSize)
+        {
+            VoronUnrecoverableErrorException.Raise(_options,
+                "The overflow page " + pageNumber + " has an invalid overflow size of " + overflowSize +
+                " bytes, spanning " + VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(overflowSize) + " pages, but only " +
+                NumberOfAllocatedPages + " pages are allocated in " + GetSourceName());
+        }
+
         [DoesNotReturn]
         public static void ThrowIncreasingDataFileInCopyOnWriteModeException(string dataFilePath, long requestedSize)
         {

--- a/src/Voron/Impl/Paging/AbstractPagerExtensions.cs
+++ b/src/Voron/Impl/Paging/AbstractPagerExtensions.cs
@@ -13,8 +13,12 @@ namespace Voron.Impl.Paging
             if ((pageHeader->Flags & PageFlags.Overflow) != PageFlags.Overflow)
                 return (byte*)pageHeader;
 
+            pager.ThrowIfOverflowExtentExceedsAllocatedPages(pageNumber, pageHeader);
+
+            var numberOfOverflowPages = GetNumberOfOverflowPages(pageHeader->OverflowSize);
+
             // Case 2: Page is overflow and already mapped large enough ==> no problem, returning a pointer to existing mapping
-            if (pager.EnsureMapped(tx, pageNumber, GetNumberOfOverflowPages(pageHeader->OverflowSize)) == false)
+            if (pager.EnsureMapped(tx, pageNumber, numberOfOverflowPages) == false)
                 return (byte*)pageHeader;
 
             // Case 3: Page is overflow and was ensuredMapped above, view was re-mapped so we need to acquire a pointer to the new mapping.
@@ -29,8 +33,12 @@ namespace Voron.Impl.Paging
             if ((pageHeader->Flags & PageFlags.Overflow) != PageFlags.Overflow)
                 return (byte*)pageHeader;
 
+            pager.ThrowIfOverflowExtentExceedsAllocatedPages(pageNumber, pageHeader);
+
+            var numberOfOverflowPages = GetNumberOfOverflowPages(pageHeader->OverflowSize);
+
             // Case 2: Page is overflow and already mapped large enough ==> no problem, returning a pointer to existing mapping
-            if (pager.EnsureMapped(tx, pageNumber, GetNumberOfOverflowPages(pageHeader->OverflowSize)) == false)
+            if (pager.EnsureMapped(tx, pageNumber, numberOfOverflowPages) == false)
                 return (byte*)pageHeader;
 
             // Case 3: Page is overflow and was ensuredMapped above, view was re-mapped so we need to acquire a pointer to the new mapping.
@@ -50,8 +58,8 @@ namespace Voron.Impl.Paging
             if ((header->Flags & PageFlags.Overflow) != PageFlags.Overflow)
                 return 1;
 
-            var overflowSize = header->OverflowSize + Constants.Tree.PageHeaderSize;
-            return checked((overflowSize / Constants.Storage.PageSize) + (overflowSize % Constants.Storage.PageSize == 0 ? 0 : 1));
+            long overflowSize = (long)header->OverflowSize + Constants.Tree.PageHeaderSize;
+            return (int)(overflowSize / Constants.Storage.PageSize) + (overflowSize % Constants.Storage.PageSize == 0 ? 0 : 1);
         }
     }
 }

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -231,9 +231,7 @@ namespace Voron.Impl.Paging
 
             buffer = GetBufferAndAddToTxState(pageNumber, state, numberOfPages);
 
-            var toCopy = numberOfPages * Constants.Storage.PageSize;
-
-            AssertCopyWontExceedPagerFile(toCopy, pageNumber);
+            var toCopy = numberOfPages * (long)Constants.Storage.PageSize;
 
             Memory.Copy(buffer.Pointer, pagePointer, toCopy);
 
@@ -277,18 +275,6 @@ namespace Voron.Impl.Paging
 
                 if (tx is LowLevelTransaction llt)
                     llt._pageLocator.Reset(page);
-            }
-        }
-
-        [Conditional("DEBUG")]
-        private void AssertCopyWontExceedPagerFile(int toCopy, long startPageNumberToCopy)
-        {
-            long toCopyInPages = checked(toCopy / Constants.Storage.PageSize + (toCopy % Constants.Storage.PageSize == 0 ? 0 : 1));
-
-            if (startPageNumberToCopy + toCopyInPages > NumberOfAllocatedPages)
-            {
-                throw new InvalidOperationException(
-                    $"Copying encrypted page exceeded the page file size. Number of allocated pages is {NumberOfAllocatedPages} while it attempted to access page {startPageNumberToCopy} and copy {toCopy} bytes");
             }
         }
 
@@ -392,8 +378,7 @@ namespace Voron.Impl.Paging
                 pageHeader->OverflowSize != bufferPointer->OverflowSize)
                 throw new InvalidOperationException($"The header of {pageNumber} was modified, but it was *not* changed in this transaction!");
 
-            var toCopy = numberOfPages * Constants.Storage.PageSize;
-            AssertCopyWontExceedPagerFile(toCopy, pageNumber);
+            var toCopy = numberOfPages * (long)Constants.Storage.PageSize;
 
             ulong currentHash = Hashing.XXHash64.Calculate(buffer.Pointer, (ulong)toCopy);
 

--- a/test/FastTests/Voron/Bugs/CorruptOverflowSize.cs
+++ b/test/FastTests/Voron/Bugs/CorruptOverflowSize.cs
@@ -1,0 +1,157 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using FastTests.Voron;
+using Sparrow;
+using Sparrow.Platform;
+using Sparrow.Utils;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Exceptions;
+using Voron.Global;
+using Voron.Data.Containers;
+using Voron.Impl.Journal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron.Bugs
+{
+    public class CorruptOverflowSize : StorageTest
+    {
+        public CorruptOverflowSize(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private readonly byte[] _masterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(Constants.Storage.PageSize * 1000)] // extent runs past the end of the file
+        [InlineData(int.MaxValue)] // large enough that numberOfPages * PageSize wraps negative in an int multiply
+        [InlineData(-1)] // negative overflow size must be rejected, it is never a valid payload length
+        public void CorruptOverflowSizeOnDiskIsRejectedOnReadWithoutEncryption(int corruptOverflowSize)
+        {
+            CorruptOverflowSizeOnDiskIsRejectedOnRead(corruptOverflowSize, useEncryption: false);
+        }
+
+        [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.Encryption)]
+        [InlineData(Constants.Storage.PageSize * 1000)]
+        [InlineData(int.MaxValue)]
+        [InlineData(-1)]
+        public void CorruptOverflowSizeOnDiskIsRejectedOnReadWithEncryption(int corruptOverflowSize)
+        {
+            CorruptOverflowSizeOnDiskIsRejectedOnRead(corruptOverflowSize, useEncryption: true);
+        }
+
+        private void CorruptOverflowSizeOnDiskIsRejectedOnRead(int corruptOverflowSize, bool useEncryption)
+        {
+            long overflowPage;
+
+            using (var options = CreateOptions(useEncryption))
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    var page = tx.LowLevelTransaction.AllocateOverflowRawPage(Constants.Storage.PageSize * 2, out _, zeroPage: false);
+                    overflowPage = page.PageNumber;
+                    tx.Commit();
+                }
+
+                env.FlushLogToDataFile();
+
+                using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(env.Journal.Applicator))
+                {
+                    Assert.True(operation.SyncDataFile());
+                }
+            }
+
+            using (var fileStream = SafeFileStream.Create(Path.Combine(DataDir, Constants.DatabaseFilename),
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.ReadWrite | FileShare.Delete))
+            {
+                fileStream.Position = overflowPage * Constants.Storage.PageSize + (long)Marshal.OffsetOf<PageHeader>(nameof(PageHeader.OverflowSize));
+                var bytes = BitConverter.GetBytes(corruptOverflowSize);
+                fileStream.Write(bytes, 0, bytes.Length);
+            }
+
+            using (var options = CreateOptions(useEncryption))
+            using (var env = new StorageEnvironment(options))
+            using (var tx = env.ReadTransaction())
+            {
+                Assert.Throws<VoronUnrecoverableErrorException>(() =>
+                {
+                    tx.LowLevelTransaction.GetPage(overflowPage);
+                });
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.Encryption)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NonOverflowPageCarryingItsOwnFieldsIsStillReadable(bool useEncryption)
+        {
+            // a container page keeps NumberOfOffsets and FloorOfData in the bytes an overflow page uses for OverflowSize,
+            // and FloorOfData sits near the page size, so reading them as an overflow size gives a huge extent
+            ContainerEntryId id;
+
+            using (var options = CreateOptions(useEncryption))
+            using (var env = new StorageEnvironment(options))
+            {
+                using (var tx = env.WriteTransaction())
+                {
+                    var containerId = Container.Create(tx.LowLevelTransaction);
+                    id = Container.Allocate(tx.LowLevelTransaction, containerId, sizeof(long), out var space);
+                    BitConverter.TryWriteBytes(space, 1337L);
+                    tx.Commit();
+                }
+
+                using (var tx = env.ReadTransaction())
+                {
+                    Container.Get(tx.LowLevelTransaction, id, out var item);
+                    Assert.Equal(1337L, BitConverter.ToInt64(item.ToSpan()));
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public unsafe void ValidOverflowPageIsStillReadable()
+        {
+            RequireFileBasedPager();
+
+            const int overflowSize = Constants.Storage.PageSize * 2;
+            var payload = Enumerable.Repeat((byte)0x42, overflowSize).ToArray();
+
+            long overflowPage;
+            using (var tx = Env.WriteTransaction())
+            {
+                var page = tx.LowLevelTransaction.AllocateOverflowRawPage(overflowSize, out _, zeroPage: false);
+                overflowPage = page.PageNumber;
+                fixed (byte* p = payload)
+                    Memory.Copy(page.DataPointer, p, overflowSize);
+                tx.Commit();
+            }
+
+            RestartDatabase();
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var page = tx.LowLevelTransaction.GetPage(overflowPage);
+                Assert.True(page.IsOverflow);
+                Assert.Equal(overflowSize, page.OverflowSize);
+                Assert.True(new Span<byte>(page.DataPointer, overflowSize).SequenceEqual(payload));
+            }
+        }
+
+        private StorageEnvironmentOptions CreateOptions(bool useEncryption)
+        {
+            var options = StorageEnvironmentOptions.ForPath(DataDir);
+            options.ManualFlushing = true;
+
+            if (useEncryption)
+                options.Encryption.MasterKey = _masterKey.ToArray();
+
+            return options;
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27272

### Additional description

The size of an overflow page comes from the persisted `PageHeader->OverflowSize` field. Two read paths trusted that field before bounding it, so a corrupt data file could kill the process instead of raising Voron's corruption error.

On the encrypted read path (`CryptoPager.AcquirePagePointer`), the only guard before copying the extent out of the mapping was `AssertCopyWontExceedPagerFile`, decorated `[Conditional("DEBUG")]`. Release builds compiled it out entirely, so a corrupt `OverflowSize` copied past the end of the mapping and crashed with an access violation that no `catch` could intercept. On the plain read path, `AcquirePagePointerWithOverflowHandling` never compared the extent to the file's allocated size; checksum validation then derived its hash length from the very field it was supposed to certify.

The fix bounds the extent at the single point where it is first derived from the header:

- A new `AbstractPager.ThrowIfOverflowExtentExceedsAllocatedPages` validates the raw persisted size in release builds: it rejects negative sizes and any extent that runs past `NumberOfAllocatedPages`, raising `VoronUnrecoverableErrorException` through the same `Raise` path as `ThrowOnInvalidPageNumber` (which also marks the environment for catastrophic failure).
- Both `AcquirePagePointerWithOverflowHandling` overloads call the bound before `EnsureMapped`, so no consumer — including checksum validation — ever receives an out-of-range pointer. `EnsureMapped` semantics on the 32-bit pager are unchanged.
- `CryptoPager.AcquirePagePointer` calls the bound before the buffer copy and decryption; the `[Conditional("DEBUG")]` assert was replaced by the unconditional check.
- The page-count and copy-size arithmetic was widened to `long` so a large bogus `OverflowSize` cannot wrap the `int` multiply into a negative bound. Checksum validation is untouched.

The test corrupts an overflow page's `OverflowSize` directly in the closed data file, reopens, reads, and asserts Voron reports `VoronUnrecoverableErrorException` instead of dying. The corrupt values cover the three failure shapes — past the end of the file, `int.MaxValue` (wraps the 32-bit multiply), and `-1` — each against both the plain and the encrypted path. Before the fix the out-of-bounds read kills the test host with an access violation; after it all six cases report the error. A companion test reads a valid overflow page back intact, confirming the bound rejects only corrupt extents.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
