### PR TITLE
RavenDB-27285 A rebuilt or upgraded metadata file no longer regenerates the JournalId that recovery filters by

### DIFF
--- a/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
@@ -38,10 +38,11 @@ namespace Voron.Impl.FileHeaders
                 if (_disposed)
                     throw new ObjectDisposedException("Cannot access the header after it was disposed");
 
-                MetadataAccessor.Initialize();
-
                 var hasOne = env.Options.ReadValidHeader(HeaderFileNames[0], out var headerOne);
                 var hasTwo = env.Options.ReadValidHeader(HeaderFileNames[1], out var headerTwo);
+
+                MetadataAccessor.Initialize(isNewStore: hasOne is false && hasTwo is false);
+
                 if (hasOne is false && hasTwo is false)
                 {
                     // new 

--- a/src/Voron/Impl/FileHeaders/MetadataAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/MetadataAccessor.cs
@@ -14,12 +14,26 @@ public sealed class MetadataAccessor(StorageEnvironment env)
     private MetadataFile _metadata;
     public Guid JournalId => _metadata.JournalId;
 
-    public bool Initialize()
+    public bool Initialize(bool isNewStore)
     {
         var hasMetadata = env.Options.ReadValidMetadata(MetadataName, out _metadata);
         if (hasMetadata == false)
         {
-            Modify(FillMetadata);
+            if (isNewStore)
+            {
+                Modify(FillMetadata);
+            }
+            else
+            {
+                // A fresh id on an existing store would make recovery skip the store's own
+                // journal transactions as foreign. Guid.Empty defers the choice to recovery,
+                // which resolves the id from the journals before it applies anything.
+                Modify(static (ref MetadataFile metadata) =>
+                {
+                    metadata.JournalId = Guid.Empty;
+                    metadata.Version = Constants.CurrentVersion;
+                });
+            }
             return true;
         }
 

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -391,7 +391,7 @@ namespace Voron.Impl.Journal
             return _journalInfo.LastSyncedTransactionId != -1 && transactionId <= _journalInfo.LastSyncedTransactionId;
         }
 
-        private static long GetTransactionSizeIn4Kb(TransactionHeader* current)
+        internal static long GetTransactionSizeIn4Kb(TransactionHeader* current)
         {
             var size = current->CompressedSize != -1 ? current->CompressedSize : current->UncompressedSize;
 
@@ -674,11 +674,6 @@ namespace Voron.Impl.Journal
 
                 _next4Kb = _readAt4Kb + GetTransactionSizeIn4Kb(current);
 
-                if (JournalId == Guid.Empty)
-                {
-                    JournalId = current->JournalId;
-                }
-
                 if (current->Flags == TransactionPersistenceModeFlags.LinkedJournalsRecord &&
                     _environment.Options.RootJournal is null) // this only applies to the _root_, not to branches
                 {
@@ -686,7 +681,14 @@ namespace Voron.Impl.Journal
                     _readAt4Kb += GetTransactionSizeIn4Kb(current) - 1;
                     continue;
                 }
-                
+
+                // A linked-journals record carries the sentinel id, never an environment's.
+                // Adopt only from a real transaction.
+                if (JournalId == Guid.Empty)
+                {
+                    JournalId = current->JournalId;
+                }
+
                 if ((current->JournalId == JournalId) is false &&
                     current->JournalId != Guid.Empty) // this may be legacy
                 {

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -325,6 +325,12 @@ namespace Voron.Impl.Journal
             var lastJournal = _env.Options.GetLatestJournalNumber();
             lastJournal ??= journalToStartReadingFrom;
 
+            // The id must be settled before any transaction is applied. Recovery filters
+            // transactions by it. A guessed id could let recovery apply another
+            // environment's transactions into this data file.
+            if (_headerAccessor.MetadataAccessor.JournalId == Guid.Empty)
+                ResolveRebuiltJournalId(journalToStartReadingFrom, lastJournal.Value, logInfo, addToInitLog);
+
             using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
             
             for (var journalNumber = journalToStartReadingFrom; journalNumber <= lastJournal.Value; journalNumber++)
@@ -653,6 +659,84 @@ namespace Voron.Impl.Journal
             }
 
             return requireHeaderUpdate;
+        }
+
+        // The metadata file was rebuilt without an id, and recovery filters transactions by it.
+        // Every transaction header carries the id it was stamped with. The header is AEAD
+        // additional data: plaintext even in an encrypted journal. A lone id in single-tenant
+        // journals is this environment's own and is re-adopted. Anything ambiguous fail-stops.
+        // Guessing could let recovery replay another environment's transactions into this file.
+        private void ResolveRebuiltJournalId(long firstJournal, long lastJournal, JournalInfo journalInfo, Action<LogLevel, string> addToInitLog)
+        {
+            var ids = new HashSet<Guid>();
+
+            // A branch reads multi-tenant journals by configuration.
+            var sharedEvidence = _env.Options.RootJournal != null;
+
+            for (var journalNumber = firstJournal; journalNumber <= lastJournal; journalNumber++)
+            {
+                try
+                {
+                    // A hard link proves sharing. A single link proves nothing: peers may
+                    // have unlinked. The probe can only add fail-stop evidence.
+                    sharedEvidence |= _env.Options.IsJournalHardLinked(journalNumber);
+
+                    (Pager journalPager, Pager.State journalPagerState) = _env.Options.OpenJournalPager(journalNumber, journalInfo);
+                    using var _ = journalPager;
+
+                    Pager.PagerTransactionState txState = default;
+                    try
+                    {
+                        const int pageTo4KbRatio = Constants.Storage.PageSize / (4 * Constants.Size.Kilobyte);
+                        long readAt4Kb = 0;
+                        while (readAt4Kb * (4 * Constants.Size.Kilobyte) < journalPagerState.TotalAllocatedSize)
+                        {
+                            var pageNumber = readAt4Kb / pageTo4KbRatio;
+                            var positionInsidePage = (readAt4Kb % pageTo4KbRatio) * (4 * Constants.Size.Kilobyte);
+
+                            var current = (TransactionHeader*)(journalPager.AcquirePagePointer(journalPagerState, ref txState, pageNumber) + positionInsidePage);
+                            if (current->HeaderMarker != Constants.TransactionHeaderMarker)
+                                break;
+
+                            ids.Add(current->JournalId);
+
+                            var transactionSizeIn4Kb = JournalReader.GetTransactionSizeIn4Kb(current);
+                            if (transactionSizeIn4Kb < 1)
+                                break;
+                            readAt4Kb += transactionSizeIn4Kb;
+                        }
+                    }
+                    finally
+                    {
+                        txState.InvokeDispose(_env, ref journalPagerState, ref txState);
+                    }
+                }
+                catch (Exception e)
+                {
+                    // an unreadable journal contributes no ids; recovery proper deals with it
+                    addToInitLog?.Invoke(LogLevel.Warn, $"Could not scan journal {journalNumber} for its journal id: {e.Message}");
+                }
+            }
+
+            ids.Remove(Guid.Empty);
+
+            // Only the root of a shared-journal group writes linked-journals records.
+            // The sentinel proves these journals are multi-tenant.
+            sharedEvidence |= ids.Remove(LinkedJournalsRecord.LinkedJournalId);
+
+            // In multi-tenant journals a lone id can be a sibling's: this environment's own
+            // transactions may all have been synced away. Adopting a foreign id lets recovery
+            // apply foreign transactions into this data file.
+            if (ids.Count > 1 || (ids.Count == 1 && sharedEvidence))
+            {
+                VoronUnrecoverableErrorException.Raise(_env,
+                    $"The '{MetadataAccessor.MetadataName}' file was rebuilt, but the journals carry {ids.Count} distinct journal ids ({string.Join(", ", ids)})" +
+                    (sharedEvidence ? " and show shared-journal involvement (a branch configuration, a hard-linked journal or a linked-journals record)" : "") +
+                    ", so this environment's own id cannot be determined. Restore the metadata file from a backup, or recreate the environment from its source.");
+            }
+
+            var resolved = ids.Count == 1 ? ids.First() : Guid.NewGuid();
+            _headerAccessor.MetadataAccessor.Modify((ref MetadataFile metadata) => metadata.JournalId = resolved);
         }
 
         private void CleanupNewerInvalidJournalFiles(long lastSyncedJournal)

--- a/src/Voron/Schema/Updates/From24.cs
+++ b/src/Voron/Schema/Updates/From24.cs
@@ -21,7 +21,8 @@ public class From24  : IVoronSchemaUpdate
             }
         }
 
