### PR TITLE
RavenDB-27284 A refused dispose keeps the environment intact

### DIFF
--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -498,6 +498,11 @@ namespace Voron
                 return; // already disposed
 
             _cancellationTokenSource.SafeCancel(_log, $"Disposing {Options}");
+
+            // Set when the dispose guard throws. Live transactions still map the data file
+            // and the drain restored the dispose count, so teardown must not run. A later
+            // Dispose retries the full sequence once the transactions are gone.
+            bool teardownRefused = false;
             try
             {
                 SelfReference.Owner = null;
@@ -541,37 +546,45 @@ namespace Voron
                     MoveEnvironmentToDisposeState();
                 }
             }
+            catch (TimeoutException)
+            {
+                teardownRefused = true;
+                throw;
+            }
             finally
             {
-                var errors = new List<Exception>();
-
-                OnLogsApplied = null;
-
-                _options.NullifyHandlers();
-
-                foreach (var disposable in new IDisposable[]
+                if (teardownRefused == false)
                 {
-                    _journal,
-                    _headerAccessor,
-                    _scratchBufferPool,
-                    _decompressionBuffers,
-                    _options.OwnsPagers ? _options : null,
-                })
-                {
-                    try
+                    var errors = new List<Exception>();
+
+                    OnLogsApplied = null;
+
+                    _options.NullifyHandlers();
+
+                    foreach (var disposable in new IDisposable[]
                     {
-                        disposable?.Dispose();
-                    }
-                    catch (Exception e)
+                        _journal,
+                        _headerAccessor,
+                        _scratchBufferPool,
+                        _decompressionBuffers,
+                        _options.OwnsPagers ? _options : null,
+                    })
                     {
-                        errors.Add(e);
+                        try
+                        {
+                            disposable?.Dispose();
+                        }
+                        catch (Exception e)
+                        {
+                            errors.Add(e);
+                        }
                     }
+
+                    GC.SuppressFinalize(this);
+
+                    if (errors.Count != 0)
+                        throw new AggregateException(errors);
                 }
-
-                GC.SuppressFinalize(this);
-
-                if (errors.Count != 0)
-                    throw new AggregateException(errors);
             }
         }
 

--- a/test/FastTests/Voron/DisposeGuard.cs
+++ b/test/FastTests/Voron/DisposeGuard.cs
@@ -1,0 +1,45 @@
+using System;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron
+{
+    public class DisposeGuard : StorageTest
+    {
+        public DisposeGuard(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            // Background flushing takes its own low-level transactions, which share the
+            // dispose countdown. Manual flushing keeps the countdown owned by this test
+            // alone, so both Dispose outcomes are decided by structure, not speed.
+            options.ManualFlushing = true;
+            options.DisposeWaitTime = TimeSpan.FromMilliseconds(100);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void RefusedDisposeLeavesLiveTransactionsReadable()
+        {
+            using (var txw = Env.WriteTransaction())
+            {
+                txw.CreateTree("guarded").Add("key", "value");
+                txw.Commit();
+            }
+
+            using (var txr = Env.ReadTransaction())
+            {
+                Assert.Throws<TimeoutException>(() => Env.Dispose());
+
+                var result = txr.ReadTree("guarded").Read("key");
+                Assert.NotNull(result);
+            }
+
+            // The refused dispose restored the count. With the transaction gone it completes.
+            Env.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27284

### Additional description

When `Dispose()` cannot drain active transactions within `Options.DisposeWaitTime`, it throws the guard `TimeoutException`, yet its finally block still disposes the journal, the header accessor, the scratch pool and the pagers — the exact memory those transactions still map. Live transactions are left reading an unmapped data file, and the next page read is an access violation.

`Dispose()` now tracks the guard refusal and skips teardown when the guard throws. The drain already restored the dispose count, so a later `Dispose()` retries the full sequence once the transactions are gone.

A `Dispose()` that times out on active transactions now leaves the environment fully usable (and disposable later) instead of tearing it down underneath the live transactions.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
