### PR TITLE
RavenDB-27281 Discarding a scratch modification invalidates the page locator entry

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1052,6 +1052,11 @@ namespace Voron.Impl
                 }
             }
 
+            // The locator caches the page's scratch translation. The discard makes that entry
+            // stale. A re-allocation of the same page number would not overwrite it, because
+            // SetWritable skips entries that are already writable.
+            _pageLocator.Reset(pageNumber);
+
             _dirtyPages.Remove(pageNumber);
 
             UntrackDirtyPage(pageNumber);

--- a/test/FastTests/Voron/Trees/Updates.cs
+++ b/test/FastTests/Voron/Trees/Updates.cs
@@ -161,6 +161,68 @@ namespace FastTests.Voron.Trees
             }
         }
 
-     
+        [RavenFact(RavenTestCategory.Voron)]
+        public void OverwriteThatShrinksOverflowValueReadsBackInSameTransaction()
+        {
+            var value1 = new byte[33_000];
+            var value2 = new byte[20_000];
+            new Random(1).NextBytes(value1);
+            new Random(2).NextBytes(value2);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("t");
+                tree.Add("key", value1);
+                tree.Add("key", value2);
+
+                var read = tree.Read("key");
+                Assert.Equal(value2.Length, read.Reader.Length);
+
+                var actual = new byte[value2.Length];
+                read.Reader.Read(actual, 0, actual.Length);
+                Assert.Equal(value2, actual);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void ThirdOverwriteDoesNotFreeNeighboursPages()
+        {
+            var v1 = new byte[33_000];
+            var v2 = new byte[20_000];
+            var v3 = new byte[10_000];
+            var n = new byte[10_000];
+            new Random(1).NextBytes(v1);
+            new Random(2).NextBytes(v2);
+            new Random(3).NextBytes(v3);
+            new Random(4).NextBytes(n);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("t");
+                tree.Add("K", v1);
+                tree.Add("K", v2); // shrink frees pages the next key can claim
+                tree.Add("N", n);
+                tree.Add("K", v3); // a stale overflow header here would free N's pages
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("t");
+
+                var readN = tree.Read("N");
+                Assert.Equal(n.Length, readN.Reader.Length);
+                var actualN = new byte[n.Length];
+                readN.Reader.Read(actualN, 0, actualN.Length);
+                Assert.Equal(n, actualN);
+
+                var readK = tree.Read("K");
+                Assert.Equal(v3.Length, readK.Reader.Length);
+                var actualK = new byte[v3.Length];
+                readK.Reader.Read(actualK, 0, actualK.Length);
+                Assert.Equal(v3, actualK);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27281

### Additional description

`TryOverwriteOverflowPages` shrinks an overflow value in place: `DiscardScratchModificationOn` frees the scratch slot and the page is re-allocated, but `PageLocator.SetWritable` skips the update because the cached entry has the same page number and is already writable. The locator keeps mapping the page to the freed slot, so a read of the same key later in the transaction returns the previous value with no error.

With the stale entry in place, a third overwrite of the same key reads the old, larger overflow header, computes a stale `overflowsToFree`, and frees pages a sibling key already re-allocated in the same transaction. The free-space tree then lists live pages as free, a later allocation reissues them, and one committed value silently overwrites another. The corruption is permanent on disk and unrecoverable above the engine.

The fix is one line: `DiscardScratchModificationOn` resets the locator entry for the discarded page. It also covers the `FreePage` path, which discards through the same method.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
