### PR TITLE
RavenDB-27260 Quill: Add a test button after we got the schema mapping

### DIFF
--- a/src/Raven.Quill.Web/src/components/data/expandable-list.tsx
+++ b/src/Raven.Quill.Web/src/components/data/expandable-list.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/components/shadcn/ui/button";
+
+type ExpandableListRenderProps = {
+    isExpanded: boolean;
+    visibleCount: number;
+    hiddenCount: number;
+};
+
+type ExpandableListProps = {
+    itemsCount: number;
+    collapsedItemsCount: number;
+    isExpanded: boolean;
+    setIsExpanded: (isExpanded: boolean) => void;
+    children: (props: ExpandableListRenderProps) => ReactNode;
+    className?: string;
+};
+
+/** Shows only the first `collapsedItemsCount` items until expanded, so long lists don't render
+ * an item per entry. The children render prop receives how many items to show; expansion is
+ * controlled by the parent so it can expand the list when it appends an item. */
+export function ExpandableList({
+    itemsCount,
+    collapsedItemsCount,
+    isExpanded,
+    setIsExpanded,
+    children,
+    className,
+}: ExpandableListProps) {
+    const visibleCount = isExpanded ? itemsCount : Math.min(collapsedItemsCount, itemsCount);
+    const hiddenCount = itemsCount - visibleCount;
+    const canToggle = itemsCount > collapsedItemsCount;
+
+    return (
+        <div className={className}>
+            {children({ isExpanded, visibleCount, hiddenCount })}
+            {canToggle && (
+                <div className="flex justify-center">
+                    <Button
+                        type="button"
+                        variant="link"
+                        className="h-auto gap-1 p-0 text-xs font-medium"
+                        onClick={() => setIsExpanded(!isExpanded)}
+                        aria-expanded={isExpanded}
+                    >
+                        {isExpanded ? (
+                            <>
+                                Show less
+                                <ChevronUp />
+                            </>
+                        ) : (
+                            <>
+                                Show {hiddenCount} more
+                                <ChevronDown />
+                            </>
+                        )}
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/Raven.Quill.Web/src/components/form/form-error-icon.tsx
+++ b/src/Raven.Quill.Web/src/components/form/form-error-icon.tsx
@@ -1,3 +1,7 @@
+// React Compiler memoization is disabled here: the message is derived from react-hook-form's
+// mutable errors object, which keeps a stable identity across updates.
+"use no memo";
+
 import { type Control, type FieldPath, type FieldValues, useFormState } from "react-hook-form";
 import { CircleAlert } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";

--- a/src/Raven.Quill.Web/src/components/form/wizard/wizard-step-error.test.ts
+++ b/src/Raven.Quill.Web/src/components/form/wizard/wizard-step-error.test.ts
@@ -1,0 +1,28 @@
+import { toWizardStepError } from "@/components/form/wizard/wizard-step-error";
+import { describe, expect, it } from "vitest";
+
+describe("toWizardStepError", () => {
+    it("uses the fallback message when there are no errors", () => {
+        const error = toWizardStepError([], "Something failed.");
+
+        expect(error.message).toBe("Something failed.");
+        expect(error.details).toBeUndefined();
+    });
+
+    it("keeps a single error inline", () => {
+        const error = toWizardStepError([{ message: "Table is missing.", details: "stack" }], "Something failed.");
+
+        expect(error.message).toBe("Table is missing.");
+        expect(error.details).toBe("stack");
+    });
+
+    it("summarizes multiple errors and moves the messages into details", () => {
+        const error = toWizardStepError(
+            [{ message: "First failed." }, { message: "Second failed.", details: "stack" }],
+            "Something failed.",
+        );
+
+        expect(error.message).toBe("Something failed. (2 errors)");
+        expect(error.details).toBe("First failed.\n\nSecond failed.\nstack");
+    });
+});

--- a/src/Raven.Quill.Web/src/components/form/wizard/wizard-step-error.ts
+++ b/src/Raven.Quill.Web/src/components/form/wizard/wizard-step-error.ts
@@ -24,11 +24,16 @@ export function toError(value: unknown): Error {
 
 export function toWizardStepError(errors: WizardError[] | undefined, fallbackMessage: string): WizardStepError {
     const list = errors ?? [];
-    const message = list.map((error) => error.message).join("\n") || fallbackMessage;
-    const details =
-        list
-            .map((error) => error.details)
-            .filter(Boolean)
-            .join("\n\n") || undefined;
-    return new WizardStepError(message, details);
+
+    if (list.length <= 1) {
+        return new WizardStepError(list[0]?.message || fallbackMessage, list[0]?.details || undefined);
+    }
+
+    // A long list rendered inline fills the step with red text, so the alert shows a one-line
+    // summary and the individual messages move into its details collapsible.
+    const details = list
+        .map((error) => (error.details ? `${error.message}\n${error.details}` : error.message))
+        .join("\n\n");
+
+    return new WizardStepError(`${fallbackMessage} (${list.length} errors)`, details);
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
@@ -322,11 +322,16 @@ export const VerifySchemaCdcVerificationFailed: Story = {
     // The dry run's blockers keep the wizard on this step and stay on screen until the selection changes.
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
-        const findAlert = () => canvas.queryByText(/must have the REPLICATION role attribute/i);
+        // The failed run reports an error and a warning, so the alert shows the two-entry summary
+        // and keeps the individual blockers in its collapsible details.
+        const findAlert = () => canvas.queryByText(/cdc verification failed for the selected tables/i);
 
         await userEvent.click(canvas.getByRole("button", { name: /next/i }));
         await waitFor(() => expect(findAlert()).toBeInTheDocument());
         expect(canvas.getByRole("heading", { name: /verify your schema/i })).toBeInTheDocument();
+
+        await userEvent.click(canvas.getByRole("button", { name: /show details/i }));
+        expect(canvas.getByText(/must have the REPLICATION role attribute/i)).toBeInTheDocument();
 
         await userEvent.click(canvas.getAllByRole("checkbox", { name: "Select row" })[0]);
         await waitFor(() => expect(findAlert()).not.toBeInTheDocument());

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-flow.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-flow.tsx
@@ -100,7 +100,7 @@ export const useAppSteps = (): WizardSteps<AppStepId, AppFormData> => {
             validate: "mapTables",
             onValidationFailed: focusMapTablesError,
             beforeNext: mapTablesBeforeNext,
-            isNextDisabled: isMapTablesNextDisabled,
+            isNextDisabled: isMapTablesNextDisabled || isVerifyCdcRunning,
         },
         preview: {
             title: "Preview before full ingest",

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-store.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-store.ts
@@ -59,9 +59,12 @@ export type SetupWizardState = {
     resetMapTablesUiState: () => void;
     isMapTablesRawView: boolean;
     mapTablesRawContent: string;
+    /** Whether the editor's content still parses into tables. Recorded by the writer, which parses
+     * anyway, so nothing has to re-parse a whole mapping to answer it. */
+    isMapTablesRawContentValid: boolean;
     openMapTablesRawView: (content: string) => void;
     closeMapTablesRawView: () => void;
-    setMapTablesRawContent: (content: string) => void;
+    setMapTablesRawContent: (content: string, isValid: boolean) => void;
 };
 
 const initialState: Pick<
@@ -80,6 +83,7 @@ const initialState: Pick<
     | "mapExpandedPaths"
     | "isMapTablesRawView"
     | "mapTablesRawContent"
+    | "isMapTablesRawContentValid"
 > = {
     discoverResult: null,
     discoverSchemas: [],
@@ -95,6 +99,7 @@ const initialState: Pick<
     mapExpandedPaths: {},
     isMapTablesRawView: false,
     mapTablesRawContent: "",
+    isMapTablesRawContentValid: true,
 };
 
 export const useSetupWizardStore = create<SetupWizardState>((set) => ({
@@ -150,8 +155,13 @@ export const useSetupWizardStore = create<SetupWizardState>((set) => ({
             mapExpandedPaths: {},
             isMapTablesRawView: false,
             mapTablesRawContent: "",
+            isMapTablesRawContentValid: true,
         }),
-    openMapTablesRawView: (content) => set({ isMapTablesRawView: true, mapTablesRawContent: content }),
-    closeMapTablesRawView: () => set({ isMapTablesRawView: false, mapTablesRawContent: "" }),
-    setMapTablesRawContent: (content) => set({ mapTablesRawContent: content }),
+    // The content is serialized from the form, so it parses by construction.
+    openMapTablesRawView: (content) =>
+        set({ isMapTablesRawView: true, mapTablesRawContent: content, isMapTablesRawContentValid: true }),
+    closeMapTablesRawView: () =>
+        set({ isMapTablesRawView: false, mapTablesRawContent: "", isMapTablesRawContentValid: true }),
+    setMapTablesRawContent: (content, isValid) =>
+        set({ mapTablesRawContent: content, isMapTablesRawContentValid: isValid }),
 }));

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.test.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.test.ts
@@ -39,6 +39,23 @@ function parseIssues(tables: FormTable[]) {
     return result.success ? [] : result.error.issues.map((issue) => ({ ...issue, path: issue.path.join(".") }));
 }
 
+describe("tablesSchema enabled tables", () => {
+    it("rejects a mapping with every root table disabled", () => {
+        const issues = parseIssues([rootTable({ disabled: true })]);
+
+        expect(issues.map((issue) => issue.message)).toEqual(["At least one enabled table is required"]);
+    });
+
+    it("accepts a mapping as long as one root table is enabled", () => {
+        const tables = [
+            rootTable({ disabled: true }),
+            rootTable({ collectionName: "Orders", sourceTableName: "Order" }),
+        ];
+
+        expect(parseIssues(tables)).toEqual([]);
+    });
+});
+
 describe("tablesSchema property names", () => {
     it("accepts a link whose property name does not collide", () => {
         expect(parseIssues([rootTable({ linkedTables: [linkedTable("Language")] })])).toEqual([]);

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.test.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.test.ts
@@ -56,6 +56,21 @@ describe("tablesSchema enabled tables", () => {
     });
 });
 
+describe("tablesSchema collection names", () => {
+    it("flags every root table sharing a collection name, naming the duplicate", () => {
+        const issues = parseIssues([rootTable(), rootTable({ sourceTableName: "Order" })]);
+
+        expect(issues.map((issue) => issue.path)).toEqual(["0.collectionName", "1.collectionName"]);
+        expect(issues[0].message).toContain('"Customers"');
+    });
+
+    it("accepts root tables with distinct collection names", () => {
+        const tables = [rootTable(), rootTable({ collectionName: "Orders", sourceTableName: "Order" })];
+
+        expect(parseIssues(tables)).toEqual([]);
+    });
+});
+
 describe("tablesSchema property names", () => {
     it("accepts a link whose property name does not collide", () => {
         expect(parseIssues([rootTable({ linkedTables: [linkedTable("Language")] })])).toEqual([]);

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
@@ -170,8 +170,32 @@ export const tablesSchema = z
     .refine((tables) => tables.length === 0 || tables.some((table) => !table.disabled), {
         message: "At least one enabled table is required",
     })
-    .refine((tables) => hasUniqueValues(tables.map((table) => table.collectionName)), {
-        message: "Collection names must be unique",
+    // Collection names must be unique; flagged per row so the message names the duplicate and the
+    // blocked "Next" can focus the table holding it.
+    .superRefine((tables, ctx) => {
+        const countByName = new Map<string, number>();
+
+        for (const table of tables) {
+            const name = table.collectionName.trim();
+
+            if (name) {
+                countByName.set(name, (countByName.get(name) ?? 0) + 1);
+            }
+        }
+
+        tables.forEach((table, index) => {
+            const name = table.collectionName.trim();
+
+            if (!name || (countByName.get(name) ?? 0) < 2) {
+                return;
+            }
+
+            ctx.addIssue({
+                code: "custom",
+                path: [index, "collectionName"],
+                message: `Collection name "${name}" is already used by another root table. Collection names must be unique.`,
+            });
+        });
     })
     .superRefine((tables, ctx) => {
         const countByKey = new Map<string, number>();

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
@@ -165,6 +165,11 @@ const tableSchema = z
 export const tablesSchema = z
     .array(tableSchema)
     .min(1, "At least one table is required")
+    // A mapping with every root disabled would ingest nothing, and it would skip the CDC dry run
+    // that gates the step, so it must not advance.
+    .refine((tables) => tables.length === 0 || tables.some((table) => !table.disabled), {
+        message: "At least one enabled table is required",
+    })
     .refine((tables) => hasUniqueValues(tables.map((table) => table.collectionName)), {
         message: "Collection names must be unique",
     })

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/field-mapping-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/field-mapping-editor.tsx
@@ -1,22 +1,24 @@
-// React Compiler memoization is disabled here: the array-level error message is derived
-// from react-hook-form's mutable errors object, which keeps a stable identity across updates.
-"use no memo";
-
+import { useState } from "react";
 import { ArrowRight, Plus, Trash2 } from "lucide-react";
-import { useFieldArray, useFormContext, useFormState, type FieldArrayPath, type FieldPath } from "react-hook-form";
+import { useFieldArray, useFormContext, type FieldArrayPath, type FieldPath } from "react-hook-form";
 import type { CdcColumnType } from "@/api/generated/server-api";
+import { ExpandableList } from "@/components/data/expandable-list";
+import { FormErrorIcon } from "@/components/form/form-error-icon";
 import { FormInput } from "@/components/form/form-input";
 import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
 import { Button } from "@/components/shadcn/ui/button";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import type { EmbeddedTablePath, RootTablePath } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-types";
-import { getErrorAtPath } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
 
 const COLUMN_TYPE_OPTIONS: FormSelectOption<CdcColumnType>[] = [
     { value: "Default", label: "Default" },
     { value: "Json", label: "JSON" },
     { value: "Attachment", label: "Attachment" },
 ];
+
+/** Tables can map hundreds of columns; rendering an input row per mapping makes the editor
+ * sluggish, so the list starts collapsed to this many rows. */
+const COLLAPSED_MAPPINGS_COUNT = 6;
 
 const ROW_GRID_CLASS = "grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_7rem_2rem] items-start gap-2";
 
@@ -26,6 +28,7 @@ type FieldMappingEditorProps = {
 
 export function FieldMappingEditor({ path }: FieldMappingEditorProps) {
     const { control } = useFormContext<AppFormData>();
+    const [isExpanded, setIsExpanded] = useState(false);
     const columnsPath = `${path}.columns`;
 
     const columnsFieldArray = useFieldArray({
@@ -33,20 +36,19 @@ export function FieldMappingEditor({ path }: FieldMappingEditorProps) {
         name: columnsPath as FieldArrayPath<AppFormData>,
     });
 
-    const { errors } = useFormState({ control, name: columnsPath as FieldPath<AppFormData> });
-    const columnsError = getErrorAtPath(errors, columnsPath) as { message?: string; root?: { message?: string } };
-    const errorMessage = columnsError?.message ?? columnsError?.root?.message;
+    const addFieldMapping = () => {
+        columnsFieldArray.append({ column: "", name: "", type: "Default" });
+        setIsExpanded(true);
+    };
 
     return (
         <div className="grid gap-2">
             <div className="flex items-center justify-between gap-3">
-                <div className="text-sm font-medium">Field mapping</div>
-                <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => columnsFieldArray.append({ column: "", name: "", type: "Default" })}
-                >
+                <div className="flex items-center gap-1.5 text-sm font-medium">
+                    Field mapping
+                    <FormErrorIcon control={control} paths={[columnsPath as FieldPath<AppFormData>]} />
+                </div>
+                <Button type="button" variant="ghost" size="sm" onClick={addFieldMapping}>
                     <Plus className="size-4" aria-hidden="true" />
                     Add field mapping
                 </Button>
@@ -64,38 +66,47 @@ export function FieldMappingEditor({ path }: FieldMappingEditorProps) {
                         <div>Type</div>
                         <div />
                     </div>
-                    {columnsFieldArray.fields.map((field, index) => (
-                        <div key={field.id} className={ROW_GRID_CLASS}>
-                            <FormInput
-                                control={control}
-                                name={`${columnsPath}.${index}.column` as FieldPath<AppFormData>}
-                            />
-                            <ArrowRight className="mt-2.5 size-4 text-muted-foreground" aria-hidden="true" />
-                            <FormInput
-                                control={control}
-                                name={`${columnsPath}.${index}.name` as FieldPath<AppFormData>}
-                            />
-                            <FormSelect
-                                control={control}
-                                name={`${columnsPath}.${index}.type` as FieldPath<AppFormData>}
-                                options={COLUMN_TYPE_OPTIONS}
-                            />
-                            <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="text-destructive"
-                                onClick={() => columnsFieldArray.remove(index)}
-                                aria-label="Remove field mapping"
-                                title="Remove field mapping"
-                            >
-                                <Trash2 className="size-4" aria-hidden="true" />
-                            </Button>
-                        </div>
-                    ))}
+                    <ExpandableList
+                        className="grid gap-2"
+                        itemsCount={columnsFieldArray.fields.length}
+                        collapsedItemsCount={COLLAPSED_MAPPINGS_COUNT}
+                        isExpanded={isExpanded}
+                        setIsExpanded={setIsExpanded}
+                    >
+                        {({ visibleCount }) =>
+                            columnsFieldArray.fields.slice(0, visibleCount).map((field, index) => (
+                                <div key={field.id} className={ROW_GRID_CLASS}>
+                                    <FormInput
+                                        control={control}
+                                        name={`${columnsPath}.${index}.column` as FieldPath<AppFormData>}
+                                    />
+                                    <ArrowRight className="mt-2.5 size-4 text-muted-foreground" aria-hidden="true" />
+                                    <FormInput
+                                        control={control}
+                                        name={`${columnsPath}.${index}.name` as FieldPath<AppFormData>}
+                                    />
+                                    <FormSelect
+                                        control={control}
+                                        name={`${columnsPath}.${index}.type` as FieldPath<AppFormData>}
+                                        options={COLUMN_TYPE_OPTIONS}
+                                    />
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="text-destructive"
+                                        onClick={() => columnsFieldArray.remove(index)}
+                                        aria-label="Remove field mapping"
+                                        title="Remove field mapping"
+                                    >
+                                        <Trash2 className="size-4" aria-hidden="true" />
+                                    </Button>
+                                </div>
+                            ))
+                        }
+                    </ExpandableList>
                 </div>
             )}
-            {errorMessage && <p className="text-sm text-destructive">{errorMessage}</p>}
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-step.tsx
@@ -21,11 +21,21 @@ import { TablesExplorer } from "@/pages/setup/add-app-wizard/steps/map-tables/ta
 import { UnmappedTablesAlert } from "@/pages/setup/add-app-wizard/steps/map-tables/unmapped-tables-alert";
 import { useApplyMapTables } from "@/pages/setup/add-app-wizard/steps/map-tables/use-apply-map-tables";
 import { useSuggestedMapTables } from "@/pages/setup/add-app-wizard/steps/map-tables/use-suggested-map-tables";
+import { useVerifyMapTablesState } from "@/pages/setup/add-app-wizard/steps/map-tables/use-verify-map-tables";
+import { VerifyCdcButton } from "@/pages/setup/add-app-wizard/steps/verify/verify-cdc-button";
+import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
 
-export function MapTablesStep() {
+const VERIFY_TABLES_LABELS = {
+    idle: "Verify tables",
+    verifying: "Verifying tables...",
+    verified: "Tables verified",
+};
+
+export function MapTablesStep({ isBusy }: WizardBodyComponentProps) {
     const { control, getValues, setValue } = useFormContext<AppFormData>();
     const { errors } = useFormState({ control, name: "mapTables.tables" });
     const applyMapTables = useApplyMapTables();
+    const verifyTables = useVerifyMapTablesState();
     const {
         isSuggesting,
         startedAt: suggestionStartedAt,
@@ -35,12 +45,17 @@ export function MapTablesStep() {
 
     const isRawView = useSetupWizardStore((state) => state.isMapTablesRawView);
     const rawContent = useSetupWizardStore((state) => state.mapTablesRawContent);
+    const isRawContentValid = useSetupWizardStore((state) => state.isMapTablesRawContentValid);
     const openRawView = useSetupWizardStore((state) => state.openMapTablesRawView);
     const closeRawView = useSetupWizardStore((state) => state.closeMapTablesRawView);
     const setRawContent = useSetupWizardStore((state) => state.setMapTablesRawContent);
 
     const tablesError = errors.mapTables?.tables;
     const tablesErrorMessage = tablesError?.message ?? tablesError?.root?.message;
+
+    // Invalid raw JSON means the form still holds the previous parse, so what a verify would run
+    // against is not what the editor shows.
+    const isFormBehindEditor = isRawView && !isRawContentValid;
 
     const handleToggleRawView = (checked: boolean) => {
         if (checked) {
@@ -59,9 +74,9 @@ export function MapTablesStep() {
     // Keep the form in sync with valid edits so the wizard's validation, "Next", and preview all
     // work off form state. Invalid intermediate JSON stays in the editor until it parses again.
     const handleRawChange = (value: string) => {
-        setRawContent(value);
-
         const tables = tryParseRawTablesToForm(value);
+
+        setRawContent(value, tables !== null);
 
         if (tables) {
             setValue("mapTables.tables", tables);
@@ -86,10 +101,29 @@ export function MapTablesStep() {
 
     return (
         <div className="flex min-h-0 flex-1 flex-col gap-3">
-            <Field orientation="horizontal" className="justify-self-end">
-                <Switch id="map-tables-raw-view" checked={isRawView} onCheckedChange={handleToggleRawView} />
-                <FieldLabel htmlFor="map-tables-raw-view">Raw JSON</FieldLabel>
-            </Field>
+            <div className="flex shrink-0 items-center justify-end gap-4">
+                {/* Runs the dry run Next runs, so the operator can check that the (AI-)suggested tables
+                    exist and are capturable before leaving the step. Without an enabled table there is
+                    nothing to verify, and validation blocks Next anyway, so the button stays out instead
+                    of showing up dead. */}
+                {verifyTables.selectedTables.length > 0 && (
+                    <>
+                        {/* While the form is behind the editor, verifying would answer for a mapping the
+                            operator is no longer looking at - and an earlier pass must not read as
+                            "verified" against the editor's content either. */}
+                        <VerifyCdcButton
+                            disabled={isBusy || isFormBehindEditor}
+                            state={isFormBehindEditor ? { ...verifyTables, isVerified: false } : verifyTables}
+                            labels={VERIFY_TABLES_LABELS}
+                        />
+                        <div className="h-4 w-px bg-border" />
+                    </>
+                )}
+                <Field orientation="horizontal">
+                    <Switch id="map-tables-raw-view" checked={isRawView} onCheckedChange={handleToggleRawView} />
+                    <FieldLabel htmlFor="map-tables-raw-view">Raw JSON</FieldLabel>
+                </Field>
+            </div>
 
             {isRawView ? (
                 <AceEditor
@@ -118,6 +152,8 @@ export function MapTablesStep() {
                     {tablesErrorMessage && <Alert variant="destructive">{tablesErrorMessage}</Alert>}
                 </>
             )}
+
+            {verifyTables.error && <WizardErrorAlert error={verifyTables.error} className="shrink-0" />}
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-step.tsx
@@ -150,26 +150,17 @@ export function MapTablesStep({ isBusy }: WizardBodyComponentProps) {
 function VerifyMapTablesButton({ isBusy, isFormBehindEditor }: { isBusy: boolean; isFormBehindEditor: boolean }) {
     const verifyTables = useVerifyMapTablesState();
 
-    // Runs the dry run Next runs, so the operator can check that the (AI-)suggested tables
-    // exist and are capturable before leaving the step. Without an enabled table there is
-    // nothing to verify, and validation blocks Next anyway, so the button stays out instead
-    // of showing up dead.
     if (verifyTables.selectedTables.length === 0) {
         return null;
     }
 
     return (
-        <>
-            {/* While the form is behind the editor, verifying would answer for a mapping the
-                operator is no longer looking at - and an earlier pass must not read as
-                "verified" against the editor's content either. */}
-            <VerifyCdcButton
-                disabled={isBusy || isFormBehindEditor}
-                state={isFormBehindEditor ? { ...verifyTables, isVerified: false } : verifyTables}
-                labels={VERIFY_TABLES_LABELS}
-            />
-            <div className="h-4 w-px bg-border" />
-        </>
+        <VerifyCdcButton
+            disabled={isBusy || isFormBehindEditor}
+            state={isFormBehindEditor ? { ...verifyTables, isVerified: false } : verifyTables}
+            labels={VERIFY_TABLES_LABELS}
+            variant="outline"
+        />
     );
 }
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-step.tsx
@@ -11,6 +11,7 @@ import { Switch } from "@/components/shadcn/ui/switch";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { MapTablesSuggestionProgress } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-suggestion-progress";
+import { RootTablesFieldArrayProvider } from "@/pages/setup/add-app-wizard/steps/map-tables/root-tables-field-array";
 import {
     parseRawTablesToForm,
     serializeFormTablesToRaw,
@@ -100,60 +101,65 @@ export function MapTablesStep({ isBusy }: WizardBodyComponentProps) {
     }
 
     return (
-        <div className="flex min-h-0 flex-1 flex-col gap-3">
-            <div className="flex shrink-0 items-center justify-end gap-4">
-                {/* Runs the dry run Next runs, so the operator can check that the (AI-)suggested tables
+        <RootTablesFieldArrayProvider>
+            <div className="flex min-h-0 flex-1 flex-col gap-3">
+                <div className="flex shrink-0 items-center justify-end gap-4">
+                    {/* Runs the dry run Next runs, so the operator can check that the (AI-)suggested tables
                     exist and are capturable before leaving the step. Without an enabled table there is
                     nothing to verify, and validation blocks Next anyway, so the button stays out instead
                     of showing up dead. */}
-                {verifyTables.selectedTables.length > 0 && (
-                    <>
-                        {/* While the form is behind the editor, verifying would answer for a mapping the
+                    {verifyTables.selectedTables.length > 0 && (
+                        <>
+                            {/* While the form is behind the editor, verifying would answer for a mapping the
                             operator is no longer looking at - and an earlier pass must not read as
                             "verified" against the editor's content either. */}
-                        <VerifyCdcButton
-                            disabled={isBusy || isFormBehindEditor}
-                            state={isFormBehindEditor ? { ...verifyTables, isVerified: false } : verifyTables}
-                            labels={VERIFY_TABLES_LABELS}
-                        />
-                        <div className="h-4 w-px bg-border" />
+                            <VerifyCdcButton
+                                disabled={isBusy || isFormBehindEditor}
+                                state={isFormBehindEditor ? { ...verifyTables, isVerified: false } : verifyTables}
+                                labels={VERIFY_TABLES_LABELS}
+                            />
+                            <div className="h-4 w-px bg-border" />
+                        </>
+                    )}
+                    <Field orientation="horizontal">
+                        <Switch id="map-tables-raw-view" checked={isRawView} onCheckedChange={handleToggleRawView} />
+                        <FieldLabel htmlFor="map-tables-raw-view">Raw JSON</FieldLabel>
+                    </Field>
+                </div>
+
+                {isRawView ? (
+                    <AceEditor
+                        mode="json"
+                        value={rawContent}
+                        onChange={handleRawChange}
+                        isFillHeight
+                        className="min-h-80"
+                        actions={[
+                            { component: <AceEditor.FormatAction /> },
+                            { component: <AceEditor.FullScreenAction /> },
+                        ]}
+                    />
+                ) : (
+                    <>
+                        <UnmappedTablesAlert />
+                        <ResizablePanelGroup
+                            orientation="horizontal"
+                            className="min-h-80 flex-1 rounded-lg border bg-background"
+                        >
+                            <ResizablePanel defaultSize="30%" minSize="180px" maxSize="50%" className="min-w-0">
+                                <TablesExplorer />
+                            </ResizablePanel>
+                            <ResizableHandle />
+                            <ResizablePanel className="min-w-0">
+                                <TableEditor />
+                            </ResizablePanel>
+                        </ResizablePanelGroup>
+                        {tablesErrorMessage && <Alert variant="destructive">{tablesErrorMessage}</Alert>}
                     </>
                 )}
-                <Field orientation="horizontal">
-                    <Switch id="map-tables-raw-view" checked={isRawView} onCheckedChange={handleToggleRawView} />
-                    <FieldLabel htmlFor="map-tables-raw-view">Raw JSON</FieldLabel>
-                </Field>
+
+                {verifyTables.error && <WizardErrorAlert error={verifyTables.error} className="shrink-0" />}
             </div>
-
-            {isRawView ? (
-                <AceEditor
-                    mode="json"
-                    value={rawContent}
-                    onChange={handleRawChange}
-                    isFillHeight
-                    className="min-h-80"
-                    actions={[{ component: <AceEditor.FormatAction /> }, { component: <AceEditor.FullScreenAction /> }]}
-                />
-            ) : (
-                <>
-                    <UnmappedTablesAlert />
-                    <ResizablePanelGroup
-                        orientation="horizontal"
-                        className="min-h-80 flex-1 rounded-lg border bg-background"
-                    >
-                        <ResizablePanel defaultSize="30%" minSize="180px" maxSize="50%" className="min-w-0">
-                            <TablesExplorer />
-                        </ResizablePanel>
-                        <ResizableHandle />
-                        <ResizablePanel className="min-w-0">
-                            <TableEditor />
-                        </ResizablePanel>
-                    </ResizablePanelGroup>
-                    {tablesErrorMessage && <Alert variant="destructive">{tablesErrorMessage}</Alert>}
-                </>
-            )}
-
-            {verifyTables.error && <WizardErrorAlert error={verifyTables.error} className="shrink-0" />}
-        </div>
+        </RootTablesFieldArrayProvider>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-step.tsx
@@ -33,10 +33,8 @@ const VERIFY_TABLES_LABELS = {
 };
 
 export function MapTablesStep({ isBusy }: WizardBodyComponentProps) {
-    const { control, getValues, setValue } = useFormContext<AppFormData>();
-    const { errors } = useFormState({ control, name: "mapTables.tables" });
+    const { getValues, setValue } = useFormContext<AppFormData>();
     const applyMapTables = useApplyMapTables();
-    const verifyTables = useVerifyMapTablesState();
     const {
         isSuggesting,
         startedAt: suggestionStartedAt,
@@ -50,9 +48,6 @@ export function MapTablesStep({ isBusy }: WizardBodyComponentProps) {
     const openRawView = useSetupWizardStore((state) => state.openMapTablesRawView);
     const closeRawView = useSetupWizardStore((state) => state.closeMapTablesRawView);
     const setRawContent = useSetupWizardStore((state) => state.setMapTablesRawContent);
-
-    const tablesError = errors.mapTables?.tables;
-    const tablesErrorMessage = tablesError?.message ?? tablesError?.root?.message;
 
     // Invalid raw JSON means the form still holds the previous parse, so what a verify would run
     // against is not what the editor shows.
@@ -104,23 +99,7 @@ export function MapTablesStep({ isBusy }: WizardBodyComponentProps) {
         <RootTablesFieldArrayProvider>
             <div className="flex min-h-0 flex-1 flex-col gap-3">
                 <div className="flex shrink-0 items-center justify-end gap-4">
-                    {/* Runs the dry run Next runs, so the operator can check that the (AI-)suggested tables
-                    exist and are capturable before leaving the step. Without an enabled table there is
-                    nothing to verify, and validation blocks Next anyway, so the button stays out instead
-                    of showing up dead. */}
-                    {verifyTables.selectedTables.length > 0 && (
-                        <>
-                            {/* While the form is behind the editor, verifying would answer for a mapping the
-                            operator is no longer looking at - and an earlier pass must not read as
-                            "verified" against the editor's content either. */}
-                            <VerifyCdcButton
-                                disabled={isBusy || isFormBehindEditor}
-                                state={isFormBehindEditor ? { ...verifyTables, isVerified: false } : verifyTables}
-                                labels={VERIFY_TABLES_LABELS}
-                            />
-                            <div className="h-4 w-px bg-border" />
-                        </>
-                    )}
+                    <VerifyMapTablesButton isBusy={isBusy} isFormBehindEditor={isFormBehindEditor} />
                     <Field orientation="horizontal">
                         <Switch id="map-tables-raw-view" checked={isRawView} onCheckedChange={handleToggleRawView} />
                         <FieldLabel htmlFor="map-tables-raw-view">Raw JSON</FieldLabel>
@@ -154,12 +133,66 @@ export function MapTablesStep({ isBusy }: WizardBodyComponentProps) {
                                 <TableEditor />
                             </ResizablePanel>
                         </ResizablePanelGroup>
-                        {tablesErrorMessage && <Alert variant="destructive">{tablesErrorMessage}</Alert>}
+                        <TablesListErrorAlert />
                     </>
                 )}
 
-                {verifyTables.error && <WizardErrorAlert error={verifyTables.error} className="shrink-0" />}
+                <VerifyMapTablesErrorAlert />
             </div>
         </RootTablesFieldArrayProvider>
     );
+}
+
+/* The verify state and the tables validation errors both track the whole mapTables.tables array,
+   so their consumers live in these leaf components: subscribing from MapTablesStep itself would
+   re-render the entire step (explorer, editor, all row dropdowns) on every table add/remove. */
+
+function VerifyMapTablesButton({ isBusy, isFormBehindEditor }: { isBusy: boolean; isFormBehindEditor: boolean }) {
+    const verifyTables = useVerifyMapTablesState();
+
+    // Runs the dry run Next runs, so the operator can check that the (AI-)suggested tables
+    // exist and are capturable before leaving the step. Without an enabled table there is
+    // nothing to verify, and validation blocks Next anyway, so the button stays out instead
+    // of showing up dead.
+    if (verifyTables.selectedTables.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            {/* While the form is behind the editor, verifying would answer for a mapping the
+                operator is no longer looking at - and an earlier pass must not read as
+                "verified" against the editor's content either. */}
+            <VerifyCdcButton
+                disabled={isBusy || isFormBehindEditor}
+                state={isFormBehindEditor ? { ...verifyTables, isVerified: false } : verifyTables}
+                labels={VERIFY_TABLES_LABELS}
+            />
+            <div className="h-4 w-px bg-border" />
+        </>
+    );
+}
+
+function VerifyMapTablesErrorAlert() {
+    const verifyTables = useVerifyMapTablesState();
+
+    if (!verifyTables.error) {
+        return null;
+    }
+
+    return <WizardErrorAlert error={verifyTables.error} className="shrink-0" />;
+}
+
+function TablesListErrorAlert() {
+    const { control } = useFormContext<AppFormData>();
+    const { errors } = useFormState({ control, name: "mapTables.tables" });
+
+    const tablesError = errors.mapTables?.tables;
+    const tablesErrorMessage = tablesError?.message ?? tablesError?.root?.message;
+
+    if (!tablesErrorMessage) {
+        return null;
+    }
+
+    return <Alert variant="destructive">{tablesErrorMessage}</Alert>;
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils.test.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils.test.ts
@@ -4,11 +4,16 @@ import type {
     DiscoverTableResponse,
 } from "@/api/generated/server-api";
 import {
+    collectMappedSourceTableKeys,
+    collectMappedSourceTables,
+    createEmptyEmbeddedTable,
+    createEmptyRootTable,
     makeUniquePropertyName,
     propertyNameFromJoinColumn,
     scaffoldRootTable,
     toTakenPropertyNames,
 } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
+import type { FormEmbeddedTable, FormRootTable } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-types";
 import { describe, expect, it } from "vitest";
 
 function table(overrides: Partial<DiscoverTableResponse> = {}): DiscoverTableResponse {
@@ -41,6 +46,14 @@ function foreignKey(columns: string[], referencedTable: string): DiscoverForeign
         referencedTable,
         referencedColumns: ["Id"],
     };
+}
+
+function rootTable(name: string, overrides: Partial<FormRootTable> = {}): FormRootTable {
+    return { ...createEmptyRootTable(), sourceTableSchema: "public", sourceTableName: name, ...overrides };
+}
+
+function embeddedTable(name: string, overrides: Partial<FormEmbeddedTable> = {}): FormEmbeddedTable {
+    return { ...createEmptyEmbeddedTable(), sourceTableSchema: "public", sourceTableName: name, ...overrides };
 }
 
 describe("propertyNameFromJoinColumn", () => {
@@ -136,6 +149,80 @@ describe("makeUniquePropertyName", () => {
 
     it("compares case-insensitively, like the server", () => {
         expect(makeUniquePropertyName("Language", toTakenPropertyNames(["LANGUAGE"]))).toBe("Language2");
+    });
+});
+
+describe("collectMappedSourceTables", () => {
+    const collectNames = (tables: FormRootTable[]) =>
+        collectMappedSourceTables(tables).map((mapped) => mapped.sourceTableName);
+
+    it("collects root tables and nested embedded tables", () => {
+        const tables = [
+            rootTable("Customer", {
+                embeddedTables: [embeddedTable("Address", { embeddedTables: [embeddedTable("Country")] })],
+            }),
+            rootTable("Order"),
+        ];
+
+        expect(collectNames(tables)).toEqual(["Customer", "Address", "Country", "Order"]);
+    });
+
+    it("skips linked tables - a link needs its own root mapping to be captured", () => {
+        const tables = [
+            rootTable("Order", {
+                linkedTables: [
+                    {
+                        sourceTableSchema: "public",
+                        sourceTableName: "Customer",
+                        propertyName: "Customer",
+                        joinColumns: [],
+                        linkedCollectionName: "Customers",
+                    },
+                ],
+            }),
+        ];
+
+        expect(collectNames(tables)).toEqual(["Order"]);
+    });
+
+    it("skips disabled roots including their embedded tables", () => {
+        const tables = [
+            rootTable("Customer", { disabled: true, embeddedTables: [embeddedTable("Address")] }),
+            rootTable("Order"),
+        ];
+
+        expect(collectNames(tables)).toEqual(["Order"]);
+    });
+
+    it("dedupes tables case-insensitively and drops unnamed ones", () => {
+        const tables = [
+            rootTable("Customer", { embeddedTables: [embeddedTable("CUSTOMER"), embeddedTable("")] }),
+            rootTable("customer"),
+        ];
+
+        expect(collectMappedSourceTables(tables)).toEqual([
+            { sourceTableSchema: "public", sourceTableName: "Customer" },
+        ]);
+    });
+
+    it("trims names and schemas, so a stray space cannot reach the server", () => {
+        const tables = [rootTable(" Order ", { sourceTableSchema: " sales " })];
+
+        expect(collectMappedSourceTables(tables)).toEqual([{ sourceTableSchema: "sales", sourceTableName: "Order" }]);
+    });
+
+    it("reports a blank schema as none, matching how the key treats it", () => {
+        const tables = [rootTable("Order", { sourceTableSchema: "  " })];
+
+        expect(collectMappedSourceTables(tables)).toEqual([{ sourceTableSchema: null, sourceTableName: "Order" }]);
+    });
+});
+
+describe("collectMappedSourceTableKeys", () => {
+    it("keeps disabled roots, so the unmapped alert does not offer to map them again", () => {
+        const tables = [rootTable("Customer", { disabled: true, embeddedTables: [embeddedTable("Address")] })];
+
+        expect([...collectMappedSourceTableKeys(tables)]).toEqual(["public::customer", "public::address"]);
     });
 });
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils.ts
@@ -52,25 +52,45 @@ export function getSourceTableKey(table: SourceTableRef): string | null {
     return `${table.sourceTableSchema?.trim().toLowerCase() ?? ""}::${name}`;
 }
 
-/** Collects the keys of every source table whose data is captured by the mapping: root
- * tables plus nested embedded tables. Linked tables don't count - a link only references
+/** A source table the mapping refers to, in the shape the verify-schema selection and the CDC
+ * dry run both use. */
+export type MappedSourceTable = AppFormData["verifySchema"]["tables"][number];
+
+/** Source tables whose data the given roots capture: the roots themselves plus their nested embedded
+ * tables, keyed and deduped in encounter order. Linked tables don't count - a link only references
  * documents by id, so the linked table still needs its own root mapping. */
-export function collectMappedSourceTableKeys(tables: FormRootTable[]): Set<string> {
-    const keys = new Set<string>();
+function collectSourceTables(rootTables: FormRootTable[]): Map<string, MappedSourceTable> {
+    const collected = new Map<string, MappedSourceTable>();
 
     const visit = (table: SourceTableRef & { embeddedTables?: FormEmbeddedTable[] }) => {
         const key = getSourceTableKey(table);
+        const sourceTableName = table.sourceTableName?.trim();
 
-        if (key) {
-            keys.add(key);
+        // The key already rejects a blank name; the guard is what convinces TypeScript of it.
+        if (key && sourceTableName && !collected.has(key)) {
+            // Trimmed to match the key, so a stray space cannot both dedupe as the same table and
+            // reach the server as a different one.
+            collected.set(key, { sourceTableSchema: table.sourceTableSchema?.trim() || null, sourceTableName });
         }
 
         table.embeddedTables?.forEach(visit);
     };
 
-    tables.forEach(visit);
+    rootTables.forEach(visit);
 
-    return keys;
+    return collected;
+}
+
+/** Source tables whose changes CDC must capture for the mapping to work. Disabled roots (and their
+ * subtrees) are not ingested, so they need no capture infrastructure. */
+export function collectMappedSourceTables(tables: FormRootTable[]): MappedSourceTable[] {
+    return [...collectSourceTables(tables.filter((table) => !table.disabled)).values()];
+}
+
+/** Keys of every source table the mapping refers to, disabled roots included: a disabled root was
+ * disabled on purpose, and the unmapped-tables alert would otherwise offer to map it a second time. */
+export function collectMappedSourceTableKeys(tables: FormRootTable[]): Set<string> {
+    return new Set(collectSourceTables(tables).keys());
 }
 
 export function createEmptyRootTable(): FormRootTable {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/root-tables-field-array.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/root-tables-field-array.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, type ReactNode } from "react";
+import { useFieldArray, useFormContext, type UseFieldArrayReturn } from "react-hook-form";
+import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+
+type RootTablesFieldArray = UseFieldArrayReturn<AppFormData, "mapTables.tables">;
+
+const RootTablesFieldArrayContext = createContext<RootTablesFieldArray | null>(null);
+
+/**
+ * Hosts the single useFieldArray instance for "mapTables.tables". useTableActions is mounted in
+ * every explorer row, so it cannot own the field array itself (react-hook-form requires one
+ * useFieldArray per name). Registering the path as a field array also makes react-hook-form treat
+ * whole-array setValue calls on it as a single array swap instead of recursing into every table
+ * field, which used to take hundreds of milliseconds on large schemas.
+ */
+export function RootTablesFieldArrayProvider({ children }: { children: ReactNode }) {
+    const { control } = useFormContext<AppFormData>();
+    const fieldArray = useFieldArray({ control, name: "mapTables.tables" });
+
+    return <RootTablesFieldArrayContext.Provider value={fieldArray}>{children}</RootTablesFieldArrayContext.Provider>;
+}
+
+export function useRootTablesFieldArray(): RootTablesFieldArray {
+    const fieldArray = useContext(RootTablesFieldArrayContext);
+
+    if (!fieldArray) {
+        throw new Error("useRootTablesFieldArray must be used within RootTablesFieldArrayProvider");
+    }
+
+    return fieldArray;
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/root-tables-field-array.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/root-tables-field-array.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext, type ReactNode } from "react";
 import { useFieldArray, useFormContext, type UseFieldArrayReturn } from "react-hook-form";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 
-type RootTablesFieldArray = Pick<UseFieldArrayReturn<AppFormData, "mapTables.tables">, "append" | "remove">;
+type RootTablesFieldArray = Pick<UseFieldArrayReturn<AppFormData, "mapTables.tables">, "append" | "remove" | "update">;
 
 const RootTablesFieldArrayContext = createContext<RootTablesFieldArray | null>(null);
 
@@ -14,14 +14,14 @@ const RootTablesFieldArrayContext = createContext<RootTablesFieldArray | null>(n
  * whole-array setValue calls on it as a single array swap instead of recursing into every table
  * field, which used to take hundreds of milliseconds on large schemas.
  *
- * Only the stable append/remove callbacks are exposed. The hook's `fields` state changes on every
+ * Only the append/remove/update callbacks are exposed. The hook's `fields` state changes on every
  * array operation, and passing the whole return object through context would re-render every
  * consumer for a state nobody reads.
  */
 export function RootTablesFieldArrayProvider({ children }: { children: ReactNode }) {
     const { control } = useFormContext<AppFormData>();
-    const { append, remove } = useFieldArray({ control, name: "mapTables.tables" });
-    const fieldArray = { append, remove };
+    const { append, remove, update } = useFieldArray({ control, name: "mapTables.tables" });
+    const fieldArray = { append, remove, update };
 
     return <RootTablesFieldArrayContext.Provider value={fieldArray}>{children}</RootTablesFieldArrayContext.Provider>;
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/root-tables-field-array.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/root-tables-field-array.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext, type ReactNode } from "react";
 import { useFieldArray, useFormContext, type UseFieldArrayReturn } from "react-hook-form";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 
-type RootTablesFieldArray = UseFieldArrayReturn<AppFormData, "mapTables.tables">;
+type RootTablesFieldArray = Pick<UseFieldArrayReturn<AppFormData, "mapTables.tables">, "append" | "remove">;
 
 const RootTablesFieldArrayContext = createContext<RootTablesFieldArray | null>(null);
 
@@ -13,10 +13,15 @@ const RootTablesFieldArrayContext = createContext<RootTablesFieldArray | null>(n
  * useFieldArray per name). Registering the path as a field array also makes react-hook-form treat
  * whole-array setValue calls on it as a single array swap instead of recursing into every table
  * field, which used to take hundreds of milliseconds on large schemas.
+ *
+ * Only the stable append/remove callbacks are exposed. The hook's `fields` state changes on every
+ * array operation, and passing the whole return object through context would re-render every
+ * consumer for a state nobody reads.
  */
 export function RootTablesFieldArrayProvider({ children }: { children: ReactNode }) {
     const { control } = useFormContext<AppFormData>();
-    const fieldArray = useFieldArray({ control, name: "mapTables.tables" });
+    const { append, remove } = useFieldArray({ control, name: "mapTables.tables" });
+    const fieldArray = { append, remove };
 
     return <RootTablesFieldArrayContext.Provider value={fieldArray}>{children}</RootTablesFieldArrayContext.Provider>;
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-focus-map-tables-error.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-focus-map-tables-error.ts
@@ -27,6 +27,14 @@ export function useFocusMapTablesError() {
         const target = findFirstInvalidTable(getValues("mapTables.tables") ?? [], getError);
 
         if (!target) {
+            // No table to focus, so the error is list-level (e.g. every table disabled). The raw
+            // view renders no alert for it, so the toast is the only visible reaction there.
+            const listMessage = findFirstErrorMessage(getError("mapTables.tables"));
+
+            if (listMessage) {
+                toast.error(listMessage);
+            }
+
             return;
         }
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-map-tables-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-map-tables-step.ts
@@ -1,5 +1,10 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/api";
-import { getSourceTableLabel } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
+import {
+    collectMappedSourceTables,
+    getSourceTableLabel,
+} from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
+import { fetchVerifyCdc } from "@/pages/setup/add-app-wizard/steps/verify/verify-cdc-query";
 import { mapFormTablesToDto } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-dto";
 import { parseRawTablesToForm } from "@/pages/setup/add-app-wizard/steps/map-tables/raw-tables";
 import { useApplyMapTables } from "@/pages/setup/add-app-wizard/steps/map-tables/use-apply-map-tables";
@@ -16,6 +21,7 @@ function computeMapTablesKey(connectKey: string, tables: AppFormData["mapTables"
 }
 
 export function useMapTablesStep() {
+    const queryClient = useQueryClient();
     const { getValues, setValue } = useFormContext<AppFormData>();
     const applyMapTables = useApplyMapTables();
 
@@ -32,9 +38,25 @@ export function useMapTablesStep() {
 
         const connection = getValues("externalConnection");
         const formTables = getValues("mapTables.tables");
+
+        const mappedSourceTables = collectMappedSourceTables(formTables);
+
+        if (mappedSourceTables.length > 0) {
+            // Serves the cached pass when this table set was already verified, here or from the
+            // "Verify tables" button - or from the verify step, when the mapping covers exactly
+            // its selection.
+            await fetchVerifyCdc(
+                queryClient,
+                { connectKey: store.connectKey, slug: connection.slug, selectedTables: mappedSourceTables },
+                progress,
+                "Verifying tables...",
+            );
+        }
+
         const mapTablesKey = computeMapTablesKey(computeConnectKey(connection), formTables);
 
-        if (mapTablesKey === store.mapTablesKey) {
+        // Read again: the dry run above awaited, so the snapshot taken before it can be stale.
+        if (mapTablesKey === useSetupWizardStore.getState().mapTablesKey) {
             return;
         }
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-table-actions.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-table-actions.ts
@@ -6,7 +6,6 @@ import {
     getRootTablePath,
     type EmbeddedTablePath,
     type FormEmbeddedTable,
-    type FormLinkedTable,
     type FormRootTable,
     type MapTablePath,
     type RootTablePath,
@@ -17,67 +16,107 @@ import {
     createEmptyRootTable,
 } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
 import { useRootTablesFieldArray } from "@/pages/setup/add-app-wizard/steps/map-tables/root-tables-field-array";
-import { useFormContext, type FieldPath, type PathValue } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 
 type ParentTablePath = RootTablePath | EmbeddedTablePath;
-type FormPath = FieldPath<AppFormData>;
+type ParentTable = FormRootTable | FormEmbeddedTable;
+
+/** Follows the segments below the root table, e.g. "embeddedTables.1.embeddedTables.0". Only
+ * root and embedded tables can hold children, so every list segment is "embeddedTables". */
+function getTableWithinRoot(rootTable: FormRootTable, path: ParentTablePath): ParentTable {
+    const nestedIndexes = path
+        .split(".")
+        .slice(3)
+        .filter((_, idx) => idx % 2 === 1)
+        .map(Number);
+
+    return nestedIndexes.reduce<ParentTable>((table, index) => table.embeddedTables[index], rootTable);
+}
 
 export function useTableActions() {
-    const { getValues, setValue } = useFormContext<AppFormData>();
+    const { getValues } = useFormContext<AppFormData>();
     const rootTablesFieldArray = useRootTablesFieldArray();
     const setMapActiveTable = useSetupWizardStore((state) => state.setMapActiveTable);
     const expandMapTable = useSetupWizardStore((state) => state.expandMapTable);
     const removeMapTableUiState = useSetupWizardStore((state) => state.removeMapTableUiState);
 
-    const getTableList = <TTable>(listPath: string) => (getValues(listPath as FormPath) as TTable[]) ?? [];
+    /** Changes below a root table go through the root field array's update: unlike a plain
+     * setValue, a field array operation revalidates the tables (the form validates on change),
+     * matching how the root-level append/remove already behave. */
+    const updateRootTable = <TResult>(path: MapTablePath, mutate: (rootTable: FormRootTable) => TResult): TResult => {
+        const rootIndex = Number(path.split(".")[2]);
+        const rootTable = structuredClone(getValues(getRootTablePath(rootIndex)));
+        const result = mutate(rootTable);
 
-    const setFieldValue = (path: string, value: unknown) => {
-        setValue(path as FormPath, value as PathValue<AppFormData, FormPath>);
+        rootTablesFieldArray.update(rootIndex, rootTable);
+
+        return result;
     };
 
     const addRootTable = () => {
-        const nextIndex = getTableList<FormRootTable>("mapTables.tables").length;
+        const nextIndex = (getValues("mapTables.tables") ?? []).length;
 
         rootTablesFieldArray.append(createEmptyRootTable(), { shouldFocus: false });
         setMapActiveTable({ type: "root", path: getRootTablePath(nextIndex) });
     };
 
     const addEmbeddedTable = (parentPath: ParentTablePath) => {
-        const listPath = `${parentPath}.embeddedTables`;
-        const embeddedTables = getTableList<FormEmbeddedTable>(listPath);
+        const newIndex = updateRootTable(parentPath, (rootTable) => {
+            const parentTable = getTableWithinRoot(rootTable, parentPath);
 
-        setFieldValue(listPath, [...embeddedTables, createEmptyEmbeddedTable()]);
+            parentTable.embeddedTables.push(createEmptyEmbeddedTable());
+
+            return parentTable.embeddedTables.length - 1;
+        });
+
         expandMapTable(parentPath);
-        setMapActiveTable({ type: "embedded", path: castToEmbeddedTablePath(`${listPath}.${embeddedTables.length}`) });
+        setMapActiveTable({
+            type: "embedded",
+            path: castToEmbeddedTablePath(`${parentPath}.embeddedTables.${newIndex}`),
+        });
     };
 
     const addLinkedTable = (parentPath: ParentTablePath) => {
-        const listPath = `${parentPath}.linkedTables`;
-        const linkedTables = getTableList<FormLinkedTable>(listPath);
+        const newIndex = updateRootTable(parentPath, (rootTable) => {
+            const parentTable = getTableWithinRoot(rootTable, parentPath);
 
-        setFieldValue(listPath, [...linkedTables, createEmptyLinkedTable()]);
+            parentTable.linkedTables.push(createEmptyLinkedTable());
+
+            return parentTable.linkedTables.length - 1;
+        });
+
         expandMapTable(parentPath);
-        setMapActiveTable({ type: "linked", path: castToLinkedTablePath(`${listPath}.${linkedTables.length}`) });
+        setMapActiveTable({
+            type: "linked",
+            path: castToLinkedTablePath(`${parentPath}.linkedTables.${newIndex}`),
+        });
     };
 
     const toggleRootTableDisabled = (path: RootTablePath) => {
-        setFieldValue(`${path}.disabled`, !getValues(`${path}.disabled`));
+        updateRootTable(path, (rootTable) => {
+            rootTable.disabled = !rootTable.disabled;
+        });
     };
 
     const removeTable = (path: MapTablePath) => {
-        const parts = path.split(".");
-        const index = Number(parts.at(-1));
-        const listPath = parts.slice(0, -1).join(".");
+        const segments = path.split(".");
+        const index = Number(segments.at(-1));
 
-        if (listPath === "mapTables.tables") {
+        if (segments.length === 3) {
             rootTablesFieldArray.remove(index);
         } else {
-            const tables = getTableList<unknown>(listPath);
+            const listName = segments.at(-2) as "embeddedTables" | "linkedTables";
+            const parentPath = segments.slice(0, -2).join(".") as ParentTablePath;
 
-            setFieldValue(
-                listPath,
-                tables.filter((_, idx) => idx !== index),
-            );
+            updateRootTable(path, (rootTable) => {
+                const parentTable = getTableWithinRoot(rootTable, parentPath);
+
+                if (listName === "embeddedTables") {
+                    parentTable.embeddedTables.splice(index, 1);
+                } else {
+                    parentTable.linkedTables.splice(index, 1);
+                }
+            });
         }
 
         removeMapTableUiState(path);

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-table-actions.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-table-actions.ts
@@ -16,6 +16,7 @@ import {
     createEmptyLinkedTable,
     createEmptyRootTable,
 } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
+import { useRootTablesFieldArray } from "@/pages/setup/add-app-wizard/steps/map-tables/root-tables-field-array";
 import { useFormContext, type FieldPath, type PathValue } from "react-hook-form";
 
 type ParentTablePath = RootTablePath | EmbeddedTablePath;
@@ -23,6 +24,7 @@ type FormPath = FieldPath<AppFormData>;
 
 export function useTableActions() {
     const { getValues, setValue } = useFormContext<AppFormData>();
+    const rootTablesFieldArray = useRootTablesFieldArray();
     const setMapActiveTable = useSetupWizardStore((state) => state.setMapActiveTable);
     const expandMapTable = useSetupWizardStore((state) => state.expandMapTable);
     const removeMapTableUiState = useSetupWizardStore((state) => state.removeMapTableUiState);
@@ -34,10 +36,10 @@ export function useTableActions() {
     };
 
     const addRootTable = () => {
-        const tables = getTableList<FormRootTable>("mapTables.tables");
+        const nextIndex = getTableList<FormRootTable>("mapTables.tables").length;
 
-        setFieldValue("mapTables.tables", [...tables, createEmptyRootTable()]);
-        setMapActiveTable({ type: "root", path: getRootTablePath(tables.length) });
+        rootTablesFieldArray.append(createEmptyRootTable(), { shouldFocus: false });
+        setMapActiveTable({ type: "root", path: getRootTablePath(nextIndex) });
     };
 
     const addEmbeddedTable = (parentPath: ParentTablePath) => {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-table-actions.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-table-actions.ts
@@ -68,12 +68,18 @@ export function useTableActions() {
         const parts = path.split(".");
         const index = Number(parts.at(-1));
         const listPath = parts.slice(0, -1).join(".");
-        const tables = getTableList<unknown>(listPath);
 
-        setFieldValue(
-            listPath,
-            tables.filter((_, idx) => idx !== index),
-        );
+        if (listPath === "mapTables.tables") {
+            rootTablesFieldArray.remove(index);
+        } else {
+            const tables = getTableList<unknown>(listPath);
+
+            setFieldValue(
+                listPath,
+                tables.filter((_, idx) => idx !== index),
+            );
+        }
+
         removeMapTableUiState(path);
     };
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-verify-map-tables.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/use-verify-map-tables.ts
@@ -1,0 +1,16 @@
+import { useFormContext, useWatch } from "react-hook-form";
+import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+import { collectMappedSourceTables } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
+import { useVerifyCdcState } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step";
+
+/** The CDC dry run keyed to every source table the current mapping captures, for the step and its
+ * button. When the mapping covers exactly the verify step's selection, this resolves from the entry
+ * that step already paid for. */
+export function useVerifyMapTablesState() {
+    const { control } = useFormContext<AppFormData>();
+    const tables = useWatch({ control, name: "mapTables.tables" });
+    const selectedTables = collectMappedSourceTables(tables);
+    const state = useVerifyCdcState(selectedTables);
+
+    return { selectedTables, ...state };
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map/map-source-options.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map/map-source-options.ts
@@ -9,7 +9,7 @@ type MapSourceOption = {
 export const AI_SUGGEST_OPTION: MapSourceOption = {
     value: "ai-suggested",
     label: "AI Suggest",
-    description: "LLM proposes a draft CDCSinkConfiguration based on schema + your intent prompt.",
+    description: "LLM proposes a draft configuration based on schema + your intent prompt.",
 };
 
 export const MANUAL_OPTION: MapSourceOption = {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step.ts
@@ -1,45 +1,49 @@
 import { useIsFetching, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useFormContext, useWatch } from "react-hook-form";
-import { WizardHandledError } from "@/components/form/wizard/wizard-step-error";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import {
+    fetchVerifyCdc,
     VERIFY_CDC_QUERY_KEY,
     verifyCdcQuery,
     type VerifyCdcInput,
 } from "@/pages/setup/add-app-wizard/steps/verify/verify-cdc-query";
 import type { WizardProgress } from "@/components/form/wizard/form-wizard";
 
-/** The dry-run inputs the form and the store currently hold. */
-function useVerifyCdcInput(): VerifyCdcInput {
+type SelectedTables = VerifyCdcInput["selectedTables"];
+
+/** The dry-run inputs the form and the store currently hold, for the given table set. */
+function useVerifyCdcInput(selectedTables: SelectedTables): VerifyCdcInput {
     const { control } = useFormContext<AppFormData>();
     const connectKey = useSetupWizardStore((state) => state.connectKey);
 
     // Watched rather than read through getValues, otherwise React Compiler memoizes the input against
-    // the stable getValues reference and it never follows the selection.
-    const [slug, selectedTables] = useWatch({ control, name: ["externalConnection.slug", "verifySchema.tables"] });
+    // the stable getValues reference and it never follows the form.
+    const slug = useWatch({ control, name: "externalConnection.slug" });
 
     return { connectKey, slug, selectedTables };
 }
 
 /**
  * Whether a dry run is in flight, for any selection - including one still finishing for a selection the
- * operator has since changed. It freezes everything that would invalidate the run under way: the table
- * selection, the schema list it was discovered from, and Next. Deliberately reads nothing but the fetch
- * state, so the wizard shell can hold Next back without re-rendering on every checkbox.
+ * operator has since changed. The verify step freezes its table selection and schema list behind it, and
+ * the steps that run the dry run disable Next. Deliberately reads nothing but the fetch state, so the
+ * wizard shell can hold Next back without re-rendering on every checkbox.
  */
 export function useIsVerifyCdcRunning(): boolean {
     return useIsFetching({ queryKey: VERIFY_CDC_QUERY_KEY }) > 0;
 }
 
+export type VerifyCdcState = ReturnType<typeof useVerifyCdcState>;
+
 /**
- * The dry run for the current selection. The query is only observed here, never enabled: the call
+ * The dry run for the given table set. The query is only observed here, never enabled: the call
  * provisions capture infrastructure on the source, so it runs when the operator asks for it or when
  * Next needs it, and both read their state from this one cache entry.
  */
-export function useVerifyCdcState() {
+export function useVerifyCdcState(selectedTables: SelectedTables) {
     const queryClient = useQueryClient();
-    const input = useVerifyCdcInput();
+    const input = useVerifyCdcInput(selectedTables);
     const { isFetching, isSuccess, error } = useQuery({ ...verifyCdcQuery(input), enabled: false });
     const isRunning = useIsVerifyCdcRunning();
 
@@ -61,15 +65,12 @@ export function useVerifyCdcStep() {
         const { connectKey } = useSetupWizardStore.getState();
         const { slug } = getValues("externalConnection");
 
-        try {
-            progress.report("Verifying schema...");
-            // Serves the cached pass when this selection was already verified, here or from the button.
-            await queryClient.fetchQuery(
-                verifyCdcQuery({ connectKey, slug, selectedTables: getValues("verifySchema.tables") }),
-            );
-        } catch (error) {
-            // The step renders the failure from the query, so the wizard must not alert about it again.
-            throw new WizardHandledError(error);
-        }
+        // Serves the cached pass when this selection was already verified, here or from the button.
+        await fetchVerifyCdc(
+            queryClient,
+            { connectKey, slug, selectedTables: getValues("verifySchema.tables") },
+            progress,
+            "Verifying schema...",
+        );
     };
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-verify-schema-cdc.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/use-verify-schema-cdc.ts
@@ -1,0 +1,12 @@
+import { useFormContext, useWatch } from "react-hook-form";
+import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+import { useVerifyCdcState } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step";
+
+/** The CDC dry run keyed to the verify step's table selection, for the step and its button. */
+export function useVerifySchemaCdcState() {
+    const { control } = useFormContext<AppFormData>();
+    const selectedTables = useWatch({ control, name: "verifySchema.tables" });
+    const state = useVerifyCdcState(selectedTables);
+
+    return { selectedTables, ...state };
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-cdc-button.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-cdc-button.tsx
@@ -1,4 +1,5 @@
-import { CircleCheckIcon, ShieldCheckIcon } from "lucide-react";
+import { CircleAlertIcon, CircleCheckIcon, ShieldCheckIcon } from "lucide-react";
+import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { cn } from "@/lib/utils";
 import type { VerifyCdcState } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step";
@@ -9,31 +10,62 @@ type VerifyCdcButtonProps = {
      * table selection should be watched once. */
     state: VerifyCdcState;
     labels: { idle: string; verifying: string; verified: string };
+    /** "text" blends in with surrounding inline actions, "outline" stands alone as a regular button. */
+    variant?: "text" | "outline";
 };
 
 /** Runs the CDC dry run that Next runs for the step's table set, so the operator can settle the
  * inputs before leaving the step. */
-export function VerifyCdcButton({ disabled, state, labels }: VerifyCdcButtonProps) {
-    const { isVerifying, isVerified, isRunning, verify } = state;
+export function VerifyCdcButton({ disabled, state, labels, variant = "text" }: VerifyCdcButtonProps) {
+    const { isVerifying, isVerified, isRunning, error, verify } = state;
+    const hasError = Boolean(error) && !isVerifying && !isVerified;
+
+    const icon = isVerifying ? (
+        <Spinner className="size-3.5" />
+    ) : isVerified ? (
+        <CircleCheckIcon className="size-3.5" aria-hidden="true" />
+    ) : hasError ? (
+        <CircleAlertIcon className="size-3.5" aria-hidden="true" />
+    ) : (
+        <ShieldCheckIcon className="size-3.5" aria-hidden="true" />
+    );
+    const label = isVerifying ? labels.verifying : isVerified ? labels.verified : labels.idle;
+    const isDisabled = disabled || isVerified || isRunning;
+
+    if (variant === "outline") {
+        return (
+            <Button
+                variant="outline"
+                size="sm"
+                onClick={verify}
+                disabled={isDisabled}
+                className={cn(
+                    isVerified && "text-success disabled:opacity-100",
+                    hasError && "text-destructive hover:text-destructive",
+                )}
+            >
+                {icon}
+                {label}
+            </Button>
+        );
+    }
 
     return (
         <button
             type="button"
             onClick={verify}
-            disabled={disabled || isVerified || isRunning}
+            disabled={isDisabled}
             className={cn(
                 "flex items-center gap-1.5 whitespace-nowrap transition-colors disabled:pointer-events-none",
-                isVerified ? "text-success" : "text-foreground hover:text-muted-foreground",
+                isVerified
+                    ? "text-success"
+                    : hasError
+                      ? "text-destructive hover:text-destructive/80"
+                      : "text-foreground hover:text-muted-foreground",
             )}
         >
-            {isVerifying ? (
-                <Spinner className="size-3.5" />
-            ) : isVerified ? (
-                <CircleCheckIcon className="size-3.5" aria-hidden="true" />
-            ) : (
-                <ShieldCheckIcon className="size-3.5" aria-hidden="true" />
-            )}
-            {isVerifying ? labels.verifying : isVerified ? labels.verified : labels.idle}
+            {icon}
+            {label}
         </button>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-cdc-button.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-cdc-button.tsx
@@ -1,0 +1,39 @@
+import { CircleCheckIcon, ShieldCheckIcon } from "lucide-react";
+import { Spinner } from "@/components/shadcn/ui/spinner";
+import { cn } from "@/lib/utils";
+import type { VerifyCdcState } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step";
+
+type VerifyCdcButtonProps = {
+    disabled: boolean;
+    /** Passed in rather than derived here: the step needs the same state for its error alert, and one
+     * table selection should be watched once. */
+    state: VerifyCdcState;
+    labels: { idle: string; verifying: string; verified: string };
+};
+
+/** Runs the CDC dry run that Next runs for the step's table set, so the operator can settle the
+ * inputs before leaving the step. */
+export function VerifyCdcButton({ disabled, state, labels }: VerifyCdcButtonProps) {
+    const { isVerifying, isVerified, isRunning, verify } = state;
+
+    return (
+        <button
+            type="button"
+            onClick={verify}
+            disabled={disabled || isVerified || isRunning}
+            className={cn(
+                "flex items-center gap-1.5 whitespace-nowrap transition-colors disabled:pointer-events-none",
+                isVerified ? "text-success" : "text-foreground hover:text-muted-foreground",
+            )}
+        >
+            {isVerifying ? (
+                <Spinner className="size-3.5" />
+            ) : isVerified ? (
+                <CircleCheckIcon className="size-3.5" aria-hidden="true" />
+            ) : (
+                <ShieldCheckIcon className="size-3.5" aria-hidden="true" />
+            )}
+            {isVerifying ? labels.verifying : isVerified ? labels.verified : labels.idle}
+        </button>
+    );
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-cdc-query.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-cdc-query.ts
@@ -1,7 +1,8 @@
-import { queryOptions } from "@tanstack/react-query";
+import { queryOptions, type QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "@/api/api";
-import { toWizardStepError } from "@/components/form/wizard/wizard-step-error";
+import { toWizardStepError, WizardHandledError } from "@/components/form/wizard/wizard-step-error";
+import type { WizardProgress } from "@/components/form/wizard/form-wizard";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { getTableKey } from "@/pages/setup/add-app-wizard/discover-utils";
 
@@ -32,6 +33,30 @@ export function verifyCdcQuery({ connectKey, slug, selectedTables }: VerifyCdcIn
         staleTime: Infinity,
         retry: false,
     });
+}
+
+/**
+ * Runs the dry run a "Next" needs, or serves the pass already in the cache. Failures surface as
+ * WizardHandledError: the step renders them from the cache entry, so the wizard must not alert again.
+ */
+export async function fetchVerifyCdc(
+    queryClient: QueryClient,
+    input: VerifyCdcInput,
+    progress: WizardProgress,
+    progressLabel: string,
+): Promise<void> {
+    const query = verifyCdcQuery(input);
+
+    // A cached pass answers for these inputs on its own, so only a run that really happens is reported.
+    if (queryClient.getQueryState(query.queryKey)?.status !== "success") {
+        progress.report(progressLabel);
+    }
+
+    try {
+        await queryClient.fetchQuery(query);
+    } catch (error) {
+        throw new WizardHandledError(error);
+    }
 }
 
 async function verifyCdc(slug: string, selectedTables: SelectedTables) {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-button.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-button.tsx
@@ -1,33 +1,18 @@
-import { CircleCheckIcon, ShieldCheckIcon } from "lucide-react";
-import { Spinner } from "@/components/shadcn/ui/spinner";
-import { cn } from "@/lib/utils";
-import { useVerifyCdcState } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step";
+import { useVerifySchemaCdcState } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-schema-cdc";
+import { VerifyCdcButton } from "@/pages/setup/add-app-wizard/steps/verify/verify-cdc-button";
+
+const VERIFY_SCHEMA_LABELS = {
+    idle: "Verify schema",
+    verifying: "Verifying schema...",
+    verified: "Schema verified",
+};
 
 /**
- * Runs the CDC dry run that Next runs, so the operator can settle the selection before leaving the step.
- * Lives in the selection overlay: verifying is only meaningful once at least one table is selected.
+ * The CDC dry run for the verify step's table selection. Lives in the selection overlay:
+ * verifying is only meaningful once at least one table is selected.
  */
 export function VerifySchemaButton({ disabled }: { disabled: boolean }) {
-    const { isVerifying, isVerified, isRunning, verify } = useVerifyCdcState();
+    const state = useVerifySchemaCdcState();
 
-    return (
-        <button
-            type="button"
-            onClick={verify}
-            disabled={disabled || isVerified || isRunning}
-            className={cn(
-                "flex items-center gap-1.5 whitespace-nowrap transition-colors disabled:pointer-events-none",
-                isVerified ? "text-success" : "text-foreground hover:text-muted-foreground",
-            )}
-        >
-            {isVerifying ? (
-                <Spinner className="size-3.5" />
-            ) : isVerified ? (
-                <CircleCheckIcon className="size-3.5" aria-hidden="true" />
-            ) : (
-                <ShieldCheckIcon className="size-3.5" aria-hidden="true" />
-            )}
-            {isVerifying ? "Verifying schema..." : isVerified ? "Schema verified" : "Verify schema"}
-        </button>
-    );
+    return <VerifyCdcButton disabled={disabled} state={state} labels={VERIFY_SCHEMA_LABELS} />;
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-step.tsx
@@ -18,7 +18,7 @@ import { LockedConfigAlert } from "@/pages/setup/add-app-wizard/locked-config-al
 import { DefineSchemasSheet } from "@/pages/setup/add-app-wizard/steps/verify/define-schemas-sheet";
 import { NeedsConfigTablesTable } from "@/pages/setup/add-app-wizard/steps/verify/needs-config-tables-table";
 import { useDiscoverTablesMutation } from "@/pages/setup/add-app-wizard/steps/verify/use-discover-tables";
-import { useVerifyCdcState } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-cdc-step";
+import { useVerifySchemaCdcState } from "@/pages/setup/add-app-wizard/steps/verify/use-verify-schema-cdc";
 import { VerifiedTablesTable } from "@/pages/setup/add-app-wizard/steps/verify/verified-tables-table";
 import { WizardErrorList } from "@/components/form/wizard/wizard-error-list";
 import {
@@ -35,7 +35,7 @@ export function VerifySchemaStep({ isBusy }: WizardBodyComponentProps) {
     // formState off the context does not re-render this step; only its own subscription does.
     const { errors } = useFormState({ control, name: "verifySchema.tables" });
     const tablesError = errors.verifySchema?.tables;
-    const { error: cdcError, isRunning: isVerifyCdcRunning } = useVerifyCdcState();
+    const { error: cdcError, isRunning: isVerifyCdcRunning } = useVerifySchemaCdcState();
     const discoverResult = useSetupWizardStore((state) => state.discoverResult);
     const discoverSchemas = useSetupWizardStore((state) => state.discoverSchemas);
     const isLocked = useSetupWizardStore((state) => state.configLock) === "locked";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27260

### Additional description

Verification is triggered when the 'Verify tables' or 'Next' button is clicked. When all selected tables have mappings, the step is marked as verified based on the previous step.

I also fixed several performance issues in the 'Map tables' step. Adding, deleting, and modifying tables should now be fast even with a large number of tables.

*Idle*
<img width="435" height="184" alt="image" src="https://github.com/user-attachments/assets/5885d530-ab4a-48d0-a44f-40a25e5df663" />

*Error*
<img width="439" height="158" alt="image" src="https://github.com/user-attachments/assets/78452104-a3ca-4c21-a82c-85390f028fff" />
<img width="997" height="72" alt="image" src="https://github.com/user-attachments/assets/b43385b2-a02e-40ed-9d86-b200d53f10a4" />

*Valid*
<img width="455" height="162" alt="image" src="https://github.com/user-attachments/assets/aab4a9db-e39e-47ca-823d-9ab7664825d4" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
