### PR TITLE
RavenDB-26731 Wait for old mentor to tear down its process before writing more documents in multinode task errors tests

### DIFF
--- a/test/SlowTests.Issues/Issues/RavenDB-21192.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21192.cs
@@ -2130,14 +2130,22 @@ public class RavenDB_21192_Multinode : ClusterTestBase
             Assert.Empty(otherItemErrors);
         }
         
+        await WaitAndAssertForValueAsync(() =>
+        {
+            var state = EtlProcess.GetProcessState(mentorDatabase, etlName, transformationName);
+            return state.LastProcessedEtagPerDbId.Count > 0;
+        }, true, timeout: 30_000);
+
         var newMentorTag = nodes[1].ServerStore.NodeTag;
         configuration.MentorNode = newMentorTag;
         src.Maintenance.Send(new UpdateEtlOperation<RavenConnectionString>(addResult.TaskId, configuration));
 
         var newMentorNode = nodes[1];
         var newMentorDatabase = await GetDatabase(newMentorNode, srcDatabaseName);
-        
+
         await WaitAndAssertForValueAsync(() => newMentorDatabase.EtlLoader.Processes.Any(x => x.Name == $"{etlName}/{transformationName}"), true, timeout: 30_000);
+
+        await WaitAndAssertForValueAsync(() => mentorDatabase.EtlLoader.Processes.Any(x => x.Name == $"{etlName}/{transformationName}"), false, timeout: 30_000);
 
         using (var session = src.OpenSession())
         {
@@ -2278,6 +2286,8 @@ public class RavenDB_21192_Multinode : ClusterTestBase
         var newMentorDatabase = await GetDatabase(newMentorNode, databaseName);
 
         await WaitAndAssertForValueAsync(() => newMentorDatabase.EtlLoader.Processes.Any(x => x.Name == processName), true, timeout: 30_000);
+
+        await WaitAndAssertForValueAsync(() => mentorDatabase.EtlLoader.Processes.Any(x => x.Name == processName), false, timeout: 30_000);
 
         using (var session = store.OpenSession())
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26731/SlowTests.Issues.RavenDB21192Multinode.EtlErrorsShouldBeStoredOnResponsibleNodeInCluster

### Additional description

Fixed flaky tests

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
