### PR TITLE
RavenDB-27283 A subscriber failure after the journal write is catastrophic

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1149,12 +1149,30 @@ namespace Voron.Impl
                 {
                     Environment.LastWorkTime = DateTime.UtcNow;
                 }
-                
+
                 CommitStage2_WriteToJournal();
             }
-            
-            BeforeCommitFinalization?.Invoke(this);
+
+            InvokeBeforeCommitFinalization();
             CommitStage3_DisposeTransactionResources();
+        }
+
+        /// Once the journal holds the transaction, recovery will replay it no matter what the
+        /// in-memory state decides afterwards. A subscriber failing past that point means the
+        /// application observed a rollback the store will not honor. The environment must come
+        /// down for recovery instead of serving the divergent state.
+        private void InvokeBeforeCommitFinalization()
+        {
+            try
+            {
+                BeforeCommitFinalization?.Invoke(this);
+            }
+            catch (Exception e) when (FlushedToJournal)
+            {
+                _txState |= TxState.Errored;
+                _env.Options.SetCatastrophicFailure(ExceptionDispatchInfo.Capture(e));
+                throw;
+            }
         }
 
         internal Task<bool> AsyncCommit;
@@ -1275,7 +1293,7 @@ namespace Voron.Impl
                     Environment.LastWorkTime = DateTime.UtcNow;
             }
 
-            BeforeCommitFinalization?.Invoke(this);
+            InvokeBeforeCommitFinalization();
             CommitStage3_DisposeTransactionResources();
         }
 

--- a/test/FastTests/Voron/CommitFinalizationGuard.cs
+++ b/test/FastTests/Voron/CommitFinalizationGuard.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Text;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron
+{
+    public class CommitFinalizationGuard : StorageTest
+    {
+        public CommitFinalizationGuard(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void SubscriberFailureAfterJournalWriteTakesEnvironmentDown()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.ModifyPage(0);
+                tx.LowLevelTransaction.BeforeCommitFinalization += _ => throw new InvalidOperationException("subscriber failed");
+
+                Assert.Throws<InvalidOperationException>(() => tx.Commit());
+            }
+
+            Assert.True(Env.Options.IsCatastrophicFailureSet);
+
+            // The journal already holds the transaction. Serving further writes as if it rolled
+            // back would diverge from what recovery will replay. The background flusher may have
+            // wrapped the stored failure by now. Assert on the exception chain, not the type.
+            var e = Assert.ThrowsAny<Exception>(() => Env.WriteTransaction().Dispose());
+            Assert.Contains("subscriber failed", FlattenMessages(e));
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void SubscriberFailureAfterAsyncJournalWriteTakesEnvironmentDown()
+        {
+            var tx = Env.WriteTransaction();
+            try
+            {
+                tx.LowLevelTransaction.ModifyPage(0);
+                tx.LowLevelTransaction.BeforeCommitFinalization += _ => throw new InvalidOperationException("subscriber failed");
+
+                var next = tx.BeginAsyncCommitAndStartNewTransaction(tx.LowLevelTransaction.PersistentContext);
+                try
+                {
+                    Assert.Throws<InvalidOperationException>(() => tx.EndAsyncCommit());
+                }
+                finally
+                {
+                    next.Dispose();
+                }
+            }
+            finally
+            {
+                tx.Dispose();
+            }
+
+            Assert.True(Env.Options.IsCatastrophicFailureSet);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void SubscriberFailureWithNothingJournaledIsNotCatastrophic()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.BeforeCommitFinalization += _ => throw new InvalidOperationException("subscriber failed");
+
+                Assert.Throws<InvalidOperationException>(() => tx.Commit());
+            }
+
+            Assert.False(Env.Options.IsCatastrophicFailureSet);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.ModifyPage(0);
+                tx.Commit();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void LastChanceSubscriberFailureBeforeJournalWriteIsNotCatastrophic()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.ModifyPage(0);
+                tx.LowLevelTransaction.LastChanceToReadFromWriteTransactionBeforeCommit += _ => throw new InvalidOperationException("subscriber failed");
+
+                Assert.Throws<InvalidOperationException>(() => tx.Commit());
+            }
+
+            Assert.False(Env.Options.IsCatastrophicFailureSet);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.ModifyPage(0);
+                tx.Commit();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void AfterCommitSubscriberFailureUnderPreventedTransactionsTakesEnvironmentDown()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.ModifyPage(0);
+                tx.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += _ => throw new InvalidOperationException("subscriber failed");
+
+                Assert.Throws<InvalidOperationException>(() => tx.Commit());
+            }
+
+            Assert.True(Env.Options.IsCatastrophicFailureSet);
+        }
+
+        private static string FlattenMessages(Exception e)
+        {
+            var sb = new StringBuilder();
+            for (; e != null; e = e.InnerException)
+                sb.AppendLine(e.Message);
+            return sb.ToString();
+        }
+    }
+}

--- a/test/FastTests/Voron/CommitFinalizationRecovery.cs
+++ b/test/FastTests/Voron/CommitFinalizationRecovery.cs
@@ -1,0 +1,49 @@
+using System;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron
+{
+    public class CommitFinalizationRecovery : StorageTest
+    {
+        public CommitFinalizationRecovery(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void FailedCommitAfterJournalWriteDivergesFromRecovery()
+        {
+            RequireFileBasedPager();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree").Add("key", "value");
+                tx.LowLevelTransaction.BeforeCommitFinalization += _ => throw new InvalidOperationException("subscriber failed");
+
+                Assert.Throws<InvalidOperationException>(() => tx.Commit());
+            }
+
+            bool catastrophic = Env.Options.IsCatastrophicFailureSet;
+
+            bool visibleBeforeRestart;
+            using (Env.Options.SkipCatastrophicFailureAssertion())
+            using (var tx = Env.ReadTransaction())
+                visibleBeforeRestart = tx.ReadTree("tree")?.Read("key") != null;
+
+            using (Env.Options.SkipCatastrophicFailureAssertion())
+                RestartDatabase();
+
+            bool visibleAfterRestart;
+            using (var tx = Env.ReadTransaction())
+                visibleAfterRestart = tx.ReadTree("tree")?.Read("key") != null;
+
+            // the journal holds the write the caller observed as rolled back, so recovery replays it
+            Assert.False(visibleBeforeRestart);
+            Assert.True(visibleAfterRestart);
+
+            // in-memory state and the journaled state disagree: the environment must not keep serving
+            Assert.True(catastrophic);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27283

### Additional description

`BeforeCommitFinalization` fires after `CommitStage2_WriteToJournal`. A subscriber exception skips `CommitStage3` and surfaces as a failed commit, but the journal already holds the transaction, so recovery will replay writes the application observed as rolled back. The event cannot move before the journal write, because the crypto pager encrypts its buffers on it, so the fix is a barrier, not a reorder.

`InvokeBeforeCommitFinalization` wraps the event for both the sync and the async commit paths. A subscriber failure with `FlushedToJournal` set marks the transaction errored, records the exception via `SetCatastrophicFailure`, and rethrows. The environment refuses further work and restarts into recovery, and recovery honors the journal. A failure with nothing journaled stays an ordinary rollback.

A subscriber failure after the journal write now takes the environment into catastrophic failure (restart into the journaled state) instead of serving in-memory state that diverges from what recovery will replay.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
