### PR TITLE
RavenDB-27280 An HNSW node record is untrusted until its counts fit its bytes

### DIFF
--- a/src/Raven.Client/Documents/Indexes/Vector/VectorOptions.cs
+++ b/src/Raven.Client/Documents/Indexes/Vector/VectorOptions.cs
@@ -78,7 +78,7 @@ public class VectorOptions
         PortableExceptions.ThrowIf<InvalidOperationException>(SourceEmbeddingType is VectorEmbeddingType.Text && Dimensions is not null, "Dimensions are set internally by the embedder.");
         PortableExceptions.ThrowIf<InvalidOperationException>(SourceEmbeddingType is VectorEmbeddingType.Int8 && DestinationEmbeddingType is not VectorEmbeddingType.Int8, "Quantization cannot be performed on already quantized vector.");
         PortableExceptions.ThrowIf<InvalidOperationException>(SourceEmbeddingType is VectorEmbeddingType.Binary && DestinationEmbeddingType is not VectorEmbeddingType.Binary, "Quantization cannot be performed on already quantized vector.");
-        PortableExceptions.ThrowIf<InvalidOperationException>(NumberOfEdges <= 0, "Number of edges has to be positive.");
+        PortableExceptions.ThrowIf<InvalidOperationException>(NumberOfEdges < 2, "Number of edges has to be at least 2.");
         PortableExceptions.ThrowIf<InvalidOperationException>(NumberOfCandidatesForIndexing <= 0, "Number of candidate nodes has to be positive.");
     }
     

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -624,8 +624,9 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Corax.VectorSearch.DefaultMinimumSimilarity", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public float CoraxVectorSearchDefaultMinimumSimilarity { get; protected set; }
         
-        [Description("The default number of edges created for a vector during vector indexing.")]
+        [Description("The default number of edges created for a vector during vector indexing. Cannot be less than 2.")]
         [DefaultValue(12)]
+        [MinValue(2)]
         [IndexUpdateType(IndexUpdateType.Reset)]
         [ConfigurationEntry("Indexing.Corax.VectorSearch.DefaultNumberOfEdges", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public int CoraxVectorDefaultNumberOfEdges { get; protected set; }

--- a/src/Voron/Data/Graphs/Hnsw.Node.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Node.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Runtime.CompilerServices;
 using Sparrow;
 using Sparrow.Compression;
@@ -104,14 +105,18 @@ public partial class Hnsw
 
         public static NodeReader Decode(LowLevelTransaction llt, Span<byte> span)
         {
-            var postingListId = VariableSizeEncoding.Read<long>(span, out var pos);
-            var offset = pos;
-            var vectorId = VariableSizeEncoding.Read<long>(span, out pos, offset);
-            offset += pos;
-            var countOfLevels = VariableSizeEncoding.Read<int>(span, out pos, offset);
-            offset += pos;
+            var offset = 0;
+            var postingListId = NodeReader.ReadBoundedVarInt(span, ref offset);
+            var vectorId = NodeReader.ReadBoundedVarInt(span, ref offset);
+            var countOfLevels = NodeReader.ReadBoundedVarInt(span, ref offset);
 
-            return new NodeReader(llt.Allocator, span[offset..]) { PostingListId = postingListId, VectorId = vectorId, CountOfLevels = countOfLevels };
+            // Every level costs at least one byte: its edge-count varint. A valid record is at
+            // least countOfLevels bytes longer than its fixed prefix. The count is persisted
+            // bytes sizing a native allocation. It is untrusted until this holds.
+            if (countOfLevels < 0 || countOfLevels > span.Length - offset)
+                throw new InvalidDataException($"Corrupt HNSW node record: countOfLevels {countOfLevels} does not fit the {span.Length - offset} bytes remaining in the record");
+
+            return new NodeReader(llt.Allocator, span[offset..]) { PostingListId = postingListId, VectorId = vectorId, CountOfLevels = (int)countOfLevels };
         }
 
         public Span<byte> Encode(ref ContextBoundNativeList<byte> buffer)

--- a/src/Voron/Data/Graphs/Hnsw.NodeReader.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NodeReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using Sparrow;
 using Sparrow.Compression;
 using Sparrow.Server;
@@ -25,10 +26,21 @@ public partial class Hnsw
             node.VectorId = VectorId;
             node.PostingListId = PostingListId;
             node.EdgesPerLevel.EnsureCapacityFor(allocator, CountOfLevels);
+
+            // CountOfLevels sized the allocation above. The record must deliver exactly that
+            // many level lists. The adds below are unchecked and would run past the capacity.
+            var levels = 0;
             while (NextReadEdges(out var list))
             {
+                if (levels == CountOfLevels)
+                    throw new InvalidDataException($"Corrupt HNSW node record: it holds more level lists than the {CountOfLevels} it declares");
+
                 node.EdgesPerLevel.AddUnsafe(list);
+                levels++;
             }
+
+            if (levels != CountOfLevels)
+                throw new InvalidDataException($"Corrupt HNSW node record: it declares {CountOfLevels} level lists but holds only {levels}");
         }
 
         private bool NextReadEdges(out NativeList<long> list)
@@ -39,21 +51,41 @@ public partial class Hnsw
                 return false;
             }
 
