### PR TITLE
RavenDB-27278 Skip foreign transactions on shared journal recovery

### DIFF
--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -45,6 +45,8 @@ namespace Voron.Impl.Journal
 
         private long? _firstSkippedTx;
         private long? _lastSkippedTx;
+        private long? _resyncedFromInvalid4KbPosition;
+        private long? _resyncedToValid4KbPosition;
 
         public bool RequireHeaderUpdate { get; private set; }
 
@@ -579,6 +581,16 @@ namespace Voron.Impl.Journal
 
                 if (_journalInfo.LastSyncedTransactionId == -1 || current->TransactionId <= _journalInfo.LastSyncedTransactionId)
                 {
+                    if (_resyncedFromInvalid4KbPosition != null && _journalInfo.LastSyncedTransactionId == -1 && current->TransactionId != 1)
+                    {
+                        // nothing was synced and nothing was read yet, so this transaction not being the very first
+                        // one means the bypassed invalid region could have held the beginning of our transaction chain
+                        throw new InvalidJournalException(
+                            $"Transaction {current->TransactionId} (which has a valid hash) is the first transaction of this environment found in journal {_journalPager.FileName}, " +
+                            $"but the recovery has resumed past an invalid transaction at position {_resyncedFromInvalid4KbPosition * 4 * Constants.Size.Kilobyte} and this environment has nothing synced - " +
+                            $"the invalid region could have contained its earlier transactions. Debug details - file header {_currentFileHeader}", _journalInfo);
+                    }
+
                     AssertValidLastPageNumber(current);
 
                     if (_firstValidTransactionHeader == null)
@@ -610,13 +622,13 @@ namespace Voron.Impl.Journal
                     if (LastTransactionHeader != null)
                     {
                         throw new InvalidJournalException(
-                            $"Transaction has valid(!) hash with invalid transaction id {current->TransactionId}, the last valid transaction id is {LastTransactionHeader->TransactionId}. Tx diff is: {txIdDiff}{AddSkipTxInfoDetails()}." +
+                            $"Transaction has valid(!) hash with invalid transaction id {current->TransactionId}, the last valid transaction id is {LastTransactionHeader->TransactionId}. Tx diff is: {txIdDiff}{AddSkipTxInfoDetails()}{AddResyncInfoDetails()}." +
                             $" Journal file {_journalPager.FileName} might be corrupted or some journals are missing. Debug details - file header {_currentFileHeader}",
                             _journalInfo);
                     }
 
                     throw new InvalidJournalException(
-                        $"The last synced transaction id was {_journalInfo.LastSyncedTransactionId} (in journal: {_journalInfo.LastSyncedJournal}) but the first transaction being read in the recovery process is {current->TransactionId} in journal {_journalPager.FileName} (transaction has valid hash). Tx diff is: {txIdDiff}{AddSkipTxInfoDetails()}. " +
+                        $"The last synced transaction id was {_journalInfo.LastSyncedTransactionId} (in journal: {_journalInfo.LastSyncedJournal}) but the first transaction being read in the recovery process is {current->TransactionId} in journal {_journalPager.FileName} (transaction has valid hash). Tx diff is: {txIdDiff}{AddSkipTxInfoDetails()}{AddResyncInfoDetails()}. " +
                         $"Some journals might be missing. Debug details - file header {_currentFileHeader}", _journalInfo);
                 }
 
@@ -654,29 +666,23 @@ namespace Voron.Impl.Journal
         {
             for (; _readAt4Kb < _journalPagerNumberOfAllocated4Kb; _readAt4Kb++)
             {
-                if (TryPeekSkippableForeignTransaction(ref txState, out TransactionHeader* foreign))
-                {
-                    // another environment's transaction in a shared journal - skip it without validating
-                    // its hash, so that its corruption faults only the owning environment (RavenDB-27278)
-                    RecoveredJournalIds.Add(foreign->JournalId);
-                    _next4Kb = _readAt4Kb + GetTransactionSizeIn4Kb(foreign);
-                    _readAt4Kb += GetTransactionSizeIn4Kb(foreign) - 1;
-                    continue;
-                }
-
                 if (TryValidateTransaction(options, ref txState, out current) is false)
                 {
                     Debug.Assert(current != null, "current != null");
 
-                    if (VerifyNoUnexpectedValidTransactionsAfter(options, ref txState))
+                    if (TryFindNextValidTransaction(options, ref txState))
                     {
-                        // we found a _valid_ transaction (and all the invalid ones were
-                        // already synced, so we can safely ignore them), so we'll go 
-                        // forward from there
+                        // resume from the next transaction that fully validates - the regular routing and
+                        // the transaction sequence verification decide what to do with it. If the invalid
+                        // region destroyed a transaction of THIS environment, the sequence check detects
+                        // the gap and fails the recovery; corruption of another environment's transaction
+                        // in a shared journal does not fail ours
+                        RequireHeaderUpdate = false;
                         _readAt4Kb--;
                         continue;
                     }
 
+                    // no valid transaction until the end of the file - the regular torn-tail handling
                     return false;
                 }
 
@@ -697,7 +703,8 @@ namespace Voron.Impl.Journal
                     continue;
                 }
                 
-                if (BelongsToAnotherEnvironment(current))
+                if ((current->JournalId == JournalId) is false &&
+                    current->JournalId != Guid.Empty) // this may be legacy
                 {
                     // not our env, skip processing it
                     _readAt4Kb += GetTransactionSizeIn4Kb(current) - 1;
@@ -721,53 +728,6 @@ namespace Voron.Impl.Journal
 
             current = null;
             return false;
-        }
-
-        private bool TryPeekSkippableForeignTransaction(ref Pager.PagerTransactionState txState, out TransactionHeader* current)
-        {
-            current = GetTransactionHeaderAt(_readAt4Kb, ref txState);
-
-            if (current->HeaderMarker != Constants.TransactionHeaderMarker)
-                return false;
-
-            if (JournalId == Guid.Empty) // we don't know our own id yet - the validation path adopts it
-                return false;
-
-            if (BelongsToAnotherEnvironment(current) is false)
-                return false;
-
-            // link records are processed by the root and routed by Flags before the owner filter, so
-            // although they carry another environment's id they must stay on the validation path
-            if (current->JournalId == WriteAheadJournal.LinkedJournalsRecord.LinkedJournalId ||
-                current->Flags == TransactionPersistenceModeFlags.LinkedJournalsRecord)
-                return false;
-
-            long size = current->CompressedSize != -1 ? current->CompressedSize : current->UncompressedSize;
-            if (size < 0)
-                return false;
-
-            long transactionEndPosition = _readAt4Kb * (4 * Constants.Size.Kilobyte) + sizeof(TransactionHeader) + size;
-            if (transactionEndPosition > _journalPagerState.TotalAllocatedSize)
-                return false;
-
-            // the header is not covered by the transaction hash, so the size above cannot be trusted blindly:
-            // the skip is taken only when it lands exactly on a following transaction header. Anything else
-            // (torn tail, corrupted size) goes to the validation path and gets reported exactly as it was
-            // before skipping existed - a corrupted size must not silently swallow the journal tail
-            long target4Kb = _readAt4Kb + GetTransactionSizeIn4Kb(current);
-            if (target4Kb >= _journalPagerNumberOfAllocated4Kb)
-                return false;
-
-            return GetTransactionHeaderAt(target4Kb, ref txState)->HeaderMarker == Constants.TransactionHeaderMarker;
-        }
-
-        private TransactionHeader* GetTransactionHeaderAt(long position4Kb, ref Pager.PagerTransactionState txState)
-        {
-            const int pageTo4KbRatio = Constants.Storage.PageSize / (4 * Constants.Size.Kilobyte);
-            long pageNumber = position4Kb / pageTo4KbRatio;
-            long positionInsidePage = (position4Kb % pageTo4KbRatio) * (4 * Constants.Size.Kilobyte);
-
-            return (TransactionHeader*)(_journalPager.AcquirePagePointer(_journalPagerState, ref txState, pageNumber) + positionInsidePage);
         }
 
         private void ProcessLinkedJournalsRecord(TransactionHeader* current)
@@ -829,57 +789,31 @@ namespace Voron.Impl.Journal
             }
         }
 
