### PR TITLE
RavenDB-27171 [v7.2 VERSION] Corax numerical term removal to correctly handle frequency adjustments.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -200,18 +200,22 @@ namespace Raven.Server.Documents.Indexes
             private const long LowerCasedReferences_62 = 62_005; // RavenDB-23100
             public const long CoraxPagingBasedOnEntriesId_62 = 62_006; // RavenDB-23100
             public const long CoraxUnicodeLengthAnalyzers_62 = 62_007; // RavenDB-24423
+            public const long CoraxNumericTreesWithoutFrequencies_62 = 62_008; // RavenDB-27171
+
+            public const long Base72Version = 72_001;
 
             // RavenDB-26831: compound-field numeric (long) members were encoded as raw two's-complement big-endian,
             // which is not order-preserving for negative values (negatives sort above positives). Indexes at this
             // version or higher encode them order-preserving (sign-bit flipped), so compound sorts/ranges over a
             // numeric field with negative values are correct. Older indexes keep the legacy encoding (and behavior);
             // resetting/rebuilding an index upgrades it to the fixed encoding.
-            public const long CoraxOrderPreservingCompoundNumericEncoding = 72_001; // RavenDB-26831
+            public const long CoraxOrderPreservingCompoundNumericEncoding = Base72Version; // RavenDB-26831
+            public const long CoraxNumericTreesWithoutFrequencies_72 = 72_002; // RavenDB-27171
 
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = CoraxOrderPreservingCompoundNumericEncoding;
+            public const long CurrentVersion = CoraxNumericTreesWithoutFrequencies_72;
 
             public static bool IsLowerCasedReferencesSupported(long indexVersion)
             {
@@ -252,6 +256,14 @@ namespace Raven.Server.Documents.Indexes
                     return indexVersion >= CoraxSearchWildcardAdjustment_61;
 
                 return indexVersion >= CoraxSearchWildcardAdjustment_60;
+            }
+
+            public static bool IsNumericTreesWithoutFrequenciesSupported(long indexVersion)
+            {
+                if (indexVersion >= Base72Version)
+                    return indexVersion >= CoraxNumericTreesWithoutFrequencies_72;
+
+                return indexVersion >= CoraxNumericTreesWithoutFrequencies_62;
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27171 
### Additional description

v7.2 version update after merging https://github.com/ravendb/ravendb/pull/23274 into v7.2

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