-            var count = VariableSizeEncoding.Read<int>(_buffer, out int offset, _offset);
-            _offset += offset;
+            var count = ReadBoundedVarInt(_buffer, ref _offset);
+
+            // Every edge costs at least one byte. A valid edge count cannot exceed the bytes
+            // remaining. The count is persisted bytes sizing a native allocation.
+            if (count < 0 || count > _buffer.Length - _offset)
+                throw new InvalidDataException($"Corrupt HNSW node record: edge count {count} does not fit the {_buffer.Length - _offset} bytes remaining in the record");
+
             list = new NativeList<long>();
-            list.EnsureCapacityFor(allocator, count);
+            list.EnsureCapacityFor(allocator, (int)count);
             long prev = 0;
             for (int i = 0; i < count; i++)
             {
-                var item = VariableSizeEncoding.Read<long>(_buffer, out offset, _offset);
-                _offset += offset;
-                prev += item;
+                prev += ReadBoundedVarInt(_buffer, ref _offset);
                 Debug.Assert(prev >= 0, "prev >= 0");
                 list.AddUnsafe(prev);
             }
 
             return true;
+        }
+
+        /// Reads a LEB128 varint without stepping past the buffer. The record is persisted bytes.
+        /// A truncated varint must fail as a corrupt-record error, not read adjacent memory.
+        internal static long ReadBoundedVarInt(ReadOnlySpan<byte> buffer, ref int offset)
+        {
+            ulong result = 0;
+            for (int shift = 0; shift < 64; shift += 7)
+            {
+                if (offset >= buffer.Length)
+                    throw new InvalidDataException("Corrupt HNSW node record: truncated varint");
+                byte b = buffer[offset++];
+                result |= (ulong)(b & 0x7F) << shift;
+                if (b < 0x80)
+                    return (long)result;
+            }
+            throw new InvalidDataException("Corrupt HNSW node record: varint exceeds 64 bits");
         }
 
         public UnmanagedSpan ReadVector(in SearchState state) => ReadVector(VectorId, in state);

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -36,6 +36,12 @@ public unsafe partial class Hnsw
 
     public static void Create(LowLevelTransaction llt, Slice name, int vectorSizeBytes, int numberOfEdges, int numberOfCandidates, VectorEmbeddingType embeddingType)
     {
+        // The level formula divides by Log(numberOfEdges). An edge count of 1 makes the level
+        // factor infinite. The int cast then skips graph placement and persists every
+        // non-root node with zero edges.
+        if (numberOfEdges < 2)
+            throw new ArgumentOutOfRangeException(nameof(numberOfEdges), numberOfEdges, "An HNSW graph needs at least 2 edges per node.");
+
         var tree = llt.Transaction.CreateTree(name);
         if (tree.State.Header.NumberOfEntries is not 0)
             return; // already created

--- a/test/FastTests/Voron/Graphs/BasicGraphs.cs
+++ b/test/FastTests/Voron/Graphs/BasicGraphs.cs
@@ -520,4 +520,20 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             Assert.Equal(3, read);
         }
     }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void GraphCannotBeCreatedWithSingleEdgePerNode()
+    {
+        using var _ = Slice.From(Allocator, "test", out var treeName);
+
+        using (var txw = Env.WriteTransaction())
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                Hnsw.Create(txw.LowLevelTransaction, treeName, 16, numberOfEdges: 1, 12, VectorEmbeddingType.Single));
+
+            // The floor, not a blanket rejection: 2 edges is a legal graph.
+            Hnsw.Create(txw.LowLevelTransaction, treeName, 16, numberOfEdges: 2, 12, VectorEmbeddingType.Single);
+            txw.Commit();
+        }
+    }
 }