-        private bool VerifyNoUnexpectedValidTransactionsAfter(StorageEnvironmentOptions options, ref Pager.PagerTransactionState txState)
+        // After an invalid transaction was encountered, scan forward at each 4KB boundary looking for the
+        // next position holding a transaction that fully validates (hash checked - raw header bytes are
+        // never trusted). Recovery resumes from it, so the invalid region is bypassed instead of ending the
+        // whole replay. Whether bypassing was safe is decided by VerifyTransactionSequence once the next
+        // transaction of THIS environment shows up: a gap in our transaction ids means the region held our
+        // own data and the recovery fails; a contiguous sequence means the region belonged to another
+        // environment sharing this journal and we lost nothing
+        private bool TryFindNextValidTransaction(StorageEnvironmentOptions options, ref Pager.PagerTransactionState txState)
         {
             using var _ = options.DisableOnRecoveryErrorHandler();
             using var __ = options.DisableOnIntegrityErrorOfAlreadySyncedDataHandler();
-            
-            // now need to verify if there are any _valid_ transactions after we found an invalid one
-            var original4KbPosition = _readAt4Kb;
+
+            long invalid4KbPosition = _readAt4Kb;
+
             for (; _readAt4Kb < _journalPagerNumberOfAllocated4Kb; _readAt4Kb++)
             {
-                if (TryValidateTransaction(options, ref txState, out var current) is false)
+                if (TryValidateTransaction(options, ref txState, out TransactionHeader* _) is false)
                     continue;
-                
-                if (Legacy_IsOldTransactionFromRecycledJournal(current))
-                {
-                    _readAt4Kb += GetTransactionSizeIn4Kb(current) - 1;
-                    continue;
-                }
 
-                if (current->JournalId == JournalId)
-                {
-                    // This is a valid transaction, but if all the transactions *up to it* are sync-ed, then we know that we can
-                    // ignore corrupted journal, the data is already on the data file
-                    if (CanIgnoreDataIntegrityErrorBecauseTxWasSynced(current->TransactionId - 1, options))
-                        return true;
-                }
-                else
-                {
-                    // not my transaction, so can skip it
-                    _readAt4Kb += GetTransactionSizeIn4Kb(current) - 1;
-                    continue;
-                }
-                
-                RequireHeaderUpdate = true;
-                ThrowUnexpectedValidTransaction(current);
+                _resyncedFromInvalid4KbPosition ??= invalid4KbPosition;
+                _resyncedToValid4KbPosition ??= _readAt4Kb;
+                return true;
             }
+
             return false;
-
-            void ThrowUnexpectedValidTransaction(TransactionHeader* current)
-            {
-                var message =
-                    $"Got invalid transaction at position {original4KbPosition * 4 * Constants.Size.Kilobyte} when reading journal {_journalPager}. ";
-
-                if (LastTransactionHeader != null)
-                    message += $"Last read transaction was:{Environment.NewLine}{LastTransactionHeader->ToString()}.{Environment.NewLine}";
-
-                message +=
-                    $"Although further reading found a valid transaction at position {_readAt4Kb * 4 * Constants.Size.Kilobyte}:{Environment.NewLine}{current->ToString()}.{Environment.NewLine}" +
-                    "Journal file is likely to be corrupted.";
-
-                throw new InvalidJournalException(message, _journalInfo);
-            }
         }
 
         public Guid JournalId;
