### PR TITLE
RavenDB-27168 Iterate over _transactionPages to free pages during rollback, instead of iterating and filtering over all in-use scratch pages.

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -777,6 +777,11 @@ namespace Voron.Impl
             if (_scratchPagesInUse.TryGetValue(pageNumber, out PageFromScratchBuffer value) == false)
                 throw new InvalidOperationException($"The page {pageNumber} was not previous allocated in this transaction");
 
+            // shrinking a page of a committed transaction would mutate its scratch memory in place (readers may
+            // be looking at it) and would put a foreign page into _transactionPages, which both the journal write
+            // and Rollback() treat as this transaction's own allocations
+            Debug.Assert(value.AllocatedInTransaction == Id, $"ShrinkOverflowPage({pageNumber}) on a page allocated in tx {value.AllocatedInTransaction}, current tx is {Id}");
+
             var page = value.ReadWritable(this);
             if (page.IsOverflow == false || page.OverflowSize < newSize)
                 throw new InvalidOperationException($"The page {pageNumber} was is not an overflow page greater than {newSize}");
@@ -1331,12 +1336,13 @@ namespace Voron.Impl
 
             // we need to roll back all the changes we made here
             _env.WriteTransactionPool.ScratchPagesInUse = _scratchPagesInUse = _scratchBuffersSnapshotToRollbackTo.ToBuilder();
-            foreach (var (k, maybeRollBack) in rollbackPages)
-            {
-                if (maybeRollBack.AllocatedInTransaction != Id)
-                    continue; // from a committed transaction, can keep
 
-                _env.ScratchBufferPool.FreeImmediately(this, maybeRollBack.File.Number, maybeRollBack.PositionInScratchBuffer);
+            // We need to free pages allocated by this transaction in a scratch buffer.
+            // During tx, we did partial cleanup via `DiscardScratchModificationOn`
+            // So only pages currently allocated by this transaction need to be freed.
+            foreach (var transactionPage in _transactionPages)
+            {
+                _env.ScratchBufferPool.FreeImmediately(this, transactionPage.File.Number, transactionPage.PositionInScratchBuffer);
             }
 
             RolledBack = true;

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1332,17 +1332,22 @@ namespace Voron.Impl
 
             ValidateReadOnlyPages();
 
-            var rollbackPages = _env.WriteTransactionPool.ScratchPagesInUse;
-
             // we need to roll back all the changes we made here
             _env.WriteTransactionPool.ScratchPagesInUse = _scratchPagesInUse = _scratchBuffersSnapshotToRollbackTo.ToBuilder();
 
             // We need to free pages allocated by this transaction in a scratch buffer.
             // During tx, we did partial cleanup via `DiscardScratchModificationOn`
             // So only pages currently allocated by this transaction need to be freed.
-            foreach (var transactionPage in _transactionPages)
+            var forTestingPurposes = _forTestingPurposes;
+            foreach (var scratchPage in _transactionPages)
             {
-                _env.ScratchBufferPool.FreeImmediately(this, transactionPage.File.Number, transactionPage.PositionInScratchBuffer);
+                if (forTestingPurposes != null)
+                    forTestingPurposes.ScratchPagesExaminedDuringRollback++;
+
+                Debug.Assert(scratchPage.AllocatedInTransaction == Id,
+                    $"Scratch page {scratchPage.PositionInScratchBuffer} in the pages of transaction {Id} was allocated in transaction {scratchPage.AllocatedInTransaction}");
+
+                _env.ScratchBufferPool.FreeImmediately(this, scratchPage.File.Number, scratchPage.PositionInScratchBuffer);
             }
 
             RolledBack = true;
@@ -1570,6 +1575,7 @@ namespace Voron.Impl
             private readonly LowLevelTransaction _tx;
             internal bool SimulateThrowingOnCommitStage2 = false;
 
+            internal long ScratchPagesExaminedDuringRollback;
             internal Action ActionToCallDuringEnsurePagerStateReference;
             internal Action ActionToCallJustBeforeWritingToJournal;
             internal Action ActionToCallDuringBeginAsyncCommitAndStartNewTransaction;

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -206,21 +206,17 @@ namespace Voron.Impl.Scratch
                 AllocatedInTransaction = value.AllocatedInTransaction,
             };
 