-        headerAccessor.MetadataAccessor.Modify(headerAccessor.MetadataAccessor.FillMetadata);
+        // The metadata file (and its JournalId) already exists at version 24. Regenerating the
+        // id would make recovery skip every journal transaction stamped with the previous one.
 
         versionAfterUpgrade = 25;
         return true;

--- a/test/FastTests/Voron/Bugs/MetadataJournalId.cs
+++ b/test/FastTests/Voron/Bugs/MetadataJournalId.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using System.Linq;
+using Raven.Server.Utils;
+using Sparrow.Server.Platform;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Exceptions;
+using Voron.Impl.FileHeaders;
+using Voron.Schema.Updates;
+using Xunit;
+
+namespace FastTests.Voron.Bugs;
+
+public class MetadataJournalId(ITestOutputHelper output) : StorageTest(output)
+{
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        options.ManualFlushing = true; // committed data stays journal-only, as after a crash
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CommittedDataSurvivesLosingMetadataFile()
+    {
+        RequireFileBasedPager();
+
+        using (var tx = Env.WriteTransaction())
+        {
+            tx.CreateTree("t").Add("k", "marker");
+            tx.Commit();
+        }
+
+        var originalId = Env.HeaderAccessor.MetadataAccessor.JournalId;
+
+        StopDatabase(shouldDisposeOptions: true);
+
+        File.Delete(Path.Combine(DataDir, MetadataAccessor.MetadataName));
+
+        Options = StorageEnvironmentOptions.ForPathForTests(DataDir);
+        Configure(Options);
+        StartDatabase();
+
+        using (var tx = Env.ReadTransaction())
+        {
+            Assert.NotNull(tx.ReadTree("t").Read("k"));
+        }
+
+        // the id was re-adopted from the journals, not minted fresh
+        Assert.Equal(originalId, Env.HeaderAccessor.MetadataAccessor.JournalId);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void ForeignJournalMakesRebuiltIdUnresolvable()
+    {
+        RequireFileBasedPager();
+
+        using (var tx = Env.WriteTransaction())
+        {
+            tx.CreateTree("t").Add("k", "marker");
+            tx.Commit();
+        }
+
+        // a second environment supplies a journal stamped with a different id
+        var foreignDir = RavenTestHelper.NewDataPath(nameof(MetadataJournalId), 0);
+        var foreignOptions = StorageEnvironmentOptions.ForPathForTests(foreignDir);
+        foreignOptions.ManualFlushing = true;
+        using (var foreign = new StorageEnvironment(foreignOptions))
+        using (var tx = foreign.WriteTransaction())
+        {
+            tx.CreateTree("f").Add("k", "marker");
+            tx.Commit();
+        }
+
+        StopDatabase(shouldDisposeOptions: true);
+
+        var journalsDir = Path.Combine(DataDir, "Journals");
+        var nextNumber = Directory.GetFiles(journalsDir, "*.journal").Length;
+        File.Copy(
+            Directory.GetFiles(Path.Combine(foreignDir, "Journals"), "*.journal").Single(),
+            Path.Combine(journalsDir, StorageEnvironmentOptions.JournalName(nextNumber)));
+
+        File.Delete(Path.Combine(DataDir, MetadataAccessor.MetadataName));
+
+        Options = StorageEnvironmentOptions.ForPathForTests(DataDir);
+        Configure(Options);
+
+        // Two candidate ids. Adopting either could replay a foreign environment's
+        // transactions. The open must refuse instead of guessing.
+        var e = Assert.Throws<VoronUnrecoverableErrorException>(() => StartDatabase());
+        Assert.Contains("distinct journal ids", e.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void LoneIdInHardLinkedJournalIsNotAdopted()
+    {
+        RequireFileBasedPager();
+
+        using (var tx = Env.WriteTransaction())
+        {
+            tx.CreateTree("t").Add("k", "marker");
+            tx.Commit();
+        }
+
+        var foreignDir = RavenTestHelper.NewDataPath(nameof(MetadataJournalId), 0);
+        var foreignOptions = StorageEnvironmentOptions.ForPathForTests(foreignDir);
+        foreignOptions.ManualFlushing = true;
+        using (var foreign = new StorageEnvironment(foreignOptions))
+        using (var tx = foreign.WriteTransaction())
+        {
+            tx.CreateTree("f").Add("k", "marker");
+            tx.Commit();
+        }
+
+        StopDatabase(shouldDisposeOptions: true);
+
+        // The hard-linked foreign journal becomes the only journal. The scan then sees a
+        // lone foreign id. Only the link evidence separates this from a legitimate self-heal.
+        var journalsDir = Path.Combine(DataDir, "Journals");
+        foreach (var journal in Directory.GetFiles(journalsDir, "*.journal"))
+            File.Delete(journal);
+
+        var rc = Pal.rvn_ensure_hard_link_non_durable(
+            Directory.GetFiles(Path.Combine(foreignDir, "Journals"), "*.journal").Single(),
+            Path.Combine(journalsDir, StorageEnvironmentOptions.JournalName(0)),
+            out var errorCode);
+        Assert.Equal(PalFlags.FailCodes.Success, rc);
+
+        File.Delete(Path.Combine(DataDir, MetadataAccessor.MetadataName));
+
+        Options = StorageEnvironmentOptions.ForPathForTests(DataDir);
+        Configure(Options);
+
+        var e = Assert.Throws<VoronUnrecoverableErrorException>(() => StartDatabase());
+        Assert.Contains("shared-journal involvement", e.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void UpgradeFrom24PreservesJournalId()
+    {
+        RequireFileBasedPager();
+
+        var before = Env.HeaderAccessor.MetadataAccessor.JournalId;
+
+        new From24().Update(24, Env.Options, Env.HeaderAccessor, out var versionAfterUpgrade);
+
+        Assert.Equal(25, versionAfterUpgrade);
+        Assert.Equal(before, Env.HeaderAccessor.MetadataAccessor.JournalId);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27285

### Additional description

Journal transactions are stamped with the environment's JournalId, and recovery skips any transaction whose id does not match. Two paths invented a fresh id on an existing store, so the store reopened cleanly while every committed-but-unflushed transaction in the journal was silently skipped as foreign: `MetadataAccessor.Initialize`, whenever `database.metadata` is missing or corrupt (a partial folder copy or a torn write, at any schema version), and `From24.Update`, on every v24 → v25 upgrade — a version-24 store already has a live JournalId, so the upgrade preserved journal data only by luck of flush timing.

The rebuilt metadata now carries `Guid.Empty`, and before recovery applies anything the journals are scanned header-only for the ids their transactions were stamped with. The header is AEAD additional data, so it is plaintext even in encrypted journals. Exactly one id in single-tenant journals is the environment's own: it is re-adopted and persisted, and the standalone store self-heals with its data intact. Zero ids mint a fresh one, since nothing remains to replay. Anything ambiguous fail-stops with `VoronUnrecoverableErrorException` instead of guessing: more than one id, or a lone id alongside shared-journal evidence (a branch configuration, a hard-linked journal file, or a linked-journals record seen during the scan). In shared-journal mode a lone id can be a sibling's — the root merger writes batches without any root transaction — and adopting it would let recovery replay a foreign environment's transactions into this data file. `From24.Update` no longer touches the id.

The fail-stop is deliberate: with multi-tenant journals the identity is undecidable from the disk content, and the affected environments (shared index journals) are rebuildable. `database.metadata` should be restored from a backup, or the environment recreated from its source.

An existing store whose `database.metadata` is lost or corrupt now either self-heals with its journal data intact (single-tenant, the overwhelmingly common case) or refuses to open with a clear error, instead of silently dropping committed transactions.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