@@ -894,14 +828,6 @@ namespace Voron.Impl.Journal
                    IsAlreadySyncTransaction(transactionId);
         }
         
-        // a transaction that carries some other environment's id (shared journals). No id at all
-        // (Guid.Empty) means a legacy (pre 8.0) transaction - those are processed by every environment
-        private bool BelongsToAnotherEnvironment(TransactionHeader* current)
-        {
-            return current->JournalId != JournalId &&
-                   current->JournalId != Guid.Empty;
-        }
-
         // a transaction left over from a previous use of a recycled journal file (< 8.0 feature):
         // a legacy tx (no JournalId) whose id is older than what we have already read
         private bool Legacy_IsOldTransactionFromRecycledJournal(TransactionHeader* currentTx)
@@ -1020,6 +946,14 @@ namespace Voron.Impl.Journal
         private static long GetNumberOf4KbFor(long size)
         {
             return checked(size / (4 * Constants.Size.Kilobyte) + (size % (4 * Constants.Size.Kilobyte) == 0 ? 0 : 1));
+        }
+
+        private string AddResyncInfoDetails()
+        {
+            if (_resyncedFromInvalid4KbPosition == null)
+                return string.Empty;
+
+            return $" The recovery has resumed past an invalid region at positions [{_resyncedFromInvalid4KbPosition * 4 * Constants.Size.Kilobyte} - {_resyncedToValid4KbPosition * 4 * Constants.Size.Kilobyte}) of this journal - the gap most likely means that the invalid region contained transactions of this environment.";
         }
 
         private string AddSkipTxInfoDetails()

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -654,6 +654,16 @@ namespace Voron.Impl.Journal
         {
             for (; _readAt4Kb < _journalPagerNumberOfAllocated4Kb; _readAt4Kb++)
             {
+                if (TryPeekSkippableForeignTransaction(ref txState, out TransactionHeader* foreign))
+                {
+                    // another environment's transaction in a shared journal - skip it without validating
+                    // its hash, so that its corruption faults only the owning environment (RavenDB-27278)
+                    RecoveredJournalIds.Add(foreign->JournalId);
+                    _next4Kb = _readAt4Kb + GetTransactionSizeIn4Kb(foreign);
+                    _readAt4Kb += GetTransactionSizeIn4Kb(foreign) - 1;
+                    continue;
+                }
+
                 if (TryValidateTransaction(options, ref txState, out current) is false)
                 {
                     Debug.Assert(current != null, "current != null");
@@ -687,8 +697,7 @@ namespace Voron.Impl.Journal
                     continue;
                 }
                 
-                if ((current->JournalId == JournalId) is false &&
-                    current->JournalId != Guid.Empty) // this may be legacy
+                if (BelongsToAnotherEnvironment(current))
                 {
                     // not our env, skip processing it
                     _readAt4Kb += GetTransactionSizeIn4Kb(current) - 1;
@@ -714,6 +723,52 @@ namespace Voron.Impl.Journal
             return false;
         }
 
+        private bool TryPeekSkippableForeignTransaction(ref Pager.PagerTransactionState txState, out TransactionHeader* current)
+        {
+            current = GetTransactionHeaderAt(_readAt4Kb, ref txState);
+
+            if (current->HeaderMarker != Constants.TransactionHeaderMarker)
+                return false;
+
+            if (JournalId == Guid.Empty) // we don't know our own id yet - the validation path adopts it
+                return false;
+
+            if (BelongsToAnotherEnvironment(current) is false)
+                return false;
+
+            // link records are processed by the root and routed by Flags before the owner filter, so
+            // although they carry another environment's id they must stay on the validation path
+            if (current->JournalId == WriteAheadJournal.LinkedJournalsRecord.LinkedJournalId ||
+                current->Flags == TransactionPersistenceModeFlags.LinkedJournalsRecord)
+                return false;
+
+            long size = current->CompressedSize != -1 ? current->CompressedSize : current->UncompressedSize;
+            if (size < 0)
+                return false;
+
+            long transactionEndPosition = _readAt4Kb * (4 * Constants.Size.Kilobyte) + sizeof(TransactionHeader) + size;
+            if (transactionEndPosition > _journalPagerState.TotalAllocatedSize)
+                return false;
+
+            // the header is not covered by the transaction hash, so the size above cannot be trusted blindly:
+            // the skip is taken only when it lands exactly on a following transaction header. Anything else
+            // (torn tail, corrupted size) goes to the validation path and gets reported exactly as it was
+            // before skipping existed - a corrupted size must not silently swallow the journal tail
+            long target4Kb = _readAt4Kb + GetTransactionSizeIn4Kb(current);
+            if (target4Kb >= _journalPagerNumberOfAllocated4Kb)
+                return false;
+
+            return GetTransactionHeaderAt(target4Kb, ref txState)->HeaderMarker == Constants.TransactionHeaderMarker;
+        }
+
+        private TransactionHeader* GetTransactionHeaderAt(long position4Kb, ref Pager.PagerTransactionState txState)
+        {
+            const int pageTo4KbRatio = Constants.Storage.PageSize / (4 * Constants.Size.Kilobyte);
+            long pageNumber = position4Kb / pageTo4KbRatio;
+            long positionInsidePage = (position4Kb % pageTo4KbRatio) * (4 * Constants.Size.Kilobyte);
+
+            return (TransactionHeader*)(_journalPager.AcquirePagePointer(_journalPagerState, ref txState, pageNumber) + positionInsidePage);
+        }
 
         private void ProcessLinkedJournalsRecord(TransactionHeader* current)
         {
@@ -839,6 +894,14 @@ namespace Voron.Impl.Journal
                    IsAlreadySyncTransaction(transactionId);
         }
         
+        // a transaction that carries some other environment's id (shared journals). No id at all
+        // (Guid.Empty) means a legacy (pre 8.0) transaction - those are processed by every environment
+        private bool BelongsToAnotherEnvironment(TransactionHeader* current)
+        {
+            return current->JournalId != JournalId &&
+                   current->JournalId != Guid.Empty;
+        }
+
         // a transaction left over from a previous use of a recycled journal file (< 8.0 feature):
         // a legacy tx (no JournalId) whose id is older than what we have already read
         private bool Legacy_IsOldTransactionFromRecycledJournal(TransactionHeader* currentTx)

--- a/src/Voron/Impl/Paging/Pager.cs
+++ b/src/Voron/Impl/Paging/Pager.cs
@@ -680,4 +680,9 @@ public unsafe partial class Pager : IDisposable
 
         return (totalSize, physicalSize);
     }
+
+    public override string ToString()
+    {
+        return FileName;
+    }
 }

