### PR TITLE
RavenDB-27282 Stream tags are capped to the info page

### DIFF
--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -213,8 +213,15 @@ namespace Voron.Data.BTrees
             }
         }
 
+        // The writer may force the stream info and its tag onto a fresh single page. The tag
+        // can never exceed one page's data area.
+        public const int MaxStreamTagSize = Constants.Storage.PageSize - PageHeader.SizeOf - StreamInfo.SizeOf;
+
         public void AddStream(Slice key, Stream stream, Slice? tag = null, int? initialNumberOfPagesPerChunk = null)
         {
+            if (tag is { Size: > MaxStreamTagSize })
+                throw new ArgumentException($"Stream tag of {tag.Value.Size} bytes exceeds the maximum of {MaxStreamTagSize} bytes", nameof(tag));
+
             var writer = new StreamToPageWriter();
             writer.Init(this, key, tag, initialNumberOfPagesPerChunk);
             writer.Write(stream);

--- a/test/SlowTests/Voron/Streams/CanUseStream.cs
+++ b/test/SlowTests/Voron/Streams/CanUseStream.cs
@@ -3,6 +3,7 @@ using System.IO;
 using FastTests.Voron.FixedSize;
 using Tests.Infrastructure;
 using Voron;
+using Voron.Data.BTrees;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -204,6 +205,25 @@ namespace SlowTests.Voron.Streams
                 {
                     Assert.Equal(tree.State.Header.OverflowPages + tree.State.Header.BranchPages + tree.State.Header.LeafPages, tree.AllPages().Count);
                 }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void StreamTagLargerThanInfoPageIsRejected()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Files");
+
+                Assert.Throws<ArgumentException>(() =>
+                    tree.AddStream("key", new MemoryStream(new byte[128]), tag: new string('x', Tree.MaxStreamTagSize + 1)));
+
+                // The cap, not a blanket rejection: the largest tag that fits still round-trips.
+                var maxTag = new string('x', Tree.MaxStreamTagSize);
+                tree.AddStream("key", new MemoryStream(new byte[128]), tag: maxTag);
+                Assert.Equal(maxTag, tree.GetStreamTag("key"));
+
+                tx.Commit();
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27282

### Additional description

`AddStream` accepts a tag of any size while the chunked stream format caps the info area at one page. `RecordStreamInfo` copies the tag past the 8 KB info page into adjacent scratch memory before any size check runs.

`AddStream` now rejects tags above `Tree.MaxStreamTagSize` with `ArgumentException` before any page is touched. The cap is `PageSize − PageHeader.SizeOf − StreamInfo.SizeOf` (8112 bytes), and the largest fitting tag still round-trips.

A stream tag larger than the info page now fails the `AddStream` call with `ArgumentException` instead of silently corrupting adjacent scratch memory.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