--- a/test/FastTests/Voron/Graphs/CorruptNodeRecord.cs
+++ b/test/FastTests/Voron/Graphs/CorruptNodeRecord.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Graphs;
+using Xunit;
+
+namespace FastTests.Voron.Graphs;
+
+public class CorruptNodeRecord(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void NodeRecordDeclaringMoreLevelsThanItHasBytesIsRejected()
+    {
+        using (var txw = Env.WriteTransaction())
+        {
+            // postingListId = 1, vectorId = 1, countOfLevels = 2^25 — in a 6-byte record.
+            var corrupt = new byte[] { 0x01, 0x01, 0x80, 0x80, 0x80, 0x10 };
+
+            Assert.Throws<InvalidDataException>(() => Hnsw.Node.Decode(txw.LowLevelTransaction, corrupt));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void NodeRecordTruncatedInsideVarintIsRejected()
+    {
+        using (var txw = Env.WriteTransaction())
+        {
+            // postingListId = 1, vectorId = 1, then a countOfLevels varint that never terminates.
+            var truncated = new byte[] { 0x01, 0x01, 0x80 };
+
+            Assert.Throws<InvalidDataException>(() => Hnsw.Node.Decode(txw.LowLevelTransaction, truncated));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void EdgeCountLargerThanRecordIsRejected()
+    {
+        using (var txw = Env.WriteTransaction())
+        {
+            // postingListId = 1, vectorId = 1, countOfLevels = 1, then an edge count of 100 with no edges behind it.
+            var corrupt = new byte[] { 0x01, 0x01, 0x01, 0x64 };
+
+            Assert.Throws<InvalidDataException>(() =>
+            {
+                var reader = Hnsw.Node.Decode(txw.LowLevelTransaction, corrupt);
+                var node = new Hnsw.Node();
+                reader.LoadInto(ref node);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void NodeRecordHoldingMoreLevelsThanItDeclaresIsRejected()
+    {
+        using (var txw = Env.WriteTransaction())
+        {
+            // postingListId = 1, vectorId = 1, countOfLevels = 1 — followed by four zero-edge levels.
+            var corrupt = new byte[] { 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00 };
+
+            Assert.Throws<InvalidDataException>(() =>
+            {
+                var reader = Hnsw.Node.Decode(txw.LowLevelTransaction, corrupt);
+                var node = new Hnsw.Node();
+                reader.LoadInto(ref node);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void NodeRecordHoldingFewerLevelsThanItDeclaresIsRejected()
+    {
+        using (var txw = Env.WriteTransaction())
+        {
+            // postingListId = 1, vectorId = 1, countOfLevels = 3. The three remaining bytes
+            // hold a single level (2 edges: 1, +1). The count survives Decode. Only the
+            // level tally can catch it.
+            var corrupt = new byte[] { 0x01, 0x01, 0x03, 0x02, 0x01, 0x01 };
+
+            Assert.Throws<InvalidDataException>(() =>
+            {
+                var reader = Hnsw.Node.Decode(txw.LowLevelTransaction, corrupt);
+                var node = new Hnsw.Node();
+                reader.LoadInto(ref node);
+            });
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void ValidNodeRecordStillRoundTrips()
+    {
+        using (var txw = Env.WriteTransaction())
+        {
+            // postingListId = 1, vectorId = 2, one level holding edges {3, 5} (delta-encoded 3, +2).
+            var valid = new byte[] { 0x01, 0x02, 0x01, 0x02, 0x03, 0x02 };
+
+            var reader = Hnsw.Node.Decode(txw.LowLevelTransaction, valid);
+            Assert.Equal(1, reader.PostingListId);
+            Assert.Equal(2, reader.VectorId);
+            Assert.Equal(1, reader.CountOfLevels);
+
+            var node = new Hnsw.Node();
+            reader.LoadInto(ref node);
+            Assert.Equal(1, node.EdgesPerLevel.Count);
+            Assert.Equal(2, node.EdgesPerLevel[0].Count);
+            Assert.Equal(3, node.EdgesPerLevel[0][0]);
+            Assert.Equal(5, node.EdgesPerLevel[0][1]);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27280

### Additional description

An HNSW node record is persisted bytes. Its `countOfLevels` and per-level edge counts size native allocations, and they were read with an unchecked varint reader before any length validation. A single flipped bit in the level-count byte inflates the count: the varint high bit absorbs the following record bytes as high-order count bits. A 6-byte record declaring 2^25 levels commits 512 MB of native memory. A truncated varint reads past the record through `Unsafe.Add`. In release builds `NativeList.AddUnsafe` checks capacity only with `Debug.Assert`, so a record holding more level lists than it declares can write past the allocation. Page checksums do not screen this path: they validate once per run and cannot catch malformed records written through the legitimate write path.

The fix validates the record before trusting it:

- A bounded LEB128 reader throws `InvalidDataException` on truncation or a value over 64 bits.
- `Decode` and `NextReadEdges` validate every count against the bytes remaining. Every level and every edge costs at least one byte, which bounds both counts.
- `LoadInto` enforces that the record delivers exactly the declared number of level lists, in both directions.

Separately, `Hnsw.Create` accepted `numberOfEdges < 2`. The level formula divides by `Log(numberOfEdges)`, so an edge count of 1 makes the level factor infinite, the int cast skips graph placement, and every non-root node persists with zero edges: an unsearchable graph written to disk as valid data. Creation now rejects `numberOfEdges < 2` with `ArgumentOutOfRangeException`.

A vector index configured with a single edge per node now fails at graph creation with ArgumentOutOfRangeException` instead of silently building an unsearchable graph. Corrupt node records now fail the read with `InvalidDataException` instead of over-allocating or reading past the record.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