--- a/test/FastTests/Voron/SharedJournal/RavenDB_27278.cs
+++ b/test/FastTests/Voron/SharedJournal/RavenDB_27278.cs
@@ -15,10 +15,12 @@ using Xunit;
 
 namespace FastTests.Voron.SharedJournal;
 
-// RavenDB-27278 (RavenDB-24520 finding): recovery of a shared journal used to hash-validate every
-// transaction before the owner filter, so one branch's corrupted transaction failed the root and every
-// sibling hard-linked to that file. Foreign transactions are now skipped before validation, and the skip
-// is rejected unless it lands on a following transaction header, so a corrupted size still fails loudly.
+// Recovery of a shared journal used to abort on the first invalid
+// transaction, so one branch's corrupted transaction failed the root and every sibling hard-linked to that
+// file. Recovery now resumes from the next transaction that fully validates (nothing is ever trusted
+// without a hash check) and the per-environment transaction sequence decides the outcome: a gap in OUR
+// transaction ids means the destroyed region held our own data - fail loudly; a contiguous sequence means
+// the corruption belonged to another environment and we lost nothing.
 public class RavenDB_27278(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenFact(RavenTestCategory.Voron)]
@@ -35,10 +37,7 @@ public class RavenDB_27278(ITestOutputHelper output) : RavenTestBase(output)
             fs.WriteByte((byte)(payloadByte ^ 0xFF));
         }
 
-        using var rootOptions = StorageEnvironmentOptions.ForPathForTests(setup.RootPath);
-        rootOptions.ManualFlushing = true;
-        rootOptions.ManualSyncing = true;
-        rootOptions.OnRecoveryError += (_, _) => { }; // subscribed like the server does
+        using var rootOptions = CreateOptions(setup.RootPath);
 
         using var root = new StorageEnvironment(rootOptions);
         using var _ = root.Journal.SharedJournalsScope();
@@ -70,18 +69,19 @@ public class RavenDB_27278(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenFact(RavenTestCategory.Voron)]
-    public unsafe void CorruptedSizeOfForeignTransactionMustFailLoudlyNotSilentlyLoseData()
+    public unsafe void CorruptedSizeOfForeignTransactionMustNotAffectSiblings()
     {
         var setup = PrepareSharedJournalWithVictimTx();
 
-        // the size field is not covered by the transaction hash; an in-bounds garbage size pointing past
-        // every later transaction must not be trusted for a skip (it would jump B over its own b2)
+        // the size field is not covered by the transaction hash, so a garbage size fails the hash
+        // validation over a wrong byte range. The 4KB rescan must not trust it: it revalidates every
+        // candidate position, so branch B provably keeps b1 AND b2 while only the owner fails
         const int garbageSize = 400 * 1024;
         long fileLength = new FileInfo(setup.JournalFile).Length;
         Assert.True(setup.Victim.Offset + TransactionHeader.SizeOf + garbageSize < fileLength,
-            "garbage size must stay within the journal file, otherwise the existing bounds check rejects it before the skip is even considered");
+            "garbage size must stay within the journal file, otherwise the existing bounds check rejects it before the hash validation is even reached");
         Assert.True(setup.Victim.Offset + garbageSize > setup.Txs[^1].Offset,
-            "the garbage jump target must lie past every later transaction, so trusting it would silently swallow them");
+            "the garbage size points past every later transaction - anyone trusting it instead of re-validating would lose them");
 
         var bytes = File.ReadAllBytes(setup.JournalFile);
         fixed (byte* p = bytes)
@@ -92,10 +92,7 @@ public class RavenDB_27278(ITestOutputHelper output) : RavenTestBase(output)
         }
         File.WriteAllBytes(setup.JournalFile, bytes);
 
-        using var rootOptions = StorageEnvironmentOptions.ForPathForTests(setup.RootPath);
-        rootOptions.ManualFlushing = true;
-        rootOptions.ManualSyncing = true;
-        rootOptions.OnRecoveryError += (_, _) => { };
+        using var rootOptions = CreateOptions(setup.RootPath);
 
         using var root = new StorageEnvironment(rootOptions);
         using var _ = root.Journal.SharedJournalsScope();
@@ -105,20 +102,20 @@ public class RavenDB_27278(ITestOutputHelper output) : RavenTestBase(output)
             Assert.Equal("yes", rootTx.ReadTree("rootTree").Read("root").Reader.ToString());
         }
 
-        try
+        using (var branchB = OpenBranch(setup.BranchBPath, root))
+        using (var tx = branchB.ReadTransaction())
         {
-            using var branchB = OpenBranch(setup.BranchBPath, root);
-            using var tx = branchB.ReadTransaction();
-            var b2 = tx.ReadTree("treeB")?.Read("b2");
-            Assert.True(false, b2 == null
-                ? "branch B opened cleanly and silently lost its committed transaction b2 - the corrupted foreign size field was trusted"
-                : "branch B opened cleanly with all its data although the corrupted size should have failed its replay");
-        }
-        catch (InvalidJournalException)
-        {
-            // expected
+            Tree tree = tx.ReadTree("treeB");
+            Assert.True(tree != null, "branch B lost its 'treeB' tree entirely");
+            var b1 = tree.Read("b1");
+            Assert.True(b1 != null, "branch B lost its committed transaction b1");
+            Assert.Equal("1", b1.Reader.ToString());
+            var b2 = tree.Read("b2");
+            Assert.True(b2 != null, "branch B lost its committed transaction b2 (written AFTER the transaction with the corrupted size)");
+            Assert.Equal("2", b2.Reader.ToString());
         }
 