-            // TryGettingFromAllocatedBuffer inspects the tail only, which is correct as long as the tail holds the
-            // lowest ValidAfterTransactionId in the list. Frees carrying a transaction id arrive in increasing order,
-            // so adding them at the head keeps the list descending. A page freed with -1 was never visible to any
-            // transaction (a rollback, or a page the current write tx allocated and dropped), so it belongs at the
-            // tail: it is usable right away, and putting it anywhere else would hide it behind a page that is still
-            // gated on an old read transaction.
-            if (asOfTxId == -1)
-                list.AddLast(pending);
-            else
-                list.AddFirst(pending);
-
-            // Only pages freed with a transaction id hold readers back, and a later free cannot make an earlier one
-            // available sooner, so this watermark only ever moves forward.
-            if (asOfTxId > _txIdAfterWhichLatestFreePagesBecomeAvailable)
+            if (asOfTxId >= 0)
+            {
                 _txIdAfterWhichLatestFreePagesBecomeAvailable = asOfTxId;
+                list.AddFirst(pending);
+            }
+            else
+            { 
+                // -1 indicates that this is visible to all transactions, so make it the first available in the queue 
+                list.AddLast(pending);
+            }
+
 
             return NumberOfAllocations == 0;
         }

--- a/test/FastTests/Voron/ScratchBuffer/RollbackDoesNotScanUnrelatedScratchPages.cs
+++ b/test/FastTests/Voron/ScratchBuffer/RollbackDoesNotScanUnrelatedScratchPages.cs
@@ -1,0 +1,201 @@
+using Tests.Infrastructure;
+using Voron;
+using Voron.Impl;
+using Xunit;
+
+namespace FastTests.Voron.ScratchBuffer
+{
+    public class RollbackDoesNotScanUnrelatedScratchPages : StorageTest
+    {
+        public RollbackDoesNotScanUnrelatedScratchPages(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            // the shared scratch pages table only shrinks when the journal is applied to the data file,
+            // so manual flushing lets the test hold it at a known size
+            options.ManualFlushing = true;
+            base.Configure(options);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void A_transaction_that_modified_nothing_examines_no_scratch_pages_when_rolled_back()
+        {
+            var unflushedScratchPages = PileUpUnflushedScratchPages();
+
+            LowLevelTransaction.TestingStuff testing;
+
+            using (var txw = Env.WriteTransaction())
+            {
+                testing = txw.LowLevelTransaction.ForTestingPurposesOnly();
+
+                // the shape of a RunIdleOperations cleanup: it takes the write lock, finds nothing to do
+                // and is disposed without a commit - which is a rollback
+            }
+
+            Assert.True(testing.ScratchPagesExaminedDuringRollback == 0,
+                $"rolling back a transaction that modified nothing examined {testing.ScratchPagesExaminedDuringRollback} scratch pages, " +
+                $"which is the {unflushedScratchPages} pages every write transaction since the last flush left behind. " +
+                "Rollback holds the write transaction lock, so its cost has to be bounded by the transaction being rolled back.");
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void Rollback_examines_only_the_scratch_pages_that_the_transaction_itself_allocated()
+        {
+            var unflushedScratchPages = PileUpUnflushedScratchPages();
+
+            LowLevelTransaction.TestingStuff testing;
+            int ownScratchPages;
+
+            using (var txw = Env.WriteTransaction())
+            {
+                var llt = txw.LowLevelTransaction;
+
+                testing = llt.ForTestingPurposesOnly();
+
+                txw.CreateTree("foo").Add("rolled-back", new string('r', 20000));
+
+                ownScratchPages = llt.GetTransactionPages().Count;
+
+                // no Commit()
+            }
+
+            Assert.True(ownScratchPages > 0, "the transaction is expected to have allocated scratch pages");
+            Assert.True(ownScratchPages < unflushedScratchPages,
+                $"the transaction allocated {ownScratchPages} pages out of the {unflushedScratchPages} in the table, " +
+                "otherwise this test cannot tell the two costs apart");
+
+            Assert.True(testing.ScratchPagesExaminedDuringRollback == ownScratchPages,
+                $"rolling back a transaction that allocated {ownScratchPages} scratch pages examined " +
+                $"{testing.ScratchPagesExaminedDuringRollback} of them, out of the {unflushedScratchPages} accumulated since the last flush.");
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void Rolling_back_a_transaction_that_freed_a_page_of_an_earlier_transaction_leaves_that_page_alone()
+        {
+            var overflowValue = new string('a', 20000); // an overflow, allocated as one block in the scratch space
+
+            using (var txw = Env.WriteTransaction())
+            {
+                txw.CreateTree("foo").Add("overflow", overflowValue);
+                txw.Commit();
+            }
+
+            var scratchFile = Env.ScratchBufferPool._current.File;
+            var allocatedPagesBefore = scratchFile.AllocatedPagesCount;
+
+            using (var txw = Env.WriteTransaction())
+            {
+                // the overflow pages this frees were allocated by the committed transaction above, so this
+                // transaction never owned them - rolling back must not hand them back to the scratch file
+                txw.CreateTree("foo").Delete("overflow");
+
+                // no Commit()
+            }
+
+            Assert.True(scratchFile.AllocatedPagesCount == allocatedPagesBefore,
+                $"the scratch file held {allocatedPagesBefore} allocated pages before the rolled back transaction and " +
+                $"{scratchFile.AllocatedPagesCount} after it");
+
+            // read it back under a write transaction, which resolves pages through the restored scratch pages table
+            using (var txw = Env.WriteTransaction())
+            {
+                var read = txw.CreateTree("foo").Read("overflow");
+
+                Assert.True(read != null, "the value freed by the rolled back transaction is gone");
+                Assert.Equal(overflowValue, read.Reader.ToStringValue());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void Rolling_back_the_transaction_started_by_an_async_commit_frees_only_its_own_scratch_pages()
+        {
+            var committedValue = new string('c', 20000);
+
+            LowLevelTransaction.TestingStuff testing;
+            int ownScratchPages;
+            long allocatedPagesBefore;
+
+            var tx1 = Env.WriteTransaction();
+
+            try
+            {
+                tx1.CreateTree("foo").Add("committed", committedValue);
+
+                // tx2 runs on top of tx1 while tx1 is still writing to the journal, and takes over the shared
+                // scratch pages table with tx1's pages already in it
+                using (var tx2 = tx1.BeginAsyncCommitAndStartNewTransaction(tx1.LowLevelTransaction.PersistentContext))
+                {
+                    using (tx1)
+                    {
+                        tx1.EndAsyncCommit();
+                    }
+
+                    tx1 = null;
+
+                    allocatedPagesBefore = Env.ScratchBufferPool._current.File.AllocatedPagesCount;
+
+                    testing = tx2.LowLevelTransaction.ForTestingPurposesOnly();
+
+                    tx2.CreateTree("foo").Add("rolled-back", new string('r', 20000));
+
+                    ownScratchPages = tx2.LowLevelTransaction.GetTransactionPages().Count;
+
+                    // no Commit()
+                }
+            }
+            finally
+            {
+                tx1?.Dispose();
+            }
+
+            Assert.True(ownScratchPages > 0, "the transaction is expected to have allocated scratch pages");
+
+            Assert.True(testing.ScratchPagesExaminedDuringRollback == ownScratchPages,
+                $"rolling back the transaction started by the async commit allocated {ownScratchPages} scratch pages but examined " +
+                $"{testing.ScratchPagesExaminedDuringRollback}, which includes the pages the asynchronously committed transaction left behind");
+
+            Assert.True(Env.ScratchBufferPool._current.File.AllocatedPagesCount == allocatedPagesBefore,
+                $"the scratch file held {allocatedPagesBefore} allocated pages before the rolled back transaction and " +
+                $"{Env.ScratchBufferPool._current.File.AllocatedPagesCount} after it");
+
+            using (var txw = Env.WriteTransaction())
+            {
+                var tree = txw.CreateTree("foo");
+
+                var committed = tree.Read("committed");
+
+                Assert.True(committed != null, "the asynchronously committed value did not survive the rollback of the transaction that followed it");
+                Assert.Equal(committedValue, committed.Reader.ToStringValue());
+
+                Assert.Null(tree.Read("rolled-back"));
+            }
+        }
+
+        /// <summary>
+        /// Commits enough pages to leave the shared scratch pages table well above the size of any single
+        /// transaction below. Nothing removes them - only a flush does, and flushing is disabled.
+        /// </summary>
+        private int PileUpUnflushedScratchPages()
+        {
+            var value = new string('a', 4000);
+
+            using (var txw = Env.WriteTransaction())
+            {
+                var tree = txw.CreateTree("foo");
+
+                for (var i = 0; i < 1000; i++)
+                    tree.Add($"keys/{i:D5}", value);
+
+                txw.Commit();
+            }
+
+            var count = Env.WriteTransactionPool.ScratchPagesInUse.Count;
+
+            Assert.True(count > 100, $"expected the committed pages to still be in the scratch pages table, but it holds {count} of them");
+
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27168
### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