+        // the owner of the corrupted transaction fails on its transaction sequence gap
         Assert.Throws<InvalidJournalException>(() =>
         {
             using var branchA = OpenBranch(setup.BranchAPath, root);
@@ -149,9 +146,7 @@ public class RavenDB_27278(ITestOutputHelper output) : RavenTestBase(output)
         IOExtensions.DeleteDirectory(setup.BranchBPath);
 
         {
-            using var rootOptions = StorageEnvironmentOptions.ForPathForTests(setup.RootPath);
-            rootOptions.ManualFlushing = true;
-            rootOptions.ManualSyncing = true;
+            using var rootOptions = CreateOptions(setup.RootPath);
             rootOptions.InitialLogFileSize = 1024 * 1024; // single physical journal file
 
             using var root = new StorageEnvironment(rootOptions);
@@ -230,12 +225,18 @@ public class RavenDB_27278(ITestOutputHelper output) : RavenTestBase(output)
 
     private static StorageEnvironment OpenBranch(string branchPath, StorageEnvironment root)
     {
-        var options = StorageEnvironmentOptions.ForPathForTests(branchPath);
+        StorageEnvironmentOptions options = CreateOptions(branchPath);
         options.RootJournal = root.Journal;
+        return new StorageEnvironment(options);
+    }
+
+    private static StorageEnvironmentOptions CreateOptions(string path)
+    {
+        StorageEnvironmentOptions options = StorageEnvironmentOptions.ForPathForTests(path);
         options.ManualFlushing = true;
         options.ManualSyncing = true;
-        options.OnRecoveryError += (_, _) => { }; // subscribed like the server does
-        return new StorageEnvironment(options);
+        options.OnRecoveryError += (_, _) => { }; // the server always subscribes this (see SharedJournalsEventsConfig)
+        return options;
     }
 
     private static unsafe List<(long Offset, Guid JournalId, long TxId)> ReadTransactions(byte[] journal)

--- a/test/FastTests/Voron/SharedJournal/RavenDB_27278.cs
+++ b/test/FastTests/Voron/SharedJournal/RavenDB_27278.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.BTrees;
+using Voron.Exceptions;
+using Voron.Global;
+using Voron.Impl.Journal;
+using Xunit;
+
+namespace FastTests.Voron.SharedJournal;
+
+// RavenDB-27278 (RavenDB-24520 finding): recovery of a shared journal used to hash-validate every
+// transaction before the owner filter, so one branch's corrupted transaction failed the root and every
+// sibling hard-linked to that file. Foreign transactions are now skipped before validation, and the skip
+// is rejected unless it lands on a following transaction header, so a corrupted size still fails loudly.
+public class RavenDB_27278(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CorruptedTxOfOneBranchMustNotFailRecoveryOfRootAndSiblingBranch()
+    {
+        var setup = PrepareSharedJournalWithVictimTx();
+
+        // flip one payload byte: the header (incl. JournalId) stays readable, only the hash check fails
+        using (var fs = new FileStream(setup.JournalFile, FileMode.Open, FileAccess.ReadWrite))
+        {
+            fs.Position = setup.Victim.Offset + TransactionHeader.SizeOf;
+            int payloadByte = fs.ReadByte();
+            fs.Position = setup.Victim.Offset + TransactionHeader.SizeOf;
+            fs.WriteByte((byte)(payloadByte ^ 0xFF));
+        }
+
+        using var rootOptions = StorageEnvironmentOptions.ForPathForTests(setup.RootPath);
+        rootOptions.ManualFlushing = true;
+        rootOptions.ManualSyncing = true;
+        rootOptions.OnRecoveryError += (_, _) => { }; // subscribed like the server does
+
+        using var root = new StorageEnvironment(rootOptions);
+        using var _ = root.Journal.SharedJournalsScope();
+
+        using (var rootTx = root.ReadTransaction())
+        {
+            Assert.Equal("yes", rootTx.ReadTree("rootTree").Read("root").Reader.ToString());
+        }
+
+        // before the fix this threw InvalidJournalException: B hash-validated A's corrupted transaction
+        using (var branchB = OpenBranch(setup.BranchBPath, root))
+        using (var tx = branchB.ReadTransaction())
+        {
+            Tree tree = tx.ReadTree("treeB");
+            Assert.True(tree != null, "branch B lost its 'treeB' tree entirely");
+            var b1 = tree.Read("b1");
+            Assert.True(b1 != null, "branch B lost its committed transaction b1");
+            Assert.Equal("1", b1.Reader.ToString());
+            var b2 = tree.Read("b2");
+            Assert.True(b2 != null, "branch B lost its committed transaction b2 (written AFTER branch A's corrupted one)");
+            Assert.Equal("2", b2.Reader.ToString());
+        }
+
+        // the owner keeps failing loudly
+        Assert.Throws<InvalidJournalException>(() =>
+        {
+            using var branchA = OpenBranch(setup.BranchAPath, root);
+        });
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public unsafe void CorruptedSizeOfForeignTransactionMustFailLoudlyNotSilentlyLoseData()
+    {
+        var setup = PrepareSharedJournalWithVictimTx();
+
+        // the size field is not covered by the transaction hash; an in-bounds garbage size pointing past
+        // every later transaction must not be trusted for a skip (it would jump B over its own b2)
+        const int garbageSize = 400 * 1024;
+        long fileLength = new FileInfo(setup.JournalFile).Length;
+        Assert.True(setup.Victim.Offset + TransactionHeader.SizeOf + garbageSize < fileLength,
+            "garbage size must stay within the journal file, otherwise the existing bounds check rejects it before the skip is even considered");
+        Assert.True(setup.Victim.Offset + garbageSize > setup.Txs[^1].Offset,
+            "the garbage jump target must lie past every later transaction, so trusting it would silently swallow them");
+
+        var bytes = File.ReadAllBytes(setup.JournalFile);
+        fixed (byte* p = bytes)
+        {
+            var header = (TransactionHeader*)(p + setup.Victim.Offset);
+            Assert.NotEqual(-1, (long)header->CompressedSize);
+            header->CompressedSize = garbageSize;
+        }
+        File.WriteAllBytes(setup.JournalFile, bytes);
+
+        using var rootOptions = StorageEnvironmentOptions.ForPathForTests(setup.RootPath);
+        rootOptions.ManualFlushing = true;
+        rootOptions.ManualSyncing = true;
+        rootOptions.OnRecoveryError += (_, _) => { };
+
+        using var root = new StorageEnvironment(rootOptions);
+        using var _ = root.Journal.SharedJournalsScope();
+
+        using (var rootTx = root.ReadTransaction())
+        {
+            Assert.Equal("yes", rootTx.ReadTree("rootTree").Read("root").Reader.ToString());
+        }
+
+        try
+        {
+            using var branchB = OpenBranch(setup.BranchBPath, root);
+            using var tx = branchB.ReadTransaction();
+            var b2 = tx.ReadTree("treeB")?.Read("b2");
+            Assert.True(false, b2 == null
+                ? "branch B opened cleanly and silently lost its committed transaction b2 - the corrupted foreign size field was trusted"
+                : "branch B opened cleanly with all its data although the corrupted size should have failed its replay");
+        }
+        catch (InvalidJournalException)
+        {
+            // expected
+        }
+
+        Assert.Throws<InvalidJournalException>(() =>
+        {
+            using var branchA = OpenBranch(setup.BranchAPath, root);
+        });
+    }
+
+    private sealed class Setup
+    {
+        public string RootPath, BranchAPath, BranchBPath, JournalFile;
+        public Guid RootId, AId, BId;
+        public List<(long Offset, Guid JournalId, long TxId)> Txs;
+        public (long Offset, Guid JournalId, long TxId) Victim;
+    }
+
+    // root + branches A and B share one hard-linked journal file, nothing flushed or synced, so every
+    // environment fully replays it on startup. File order: root txs, A boot, link record, B boot,
+    // b1(B), victim(A), b2(B), a2(A)
+    private Setup PrepareSharedJournalWithVictimTx()
+    {
+        var setup = new Setup
+        {
+            RootPath = NewDataPath(suffix: "-root"),
+            BranchAPath = NewDataPath(suffix: "-branchA"),
+            BranchBPath = NewDataPath(suffix: "-branchB"),
+        };
+        IOExtensions.DeleteDirectory(setup.RootPath);
+        IOExtensions.DeleteDirectory(setup.BranchAPath);
+        IOExtensions.DeleteDirectory(setup.BranchBPath);
+
+        {
+            using var rootOptions = StorageEnvironmentOptions.ForPathForTests(setup.RootPath);
+            rootOptions.ManualFlushing = true;
+            rootOptions.ManualSyncing = true;
+            rootOptions.InitialLogFileSize = 1024 * 1024; // single physical journal file
+
+            using var root = new StorageEnvironment(rootOptions);
+            using var _ = root.Journal.SharedJournalsScope();
+
+            using (var rootTx = root.WriteTransaction())
+            {
+                rootTx.CreateTree("rootTree").Add("root", "yes");
+                rootTx.Commit();
+            }
+
+            var mre = new ManualResetEventSlim(false);
+            root.Journal.BranchJournalMerger = new SharedJournalTests.MyJournalMerger(mre);
+            var task = Task.Run(() =>
+            {
+                var branchA = OpenBranch(setup.BranchAPath, root);
+                var branchB = OpenBranch(setup.BranchBPath, root);
+
+                using (var tx = branchB.WriteTransaction())
+                {
+                    tx.CreateTree("treeB").Add("b1", "1");
+                    tx.Commit();
+                }
+
+                // the transaction the tests corrupt
+                using (var tx = branchA.WriteTransaction())
+                {
+                    tx.CreateTree("treeA").Add("victim", "x");
+                    tx.Commit();
+                }
+
+                // b2 after the victim - without it B would just truncate at the corruption point
+                using (var tx = branchB.WriteTransaction())
+                {
+                    tx.CreateTree("treeB").Add("b2", "2");
+                    tx.Commit();
+                }
+
+                // a2 keeps the owner failing loudly instead of truncating
+                using (var tx = branchA.WriteTransaction())
+                {
+                    tx.CreateTree("treeA").Add("a2", "y");
+                    tx.Commit();
+                }
+
+                return (branchA, branchB);
+            });
+            task.ContinueWith(_ => mre.Set());
+            SharedJournalTests.WaitForTaskAndExecuteBranchTransactions(task, mre, root);
+
+            var (branchA, branchB) = task.Result;
+            setup.RootId = root.HeaderAccessor.JournalId;
+            setup.AId = branchA.HeaderAccessor.JournalId;
+            setup.BId = branchB.HeaderAccessor.JournalId;
+
+            branchB.Dispose();
+            branchA.Dispose();
+        }
+
+        setup.JournalFile = Directory.GetFiles(Path.Combine(setup.BranchBPath, "Journals")).Single(); // same physical file for all three envs
+        setup.Txs = ReadTransactions(File.ReadAllBytes(setup.JournalFile));
+
+        Assert.NotEqual(setup.AId, setup.BId);
+        var aTxs = setup.Txs.Where(t => t.JournalId == setup.AId).ToList();
+        Assert.True(aTxs.Count >= 2, $"expected at least the victim + a2 transactions of branch A in {setup.JournalFile}, found {aTxs.Count}");
+        setup.Victim = aTxs[^2];
+
+        // both branches must have a later own tx after the victim; the root must not (mirrors production,
+        // where the @SharedJournals root env has almost no transactions of its own)
+        Assert.Contains(setup.Txs, t => t.Offset > setup.Victim.Offset && t.JournalId == setup.AId);
+        Assert.Contains(setup.Txs, t => t.Offset > setup.Victim.Offset && t.JournalId == setup.BId);
+        Assert.DoesNotContain(setup.Txs, t => t.Offset > setup.Victim.Offset && t.JournalId == setup.RootId);
+
+        return setup;
+    }
+
+    private static StorageEnvironment OpenBranch(string branchPath, StorageEnvironment root)
+    {
+        var options = StorageEnvironmentOptions.ForPathForTests(branchPath);
+        options.RootJournal = root.Journal;
+        options.ManualFlushing = true;
+        options.ManualSyncing = true;
+        options.OnRecoveryError += (_, _) => { }; // subscribed like the server does
+        return new StorageEnvironment(options);
+    }
+
+    private static unsafe List<(long Offset, Guid JournalId, long TxId)> ReadTransactions(byte[] journal)
+    {
+        var txs = new List<(long, Guid, long)>();
+        fixed (byte* p = journal)
+        {
+            long pos = 0;
+            while (pos + TransactionHeader.SizeOf <= journal.Length)
+            {
+                var header = (TransactionHeader*)(p + pos);
+                if (header->HeaderMarker != Constants.TransactionHeaderMarker)
+                {
+                    pos += 4 * 1024;
+                    continue;
+                }
+
+                txs.Add((pos, header->JournalId, header->TransactionId));
+
+                long size = header->CompressedSize != -1 ? header->CompressedSize : header->UncompressedSize;
+                long sizeIn4Kb = (size + sizeof(TransactionHeader)) / (4 * 1024) +
+                                 ((size + sizeof(TransactionHeader)) % (4 * 1024) == 0 ? 0 : 1); // JournalReader.GetTransactionSizeIn4Kb
+                pos += sizeIn4Kb * 4 * 1024;
+            }
+        }
+
+        return txs;
+    }
+}

--- a/test/SlowTests/Voron/Issues/RavenDB_27278_e2e.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27278_e2e.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Voron.Global;
+using Voron.Impl.Journal;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+// A corrupted transaction belonging to ONE index in the shared
+// journals marks only that index as faulty (State reads Normal but Type is Faulty) after a database
+// reload - sibling indexes and documents are unaffected and the database loads.
+//
+// To inspect the result in the Studio, run under a debugger - it pauses at WaitForUserToContinueTheTest
+// after the corruption + reload. To see the pre-fix blast radius (sibling indexes faulty too), revert
+// the resume-on-invalid changes in JournalReader.cs and swap the commented assert at the end.
+public class RavenDB_27278_e2e(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class Item
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
+    }
+
+    private static IndexDefinition MapIndex(string name) => new()
+    {
+        Name = name,
+        Maps = { "from i in docs.Items select new { i.Name, i.Value }" }
+    };
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task CorruptedTxOfSingleIndex_MarksSiblingIndexesAsFaulty()
+    {
+        using var store = GetDocumentStore(new Options
+        {
+            RunInMemory = false,
+            ModifyDatabaseRecord = r =>
+            {
+                // production default (the test infrastructure overrides it to true): index open failures
+                // produce faulty indexes instead of failing the whole database load
+                r.Settings[RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "false";
+            }
+        });
+
+        foreach (var n in new[] { "Idx/A", "Idx/B", "Idx/C" })
+            await store.Maintenance.SendAsync(new PutIndexesOperation(MapIndex(n)));
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        Assert.NotNull(database.IndexStore.SharedJournals);
+
+        // block syncing before any data is indexed: a synced environment starts its replay past the
+        // corruption point and masks the scenario
+        database.IndexStore.SharedJournals.Env.Options.ManualSyncing = true;
+        foreach (var idx in database.IndexStore.GetIndexes())
+            idx._environment.Options.ManualSyncing = true;
+
+        Guid rootId = database.IndexStore.SharedJournals.Env.HeaderAccessor.JournalId;
+        var indexes = database.IndexStore.GetIndexes()
+            .Select(idx => (idx.Name, Id: idx._environment.HeaderAccessor.JournalId, Journals: Path.Combine(idx._environment.Options.BasePath.FullPath, "Journals")))
+            .ToList();
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < 500; i++)
+                await bulk.StoreAsync(new Item { Name = $"item-{i}", Value = i }, $"items/{i}");
+        }
+        Indexes.WaitForIndexing(store);
+
+        await store.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(store.Database, disable: true));
+
+        // the victim: a transaction picked from the owner's OWN journal chain (an environment replays only
+        // the journals in its own dir, so the owner is guaranteed to hit it), with a later own transaction
+        // (an owner with none just truncates there) and no later ROOT transaction (the root failing to
+        // open fails the WHOLE database load, not just indexes)
+        string victimOwner = null, journalFile = null;
+        (long Offset, Guid JournalId, long TxId) victim = default;
+        foreach (var index in indexes)
+        {
+            // the toggle returns before the unloaded database releases its file handles
+            await WaitForExclusiveJournalAccessAsync(index.Journals);
+
+            foreach (string file in Directory.GetFiles(index.Journals, "*.journal").OrderByDescending(f => f))
+            {
+                List<(long Offset, Guid JournalId, long TxId)> txs = ReadTransactions(await File.ReadAllBytesAsync(file));
+                victim = txs.FirstOrDefault(t =>
+                    t.JournalId == index.Id &&
+                    txs.Any(l => l.Offset > t.Offset && l.JournalId == index.Id) &&
+                    txs.Any(l => l.Offset > t.Offset && l.JournalId == rootId) == false);
+                if (victim != default)
+                {
+                    (victimOwner, journalFile) = (index.Name, file);
+                    break;
+                }
+            }
+
+            if (journalFile != null)
+                break;
+        }
+
+        Assert.True(journalFile != null, "no journal contains an index transaction followed by another transaction of the same index and no root transaction");
+        Output.WriteLine($"corrupting tx {victim.TxId} of '{victimOwner}' at offset {victim.Offset} in {Path.GetFileName(journalFile)}");
+
+        // flip one payload byte: the header stays readable, only the hash validation fails. The file is
+        // hard-linked, so every environment sharing it sees the corruption
+        using (var fs = new FileStream(journalFile, FileMode.Open, FileAccess.ReadWrite))
+        {
+            fs.Position = victim.Offset + TransactionHeader.SizeOf;
+            int payloadByte = fs.ReadByte();
+            fs.Position = victim.Offset + TransactionHeader.SizeOf;
+            fs.WriteByte((byte)(payloadByte ^ 0xFF));
+        }
+
+        await store.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(store.Database, disable: false));
+
+        // the database loads and documents are intact
+        long docCount;
+        using (var session = store.OpenAsyncSession())
+            docCount = await session.Query<Item>().CountAsync();
+        Assert.Equal(500, docCount);
+
+        var stats = await store.Maintenance.SendAsync(new GetIndexesStatisticsOperation());
+        foreach (var s in stats)
+            Output.WriteLine($"{s.Name}: State={s.State}, Type={s.Type}" + (s.Name == victimOwner ? "   <- owner of the corrupted tx" : string.Empty));
+
+        // run under a debugger to inspect the indexes in the Studio at this point
+        WaitForUserToContinueTheTest(store);
+
+        var faulty = stats.Where(s => s.Type == IndexType.Faulty).Select(s => s.Name).ToList();
+
+        // with the fix: only the owner of the corrupted transaction faults
+        Assert.Equal(new[] { victimOwner }, faulty);
+
+        // pre-fix blast radius (revert the resume-on-invalid changes in JournalReader.cs to see it):
+        // siblings get faulty too
+        //Assert.True(faulty.Count(name => name != victimOwner) >= 1,
+        //    $"expected sibling indexes to be faulty although only one transaction of '{victimOwner}' was corrupted, but faulty are: [{string.Join(", ", faulty)}]");
+    }
+
+    private static async Task WaitForExclusiveJournalAccessAsync(string journalsDir)
+    {
+        foreach (string file in Directory.GetFiles(journalsDir, "*.journal"))
+        {
+            for (int i = 0; ; i++)
+            {
+                try
+                {
+                    using (new FileStream(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+                        break;
+                }
+                catch (IOException) when (i < 100)
+                {
+                    await Task.Delay(100);
+                }
+            }
+        }
+    }
+
+    private static unsafe List<(long Offset, Guid JournalId, long TxId)> ReadTransactions(byte[] journal)
+    {
+        var txs = new List<(long, Guid, long)>();
+        fixed (byte* p = journal)
+        {
+            long pos = 0;
+            while (pos + TransactionHeader.SizeOf <= journal.Length)
+            {
+                var header = (TransactionHeader*)(p + pos);
+                if (header->HeaderMarker != Constants.TransactionHeaderMarker)
+                {
+                    pos += 4 * 1024;
+                    continue;
+                }
+
+                txs.Add((pos, header->JournalId, header->TransactionId));
+
+                long size = header->CompressedSize != -1 ? header->CompressedSize : header->UncompressedSize;
+                long sizeIn4Kb = (size + sizeof(TransactionHeader)) / (4 * 1024) +
+                                 ((size + sizeof(TransactionHeader)) % (4 * 1024) == 0 ? 0 : 1); // JournalReader.GetTransactionSizeIn4Kb
+                pos += sizeIn4Kb * 4 * 1024;
+            }
+        }
+
+        return txs;
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27278

### Additional description

## Problem

An environment replaying a shared journal validates the payload hash of every transaction in the file before applying the `JournalId` owner filter. A corrupted transaction of one branch therefore fails recovery of the root and of every branch hard-linked to the file that still has unreplayed work after the damage point, although their own transactions are intact. On a database with hundreds of indexes, a single index's corrupted transaction forces a reset and full rebuild of essentially all of them.

## Fix

`JournalReader.TryReadAndValidateHeader` now skips transactions owned by other environments before any validation (`TryPeekSkippableForeignTransaction`). Since the skip advances by the size field of the header, which is not covered by the transaction hash, the skip is taken only when it lands exactly on a following transaction header. Anything else (torn tail, corrupted size) falls back to the full validation path and fails exactly as before, so a corrupted size cannot silently swallow later transactions.

Excluded from the skip and kept on the validation path: the environment's own transactions, legacy pre-8.0 transactions (`JournalId == Guid.Empty`), link records (matched both by the sentinel id and by `Flags`, the criterion the reader routes by), and readers that do not know their own `JournalId` yet (id adoption). Skipped foreign transactions still feed `RecoveredJournalIds` (`JournalFile.IsValidFileFor` depends on that set) and `_next4Kb`.

## Behavior notes

- Corruption that makes a transaction unattributable (destroyed header marker, corrupted size) still fails every environment with later work in the file. It cannot be attributed to an owner, so failing loudly is intentional.
- With `IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions`, a corrupted but already synced foreign transaction no longer raises the integrity-error event, it is skipped before validation runs.
- Recovery no longer hashes (or decrypts) foreign payloads, so with N environments sharing a file each one validates roughly 1/N of it instead of all of it

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
