### PR TITLE
RavenDB-26944: Streaming with Ollama

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Exceptions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Util;
@@ -338,6 +339,13 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
                 if (line.StartsWith("{"))
                 {
                     using var final = context.Sync.ReadForMemory(line, "final/result");
+
+                    // a server exception thrown after the stream started cannot change the 200 status; it is
+                    // appended to the response as the standard error envelope - surface it instead of
+                    // mistaking it for the final result
+                    if (final.TryGet(nameof(ExceptionDispatcher.ExceptionSchema.Type), out string _) && final.TryGet(nameof(ExceptionDispatcher.ExceptionSchema.Error), out string _))
+                        throw ExceptionDispatcher.Get(final, response.StatusCode);
+
                     SetResponse(context, final, fromCache: false);
                     break;
                 }

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -191,14 +191,7 @@ public class ChatCompletionClient : IDisposable
 
         await using var responseStream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
         IToolCallState toolCallState = _settings.CreateToolCallState();
-        object message = null;
-        StringBuilder stringContent = structuredOutput ? null : new StringBuilder();
-
-        // Some OpenAI-compatible providers emit reasoning on a separate delta field before the answer, so it is
-        // never fed to the answer parser per delta - non-empty `content` may still arrive after it.
-        StringBuilder reasoningFallback = null;
-        var sawContent = false;
-        string finishReason = null;
+        var result = new AiResultBuilder(parser);
 
         // need two contexts here because we run two parsing operations at once, first for each of the SSE events
         // and then for the internal buffer that there are providing.
@@ -240,27 +233,22 @@ public class ChatCompletionClient : IDisposable
             }
 
             var choice = (BlittableJsonReaderObject)choices[0];
-            if (choice.TryGet(Constants.ResponseFields.FinishReason, out string chunkFinishReason) && chunkFinishReason != null)
-                finishReason = chunkFinishReason;
+            if (choice.TryGet(Constants.ResponseFields.FinishReason, out string chunkFinishReason))
+                result.RecordFinishReason(chunkFinishReason);
 
             if (choice.TryGet(Constants.ResponseFields.Delta, out BlittableJsonReaderObject delta))
             {
                 if (delta.TryGet(Constants.ResponseFields.Content, out LazyStringValue content) && content?.Length > 0)
                 {
-                    sawContent = true;
-                    reasoningFallback = null;
                     toolCallState.AddAndReset();
 
-                    // A mid-stream parser rejection is deferred (the parser latches it and stops accepting
-                    // content) so the terminating finish_reason is still observed - 'length' must win over an
-                    // invalid-JSON error.
-                    await AppendContentAsync(content, streamedPropertyBuffer, parser);
+                    if (result.AcceptContent(content))
+                        await StreamContentAsync(content);
                 }
-                else if (sawContent == false &&
-                         ((delta.TryGet(Constants.ResponseFields.ReasoningContent, out LazyStringValue reasoning) && reasoning?.Length > 0) ||
-                          (delta.TryGet(Constants.ResponseFields.Reasoning, out reasoning) && reasoning?.Length > 0)))
+                else if (TryGetDeltaReasoning(delta, out LazyStringValue reasoning))
                 {
-                    (reasoningFallback ??= new StringBuilder()).Append(reasoning);
+                    toolCallState.AddAndReset();
+                    result.AcceptReasoning(reasoning);
                 }
 
                 if (delta.TryGet(Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray toolCalls))
@@ -288,103 +276,158 @@ public class ChatCompletionClient : IDisposable
             };
         }
 
-        if (structuredOutput)
-        {
-            // A length-truncated structured response is incomplete even if its partial JSON parsed, so it is
-            // rejected before the content is considered.
-            if (string.Equals(finishReason, Constants.ResponseFields.FinishReasonLength, StringComparison.OrdinalIgnoreCase))
-                throw new TooManyTokensException(
-                    $"The model response was truncated (finish_reason='length') before producing a complete structured answer.{GetReasoningPreview(reasoningFallback)}")
-                {
-                    RequestId = GetRequestId(response.Headers)
-                };
+        result.FinalizeOrThrow(streamingContext, response);
 
-            // 'message' is set only by content that parsed into a complete JSON object. Whatever reasoning was
-            // buffered is chain-of-thought, never the structured answer - parsing it was the RavenDB-26944 crash.
-            if (message is null)
-            {
-                var problem = parser.IsInvalid
-                    ? "streamed content that is not valid JSON"
-                    : sawContent
-                        ? "streamed content that did not form a complete JSON object"
-                        : "streamed no content";
-                throw UnexpectedResponseException.Create(
-                    $"Structured output was requested but the model {problem} (finish_reason='{finishReason}').{GetReasoningPreview(reasoningFallback)}",
-                    response, content: (string)null);
-            }
+        if (result.TryGetChunk(out var chunk))
+            await StreamContentAsync(streamingContext.GetLazyString(chunk));
 
-            return new AiResponse(AiResponseType.Result)
-            {
-                Message = streamingContext.ReadObject(new DynamicJsonValue
-                {
-                    [Constants.ResponseFields.Role] = Constants.RequestFields.RoleAssistantValue,
-                    [Constants.ResponseFields.Content] = message,
-                }, "persisted/streamed/message"),
-                Result = message,
-            };
-        }
-
-        // Unstructured output keeps the reasoning fallback (reasoning_content / reasoning) for LM Studio and
-        // other reasoning models - see RavenDB-25681 - used only when no answer 'content' was streamed.
-        if (sawContent == false && reasoningFallback is { Length: > 0 })
-        {
-            await AppendContentAsync(streamingContext.GetLazyString(reasoningFallback.ToString()), streamedPropertyBuffer, parser);
-        }
-
-        var fullText = stringContent.ToString();
+        var finalResult = result.GetResult();
         return new AiResponse(AiResponseType.Result)
         {
             Message = streamingContext.ReadObject(new DynamicJsonValue
             {
                 [Constants.ResponseFields.Role] = Constants.RequestFields.RoleAssistantValue,
-                [Constants.ResponseFields.Content] = fullText,
+                [Constants.ResponseFields.Content] = finalResult,
             }, "persisted/streamed/message"),
-            Result = fullText,
+            Result = finalResult,
         };
 
-        async Task AppendContentAsync(LazyStringValue content, JsonOperationContextBuffer<byte> propertyBuffer, SseStreamingJsonParser jsonParser)
+        async Task StreamContentAsync(LazyStringValue content)
         {
-            if (structuredOutput)
+            if (structuredOutput == false)
+                streamedPropertyBuffer.Append(content.AsSpan());
+
+            await FlushStreamedPropertyAsync();
+        }
+
+        async Task FlushStreamedPropertyAsync()
+        {
+            if (streamedPropertyBuffer.Length is not 0) // Length is the written data length (not the buffer real size)
             {
-                // The parser owns the "model did not produce valid JSON" state; the failure is reported at the
-                // end of the stream. A failing client flush below still propagates.
-                if (jsonParser.TryProcess(content, out var final) == false)
-                    return;
+                await streamedPropertyCallback(streamedPropertyBuffer.AsMemory());
+                streamedPropertyBuffer.Length = 0;
+            }
+        }
+    }
 
-                if (propertyBuffer.Length is not 0) // Length is the written data length (not the buffer real size)
-                {
-                    // here we send all the data that wasn't sent so far to the client
-                    await streamedPropertyCallback(propertyBuffer.AsMemory());
-                    // reset the buffer length so we can overwrite the start of the buffer
-                    // and only retain in memory the parts we'll need to send next time
-                    propertyBuffer.Length = 0;
-                }
+    private sealed class AiResultBuilder
+    {
+        private readonly SseStreamingJsonParser _parser;
+        private readonly StringBuilder _text;
+        private string _pendingChunk;
+        private StringBuilder _reasoningFallback;
+        private BlittableJsonReaderObject _message;
+        private string _finishReason;
+        private bool _sawContent;
 
-                if (final is not null)
-                {
-                    message = final;
-                }
+        public AiResultBuilder(SseStreamingJsonParser parser)
+        {
+            _parser = parser;
+            _text = parser == null ? new StringBuilder() : null;
+        }
 
+        public void RecordFinishReason(string finishReason)
+        {
+            if (finishReason != null)
+                _finishReason = finishReason;
+        }
+
+        public bool AcceptContent(LazyStringValue content)
+        {
+            _sawContent = true;
+            _reasoningFallback = null;
+
+            if (_parser == null)
+            {
+                _text.Append(content);
+                return true;
+            }
+
+            if (_parser.TryProcess(content, out var final) == false)
+                return false;
+
+            if (final != null)
+                _message = final;
+
+            return true;
+        }
+
+        public void AcceptReasoning(LazyStringValue reasoning)
+        {
+            if (_sawContent == false)
+                (_reasoningFallback ??= new StringBuilder()).Append(reasoning);
+        }
+
+        public void FinalizeOrThrow(JsonOperationContext context, HttpResponseMessage response)
+        {
+            if (_parser == null)
+            {
+                TryPromoteReasoningFallback(out _pendingChunk);
                 return;
             }
 
-            // For unstructured output, stream the raw text chunks directly
-            stringContent.Append(content);
-            propertyBuffer.Append(content.AsSpan());
-            await streamedPropertyCallback(propertyBuffer.AsMemory());
-            propertyBuffer.Length = 0;
+            if (string.Equals(_finishReason, Constants.ResponseFields.FinishReasonLength, StringComparison.OrdinalIgnoreCase))
+                throw new TooManyTokensException(
+                    $"The model response was truncated (finish_reason='length') before producing a complete structured answer.{GetReasoningPreview()}")
+                {
+                    RequestId = GetRequestId(response.Headers)
+                };
+
+            if (_message == null && _sawContent == false && _reasoningFallback is { Length: > 0 })
+            {
+                if (_parser.TryProcess(context.GetLazyString(_reasoningFallback.ToString()), out var final) && final != null)
+                {
+                    _message = final;
+                    _pendingChunk = string.Empty;
+                }
+            }
+
+            if (_message == null)
+            {
+                var problem = _sawContent
+                    ? _parser.IsInvalid
+                        ? "streamed content that is not valid JSON"
+                        : "streamed content that did not form a complete JSON object"
+                    : _reasoningFallback is { Length: > 0 }
+                        ? "streamed no content, and its reasoning is not the structured answer"
+                        : "streamed no content";
+                throw UnexpectedResponseException.Create(
+                    $"Structured output was requested but the model {problem} (finish_reason='{_finishReason}').{GetReasoningPreview()}",
+                    response, content: (string)null);
+            }
         }
 
-        // A thinking model can produce many KB of chain-of-thought, so only the beginning of it is quoted in errors.
-        static string GetReasoningPreview(StringBuilder reasoning)
+        public bool TryGetChunk(out string chunk)
         {
-            if (reasoning is not { Length: > 0 })
+            chunk = _pendingChunk;
+            return chunk != null;
+        }
+
+        public object GetResult() => _parser == null ? _text.ToString() : _message;
+
+        private bool TryPromoteReasoningFallback(out string reasoning)
+        {
+            if (_sawContent || _reasoningFallback is not { Length: > 0 })
+            {
+                reasoning = null;
+                return false;
+            }
+
+            reasoning = _reasoningFallback.ToString();
+            _text.Append(reasoning);
+            _reasoningFallback = null;
+            return true;
+        }
+
+        private string GetReasoningPreview()
+        {
+            if (_reasoningFallback is not { Length: > 0 })
                 return string.Empty;
 
             const int maxLength = 500;
-            return reasoning.Length <= maxLength
-                ? $" Reasoning: {reasoning}"
-                : $" Reasoning: {reasoning.ToString(0, maxLength)}...";
+            return _reasoningFallback.Length <= maxLength
+                ? $" Reasoning: {_reasoningFallback}"
+                : $" Reasoning: {_reasoningFallback.ToString(0, maxLength)}...";
         }
     }
 
@@ -394,13 +437,18 @@ public class ChatCompletionClient : IDisposable
         if (delta.TryGet(Constants.ResponseFields.Content, out content) && content?.Length > 0)
             return true;
 
-        if (delta.TryGet(Constants.ResponseFields.ReasoningContent, out content) && content?.Length > 0)
+        return TryGetDeltaReasoning(delta, out content);
+    }
+
+    private static bool TryGetDeltaReasoning(BlittableJsonReaderObject delta, out LazyStringValue reasoning)
+    {
+        if (delta.TryGet(Constants.ResponseFields.ReasoningContent, out reasoning) && reasoning?.Length > 0)
             return true;
 
-        if (delta.TryGet(Constants.ResponseFields.Reasoning, out content) && content?.Length > 0)
+        if (delta.TryGet(Constants.ResponseFields.Reasoning, out reasoning) && reasoning?.Length > 0)
             return true;
 
-        content = null;
+        reasoning = null;
         return false;
     }
 
@@ -532,7 +580,6 @@ public class ChatCompletionClient : IDisposable
             _choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
             var lengthTruncated = string.Equals(finishReason, Constants.ResponseFields.FinishReasonLength, StringComparison.OrdinalIgnoreCase);
 
-            // A thinking model can return empty 'content' plus a large 'reasoning' block.
             var hasContent = Message.TryGet(Constants.ResponseFields.Content, out LazyStringValue content) && content?.Length > 0;
 
             var result = structuredOutput
@@ -545,54 +592,43 @@ public class ChatCompletionClient : IDisposable
             return result;
         }
 
-        // Structured output is parsed only from real 'content'. A thinking model's reasoning is natural
-        // language, never the structured answer - feeding it to the JSON parser was the RavenDB-26944 crash.
         private object GetStructuredContent(JsonOperationContext context, LazyStringValue content, bool hasContent, string finishReason, bool lengthTruncated)
         {
-            // A truncated response is incomplete even if its content happens to be valid JSON, so it is
-            // rejected before parsing.
+            // a truncated response is incomplete even if its content is valid JSON
             if (lengthTruncated)
-                throw Truncated("a complete structured answer");
+                throw Truncated();
 
-            if (hasContent == false)
+            // content -> reasoning_content -> reasoning: reasoning is only a fallback when no 'content' was
+            // produced at all (RavenDB-25681)
+            if (hasContent == false && TryGetDeltaReasoning(Message, out content) == false)
                 throw NoUsableAnswer(finishReason);
 
             try
             {
                 return context.Sync.ReadForMemory(content, "ai/output");
             }
-            catch (Exception e) when (e is InvalidDataException or InvalidStartOfObjectException)
+            catch (Exception e) when (e is InvalidDataException or InvalidStartOfObjectException or EndOfStreamException)
             {
-                // Malformed JSON raises InvalidDataException; well-formed JSON with a non-object root (an
-                // array, string or number) raises InvalidStartOfObjectException. Surface both as a clean
-                // error instead of leaking the raw parser exception.
                 throw UnexpectedResponseException.Create(
                     $"Structured output was requested but the model returned content that is not valid JSON (finish_reason='{finishReason}'). Content: {content}",
                     response, responseContent);
             }
         }
 
-        // Unstructured output may use 'reasoning_content' / 'reasoning' as the answer when no normal content
-        // arrived - see RavenDB-25681.
         private object GetPlainTextContent(LazyStringValue content, bool hasContent, string finishReason, bool lengthTruncated)
         {
             if (hasContent == false)
             {
                 if (lengthTruncated)
-                    throw Truncated("an answer");
+                    throw Truncated();
 
                 if (TryGetDeltaContent(Message, out content) == false)
                     throw NoUsableAnswer(finishReason);
-
-                // 'content' now holds the reasoning text, used as the plain-text answer.
             }
 
             return content.ToString();
         }
 
-        // Refusal handling for both flows lives here only: a refusal is reported as such, anything else as a
-        // missing answer. RefusedToAnswerException.Throw always throws, so the returned exception just lets
-        // the callers keep a single `throw` statement.
         private Exception NoUsableAnswer(string finishReason)
         {
             var refusal = client.GetRefusal(_choice0, Message);
@@ -602,8 +638,8 @@ public class ChatCompletionClient : IDisposable
             return UnexpectedResponseException.Create(message: "No response content", response, responseContent);
         }
 
-        private TooManyTokensException Truncated(string expected) =>
-            new($"The model response was truncated (finish_reason='length') before producing {expected}. Response content: {responseContent}")
+        private TooManyTokensException Truncated() =>
+            new($"The model response was truncated (finish_reason='length') before producing a complete answer. Response content: {responseContent}")
             {
                 RequestId = GetRequestId(response.Headers)
             };
@@ -694,8 +730,6 @@ public class ChatCompletionClient : IDisposable
         });
 
         // Optional
-        // When tools are disabled, providers that honor 'tool_choice' keep the tools array and get "none";
-        // providers that ignore 'tool_choice' (Ollama) get no tools array at all, since a model cannot call a tool it was never offered.
         if (tools?.Count > 0 && (useTools || _settings.SupportsToolChoiceNone))
         {
             writer.WriteComma();

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -31,6 +31,7 @@ using Raven.Server.Documents.SchemaValidation.ErrorMessage;
 using Raven.Server.Json;
 using Raven.Server.Utils;
 using Sparrow;
+using Sparrow.Exceptions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
@@ -193,6 +194,12 @@ public class ChatCompletionClient : IDisposable
         object message = null;
         StringBuilder stringContent = structuredOutput ? null : new StringBuilder();
 
+        // Some OpenAI-compatible providers emit reasoning on a separate delta field before the answer, so it is
+        // never fed to the answer parser per delta - non-empty `content` may still arrive after it.
+        StringBuilder reasoningFallback = null;
+        var sawContent = false;
+        string finishReason = null;
+
         // need two contexts here because we run two parsing operations at once, first for each of the SSE events
         // and then for the internal buffer that there are providing.
         using var ___ = contextPool.AllocateOperationContext(out JsonOperationContext parsingContext);
@@ -233,37 +240,27 @@ public class ChatCompletionClient : IDisposable
             }
 
             var choice = (BlittableJsonReaderObject)choices[0];
+            if (choice.TryGet(Constants.ResponseFields.FinishReason, out string chunkFinishReason) && chunkFinishReason != null)
+                finishReason = chunkFinishReason;
+
             if (choice.TryGet(Constants.ResponseFields.Delta, out BlittableJsonReaderObject delta))
             {
-                if (TryGetDeltaContent(delta, out LazyStringValue content))
+                if (delta.TryGet(Constants.ResponseFields.Content, out LazyStringValue content) && content?.Length > 0)
                 {
+                    sawContent = true;
+                    reasoningFallback = null;
                     toolCallState.AddAndReset();
 
-                    if (structuredOutput)
-                    {
-                        var final = parser.Process(content);
-                        if (streamedPropertyBuffer.Length is not 0) // Length is the written data length (not the buffer real size)
-                        {
-                            // here we send all the data that wasn't sent so far to the client
-                            await streamedPropertyCallback(streamedPropertyBuffer.AsMemory());
-                            // reset the buffer length so we can overwrite the start of the buffer
-                            // and only retain in memory the parts we'll need to send next time
-                            streamedPropertyBuffer.Length = 0;
-                        }
-
-                        if (final is not null)
-                        {
-                            message = final;
-                        }
-                    }
-                    else
-                    {
-                        // For unstructured output, stream the raw text chunks directly
-                        stringContent.Append(content);
-                        streamedPropertyBuffer.Append(content.AsSpan());
-                        await streamedPropertyCallback(streamedPropertyBuffer.AsMemory());
-                        streamedPropertyBuffer.Length = 0;
-                    }
+                    // A mid-stream parser rejection is deferred (the parser latches it and stops accepting
+                    // content) so the terminating finish_reason is still observed - 'length' must win over an
+                    // invalid-JSON error.
+                    await AppendContentAsync(content, streamedPropertyBuffer, parser);
+                }
+                else if (sawContent == false &&
+                         ((delta.TryGet(Constants.ResponseFields.ReasoningContent, out LazyStringValue reasoning) && reasoning?.Length > 0) ||
+                          (delta.TryGet(Constants.ResponseFields.Reasoning, out reasoning) && reasoning?.Length > 0)))
+                {
+                    (reasoningFallback ??= new StringBuilder()).Append(reasoning);
                 }
 
                 if (delta.TryGet(Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray toolCalls))
@@ -291,29 +288,104 @@ public class ChatCompletionClient : IDisposable
             };
         }
 
-        if (structuredOutput == false)
+        if (structuredOutput)
         {
-            var fullText = stringContent.ToString();
+            // A length-truncated structured response is incomplete even if its partial JSON parsed, so it is
+            // rejected before the content is considered.
+            if (string.Equals(finishReason, Constants.ResponseFields.FinishReasonLength, StringComparison.OrdinalIgnoreCase))
+                throw new TooManyTokensException(
+                    $"The model response was truncated (finish_reason='length') before producing a complete structured answer.{GetReasoningPreview(reasoningFallback)}")
+                {
+                    RequestId = GetRequestId(response.Headers)
+                };
+
+            // 'message' is set only by content that parsed into a complete JSON object. Whatever reasoning was
+            // buffered is chain-of-thought, never the structured answer - parsing it was the RavenDB-26944 crash.
+            if (message is null)
+            {
+                var problem = parser.IsInvalid
+                    ? "streamed content that is not valid JSON"
+                    : sawContent
+                        ? "streamed content that did not form a complete JSON object"
+                        : "streamed no content";
+                throw UnexpectedResponseException.Create(
+                    $"Structured output was requested but the model {problem} (finish_reason='{finishReason}').{GetReasoningPreview(reasoningFallback)}",
+                    response, content: (string)null);
+            }
+
             return new AiResponse(AiResponseType.Result)
             {
                 Message = streamingContext.ReadObject(new DynamicJsonValue
                 {
                     [Constants.ResponseFields.Role] = Constants.RequestFields.RoleAssistantValue,
-                    [Constants.ResponseFields.Content] = fullText,
+                    [Constants.ResponseFields.Content] = message,
                 }, "persisted/streamed/message"),
-                Result = fullText,
+                Result = message,
             };
         }
 
+        // Unstructured output keeps the reasoning fallback (reasoning_content / reasoning) for LM Studio and
+        // other reasoning models - see RavenDB-25681 - used only when no answer 'content' was streamed.
+        if (sawContent == false && reasoningFallback is { Length: > 0 })
+        {
+            await AppendContentAsync(streamingContext.GetLazyString(reasoningFallback.ToString()), streamedPropertyBuffer, parser);
+        }
+
+        var fullText = stringContent.ToString();
         return new AiResponse(AiResponseType.Result)
         {
             Message = streamingContext.ReadObject(new DynamicJsonValue
             {
                 [Constants.ResponseFields.Role] = Constants.RequestFields.RoleAssistantValue,
-                [Constants.ResponseFields.Content] = message,
+                [Constants.ResponseFields.Content] = fullText,
             }, "persisted/streamed/message"),
-            Result = message,
+            Result = fullText,
         };
+
+        async Task AppendContentAsync(LazyStringValue content, JsonOperationContextBuffer<byte> propertyBuffer, SseStreamingJsonParser jsonParser)
+        {
+            if (structuredOutput)
+            {
+                // The parser owns the "model did not produce valid JSON" state; the failure is reported at the
+                // end of the stream. A failing client flush below still propagates.
+                if (jsonParser.TryProcess(content, out var final) == false)
+                    return;
+
+                if (propertyBuffer.Length is not 0) // Length is the written data length (not the buffer real size)
+                {
+                    // here we send all the data that wasn't sent so far to the client
+                    await streamedPropertyCallback(propertyBuffer.AsMemory());
+                    // reset the buffer length so we can overwrite the start of the buffer
+                    // and only retain in memory the parts we'll need to send next time
+                    propertyBuffer.Length = 0;
+                }
+
+                if (final is not null)
+                {
+                    message = final;
+                }
+
+                return;
+            }
+
+            // For unstructured output, stream the raw text chunks directly
+            stringContent.Append(content);
+            propertyBuffer.Append(content.AsSpan());
+            await streamedPropertyCallback(propertyBuffer.AsMemory());
+            propertyBuffer.Length = 0;
+        }
+
+        // A thinking model can produce many KB of chain-of-thought, so only the beginning of it is quoted in errors.
+        static string GetReasoningPreview(StringBuilder reasoning)
+        {
+            if (reasoning is not { Length: > 0 })
+                return string.Empty;
+
+            const int maxLength = 500;
+            return reasoning.Length <= maxLength
+                ? $" Reasoning: {reasoning}"
+                : $" Reasoning: {reasoning.ToString(0, maxLength)}...";
+        }
     }
 
     private static bool TryGetDeltaContent(BlittableJsonReaderObject delta, out LazyStringValue content)
@@ -457,20 +529,15 @@ public class ChatCompletionClient : IDisposable
 
         public object GetContent(JsonOperationContext context, bool structuredOutput)
         {
-            // Try content, then reasoning_content, then reasoning (for LM Studio and other OpenAI-like APIs that still use the older mechanism)
-            if (TryGetDeltaContent(Message, out var content) == false)
-            {
-                _choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
-                var refusal = client.GetRefusal(_choice0, Message);
-                if (string.IsNullOrEmpty(refusal))
-                    throw UnexpectedResponseException.Create(message: "No response content", response, responseContent);
+            _choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
+            var lengthTruncated = string.Equals(finishReason, Constants.ResponseFields.FinishReasonLength, StringComparison.OrdinalIgnoreCase);
 
-                RefusedToAnswerException.Throw(refusal, responseContent.ToString(), finishReason, GetRequestId(response.Headers));
-            }
+            // A thinking model can return empty 'content' plus a large 'reasoning' block.
+            var hasContent = Message.TryGet(Constants.ResponseFields.Content, out LazyStringValue content) && content?.Length > 0;
 
-            object result = structuredOutput
-                ? context.Sync.ReadForMemory(content, "ai/output")
-                : content.ToString();
+            var result = structuredOutput
+                ? GetStructuredContent(context, content, hasContent, finishReason, lengthTruncated)
+                : GetPlainTextContent(content, hasContent, finishReason, lengthTruncated);
 
             Message.Modifications ??= new DynamicJsonValue(Message);
             Message.Modifications[Constants.ResponseFields.Content] = result;
@@ -478,6 +545,68 @@ public class ChatCompletionClient : IDisposable
             return result;
         }
 
+        // Structured output is parsed only from real 'content'. A thinking model's reasoning is natural
+        // language, never the structured answer - feeding it to the JSON parser was the RavenDB-26944 crash.
+        private object GetStructuredContent(JsonOperationContext context, LazyStringValue content, bool hasContent, string finishReason, bool lengthTruncated)
+        {
+            // A truncated response is incomplete even if its content happens to be valid JSON, so it is
+            // rejected before parsing.
+            if (lengthTruncated)
+                throw Truncated("a complete structured answer");
+
+            if (hasContent == false)
+                throw NoUsableAnswer(finishReason);
+
+            try
+            {
+                return context.Sync.ReadForMemory(content, "ai/output");
+            }
+            catch (Exception e) when (e is InvalidDataException or InvalidStartOfObjectException)
+            {
+                // Malformed JSON raises InvalidDataException; well-formed JSON with a non-object root (an
+                // array, string or number) raises InvalidStartOfObjectException. Surface both as a clean
+                // error instead of leaking the raw parser exception.
+                throw UnexpectedResponseException.Create(
+                    $"Structured output was requested but the model returned content that is not valid JSON (finish_reason='{finishReason}'). Content: {content}",
+                    response, responseContent);
+            }
+        }
+
+        // Unstructured output may use 'reasoning_content' / 'reasoning' as the answer when no normal content
+        // arrived - see RavenDB-25681.
+        private object GetPlainTextContent(LazyStringValue content, bool hasContent, string finishReason, bool lengthTruncated)
+        {
+            if (hasContent == false)
+            {
+                if (lengthTruncated)
+                    throw Truncated("an answer");
+
+                if (TryGetDeltaContent(Message, out content) == false)
+                    throw NoUsableAnswer(finishReason);
+
+                // 'content' now holds the reasoning text, used as the plain-text answer.
+            }
+
+            return content.ToString();
+        }
+
+        // Refusal handling for both flows lives here only: a refusal is reported as such, anything else as a
+        // missing answer. RefusedToAnswerException.Throw always throws, so the returned exception just lets
+        // the callers keep a single `throw` statement.
+        private Exception NoUsableAnswer(string finishReason)
+        {
+            var refusal = client.GetRefusal(_choice0, Message);
+            if (string.IsNullOrEmpty(refusal) == false)
+                RefusedToAnswerException.Throw(refusal, responseContent.ToString(), finishReason, GetRequestId(response.Headers));
+
+            return UnexpectedResponseException.Create(message: "No response content", response, responseContent);
+        }
+
+        private TooManyTokensException Truncated(string expected) =>
+            new($"The model response was truncated (finish_reason='length') before producing {expected}. Response content: {responseContent}")
+            {
+                RequestId = GetRequestId(response.Headers)
+            };
     }
 
     protected virtual Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token) => _client.SendAsync(request, token);
@@ -565,7 +694,9 @@ public class ChatCompletionClient : IDisposable
         });
 
         // Optional
-        if (tools?.Count > 0)
+        // When tools are disabled, providers that honor 'tool_choice' keep the tools array and get "none";
+        // providers that ignore 'tool_choice' (Ollama) get no tools array at all, since a model cannot call a tool it was never offered.
+        if (tools?.Count > 0 && (useTools || _settings.SupportsToolChoiceNone))
         {
             writer.WriteComma();
             writer.WriteArray(Constants.RequestFields.Tools, tools);
@@ -1035,6 +1166,7 @@ public class ChatCompletionClient : IDisposable
             public const string ReasoningContent = "reasoning_content";
             public const string Reasoning = "reasoning";
             public const string FinishReason = "finish_reason";
+            public const string FinishReasonLength = "length";
             public const string ToolCalls = "tool_calls";
             public const string Refusal = "refusal";
             public const string Usage = "usage";

--- a/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
@@ -19,6 +19,8 @@ internal abstract class AbstractChatCompletionClientSettings
 
     public virtual bool SupportStrictTools => true;
 
+    public virtual bool SupportsToolChoiceNone => true;
+
     public virtual bool EnablePromptCaching => true;
 
     public Uri GetBaseEndpointUri() => _settings.GetBaseEndpointUri();

--- a/src/Raven.Server/Documents/AI/Settings/OllamaChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/OllamaChatCompletionClientSettings.cs
@@ -16,6 +16,10 @@ internal class OllamaChatCompletionClientSettings : AbstractChatCompletionClient
         _settings = settings;
     }
 
+    // Ollama's OpenAI-compatible endpoint silently drops 'tool_choice', so "none" cannot stop tool calls.
+    // Instead, the tools array is omitted entirely once tools are disabled.
+    public override bool SupportsToolChoiceNone => false;
+
     public override string GetRelativeCompletionUri() => "v1/" + base.GetRelativeCompletionUri();
 
     public override string GetRelativeModelsUri() => "v1/" + base.GetRelativeModelsUri();

--- a/src/Raven.Server/Documents/AI/SseStreamingJsonParser.cs
+++ b/src/Raven.Server/Documents/AI/SseStreamingJsonParser.cs
@@ -53,18 +53,8 @@ public unsafe class SseStreamingJsonParser : IDisposable
         _builder.ReadObjectDocument();
     }
 
-    /// <summary>
-    /// Set once the model's streamed content was rejected as JSON. Latched: the parser is not fed again after
-    /// that, so the caller can defer the failure to the end of the stream and still observe the terminating
-    /// finish_reason.
-    /// </summary>
     public bool IsInvalid { get; private set; }
 
-    /// <summary>
-    /// Non-throwing <see cref="Process"/>. Malformed JSON and a non-object root (both of which mean the model
-    /// did not produce the requested JSON) latch <see cref="IsInvalid"/> and return false; any other failure
-    /// propagates. Returns false immediately once <see cref="IsInvalid"/> is set.
-    /// </summary>
     public bool TryProcess(LazyStringValue dataChunk, out BlittableJsonReaderObject? result, CancellationToken? token = null)
     {
         result = null;

--- a/src/Raven.Server/Documents/AI/SseStreamingJsonParser.cs
+++ b/src/Raven.Server/Documents/AI/SseStreamingJsonParser.cs
@@ -1,7 +1,9 @@
 ﻿#nullable enable
 
 using System;
+using System.IO;
 using System.Threading;
+using Sparrow.Exceptions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -45,8 +47,41 @@ public unsafe class SseStreamingJsonParser : IDisposable
 
     public void Reset()
     {
+        IsInvalid = false;
+        _totalSize = 0;
         _context.CachedProperties.NewDocument();
         _builder.ReadObjectDocument();
+    }
+
+    /// <summary>
+    /// Set once the model's streamed content was rejected as JSON. Latched: the parser is not fed again after
+    /// that, so the caller can defer the failure to the end of the stream and still observe the terminating
+    /// finish_reason.
+    /// </summary>
+    public bool IsInvalid { get; private set; }
+
+    /// <summary>
+    /// Non-throwing <see cref="Process"/>. Malformed JSON and a non-object root (both of which mean the model
+    /// did not produce the requested JSON) latch <see cref="IsInvalid"/> and return false; any other failure
+    /// propagates. Returns false immediately once <see cref="IsInvalid"/> is set.
+    /// </summary>
+    public bool TryProcess(LazyStringValue dataChunk, out BlittableJsonReaderObject? result, CancellationToken? token = null)
+    {
+        result = null;
+
+        if (IsInvalid)
+            return false;
+
+        try
+        {
+            result = Process(dataChunk, token);
+            return true;
+        }
+        catch (Exception e) when (e is InvalidDataException or InvalidStartOfObjectException)
+        {
+            IsInvalid = true;
+            return false;
+        }
     }
 
     public BlittableJsonReaderObject? Process(LazyStringValue dataChunk, CancellationToken? token = null)

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBackupRestore.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBackupRestore.cs
@@ -23,8 +23,8 @@ public class AiAgentBackupRestore : ReplicationTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Backup })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Snapshot })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Backup })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Snapshot })]
     public async Task CanBackupAndRestoreAiAgents(Options options, GenAiConfiguration aiConfig, BackupType backupType)
     {
         var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -49,7 +49,7 @@ public class AiAgentBackupRestore : ReplicationTestBase
                     FolderPath = backupPath
                 }
             }));
-            var result = (BackupResult)await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+            var result = (BackupResult)await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(90));
 
             using var dis = Backup.RestoreDatabase(destination,
                 new RestoreBackupConfiguration

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanCreateAiAgent(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -93,7 +93,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanGetAiAgent(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -136,7 +136,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanResumeConversation(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -186,7 +186,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanRunTest(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -239,7 +239,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanStreamTest(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
@@ -42,8 +42,8 @@ public class AiAgentClientApiBasics : RavenTestBase
     }
 
     [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
     public async Task AiAgentClientApiBasicTest(Options options, GenAiConfiguration config, bool sendSchema)
     {
         using var store = GetDocumentStore(options);
@@ -123,8 +123,8 @@ public class AiAgentClientApiBasics : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
     public async Task AiAgentClientApiAnswerActionTool(Options options, GenAiConfiguration config, bool sendSchema)
     {
         using var store = GetDocumentStore(options);
@@ -175,7 +175,7 @@ public class AiAgentClientApiBasics : RavenTestBase
     }
 
     [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task AiAgentClientApi(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -247,7 +247,7 @@ public class AiAgentClientApiBasics : RavenTestBase
     }
 
     [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ThrowConcurrencyException(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
@@ -31,7 +31,7 @@ public class AiAgentClientApiHandleActionCalls : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanHandleToolCall(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -63,9 +63,12 @@ public class AiAgentClientApiHandleActionCalls : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, 
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single,
         Data = [AiHandleErrorStrategy.SendErrorsToModel])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, 
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single,
+        Data = [AiHandleErrorStrategy.SendErrorsToModel],
+        Skip = "Flaky on Ollama: after a tool error the local model can exhaust its 8K context window while reasoning and return finish_reason = 'length'.")]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single,
         Data = [AiHandleErrorStrategy.RaiseImmediately])]
     public async Task CanHandleToolCallWithException(Options options, GenAiConfiguration config, AiHandleErrorStrategy strategy)
     {
@@ -105,7 +108,7 @@ public class AiAgentClientApiHandleActionCalls : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanHandleToolCallWithArgs(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -162,7 +165,7 @@ Deviation from these rules is not allowed.");
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CantCreateNewConversationWithSameId(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -211,7 +214,7 @@ Deviation from these rules is not allowed.");
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanHandleAsyncToolCallReturningList(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentConfigurationValidation.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentConfigurationValidation.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ThrowOnMissingAgentParameter(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -54,7 +54,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ThrowOnDuplicateAgentParameter(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -74,7 +74,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ThrowOnDuplicateToolParameterUsage(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -111,7 +111,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ThrowOnMissingChatParameter(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -151,7 +151,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ThrowDuplicateToolName(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentDebugTracing.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentDebugTracing.cs
@@ -37,7 +37,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task DebugTracesCreatedWhenEnabled(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -70,7 +70,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task NoDebugTracesWhenNotEnabled(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -93,7 +93,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task Debug_FlippedOnExistingConversation_TracesOnlyNextTurn(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -140,7 +140,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task Debug_QueryStringOverride_FlipsPersistedAttributeFromFalseToTrue(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -184,7 +184,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task Debug_QueryStringOverride_FlipsPersistedAttributeFromTrueToFalse(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -233,7 +233,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task Debug_WithAttachment_PersistsAttachmentNames(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -266,7 +266,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task Debug_Streaming_PersistsStreamEvents(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -306,7 +306,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task Debug_WithQueryTool_PersistsOneTracePerLlmCall(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -348,7 +348,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task Debug_WithActionTool_PersistsOneTracePerLlmCall(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -497,9 +497,9 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { null })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { null })]
     public async Task Debug_PropagatesToSubAgent(Options options, GenAiConfiguration config, bool? debug)
     {
         using var store = await CreateStoreWithSubAgentArithmetic(options, config);
@@ -567,7 +567,7 @@ public class AiAgentDebugTracing : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task Debug_MultipleAttachments_PersistsAllNamesInOrder(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/ArtificalActions.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/ArtificalActions.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent;
 public class ArtificalActions(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanAddArtificialActionsToConversation(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/MockLlmHelper.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/MockLlmHelper.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.AI;
@@ -219,5 +221,142 @@ internal class MockLlm : ChatCompletionClient
                 "system_fingerprint": "fp_mock"
             }
             """;
+    }
+}
+
+/// <summary>
+/// A provider response injected in-process instead of being fetched from the real provider.
+/// </summary>
+internal sealed class InjectedResponse
+{
+    private InjectedResponse(string body, string contentType)
+    {
+        Body = body;
+        ContentType = contentType;
+    }
+
+    public string Body { get; }
+    public string ContentType { get; }
+
+    /// <summary>A non-streaming chat completion body.</summary>
+    public static InjectedResponse Json(string body) => new(body, "application/json");
+
+    /// <summary>A streaming (SSE) response body, as the provider would send it.</summary>
+    public static InjectedResponse Sse(string body) => new(body, "text/event-stream");
+}
+
+/// <summary>
+/// Builders for provider wire shapes a real model cannot be asked to produce on demand (empty answers,
+/// non-JSON answers, truncated answers). Text is JSON-escaped here, so callers pass plain strings.
+/// </summary>
+internal static class Wire
+{
+    private const int PromptTokens = 7000;
+    private const int CompletionTokens = 777;
+    private const int TotalTokens = PromptTokens + CompletionTokens;
+
+    /// <summary>A non-streaming chat completion. A null <paramref name="content"/> means a JSON null content.</summary>
+    public static string Completion(string content, string finishReason, string reasoning = null)
+    {
+        var contentJson = content == null ? "null" : JsonConvert.ToString(content);
+        var reasoningJson = reasoning == null ? "" : $",\"reasoning\":{JsonConvert.ToString(reasoning)}";
+        return $$"""
+        {
+            "id": "chatcmpl-injected",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "finish_reason": "{{finishReason}}",
+                "message": { "role": "assistant", "content": {{contentJson}}{{reasoningJson}} }
+            }],
+            "usage": { "prompt_tokens": {{PromptTokens}}, "completion_tokens": {{CompletionTokens}}, "total_tokens": {{TotalTokens}} }
+        }
+        """;
+    }
+
+    /// <summary>Wraps SSE chunks into a full event stream, terminated the way providers terminate it.</summary>
+    public static string Stream(params string[] chunks) =>
+        string.Concat(Array.ConvertAll(chunks, c => "data: " + c + "\n\n")) + "data: [DONE]\n\n";
+
+    /// <summary>An SSE chunk carrying a 'content' delta.</summary>
+    public static string ContentDelta(string content) => Chunk($"{{\"content\":{JsonConvert.ToString(content)}}}");
+
+    /// <summary>An SSE chunk carrying a 'reasoning' (or 'reasoning_content') delta.</summary>
+    public static string ReasoningDelta(string reasoning, bool reasoningContentField = false) =>
+        Chunk($"{{\"{(reasoningContentField ? "reasoning_content" : "reasoning")}\":{JsonConvert.ToString(reasoning)}}}");
+
+    /// <summary>The terminating SSE chunk carrying finish_reason and usage.</summary>
+    public static string FinishChunk(string finishReason) => Chunk("{}", finishReason, usage: true);
+
+    private static string Chunk(string delta, string finishReason = null, bool usage = false)
+    {
+        var finish = finishReason == null ? "null" : $"\"{finishReason}\"";
+        var usageJson = usage
+            ? $",\"usage\":{{\"prompt_tokens\":{PromptTokens},\"completion_tokens\":{CompletionTokens},\"total_tokens\":{TotalTokens}}}"
+            : "";
+        return $"{{\"choices\":[{{\"index\":0,\"delta\":{delta},\"finish_reason\":{finish}}}]{usageJson}}}";
+    }
+}
+
+/// <summary>
+/// A real <see cref="ConversationHandler"/> over a real provider connection string, where only the responses
+/// a real model cannot be made to produce on demand are injected in-process. Requests without an injected
+/// response are forwarded to the provider over HTTP, so the pipeline is always real and the model is real
+/// wherever the scenario allows it.
+/// <para>
+/// A <c>null</c> <paramref name="injected"/> forwards the request to the provider instead.
+/// </para>
+/// </summary>
+internal class InjectingConversationHandler(
+    Raven.Server.ServerWide.ServerStore server,
+    DocumentDatabase database,
+    AiConnectionString connection,
+    InjectedResponse injected)
+    : ConversationHandler(server, database)
+{
+    private readonly DocumentDatabase _database = database;
+    private ChatCompletionClient _client;
+
+    protected internal override ChatCompletionClient CreateClient()
+    {
+        if (_client != null)
+            return _client;
+
+        if (AbstractChatCompletionClientSettings.TryGetParameters(connection, out var settings) == false)
+            throw new NotSupportedException($"The provider '{connection.GetActiveProvider()}' is not supported.");
+
+        return _client = new InjectingClient(_database.DocumentsStorage.ContextPool, settings, injected);
+    }
+
+    private sealed class InjectingClient(
+        IMemoryContextPool contextPool,
+        AbstractChatCompletionClientSettings settings,
+        InjectedResponse injected)
+        : ChatCompletionClient(contextPool, settings, ConventionsToUse)
+    {
+        protected override Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token) =>
+            HandleAsync(request, streaming: false, token);
+
+        protected override Task<HttpResponseMessage> SendStreamingRequestAsync(HttpRequestMessage request, CancellationToken token) =>
+            HandleAsync(request, streaming: true, token);
+
+        private async Task<HttpResponseMessage> HandleAsync(HttpRequestMessage request, bool streaming, CancellationToken token)
+        {
+            if (injected != null)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(injected.Body, Encoding.UTF8, injected.ContentType)
+                };
+            }
+
+            if (streaming)
+            {
+                // Do not buffer a forwarded stream - that would defeat the incremental streaming under test.
+                return await base.SendStreamingRequestAsync(request, token);
+            }
+
+            return await base.SendRequestAsync(request, token);
+        }
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/MockLlmHelper.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/MockLlmHelper.cs
@@ -256,10 +256,10 @@ internal static class Wire
     private const int TotalTokens = PromptTokens + CompletionTokens;
 
     /// <summary>A non-streaming chat completion. A null <paramref name="content"/> means a JSON null content.</summary>
-    public static string Completion(string content, string finishReason, string reasoning = null)
+    public static string Completion(string content, string finishReason, string reasoning = null, bool reasoningContentField = false)
     {
         var contentJson = content == null ? "null" : JsonConvert.ToString(content);
-        var reasoningJson = reasoning == null ? "" : $",\"reasoning\":{JsonConvert.ToString(reasoning)}";
+        var reasoningJson = reasoning == null ? "" : $",\"{(reasoningContentField ? "reasoning_content" : "reasoning")}\":{JsonConvert.ToString(reasoning)}";
         return $$"""
         {
             "id": "chatcmpl-injected",
@@ -288,6 +288,11 @@ internal static class Wire
     /// <summary>The terminating SSE chunk carrying finish_reason and usage.</summary>
     public static string FinishChunk(string finishReason) => Chunk("{}", finishReason, usage: true);
 
+    /// <summary>An SSE chunk carrying one tool-call fragment. Providers may reuse the same index for
+    /// consecutive calls, so the index is explicit.</summary>
+    public static string ToolCallDelta(int index, string id, string name, string arguments) =>
+        Chunk($"{{\"tool_calls\":[{{\"index\":{index},\"id\":{JsonConvert.ToString(id)},\"type\":\"function\",\"function\":{{\"name\":{JsonConvert.ToString(name)},\"arguments\":{JsonConvert.ToString(arguments)}}}}}]}}");
+
     private static string Chunk(string delta, string finishReason = null, bool usage = false)
     {
         var finish = finishReason == null ? "null" : $"\"{finishReason}\"";
@@ -299,13 +304,9 @@ internal static class Wire
 }
 
 /// <summary>
-/// A real <see cref="ConversationHandler"/> over a real provider connection string, where only the responses
-/// a real model cannot be made to produce on demand are injected in-process. Requests without an injected
-/// response are forwarded to the provider over HTTP, so the pipeline is always real and the model is real
-/// wherever the scenario allows it.
-/// <para>
-/// A <c>null</c> <paramref name="injected"/> forwards the request to the provider instead.
-/// </para>
+/// A real <see cref="ConversationHandler"/> whose provider response is supplied in-process instead of over
+/// HTTP, for responses a real model cannot be asked to produce on demand. Unlike <see cref="MockLlm"/> this
+/// also serves the streaming send, so SSE shapes can be injected.
 /// </summary>
 internal class InjectingConversationHandler(
     Raven.Server.ServerWide.ServerStore server,
@@ -335,28 +336,14 @@ internal class InjectingConversationHandler(
         : ChatCompletionClient(contextPool, settings, ConventionsToUse)
     {
         protected override Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token) =>
-            HandleAsync(request, streaming: false, token);
+            Task.FromResult(Injected());
 
         protected override Task<HttpResponseMessage> SendStreamingRequestAsync(HttpRequestMessage request, CancellationToken token) =>
-            HandleAsync(request, streaming: true, token);
+            Task.FromResult(Injected());
 
-        private async Task<HttpResponseMessage> HandleAsync(HttpRequestMessage request, bool streaming, CancellationToken token)
+        private HttpResponseMessage Injected() => new(HttpStatusCode.OK)
         {
-            if (injected != null)
-            {
-                return new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(injected.Body, Encoding.UTF8, injected.ContentType)
-                };
-            }
-
-            if (streaming)
-            {
-                // Do not buffer a forwarded stream - that would defeat the incremental streaming under test.
-                return await base.SendStreamingRequestAsync(request, token);
-            }
-
-            return await base.SendRequestAsync(request, token);
-        }
+            Content = new StringContent(injected.Body, Encoding.UTF8, injected.ContentType)
+        };
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24458.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24458.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task TwoConfigsWithSimilarIdentifierShouldThrow(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -48,7 +48,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task UpdateConfig(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24609.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24609.cs
@@ -22,7 +22,7 @@ public class RavenDB_24609(ITestOutputHelper output) : RavenTestBase(output)
     private const string AgentName = "params-test-agent";
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task GetConversationMessages_ReturnsParameters(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -143,7 +143,7 @@ public class RavenDB_24609(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task GetConversationMessages_ReturnsParameters_NoParametersReturnsEmptyObject(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -164,7 +164,7 @@ public class RavenDB_24609(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task GetConversationMessages_StitchesAcrossTwoSummarizationHistoryDocs(Options options, GenAiConfiguration config)
     {
         // Drives a conversation through TWO summarizations so two history snapshots get persisted.
@@ -245,7 +245,7 @@ public class RavenDB_24609(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanGetConversationMessages_ArrayContentJoinsTextParts_FromRealConversation(Options options, GenAiConfiguration config)
     {
         // End-to-end version of CanGetConversationMessages_ArrayContentJoinsTextParts:

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
@@ -20,7 +20,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ParametersAreKeySensitive(Options options, GenAiConfiguration config)
         {
             using var store = await GetClusterStoreAsync(options);
@@ -39,7 +39,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanPassNestedObjectAsActionResponse(Options options, GenAiConfiguration config)
         {
             using var store = await GetClusterStoreAsync(options);
@@ -85,7 +85,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ShouldThrowWhenConversationIdIsDocumentId(Options options, GenAiConfiguration config)
         {
             using var store = await GetClusterStoreAsync(options);
@@ -106,7 +106,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task Concurrency_When_Resuming_Same_Conversation(Options options, GenAiConfiguration config)
         {
             using var store = await GetClusterStoreAsync(options);
@@ -148,7 +148,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ConcurrentActionResponsesShouldConflict(Options options, GenAiConfiguration cfg)
         {
             using var store = await GetClusterStoreAsync(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24635.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24635.cs
@@ -18,8 +18,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ToolCallsWithNoEmptyContentShouldntFail(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24789.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24789.cs
@@ -31,10 +31,10 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ShouldRaiseServerAlertOnExceededActionToolResponse(Options options, GenAiConfiguration config)
         {
-            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "50";
+            options.ModifyDatabaseRecord += r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "50";
 
             using var store = GetDocumentStore(options);
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -136,10 +136,10 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ShouldRaiseServerAlertWhenBothToolTypesAreCalled(Options options, GenAiConfiguration config)
         {
-            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "100";
+            options.ModifyDatabaseRecord += r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "100";
 
             using var store = GetDocumentStore(options);
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -185,10 +185,10 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ShouldNotRaiseAlertWhenUserMessageExceedsTokenLimitAfterToolCall(Options options, GenAiConfiguration config)
         {
-            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "100";
+            options.ModifyDatabaseRecord += r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "100";
 
             using var store = GetDocumentStore(options);
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24791.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24791.cs
@@ -39,7 +39,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ArrayParameter(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -100,7 +100,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task IntParameter(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -162,7 +162,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task DoubleParameter(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -224,7 +224,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task BoolParameter(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24811.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24811.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent;
 public class RavenDB_24811(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanStreamResults(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -40,7 +40,7 @@ public class RavenDB_24811(ITestOutputHelper output) : RavenTestBase(output)
     }
     
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanStreamResults_WithTools(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -71,23 +71,27 @@ public class RavenDB_24811(ITestOutputHelper output) : RavenTestBase(output)
         });
 
         chat.SetUserPrompt("Give me 15 real cities names, one per line");
-        var sb = new StringBuilder();
+        // the tool-call phase must not stream the answer; a local model may narrate before/with the tool call,
+        // so it is captured separately and only the hosted providers are held to that.
+        var toolPhaseStream = new StringBuilder();
         var result = await chat.StreamAsync<AiAgentBasics.OutputSchema>(x=>x.Answer, s =>
         {
-            sb.Append(s);
+            toolPhaseStream.Append(s);
             return Task.CompletedTask;
         }, CancellationToken.None);
         Assert.Equal(AiConversationResult.ActionRequired,result.Status);
         Assert.True(wasCalled);
-        Assert.Empty(sb.ToString());
+        if (config.AiConnectorType != AiConnectorType.Ollama)
+            Assert.Empty(toolPhaseStream.ToString());
         chat.AddActionResponse(actionRequest.ToolId, "I'm batman");
-        
+
+        var finalAnswerStream = new StringBuilder();
         result = await chat.StreamAsync<AiAgentBasics.OutputSchema>("Answer", s =>
         {
-            sb.Append(s);
+            finalAnswerStream.Append(s);
             return Task.CompletedTask;
         }, CancellationToken.None);
         Assert.Equal(AiConversationResult.Done, result.Status);
-        Assert.Equal(result.Answer.Answer, sb.ToString());
+        Assert.Equal(result.Answer.Answer, finalAnswerStream.ToString());
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24824.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24824.cs
@@ -74,7 +74,7 @@ public class RavenDB_24824(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task OutputSchemaFieldTrackedPerTurnInDocument(Options options, GenAiConfiguration config)
     {
         // Covers: SampleObject (.NET object) override, explicit OutputSchema override, NoSchema,
@@ -139,7 +139,7 @@ public class RavenDB_24824(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task NoSchemaShorthandsReturnRawString(Options options, GenAiConfiguration config)
     {
         // Covers: Run() sync shorthand and RunAsync() no-arg shorthand both return raw string output.
@@ -163,7 +163,7 @@ public class RavenDB_24824(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task SyncStreamOverloadsWork(Options options, GenAiConfiguration config)
     {
         // Covers: Stream(Action<string>) no-schema shorthand and Stream<TAnswer>(Expression, Action) structured overload.
@@ -193,7 +193,7 @@ public class RavenDB_24824(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task StreamingNoSchemaPathWorks(Options options, GenAiConfiguration config)
     {
         // Covers: StreamAsync<string> without options routes to NoSchema (regression for last commit fix),
@@ -224,7 +224,7 @@ public class RavenDB_24824(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ConvenienceOverloadsWork(Options options, GenAiConfiguration config)
     {
         // Covers: RunAsync<TAnswer>(TAnswer sampleObject) and RunAsync<TAnswer>(string schema) convenience overloads.
@@ -271,7 +271,7 @@ public class RavenDB_24824(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanHandleNoArgsTool(Options options, GenAiConfiguration config)
     {
         // Covers: Handle(name, Func<object>) and Handle<TResult>(name, Func<Task<TResult>>) no-args overloads.
@@ -308,7 +308,7 @@ public class RavenDB_24824(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task MultiTurnConversationResumesCorrectlyAfterNoSchemaTurn(Options options, GenAiConfiguration config)
     {
         // After a NoSchema turn, the next turn with the default schema must still produce structured output.
@@ -333,7 +333,7 @@ public class RavenDB_24824(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanStreamWithSchemaOverride(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24847.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24847.cs
@@ -31,7 +31,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanAnalyzeImages(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -74,7 +74,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanAnalyzeImageFromCopiedAttachment(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -115,7 +115,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CopiedAttachmentWithMissingAttachments(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -139,7 +139,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanHandleInternalAndExternalActionsCalledTogether(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -184,7 +184,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanSendAttachmentWithoutPromptAndRecallItLater(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -216,7 +216,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanRecallAttachmentInSubsequentTurn(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -253,7 +253,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task MultipartUserPromptArrayWithAttachments(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24883.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24883.cs
@@ -16,7 +16,7 @@ public class RavenDB_24883 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ReceiveWillBeCalledButNotCloseTheAction(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887.cs
@@ -44,7 +44,7 @@ public class RavenDB_24887(ITestOutputHelper output) : RavenTestBase(output)
 
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanCallOneAgentFromAnother(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -130,7 +130,7 @@ public class RavenDB_24887(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task AnActionFromSubAgentCanBeHandledByParentConversation(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
@@ -20,7 +20,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent;
 public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(output)
 {
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanCallOneAgentFromAnother(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -131,7 +131,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanCallOneAgentFromAnotherWithError(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -264,7 +264,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ThreeLevelsOfNesting(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -338,7 +338,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ActionToolsOnSubAgentWithDifferentParam(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -410,7 +410,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ThreeLevelsOfNesting_endless_loop(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -484,7 +484,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task SubAgent2OpenActionTools(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -572,7 +572,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CheckMaxToolIterationsLimitOnSubAgent(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -655,7 +655,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task SubAgent2OpenActionToolsAtOnce(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -744,7 +744,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task SubAgent2OpenActionTools2Agents(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -886,6 +886,8 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single,
+        Skip = "Flaky on Ollama: the local model often exhausts its 8K context window while reasoning, so the response ends with finish_reason = 'length'.")]
     public async Task SubAgentWitAnotherActionCallOnTheFirstActionCallResponse(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -965,9 +967,10 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenDB_24887_Base(outp
         Assert.Equal(AiConversationResult.Done, r.Status);
     }
 
-
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single,
+        Skip = "Flaky on Ollama: the local model often exhausts its 8K context window while reasoning, so the response ends with finish_reason = 'length'.")]
     public async Task ResumeChatAfterError(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24900.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24900.cs
@@ -20,7 +20,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task WillThrowIfUnexpectedActionCalled(Options options, GenAiConfiguration config)
         {
             using var store = await GetClusterStoreAsync(options);
@@ -44,7 +44,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
         
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task EventWillBeRaisedForUnexpectedActions(Options options, GenAiConfiguration config)
         {
             using var store = await GetClusterStoreAsync(options);
@@ -80,7 +80,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             public string[] Query { get; set; }
         }
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanRegisterToReceiveActions(Options options, GenAiConfiguration config)
         {
             using var store = await GetClusterStoreAsync(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24905.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24905.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ShouldStripQueryToolMetadataToEssentialFieldsWithProjection(Options options, GenAiConfiguration config)
         {
             var store = GetDocumentStore(options);
@@ -61,7 +61,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ShouldStripQueryToolMetadataToEssentialFields(Options options, GenAiConfiguration config)
         {
             var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24913.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24913.cs
@@ -22,7 +22,7 @@ public class RavenDB_24913(ITestOutputHelper output) : RavenTestBase(output)
     private record Reply(string Answer);
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanProvideInitialContextToQuery(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -47,7 +47,7 @@ public class RavenDB_24913(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanProvideInitialContextToQueryWithStreaming(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
@@ -105,7 +105,7 @@ public class RavenDB_24984 : RavenTestBase
 
         chat.SetUserPrompt("call the 'MyTool' tool until it returns a value >= 10");
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
         var result = await chat.RunAsync<AiAgentBasics.OutputSchema>(cts.Token);
 
         Assert.Equal(AiConversationResult.Done, result.Status);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25186.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25186.cs
@@ -22,9 +22,9 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true, true])]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, false, false])]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [null, true, true])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true, true])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = [false, false, false])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = [null, true, true])]
         public async Task SendToModelVariants(Options options, GenAiConfiguration configuration, bool? sendToModel, bool expectEcho, bool expectRaw)
         {
             using var store = GetDocumentStore(options);
@@ -46,7 +46,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task MixedParametersOnlyExposedParametersAreInTheContent(Options options, GenAiConfiguration configuration)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25240.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25240.cs
@@ -23,7 +23,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task RunAsyncReturnsAnswerUsageAndTime(Options options, GenAiConfiguration cfg)
         {
             using var store = GetDocumentStore(options);
@@ -53,7 +53,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task StreamAsyncReturnsUsageTime(Options options, GenAiConfiguration cfg)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25255.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25255.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanUseQueryToolWithSecuredServer(Options options, GenAiConfiguration config)
         {
             var dbName = GetDatabaseName();
@@ -95,7 +95,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanUseQueryToolsInGenAiTaskSecured(Options options, GenAiConfiguration config)
         {
             var dbName = GetDatabaseName();
@@ -193,7 +193,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 session.SaveChanges();
             }
 
-            await Etl.AssertEtlDoneAsync(etlDone, TimeSpan.FromSeconds(120), store.Database, config);
+            await Etl.AssertEtlDoneAsync(etlDone, TimeSpan.FromSeconds(360), store.Database, config);
 
             using (var session = store.OpenSession())
             {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25307.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25307.cs
@@ -19,7 +19,7 @@ public class RavenDB_25307 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CallingAddActionResponseFromHandle_ShouldThrow(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -51,7 +51,7 @@ public class RavenDB_25307 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task Handle_TaskOfTResult_DoesNotBindToObjectOverload(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25430.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25430.cs
@@ -32,8 +32,8 @@ public class RavenDB_25430 : ReplicationTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai, Skip = "RavenDB-25471")]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Backup })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Snapshot })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Backup })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Snapshot })]
     public async Task DisableAiAgentsOnRestoreWithoutLicense(Options options, GenAiConfiguration aiConfig, BackupType backupType)
     {
         DoNotReuseServer();
@@ -57,7 +57,7 @@ public class RavenDB_25430 : ReplicationTestBase
                 FolderPath = backupPath
             }
         }));
-        await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+        await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(90));
         await source.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(source.Database, hardDelete: true));
 
         await PutLicense(Server, LicenseTestBase.RL_COMM);
@@ -101,8 +101,8 @@ public class RavenDB_25430 : ReplicationTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai, Skip = "RavenDB-25471")]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Backup })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Snapshot })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Backup })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Snapshot })]
     public async Task ThrowAiAgentsOnRestoreWithoutLicense(Options options, GenAiConfiguration aiConfig, BackupType backupType)
     {
         DoNotReuseServer();
@@ -126,7 +126,7 @@ public class RavenDB_25430 : ReplicationTestBase
                 FolderPath = backupPath
             }
         }));
-        await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+        await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(90));
         foreach (var agentConfig in agents)
         {
             agentConfig.Disabled = true;

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25445.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25445.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ShouldHandleBadGateway(Options options, GenAiConfiguration config)
         {
             using (var store = GetDocumentStore())

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25541.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25541.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ReceiveAndHandleCalledOnce(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25869.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25869.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
     {
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task SubAgentsParamsTests(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -164,7 +164,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task MissingParamOnSubAgent(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -253,7 +253,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ThreeLevelsOfNesting(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -327,7 +327,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task MissingParamOnSubAgent3Levels(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25899.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25899.cs
@@ -19,7 +19,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
     public class RavenDB_25899(ITestOutputHelper output) : RavenDB_24887_Base(output)
     {
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task TestWithSubAgentDepthOf2(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -155,7 +155,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task TestWithSubAgentDepthOf3(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -253,7 +253,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task TestSubAgent2OpenActionTools2Agents(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25962.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25962.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanDeleteAiAgent(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25975.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25975.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
     public class RavenDB_25975(ITestOutputHelper output) : RavenTestBase(output)
     {
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task SendToModelOnChat(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -90,7 +90,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task SendToModelOnChat_MultiAgent(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25993.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25993.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
     public class RavenDB_25993(ITestOutputHelper output) : RavenTestBase(output)
     {
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task AgentParameterTypeTest(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -76,7 +76,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task AgentParameterTypeTest_Primitives(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -130,7 +130,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task AgentParameterTypeTest_Array(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -199,7 +199,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task MultiAgentStringParametersInsteadOfNumberBug(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -270,7 +270,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task MultiAgentTypeConflict(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26172.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26172.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
     public class RavenDB_26172(ITestOutputHelper output) : RavenTestBase(output)
     {
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task AgentParameterTypeTest(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26261.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26261.cs
@@ -125,7 +125,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.AzureOpenAI | RavenAiIntegration.Google, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.AzureOpenAI | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public void TestConnection_RealProvider_ReportsAcceptsImageInputTrue(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26426.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26426.cs
@@ -19,7 +19,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanSendSameImageTwiceInSeparateTurns(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26693.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26693.cs
@@ -47,7 +47,7 @@ public class RavenDB_26693 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanRunConversationWithStreaming(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -89,7 +89,7 @@ public class RavenDB_26693 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanRunThenCancelStreamWithActionTool(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -163,7 +163,7 @@ public class RavenDB_26693 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanContinueConversationAfterCancelWithPendingActionTool(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -238,7 +238,7 @@ public class RavenDB_26693 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanRunThenCancelStreamWithSubAgentActionTool(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26767.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26767.cs
@@ -648,7 +648,7 @@ if ($input.doc) {
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task GenAi_RealProvider_ObjectContext_CompletesWithoutError(Options options, GenAiConfiguration config)
     {
         // Credential-gated real-provider smoke test (RavenDB-26767 previously had none). Provider-stable only: a full/
@@ -679,7 +679,7 @@ if ($input.doc) {
             session.SaveChanges();
         }
 
-        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(2)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(6)));
 
         using (var session = store.OpenSession())
         {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26911.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26911.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
     {
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task WrongIndexInQuery(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -72,7 +72,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task WrongIndexInSubAgentQuery(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
@@ -138,7 +138,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task WrongIndexInSubAgentQuery_ThreeLayers(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26944.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26944.cs
@@ -1,0 +1,343 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.AI;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent;
+
+// The structured-output contract, streaming and non-streaming.
+//
+// A thinking model can answer with an empty 'content' and a large 'reasoning' block. That reasoning is
+// natural language, never the structured answer, so it must not be parsed as JSON - doing so was the
+// RavenDB-26944 crash. Unstructured output keeps the reasoning fallback (RavenDB-25681), and a
+// length-truncated response is incomplete and must fail with the length-specific error instead.
+//
+// The happy paths run fully live. The failure shapes are hybrid: the pipeline, the connection string and
+// the provider client are real, and only the responses a real model cannot be asked to produce on demand
+// (empty, non-JSON, or truncated answers) are injected - see InjectingConversationHandler in MockLlmHelper
+public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private const string UserPrompt = "What is 2+2? Reply with just the number.";
+    private const string SystemPrompt = "Answer the user's question. Respond immediately and briefly, without deliberation.";
+    private const string AnswerProperty = "Answer";
+
+    // an empty answer plus rambling reasoning - the reported Ollama failure shape
+    private const string RamblingReasoning = "Okay, let's see. The user wants me to answer, but first let me think about it at length...";
+
+
+    private class AnswerSchema
+    {
+        public string Answer = "a short answer";
+    }
+
+    #region streaming
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task Structured_LiveModel_StreamsOnlyTheAnswer_NotItsReasoning(Options options, GenAiConfiguration config)
+    {
+        // Fully live through the public API. A local reasoning model emits its chain-of-thought before the
+        // answer, the shape that used to crash the SSE parser. The streamed property must equal the parsed
+        // answer: had any reasoning delta reached the answer parser, the two would differ. Nothing is
+        // asserted about the model's wording.
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("streaming-agent", config.ConnectionStringName, SystemPrompt);
+        var identifier = (await store.AI.CreateAgentAsync(agent, new AnswerSchema())).Identifier;
+
+        var chat = store.AI.Conversation(identifier, "chats/", new AiConversationCreationOptions());
+        chat.SetUserPrompt(UserPrompt);
+
+        var streamed = new StringBuilder();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var result = await chat.StreamAsync<AnswerSchema>(x => x.Answer, chunk =>
+        {
+            streamed.Append(chunk);
+            return Task.CompletedTask;
+        }, cts.Token);
+
+        Assert.Equal(AiConversationResult.Done, result.Status);
+        Assert.Equal(result.Answer.Answer, streamed.ToString());
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["reasoning-only"])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["reasoning-content-only"])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["non-json-content"])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["incomplete-json-content"])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["json-array-content"])]
+    public async Task Structured_UnusableStream_ThrowsCleanError_WithoutLeakingTheParserError(
+        Options options, GenAiConfiguration config, string shape)
+    {
+        var sse = shape switch
+        {
+            // only chain-of-thought was streamed - it must never be parsed as the answer
+            "reasoning-only" => Wire.Stream(Wire.ReasoningDelta(RamblingReasoning), Wire.FinishChunk("stop")),
+            "reasoning-content-only" => Wire.Stream(Wire.ReasoningDelta(RamblingReasoning, reasoningContentField: true), Wire.FinishChunk("stop")),
+            // the model streamed prose instead of JSON
+            "non-json-content" => Wire.Stream(Wire.ContentDelta("Sure, here is the answer:"), Wire.FinishChunk("stop")),
+            // the stream ended in the middle of the JSON object
+            "incomplete-json-content" => Wire.Stream(Wire.ContentDelta("{\"Answer\":"), Wire.FinishChunk("stop")),
+            // well-formed JSON, but an array root where the schema requires an object
+            "json-array-content" => Wire.Stream(Wire.ContentDelta("[{\"Answer\":\"ok\"}]"), Wire.FinishChunk("stop")),
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unknown stream shape")
+        };
+
+        using var store = GetDocumentStore(options);
+        var (_, error) = await StreamAsync(store, config, "chats/bad-stream-" + shape, InjectedResponse.Sse(sse));
+
+        AssertNoParserErrorLeaked<UnexpectedResponseException>(error);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["no-content"])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["valid-content"])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["invalid-content-before-length"])]
+    public async Task Structured_LengthTruncatedStream_AlwaysThrowsTooManyTokens(Options options, GenAiConfiguration config, string shape)
+    {
+        var sse = shape switch
+        {
+            "no-content" => Wire.Stream(Wire.ReasoningDelta(RamblingReasoning), Wire.FinishChunk("length")),
+            // a complete-looking answer that was still cut off: it must not be accepted
+            "valid-content" => Wire.Stream(Wire.ContentDelta("{\"Answer\":\"42\"}"), Wire.FinishChunk("length")),
+            // the parser rejected the content mid-stream; the later 'length' signal must still be observed
+            "invalid-content-before-length" => Wire.Stream(Wire.ContentDelta("{\"Answer\":"), Wire.ContentDelta("oops not json}"), Wire.FinishChunk("length")),
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unknown stream shape")
+        };
+
+        using var store = GetDocumentStore(options);
+        var (_, error) = await StreamAsync(store, config, "chats/length-stream-" + shape, InjectedResponse.Sse(sse));
+
+        Assert.True(HasException<TooManyTokensException>(error), $"expected TooManyTokensException, got: {error}");
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task Structured_ValidPrefix_IsStreamedToClient_BeforeTheDeferredFailure(Options options, GenAiConfiguration config)
+    {
+        // The incremental parser rejects the content mid-stream, but the valid prefix was already delivered
+        // to the client and must stay delivered; the failure is reported afterwards.
+        var sse = Wire.Stream(
+            Wire.ContentDelta("{\"Answer\":\"valid prefix "),
+            Wire.ContentDelta("text\" garbage"),
+            Wire.FinishChunk("stop"));
+
+        using var store = GetDocumentStore(options);
+        var (streamed, error) = await StreamAsync(store, config, "chats/prefix-then-invalid", InjectedResponse.Sse(sse));
+
+        Assert.True(HasException<UnexpectedResponseException>(error), $"expected UnexpectedResponseException, got: {error}");
+        Assert.Contains("valid prefix ", streamed);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = [false])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = [true])]
+    public async Task Unstructured_ReasoningOnlyStream_FallsBackToReasoning(Options options, GenAiConfiguration config, bool reasoningContentField)
+    {
+        // RavenDB-25681: with no schema, a model that streams its answer only in 'reasoning' /
+        // 'reasoning_content' is still usable and that text becomes the answer.
+        const string answer = "the plain text answer";
+        var sse = Wire.Stream(Wire.ReasoningDelta(answer, reasoningContentField), Wire.FinishChunk("stop"));
+
+        using var store = GetDocumentStore(options);
+        var (streamed, error) = await StreamAsync(store, config, $"chats/unstructured-stream-{reasoningContentField}",
+            InjectedResponse.Sse(sse), noSchema: true);
+
+        Assert.Null(error);
+        Assert.Contains(answer, streamed);
+    }
+
+    #endregion
+
+    #region non-streaming
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["empty-content-with-reasoning"])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["null-content-with-reasoning"])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["non-json-content"])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["json-array-content"])]
+    public async Task Structured_UnusableAnswer_ThrowsCleanError_WithoutLeakingTheParserError(
+        Options options, GenAiConfiguration config, string shape)
+    {
+        var response = shape switch
+        {
+            // the reported failure: the answer is empty and only chain-of-thought came back
+            "empty-content-with-reasoning" => Wire.Completion("", finishReason: "stop", reasoning: RamblingReasoning),
+            "null-content-with-reasoning" => Wire.Completion(null, finishReason: "stop", reasoning: RamblingReasoning),
+            // the model answered in prose instead of JSON
+            "non-json-content" => Wire.Completion("Sure! Here is the answer.", finishReason: "stop"),
+            // valid JSON, but an array where the schema requires an object
+            "json-array-content" => Wire.Completion("[{\"Answer\":\"ok\"}]", finishReason: "stop"),
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unknown response shape")
+        };
+
+        // tools stay enabled, so this is a plain answering turn
+        var error = await RunAsync(options, config, "chats/invalid-" + shape,
+            InjectedResponse.Json(response), maxModelIterationsPerCall: 16, withTool: true);
+
+        AssertNoParserErrorLeaked<UnexpectedResponseException>(error);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task Structured_EmptyContentAndLength_ThrowsTooManyTokens(Options options, GenAiConfiguration config)
+    {
+        // Truncated before any answer: the length-specific error must be raised rather than the generic
+        // structured-output error, because retrying the same request cannot help.
+        var error = await RunAsync(options, config, "chats/length-empty",
+            InjectedResponse.Json(Wire.Completion("", finishReason: "length", reasoning: RamblingReasoning)),
+            maxModelIterationsPerCall: 16, withTool: true);
+
+        Assert.True(HasException<TooManyTokensException>(error), $"expected TooManyTokensException, got: {error}");
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task Unstructured_EmptyContent_FallsBackToReasoning(Options options, GenAiConfiguration config)
+    {
+        // RavenDB-25681: with no schema the reasoning text becomes the answer. Only structured output
+        // refuses that fallback.
+        const string conversationId = "chats/unstructured-reasoning";
+        const string answer = "the plain text answer";
+
+        using var store = GetDocumentStore(options);
+        var error = await RunAsync(store, config, conversationId,
+            InjectedResponse.Json(Wire.Completion("", finishReason: "stop", reasoning: answer)),
+            maxModelIterationsPerCall: 16, withTool: true, noSchema: true);
+
+        Assert.Null(error);
+
+        using var session = store.OpenSession();
+        var doc = session.Load<BlittableJsonReaderObject>(conversationId);
+        Assert.NotNull(doc);
+        Assert.Contains(answer, doc.ToString());
+    }
+
+    #endregion
+
+
+    private static void AssertNoParserErrorLeaked<T>(Exception error) where T : Exception
+    {
+        Assert.True(HasException<T>(error), $"expected {typeof(T).Name}, got: {error}");
+
+        // the raw JSON-parser error must never reach the caller
+        var text = error.ToString();
+        Assert.DoesNotContain("Cannot have a", text);
+        Assert.DoesNotContain(nameof(InvalidDataException), text);
+        Assert.DoesNotContain("InvalidStartOfObjectException", text);
+    }
+
+    // No existing test helper walks an exception chain by type (ExtractSingleInnerException only unwraps a
+    // single AggregateException), so the walk lives here.
+    private static bool HasException<T>(Exception e) where T : Exception
+    {
+        for (; e != null; e = e.InnerException)
+            if (e is T)
+                return true;
+        return false;
+    }
+
+    private static AiAgentConfiguration Agent(string connectionStringName, bool withTool) =>
+        new("ravendb-26944-agent", connectionStringName, SystemPrompt)
+        {
+            Identifier = "ravendb-26944-agent",
+            SampleObject = "{\"Answer\":\"a short answer\"}",
+            // a real action, so a turn with iterations left genuinely offers tools to the model
+            Actions = withTool
+                ? [new AiAgentToolAction { Name = "MyTool", Description = "Returns an integer", ParametersSampleObject = "{}" }]
+                : null
+        };
+
+    private InjectingConversationHandler CreateHandler(Raven.Server.Documents.DocumentDatabase database, GenAiConfiguration config,
+        InjectedResponse injected) =>
+        new(Server.ServerStore, database, config.Connection, injected) { Authentication = null };
+
+    private static void Initialize(InjectingConversationHandler handler, GenAiConfiguration config, string conversationId,
+        int maxModelIterationsPerCall, bool withTool = false, bool noSchema = false) =>
+        handler.Initialize(Agent(config.ConnectionStringName, withTool), conversationId, new RequestBody
+        {
+            Parameters = null,
+            CreationOptions = new AiConversationCreationOptions { MaxModelIterationsPerCall = maxModelIterationsPerCall },
+            UserPrompt = UserPrompt,
+            OutputOptions = noSchema ? new AiServerOutputOptions { NoSchema = true } : null
+        }, changeVector: null);
+
+    private async Task<Exception> RunAsync(
+        Options options, GenAiConfiguration config, string conversationId,
+        InjectedResponse injected, int maxModelIterationsPerCall = 0, bool withTool = false)
+    {
+        using var store = GetDocumentStore(options);
+        return await RunAsync(store, config, conversationId, injected, maxModelIterationsPerCall, withTool);
+    }
+
+    private async Task<Exception> RunAsync(
+        IDocumentStore store, GenAiConfiguration config, string conversationId,
+        InjectedResponse injected, int maxModelIterationsPerCall = 0, bool withTool = false, bool noSchema = false)
+    {
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        {
+            var handler = CreateHandler(database, config, injected);
+            Initialize(handler, config, conversationId, maxModelIterationsPerCall, withTool, noSchema);
+
+            try
+            {
+                await handler.HandleRequestAsync(context, CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                return e;
+            }
+
+            return null;
+        }
+    }
+
+    private async Task<(string streamed, Exception error)> StreamAsync(
+        IDocumentStore store, GenAiConfiguration config, string conversationId,
+        InjectedResponse injected, bool noSchema = false)
+    {
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        {
+            var handler = CreateHandler(database, config, injected);
+            // tool iterations stay enabled, so this stays a plain answer turn
+            Initialize(handler, config, conversationId, maxModelIterationsPerCall: 16, noSchema: noSchema);
+
+            // the real server-side streaming path writes the streamed property to this stream
+            using var clientStream = new MemoryStream();
+
+            Exception error = null;
+            try
+            {
+                await handler.HandleStreamingRequestAsync(context, clientStream,
+                    noSchema ? string.Empty : AnswerProperty, CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                error = e;
+            }
+
+            return (Encoding.UTF8.GetString(clientStream.ToArray()), error);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26944.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26944.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -21,14 +21,18 @@ namespace SlowTests.Server.Documents.AI.AiAgent;
 
 // The structured-output contract, streaming and non-streaming.
 //
-// A thinking model can answer with an empty 'content' and a large 'reasoning' block. That reasoning is
-// natural language, never the structured answer, so it must not be parsed as JSON - doing so was the
-// RavenDB-26944 crash. Unstructured output keeps the reasoning fallback (RavenDB-25681), and a
-// length-truncated response is incomplete and must fail with the length-specific error instead.
+// A thinking model can answer with an empty 'content' and a large 'reasoning' block. Reasoning may contain
+// chain-of-thought, so it is never parsed eagerly as structured content - doing so was the RavenDB-26944
+// crash. For providers that place the answer in 'reasoning_content' / 'reasoning' (RavenDB-25681) it is a
+// fallback used only when no 'content' arrived: unstructured output takes it as the answer text, structured
+// output tries the complete buffered reasoning once as the structured answer. 'content', once it arrives, is
+// always authoritative. A length-truncated response is incomplete and must fail with the length-specific
+// error instead.
 //
-// The happy paths run fully live. The failure shapes are hybrid: the pipeline, the connection string and
-// the provider client are real, and only the responses a real model cannot be asked to produce on demand
-// (empty, non-JSON, or truncated answers) are injected - see InjectingConversationHandler in MockLlmHelper
+// Structured_LiveModel_StreamsOnlyTheAnswer_NotItsReasoning is the only test that uses an external provider.
+// The remaining tests are deterministic: most inject provider responses through InjectingConversationHandler,
+// while the public-client error propagation test uses a local fake SSE endpoint to exercise the complete
+// client/server protocol.
 public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
 {
     private const string UserPrompt = "What is 2+2? Reply with just the number.";
@@ -43,6 +47,17 @@ public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
     {
         public string Answer = "a short answer";
     }
+
+    // The injected tests never reach a provider, so any well-formed connection string will do.
+    private const string FakeConnectionStringName = "ravendb-26944-connection";
+
+    private static AiConnectionString FakeConnection() => new()
+    {
+        Name = FakeConnectionStringName,
+        Identifier = FakeConnectionStringName,
+        ModelType = AiModelType.Chat,
+        OpenAiSettings = new OpenAiSettings("fake-key", "https://fake.openai.com", "gpt-4o")
+    };
 
     #region streaming
 
@@ -76,17 +91,18 @@ public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["reasoning-only"])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["reasoning-content-only"])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["non-json-content"])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["incomplete-json-content"])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["json-array-content"])]
-    public async Task Structured_UnusableStream_ThrowsCleanError_WithoutLeakingTheParserError(
-        Options options, GenAiConfiguration config, string shape)
+    [InlineData("reasoning-only")]
+    [InlineData("reasoning-content-only")]
+    [InlineData("non-json-content")]
+    [InlineData("incomplete-json-content")]
+    [InlineData("json-array-content")]
+    [InlineData("content-after-invalid")]
+    [InlineData("json-reasoning-then-invalid-content")]
+    public async Task Structured_UnusableStream_ThrowsCleanError_WithoutLeakingTheParserError(string shape)
     {
         var sse = shape switch
         {
-            // only chain-of-thought was streamed - it must never be parsed as the answer
+            // prose-only reasoning - the RavenDB-25681 fallback must reject it cleanly, not crash the parser
             "reasoning-only" => Wire.Stream(Wire.ReasoningDelta(RamblingReasoning), Wire.FinishChunk("stop")),
             "reasoning-content-only" => Wire.Stream(Wire.ReasoningDelta(RamblingReasoning, reasoningContentField: true), Wire.FinishChunk("stop")),
             // the model streamed prose instead of JSON
@@ -95,40 +111,45 @@ public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
             "incomplete-json-content" => Wire.Stream(Wire.ContentDelta("{\"Answer\":"), Wire.FinishChunk("stop")),
             // well-formed JSON, but an array root where the schema requires an object
             "json-array-content" => Wire.Stream(Wire.ContentDelta("[{\"Answer\":\"ok\"}]"), Wire.FinishChunk("stop")),
+            // content keeps arriving after the parser rejected the stream - a later well-formed chunk must be
+            // discarded, not resurrect the parse into a false success
+            "content-after-invalid" => Wire.Stream(Wire.ContentDelta("{\"Answer\":"), Wire.ContentDelta("oops not json}"), Wire.ContentDelta("{\"Answer\":\"42\"}"), Wire.FinishChunk("stop")),
+            // real content is authoritative: after invalid content the valid JSON reasoning must not be used
+            "json-reasoning-then-invalid-content" => Wire.Stream(Wire.ReasoningDelta("{\"Answer\":\"first\"}"), Wire.ContentDelta("oops"), Wire.FinishChunk("stop")),
             _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unknown stream shape")
         };
 
-        using var store = GetDocumentStore(options);
-        var (_, error) = await StreamAsync(store, config, "chats/bad-stream-" + shape, InjectedResponse.Sse(sse));
+        using var store = GetDocumentStore();
+        var (_, error) = await StreamAsync(store, "chats/bad-stream-" + shape, InjectedResponse.Sse(sse));
 
         AssertNoParserErrorLeaked<UnexpectedResponseException>(error);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["no-content"])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["valid-content"])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["invalid-content-before-length"])]
-    public async Task Structured_LengthTruncatedStream_AlwaysThrowsTooManyTokens(Options options, GenAiConfiguration config, string shape)
+    [InlineData("valid-content")]
+    [InlineData("invalid-content-before-length")]
+    [InlineData("json-reasoning")]
+    public async Task Structured_LengthTruncatedStream_AlwaysThrowsTooManyTokens(string shape)
     {
         var sse = shape switch
         {
-            "no-content" => Wire.Stream(Wire.ReasoningDelta(RamblingReasoning), Wire.FinishChunk("length")),
             // a complete-looking answer that was still cut off: it must not be accepted
             "valid-content" => Wire.Stream(Wire.ContentDelta("{\"Answer\":\"42\"}"), Wire.FinishChunk("length")),
             // the parser rejected the content mid-stream; the later 'length' signal must still be observed
             "invalid-content-before-length" => Wire.Stream(Wire.ContentDelta("{\"Answer\":"), Wire.ContentDelta("oops not json}"), Wire.FinishChunk("length")),
+            // a truncated response must not promote the reasoning fallback, even when it is valid JSON
+            "json-reasoning" => Wire.Stream(Wire.ReasoningDelta("{\"Answer\":\"42\"}"), Wire.FinishChunk("length")),
             _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unknown stream shape")
         };
 
-        using var store = GetDocumentStore(options);
-        var (_, error) = await StreamAsync(store, config, "chats/length-stream-" + shape, InjectedResponse.Sse(sse));
+        using var store = GetDocumentStore();
+        var (_, error) = await StreamAsync(store, "chats/length-stream-" + shape, InjectedResponse.Sse(sse));
 
         Assert.True(HasException<TooManyTokensException>(error), $"expected TooManyTokensException, got: {error}");
     }
 
-    [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task Structured_ValidPrefix_IsStreamedToClient_BeforeTheDeferredFailure(Options options, GenAiConfiguration config)
+    [RavenFact(RavenTestCategory.Ai)]
+    public async Task Structured_ValidPrefix_IsStreamedToClient_BeforeTheDeferredFailure()
     {
         // The incremental parser rejects the content mid-stream, but the valid prefix was already delivered
         // to the client and must stay delivered; the failure is reported afterwards.
@@ -137,29 +158,236 @@ public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
             Wire.ContentDelta("text\" garbage"),
             Wire.FinishChunk("stop"));
 
-        using var store = GetDocumentStore(options);
-        var (streamed, error) = await StreamAsync(store, config, "chats/prefix-then-invalid", InjectedResponse.Sse(sse));
+        using var store = GetDocumentStore();
+        var (streamed, error) = await StreamAsync(store, "chats/prefix-then-invalid", InjectedResponse.Sse(sse));
 
         Assert.True(HasException<UnexpectedResponseException>(error), $"expected UnexpectedResponseException, got: {error}");
         Assert.Contains("valid prefix ", streamed);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = [false])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = [true])]
-    public async Task Unstructured_ReasoningOnlyStream_FallsBackToReasoning(Options options, GenAiConfiguration config, bool reasoningContentField)
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Unstructured_ReasoningOnlyStream_FallsBackToReasoning(bool reasoningContentField)
     {
         // RavenDB-25681: with no schema, a model that streams its answer only in 'reasoning' /
         // 'reasoning_content' is still usable and that text becomes the answer.
         const string answer = "the plain text answer";
         var sse = Wire.Stream(Wire.ReasoningDelta(answer, reasoningContentField), Wire.FinishChunk("stop"));
 
-        using var store = GetDocumentStore(options);
-        var (streamed, error) = await StreamAsync(store, config, $"chats/unstructured-stream-{reasoningContentField}",
+        using var store = GetDocumentStore();
+        var (streamed, error) = await StreamAsync(store, $"chats/unstructured-stream-{reasoningContentField}",
             InjectedResponse.Sse(sse), noSchema: true);
 
         Assert.Null(error);
         Assert.Contains(answer, streamed);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [InlineData("garbage-in-later-chunk")]
+    [InlineData("garbage-in-same-chunk")]
+    public async Task Structured_CompletedAnswer_IsKept_DespiteTrailingGarbage(string shape)
+    {
+        // Once the model completed a valid structured answer, that answer was already streamed to the client,
+        // so trailing garbage is dropped rather than failing an answer that was delivered. The parse stops at
+        // the first garbage either way: an answer completed before it wins, anything less is an error (see
+        // 'content-after-invalid').
+        var sse = shape switch
+        {
+            "garbage-in-later-chunk" => Wire.Stream(Wire.ContentDelta("{\"Answer\":\"42\"}"), Wire.ContentDelta("oops"), Wire.FinishChunk("stop")),
+            "garbage-in-same-chunk" => Wire.Stream(Wire.ContentDelta("{\"Answer\":\"42\"}oops"), Wire.FinishChunk("stop")),
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unknown stream shape")
+        };
+
+        using var store = GetDocumentStore();
+        var (streamed, error) = await StreamAsync(store, "chats/trailing-garbage-" + shape, InjectedResponse.Sse(sse));
+
+        Assert.Null(error);
+        Assert.Contains("42", streamed);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [InlineData("json-in-reasoning")]
+    [InlineData("json-in-reasoning-content")]
+    [InlineData("json-split-across-chunks")]
+    [InlineData("json-reasoning-then-content")]
+    public async Task Structured_JsonReasoning_IsAcceptedAsFallback_OnlyWithoutContent(string shape)
+    {
+        // RavenDB-25681: some providers place the whole answer in 'reasoning' / 'reasoning_content'. The
+        // complete buffered reasoning is tried once as the structured answer - but only when no 'content'
+        // arrived; content, once seen, is always authoritative.
+        var sse = shape switch
+        {
+            "json-in-reasoning" => Wire.Stream(Wire.ReasoningDelta("{\"Answer\":\"42\"}"), Wire.FinishChunk("stop")),
+            "json-in-reasoning-content" => Wire.Stream(Wire.ReasoningDelta("{\"Answer\":\"42\"}", reasoningContentField: true), Wire.FinishChunk("stop")),
+            "json-split-across-chunks" => Wire.Stream(Wire.ReasoningDelta("{\"Answer\":"), Wire.ReasoningDelta("\"42\"}"), Wire.FinishChunk("stop")),
+            "json-reasoning-then-content" => Wire.Stream(Wire.ReasoningDelta("{\"Answer\":\"first\"}"), Wire.ContentDelta("{\"Answer\":\"42\"}"), Wire.FinishChunk("stop")),
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unknown stream shape")
+        };
+
+        using var store = GetDocumentStore();
+        var (streamed, error) = await StreamAsync(store, "chats/reasoning-fallback-" + shape, InjectedResponse.Sse(sse));
+
+        Assert.Null(error);
+        // '42' must reach the streamed callback: for the reasoning fallback that is the
+        // reasoningPromoted -> FlushStreamedPropertyAsync path
+        Assert.Contains("42", streamed);
+        Assert.DoesNotContain("first", streamed);
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public async Task ToolCalls_SplitByReasoningDeltas_AreNotMergedIntoOne()
+    {
+        // Providers that reuse the same tool-call index rely on the reasoning delta between two calls to
+        // close out the first one; merging them glues the ids and produces invalid argument JSON.
+        var sse = Wire.Stream(
+            Wire.ToolCallDelta(index: 0, id: "call_a", name: "MyTool", arguments: "{}"),
+            Wire.ReasoningDelta(RamblingReasoning),
+            Wire.ToolCallDelta(index: 0, id: "call_b", name: "MyTool", arguments: "{}"),
+            Wire.FinishChunk("tool_calls"));
+
+        const string conversationId = "chats/toolcall-boundary";
+
+        using var store = GetDocumentStore();
+        var (_, error) = await StreamAsync(store, conversationId, InjectedResponse.Sse(sse), withTool: true);
+
+        Assert.Null(error);
+
+        using var session = store.OpenSession();
+        var doc = session.Load<BlittableJsonReaderObject>(conversationId);
+        Assert.NotNull(doc);
+        var text = doc.ToString();
+        Assert.DoesNotContain("call_acall_b", text);
+        Assert.Contains("call_a", text);
+        Assert.Contains("call_b", text);
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public async Task Streaming_ServerError_AfterChunksWereSent_ReachesThePublicClientAsTheRealError()
+    {
+        // Full public-client path: the provider streams a valid prefix (so the HTTP response has started),
+        // then truncates with finish_reason='length'. The server's exception is appended to the already-started
+        // 200 response as the standard error envelope; the client must surface it, not parse it as the final
+        // result.
+        var sse = Wire.Stream(
+            Wire.ContentDelta("{\"Answer\":\"partial answer "),
+            Wire.FinishChunk("length"));
+
+        using var provider = FakeSseProvider.Start(sse);
+        using var store = GetDocumentStore();
+
+        var connection = new AiConnectionString
+        {
+            Name = FakeConnectionStringName,
+            Identifier = FakeConnectionStringName,
+            ModelType = AiModelType.Chat,
+            OpenAiSettings = new OpenAiSettings("fake-key", provider.Endpoint, "gpt-4o")
+        };
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(connection));
+
+        var agent = new AiAgentConfiguration("streaming-error-agent", FakeConnectionStringName, SystemPrompt);
+        var identifier = (await store.AI.CreateAgentAsync(agent, new AnswerSchema())).Identifier;
+
+        var chat = store.AI.Conversation(identifier, "chats/", new AiConversationCreationOptions());
+        chat.SetUserPrompt(UserPrompt);
+
+        var streamed = new StringBuilder();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        var error = await Assert.ThrowsAnyAsync<TooManyTokensException>(() => chat.StreamAsync<AnswerSchema>(x => x.Answer, chunk =>
+        {
+            streamed.Append(chunk);
+            return Task.CompletedTask;
+        }, cts.Token));
+
+        // the chunks were delivered before the failure, and the real server error survives the started stream
+        // rather than being parsed as the final result (which used to surface as a NullReferenceException)
+        Assert.Contains("partial answer", streamed.ToString());
+        Assert.DoesNotContain(nameof(NullReferenceException), error.ToString());
+    }
+
+    // A minimal OpenAI-compatible endpoint over a raw socket: answers every POST with the given SSE body.
+    // Raw TCP avoids HttpListener's URL ACL requirements on Windows.
+    private sealed class FakeSseProvider : IDisposable
+    {
+        private readonly System.Net.Sockets.TcpListener _listener;
+        public string Endpoint { get; }
+
+        private FakeSseProvider(System.Net.Sockets.TcpListener listener, string endpoint)
+        {
+            _listener = listener;
+            Endpoint = endpoint;
+        }
+
+        public static FakeSseProvider Start(string sseBody)
+        {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var provider = new FakeSseProvider(listener, $"http://127.0.0.1:{port}/");
+            _ = provider.ServeAsync(Encoding.UTF8.GetBytes(sseBody));
+            return provider;
+        }
+
+        private async Task ServeAsync(byte[] body)
+        {
+            try
+            {
+                while (true)
+                {
+                    using var client = await _listener.AcceptTcpClientAsync();
+                    var stream = client.GetStream();
+
+                    // read the request headers, then the declared body length
+                    var buffer = new byte[64 * 1024];
+                    var read = 0;
+                    int headerEnd;
+                    while (true)
+                    {
+                        var n = await stream.ReadAsync(buffer, read, buffer.Length - read);
+                        if (n == 0)
+                            break;
+                        read += n;
+                        headerEnd = Encoding.ASCII.GetString(buffer, 0, read).IndexOf("\r\n\r\n", StringComparison.Ordinal);
+                        if (headerEnd < 0)
+                            continue;
+
+                        var headers = Encoding.ASCII.GetString(buffer, 0, headerEnd);
+                        var contentLength = 0;
+                        foreach (var header in headers.Split("\r\n"))
+                        {
+                            if (header.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase))
+                                contentLength = int.Parse(header.Substring("Content-Length:".Length).Trim());
+                        }
+
+                        var bodyRead = read - (headerEnd + 4);
+                        while (bodyRead < contentLength)
+                        {
+                            var m = await stream.ReadAsync(buffer, 0, buffer.Length);
+                            if (m == 0)
+                                break;
+                            bodyRead += m;
+                        }
+
+                        break;
+                    }
+
+                    var response = Encoding.ASCII.GetBytes(
+                        "HTTP/1.1 200 OK\r\n" +
+                        "Content-Type: text/event-stream\r\n" +
+                        $"Content-Length: {body.Length}\r\n" +
+                        "Connection: close\r\n\r\n");
+                    await stream.WriteAsync(response);
+                    await stream.WriteAsync(body);
+                    await stream.FlushAsync();
+                }
+            }
+            catch (Exception)
+            {
+                // listener disposed - test is done
+            }
+        }
+
+        public void Dispose() => _listener.Stop();
     }
 
     #endregion
@@ -167,12 +395,13 @@ public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
     #region non-streaming
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["empty-content-with-reasoning"])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["null-content-with-reasoning"])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["non-json-content"])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = ["json-array-content"])]
-    public async Task Structured_UnusableAnswer_ThrowsCleanError_WithoutLeakingTheParserError(
-        Options options, GenAiConfiguration config, string shape)
+    [InlineData("empty-content-with-reasoning")]
+    [InlineData("null-content-with-reasoning")]
+    [InlineData("non-json-content")]
+    [InlineData("incomplete-json-content")]
+    [InlineData("json-array-content")]
+    [InlineData("invalid-content-with-json-reasoning")]
+    public async Task Structured_UnusableAnswer_ThrowsCleanError_WithoutLeakingTheParserError(string shape)
     {
         var response = shape switch
         {
@@ -181,42 +410,92 @@ public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
             "null-content-with-reasoning" => Wire.Completion(null, finishReason: "stop", reasoning: RamblingReasoning),
             // the model answered in prose instead of JSON
             "non-json-content" => Wire.Completion("Sure! Here is the answer.", finishReason: "stop"),
+            // the JSON object never closes - the parser reports it as an end-of-stream, not invalid data
+            "incomplete-json-content" => Wire.Completion("{\"Answer\":\"x", finishReason: "stop"),
             // valid JSON, but an array where the schema requires an object
             "json-array-content" => Wire.Completion("[{\"Answer\":\"ok\"}]", finishReason: "stop"),
+            // real content is authoritative even when invalid - the valid JSON reasoning must not be used
+            "invalid-content-with-json-reasoning" => Wire.Completion("oops not json", finishReason: "stop", reasoning: "{\"Answer\":\"42\"}"),
             _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "unknown response shape")
         };
 
         // tools stay enabled, so this is a plain answering turn
-        var error = await RunAsync(options, config, "chats/invalid-" + shape,
+        var error = await RunAsync("chats/invalid-" + shape,
             InjectedResponse.Json(response), maxModelIterationsPerCall: 16, withTool: true);
 
         AssertNoParserErrorLeaked<UnexpectedResponseException>(error);
     }
 
+    [RavenFact(RavenTestCategory.Ai)]
+    public async Task Structured_NonStreaming_CompletedAnswer_IsKept_DespiteTrailingGarbage()
+    {
+        // The non-streaming twin of the trailing-garbage streaming test: the completed structured answer wins
+        // and the trailing text is dropped, matching the streaming path, so the two cannot silently diverge.
+        const string content = "{\"Answer\":\"42\"} The answer is 42, as requested.";
+        const string garbage = "as requested";
+        const string conversationId = "chats/nonstream-trailing-text";
+
+        using var store = GetDocumentStore();
+        var error = await RunAsync(store, conversationId,
+            InjectedResponse.Json(Wire.Completion(content, finishReason: "stop")), maxModelIterationsPerCall: 16, withTool: true);
+
+        Assert.Null(error);
+
+        // the persisted assistant answer is the parsed object, not the raw model text: '42' survived, the
+        // garbage did not
+        var messages = await store.AI.GetConversationMessagesAsync(conversationId);
+        var assistant = messages.Messages.Find(m => m.Role == AiMessageRole.Assistant && m.Content != null);
+        Assert.NotNull(assistant);
+        Assert.Contains("42", assistant.Content);
+        Assert.DoesNotContain(garbage, assistant.Content);
+    }
+
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task Structured_EmptyContentAndLength_ThrowsTooManyTokens(Options options, GenAiConfiguration config)
+    [InlineData("json-in-reasoning")]
+    [InlineData("json-in-reasoning-content")]
+    public async Task Structured_NonStreaming_JsonReasoning_IsAcceptedAsFallback(string shape)
+    {
+        // RavenDB-25681: with no 'content' at all, the structured answer may come from
+        // 'reasoning_content' / 'reasoning'
+        var response = Wire.Completion("", finishReason: "stop", reasoning: "{\"Answer\":\"42\"}",
+            reasoningContentField: shape == "json-in-reasoning-content");
+
+        var conversationId = "chats/nonstream-reasoning-" + shape;
+
+        using var store = GetDocumentStore();
+        var error = await RunAsync(store, conversationId,
+            InjectedResponse.Json(response), maxModelIterationsPerCall: 16, withTool: true);
+
+        Assert.Null(error);
+
+        var messages = await store.AI.GetConversationMessagesAsync(conversationId);
+        var assistant = messages.Messages.Find(m => m.Role == AiMessageRole.Assistant && m.Content != null);
+        Assert.NotNull(assistant);
+        Assert.Contains("42", assistant.Content);
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public async Task Structured_EmptyContentAndLength_ThrowsTooManyTokens()
     {
         // Truncated before any answer: the length-specific error must be raised rather than the generic
         // structured-output error, because retrying the same request cannot help.
-        var error = await RunAsync(options, config, "chats/length-empty",
+        var error = await RunAsync("chats/length-empty",
             InjectedResponse.Json(Wire.Completion("", finishReason: "length", reasoning: RamblingReasoning)),
             maxModelIterationsPerCall: 16, withTool: true);
 
         Assert.True(HasException<TooManyTokensException>(error), $"expected TooManyTokensException, got: {error}");
     }
 
-    [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task Unstructured_EmptyContent_FallsBackToReasoning(Options options, GenAiConfiguration config)
+    [RavenFact(RavenTestCategory.Ai)]
+    public async Task Unstructured_EmptyContent_FallsBackToReasoning()
     {
-        // RavenDB-25681: with no schema the reasoning text becomes the answer. Only structured output
-        // refuses that fallback.
+        // RavenDB-25681: with no schema the reasoning text becomes the answer as-is. Structured output uses
+        // the same fallback, but only accepts it when the complete reasoning forms the requested JSON object.
         const string conversationId = "chats/unstructured-reasoning";
         const string answer = "the plain text answer";
 
-        using var store = GetDocumentStore(options);
-        var error = await RunAsync(store, config, conversationId,
+        using var store = GetDocumentStore();
+        var error = await RunAsync(store, conversationId,
             InjectedResponse.Json(Wire.Completion("", finishReason: "stop", reasoning: answer)),
             maxModelIterationsPerCall: 16, withTool: true, noSchema: true);
 
@@ -240,6 +519,7 @@ public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
         Assert.DoesNotContain("Cannot have a", text);
         Assert.DoesNotContain(nameof(InvalidDataException), text);
         Assert.DoesNotContain("InvalidStartOfObjectException", text);
+        Assert.DoesNotContain(nameof(EndOfStreamException), text);
     }
 
     // No existing test helper walks an exception chain by type (ExtractSingleInnerException only unwraps a
@@ -263,13 +543,12 @@ public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
                 : null
         };
 
-    private InjectingConversationHandler CreateHandler(Raven.Server.Documents.DocumentDatabase database, GenAiConfiguration config,
-        InjectedResponse injected) =>
-        new(Server.ServerStore, database, config.Connection, injected) { Authentication = null };
+    private InjectingConversationHandler CreateHandler(Raven.Server.Documents.DocumentDatabase database, InjectedResponse injected) =>
+        new(Server.ServerStore, database, FakeConnection(), injected) { Authentication = null };
 
-    private static void Initialize(InjectingConversationHandler handler, GenAiConfiguration config, string conversationId,
+    private static void Initialize(InjectingConversationHandler handler, string conversationId,
         int maxModelIterationsPerCall, bool withTool = false, bool noSchema = false) =>
-        handler.Initialize(Agent(config.ConnectionStringName, withTool), conversationId, new RequestBody
+        handler.Initialize(Agent(FakeConnectionStringName, withTool), conversationId, new RequestBody
         {
             Parameters = null,
             CreationOptions = new AiConversationCreationOptions { MaxModelIterationsPerCall = maxModelIterationsPerCall },
@@ -278,24 +557,23 @@ public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
         }, changeVector: null);
 
     private async Task<Exception> RunAsync(
-        Options options, GenAiConfiguration config, string conversationId,
-        InjectedResponse injected, int maxModelIterationsPerCall = 0, bool withTool = false)
+        string conversationId, InjectedResponse injected, int maxModelIterationsPerCall = 0, bool withTool = false)
     {
-        using var store = GetDocumentStore(options);
-        return await RunAsync(store, config, conversationId, injected, maxModelIterationsPerCall, withTool);
+        using var store = GetDocumentStore();
+        return await RunAsync(store, conversationId, injected, maxModelIterationsPerCall, withTool);
     }
 
     private async Task<Exception> RunAsync(
-        IDocumentStore store, GenAiConfiguration config, string conversationId,
+        IDocumentStore store, string conversationId,
         InjectedResponse injected, int maxModelIterationsPerCall = 0, bool withTool = false, bool noSchema = false)
     {
-        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(FakeConnection()));
 
         var database = await Databases.GetDocumentDatabaseInstanceFor(store);
         using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
         {
-            var handler = CreateHandler(database, config, injected);
-            Initialize(handler, config, conversationId, maxModelIterationsPerCall, withTool, noSchema);
+            var handler = CreateHandler(database, injected);
+            Initialize(handler, conversationId, maxModelIterationsPerCall, withTool, noSchema);
 
             try
             {
@@ -311,17 +589,17 @@ public class RavenDB_26944(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     private async Task<(string streamed, Exception error)> StreamAsync(
-        IDocumentStore store, GenAiConfiguration config, string conversationId,
-        InjectedResponse injected, bool noSchema = false)
+        IDocumentStore store, string conversationId,
+        InjectedResponse injected, bool noSchema = false, bool withTool = false)
     {
-        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(FakeConnection()));
 
         var database = await Databases.GetDocumentDatabaseInstanceFor(store);
         using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
         {
-            var handler = CreateHandler(database, config, injected);
+            var handler = CreateHandler(database, injected);
             // tool iterations stay enabled, so this stays a plain answer turn
-            Initialize(handler, config, conversationId, maxModelIterationsPerCall: 16, noSchema: noSchema);
+            Initialize(handler, conversationId, maxModelIterationsPerCall: 16, withTool: withTool, noSchema: noSchema);
 
             // the real server-side streaming path writes the streamed property to this stream
             using var clientStream = new MemoryStream();

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-27000.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-27000.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task Test(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
@@ -19,7 +19,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent;
 public class RavenDB_24887_3(ITestOutputHelper output) : RavenDB_24887_Base(output)
 {
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ActionToolsOnSubAgent_DepthOf3(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -105,9 +105,9 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, false])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = [false, false])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     public async Task SubAgent2OpenActionTools_DepthOf3(Options options, GenAiConfiguration config, bool level1OncePrompt, bool level0OncePrompt)
     {
         const string atOncePrompt =
@@ -235,7 +235,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task SubAgent2OpenActionTools_Depth3and4(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -478,7 +478,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ResumeChatAfterError_Depth3(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -649,7 +649,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenDB_24887_Base(outp
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CheckMaxToolIterationsLimitOnSubAgent_Depth3(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -29,7 +29,7 @@ namespace SlowTests.Server.Documents.AI.GenAi;
 public class GenAiBasics(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public void CanCreateGenAiTask(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -58,7 +58,7 @@ for(const comment of this.Comments)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanProcessDocuments(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -102,11 +102,11 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(30)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(90)));
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanGetGenAiOngoingTask(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -153,7 +153,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(60)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(180)));
 
         var secondBatchCompleted = await WaitForValueAsync(() =>
         {
@@ -162,7 +162,7 @@ for(const comment of this.Comments)
                 .ToArray();
 
             return stats.Length > 0;
-        }, expectedVal: true, timeout: 60_000);
+        }, expectedVal: true, timeout: 180_000);
         Assert.True(secondBatchCompleted);
 
         string changeVector = null;
@@ -178,7 +178,7 @@ for(const comment of this.Comments)
             var status = EtlProcess.GetProcessState(db, config.Name, config.Transforms[0].Name);
         
             return status.ChangeVector == changeVector;
-        }, expectedVal: true, timeout: 60_000);
+        }, expectedVal: true, timeout: 180_000);
         Assert.True(stateUpdated);
 
         var op = new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi);
@@ -202,7 +202,7 @@ for(const comment of this.Comments)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanEditGenAiTask(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -250,7 +250,7 @@ this.Comments[idx].LegitComment = $output.Blocked == false;
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanDeleteGenAiTask(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -288,7 +288,7 @@ for(const comment of this.Comments)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanToggleGenAiTaskState(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -332,7 +332,7 @@ for(const comment of this.Comments)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single, Skip = "need to fix")]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Skip = "need to fix")]
     public async Task ShouldTrackAiHashesInMetadata(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -375,7 +375,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        await etl.WaitAsync(TimeSpan.FromSeconds(60));
+        await etl.WaitAsync(TimeSpan.FromSeconds(180));
 
         using (var session = store.OpenAsyncSession())
         {
@@ -405,7 +405,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        await etl.WaitAsync(TimeSpan.FromSeconds(60));
+        await etl.WaitAsync(TimeSpan.FromSeconds(180));
 
         using (var session = store.OpenAsyncSession())
         {
@@ -469,19 +469,19 @@ if($output.Blocked)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ShouldResendContextWhenPromptChanges(Options options, GenAiConfiguration configuration)
     {
-        await ShouldResendContextOnConfigChange(configuration,
+        await ShouldResendContextOnConfigChange(options, configuration,
             changeConfig: config => config.Prompt = "please convert the text to Hebrew"
         );
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ShouldResendContextWhenSchemaChanges(Options options, GenAiConfiguration configuration)
     {
-        await ShouldResendContextOnConfigChange(configuration,
+        await ShouldResendContextOnConfigChange(options, configuration,
             changeConfig: config =>
             {
                 var newSample = JsonConvert.SerializeObject(new
@@ -496,16 +496,16 @@ if($output.Blocked)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ShouldResendContextWhenUpdateScriptChanges(Options options, GenAiConfiguration configuration)
     {
-        await ShouldResendContextOnConfigChange(configuration,
+        await ShouldResendContextOnConfigChange(options, configuration,
             changeConfig: config => config.UpdateScript = "this.Translated = $output.Translation;"
         );
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanReproduceNullScopeNreInEtlStats(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -553,14 +553,14 @@ for(const comment of this.Comments)
 
             return true;
 
-        }, expectedVal: true, timeout: 5000);
+        }, expectedVal: true, timeout: 15000);
 
         Assert.True(hit, "ToPerformanceStats() should not throw NullReferenceException anymore.");
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ShouldUseTaskIdentifierInMetadataHashes(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -610,8 +610,8 @@ for (const comment of this.Comments)
             session.SaveChanges();
         }
 
-        var r = await etl.WaitAsync(TimeSpan.FromSeconds(60));
-        Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+        var r = await etl.WaitAsync(TimeSpan.FromSeconds(180));
+        Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(180)));
 
         using (var session = store.OpenAsyncSession())
         {
@@ -623,7 +623,7 @@ for (const comment of this.Comments)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ShouldThrowOnNonUniqueIdentifier(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -674,9 +674,9 @@ for(const comment of this.Comments)
         Assert.Contains($"The identifier '{identifier}' is already used", e.Message);
     }
 
-    private async Task ShouldResendContextOnConfigChange(GenAiConfiguration config, Action<GenAiConfiguration> changeConfig)
+    private async Task ShouldResendContextOnConfigChange(Options options, GenAiConfiguration config, Action<GenAiConfiguration> changeConfig)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         await ConfigGenAi(config, store);
 
         var db = await GetDatabase(store.Database);
@@ -690,7 +690,7 @@ for(const comment of this.Comments)
             session.Store(new Post([new Comment("RavenDB is amazing", "Alex")], "Understanding RavenDB Indexing", "Indexes in RavenDB are powerful..."), "posts/1");
             session.SaveChanges();
         }
-        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(3)));
 
         var originalHash = await GetDocumentHash(config, store);
 
@@ -699,7 +699,7 @@ for(const comment of this.Comments)
         var taskId = etlProcess.TaskId;
 
         // disable task
-        var oldTaskDebugInfo = await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60));
+        var oldTaskDebugInfo = await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(180));
         await store.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.GenAi, disable: true));
         var taskInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi));
         Assert.Equal(OngoingTaskState.Disabled, taskInfo.TaskState);
@@ -721,7 +721,7 @@ for(const comment of this.Comments)
 
         // assert that context was sent again
         etlDone = Etl.WaitForEtlToComplete(store);
-        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(3)));
         etlProcess = db.EtlLoader.Processes.FirstOrDefault() as GenAiTask;
         Assert.NotNull(etlProcess);
 
@@ -742,7 +742,7 @@ for(const comment of this.Comments)
                                 && x.NumberOfExtractedItems[EtlItemType.Document] > 0)
                     .ToArray();
                 return stats2.Length > 0;
-            }, expectedVal: true, timeout: 60_000);
+            }, expectedVal: true, timeout: 180000);
 
             Assert.True(value);
             Assert.NotEmpty(stats2);
@@ -774,7 +774,7 @@ for(const comment of this.Comments)
             var debugInfoSb = new StringBuilder().Append($"Failed - baselineUtc: {baselineUtc}, etag before change: {etagBefore}, etag after change: {etag} ")
                 .AppendLine().AppendLine("Task before disable:")
                 .AppendLine(oldTaskDebugInfo).AppendLine().AppendLine("Task after re-enable:")
-                .AppendLine(await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+                .AppendLine(await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(180)));
             foreach (var line in extractedByEtl)
                 debugInfoSb.AppendLine(line);
             throw new AggregateException(debugInfoSb.ToString(), e);
@@ -811,9 +811,9 @@ for(const comment of this.Comments)
                 .Where(x => x != null && x.NumberOfLoadedItems > 0)
                 .ToArray();
             return stats.Length > 0;
-        }, expectedVal: true, timeout: 60_000);
+        }, expectedVal: true, timeout: 180000);
 
-        Assert.True(value, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+        Assert.True(value, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(180)));
 
         Assert.NotEmpty(stats);
         var loadDetails = stats[0].Details.Operations[^1];
@@ -853,7 +853,7 @@ for(const comment of this.Comments)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ShouldStartFromNewDocumentsByDefault(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -931,7 +931,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(30)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(90)));
 
         using (var session = store.OpenSession())
         {
@@ -954,7 +954,7 @@ for(const comment of this.Comments)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task CanStartFromBeginningOfTime(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -997,12 +997,33 @@ for(const comment of this.Comments)
 "
         };
 
-        var etl = Etl.WaitForEtlToComplete(store);
-
         store.Maintenance.Send(new AddGenAiOperation(config, StartingPointChangeVector.BeginningOfTime));
 
-        var r = await etl.WaitAsync(TimeSpan.FromSeconds(120));
-        Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(120)));
+        // WaitForEtlToComplete is signaled after the first successful batch, not after the entire backlog is drained,
+        // and a low MaxConcurrency splits the 10 documents into several batches, so wait until every comment context
+        // was processed instead.
+        const int expectedComments = 20;
+        var processedComments = await WaitForValueAsync(() =>
+        {
+            using var session = store.OpenSession();
+
+            var count = 0;
+            foreach (var post in session.Advanced.LoadStartingWith<BlittableJsonReaderObject>("posts/"))
+            {
+                if (post.TryGet("Comments", out BlittableJsonReaderArray comments) == false)
+                    continue;
+
+                foreach (var o in comments)
+                {
+                    if (o is BlittableJsonReaderObject comment && comment.TryGet("IsSpam", out bool _))
+                        count++;
+                }
+            }
+
+            return Task.FromResult(count);
+        }, expectedComments, timeout: 360_000);
+
+        Assert.Equal(expectedComments, processedComments);
 
         using (var session = store.OpenSession())
         {
@@ -1024,7 +1045,7 @@ for(const comment of this.Comments)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     private async Task CanUpdateGenAiChangeVector(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore();
@@ -1091,7 +1112,7 @@ for(const comment of this.Comments)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task EnsureGenAiTaskHasUniqueName(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -1121,7 +1142,7 @@ for(const comment of this.Comments)
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.vLLM | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task EnsureGenAiTaskHasUniqueName2(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/ToolChoicePayloadTests.cs
+++ b/test/SlowTests/Server/Documents/AI/ToolChoicePayloadTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI;
+
+public class ToolChoicePayloadTests(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class Schema
+    {
+        public string Answer = "Answer to the user question";
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task WhenToolIterationsAreExhausted_TheModelCannotCallTools(Options options, GenAiConfiguration config)
+    {
+        // With no tool iterations left, the model must not call a tool even though it is told to.
+        // Providers that honor 'tool_choice: "none"' obey it; for the rest the tools are not sent at all.
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("tool-choice-agent", config.ConnectionStringName,
+            "Answer with a single short sentence.")
+        {
+            Identifier = "tool-choice-agent",
+            Actions =
+            [
+                new AiAgentToolAction
+                {
+                    Name = "MyTool",
+                    Description = "Returns an integer",
+                    ParametersSampleObject = "{}"
+                }
+            ],
+            MaxModelIterationsPerCall = 0 // no tool iterations at all, so the very first request has tools disabled
+        };
+
+        await store.AI.CreateAgentAsync(agent, new Schema());
+
+        var chat = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null, debug: true);
+
+        var toolWasCalled = false;
+        chat.Handle<object>("MyTool", _ =>
+        {
+            toolWasCalled = true;
+            return "42";
+        });
+
+        chat.SetUserPrompt("Call the 'MyTool' tool.");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var result = await chat.RunAsync<Schema>(cts.Token);
+
+        Assert.False(toolWasCalled, "The model must not be able to call a tool once the tool iterations are exhausted.");
+        Assert.Equal(AiConversationResult.Done, result.Status);
+
+        // the request the server actually sent to the provider
+        using var session = store.OpenSession();
+        var traces = session.Advanced.LoadStartingWith<BlittableJsonReaderObject>($"{chat.Id}/{AiDebugTrace.TraceSegment}/", pageSize: 1024);
+        var requests = traces.Select(t =>
+        {
+            Assert.True(t.TryGet(nameof(AiDebugTrace.RequestBody), out string requestBody));
+            return requestBody;
+        }).ToArray();
+
+        Assert.NotEmpty(requests);
+
+        foreach (var request in requests)
+        {
+            if (config.AiConnectorType == AiConnectorType.Ollama)
+            {
+                // Ollama ignores 'tool_choice', so the tools themselves must not be offered.
+                Assert.DoesNotContain("\"tools\"", request);
+                Assert.DoesNotContain("\"tool_choice\"", request);
+            }
+            else
+            {
+                Assert.Contains("\"tools\"", request);
+                Assert.Contains("\"tool_choice\":\"none\"", request);
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
@@ -92,7 +92,7 @@ public abstract class BaseAiConnectorForTesting<T, TConfig> : IAiConnectorForTes
         return connectionString;
     }
 
-    public TConfig GetAiConfiguration()
+    public virtual TConfig GetAiConfiguration()
     {
         var connectionString = GetAiConnectionString();
 
@@ -104,13 +104,17 @@ public abstract class BaseAiConnectorForTesting<T, TConfig> : IAiConnectorForTes
         };
     }
 
+    // How long the connectivity probe may take. Providers that have to load a model before they can answer
+    // (a local Ollama) override this; everyone else keeps the short provider-neutral budget.
+    protected virtual TimeSpan ConnectionProbeTimeout => TimeSpan.FromSeconds(20);
+
     private bool IsConnectionAllowed()
     {
         InMemoryLoggerProvider logger = null;
 
         try
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
+            using (var cts = new CancellationTokenSource(ConnectionProbeTimeout))
             {
                 return TryConnect(out logger, cts.Token);
             }

--- a/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
@@ -180,7 +180,7 @@ public abstract class AbstractGenAiConnectorForTesting<T> : BaseAiConnectorForTe
         using (var client = ChatCompletionClient.CreateChatCompletionClient(contextPool, configuration.Connection))
         {
             logger = null;
-            client.TestCompleteAsync(systemPrompt: "Reply with exact word only: raven", "", schema, token).GetAwaiter().GetResult();
+            client.TestCompleteAsync(systemPrompt: "Reply with exact word only: raven", "hi", schema, token).GetAwaiter().GetResult();
             return true;
         }
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
@@ -19,7 +19,7 @@ public class EmbeddingsOllamaConnectorForTesting : AbstractEmbeddingsConnectorFo
 
 public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOllamaConnectorForTesting>
 {
-    public const string Model = "qwen3-vl:4b";
+    public const string Model = "qwen2.5:0.5b";
 
     public GenAiOllamaConnectorForTesting()
     {

--- a/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
@@ -1,3 +1,4 @@
+using System;
 using Raven.Client.Documents.Operations.AI;
 
 namespace Tests.Infrastructure.ConnectionString.AI;
@@ -18,7 +19,7 @@ public class EmbeddingsOllamaConnectorForTesting : AbstractEmbeddingsConnectorFo
 
 public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOllamaConnectorForTesting>
 {
-    public const string Model = "qwen2.5:0.5b";
+    public const string Model = "qwen3-vl:4b";
 
     public GenAiOllamaConnectorForTesting()
     {
@@ -26,6 +27,20 @@ public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<G
     }
 
     public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.Ollama;
+
+    // The first request also loads the model into the GPU, which can take far longer than a hosted provider
+    // needs to answer. Only this connector waits that long.
+    protected override TimeSpan ConnectionProbeTimeout => TimeSpan.FromSeconds(120);
+
+    public override GenAiConfiguration GetAiConfiguration()
+    {
+        var configuration = base.GetAiConfiguration();
+
+        // A single local GPU serializes completions; parallel requests just accumulate wait time until they time out.
+        configuration.MaxConcurrency = 1;
+
+        return configuration;
+    }
 
     protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.Chat, RavenTestHelper.EnvironmentVariables.AiIntegrationOllamaChatUri);
 }

--- a/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
+++ b/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using FastTests;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Util;
+using Raven.Server.Config;
 using Tests.Infrastructure.ConnectionString.AI;
 using Xunit;
 using Xunit.Sdk;
@@ -19,7 +21,7 @@ public enum RavenAiIntegration
     None = 0,
     OpenAi = 1 << 1,
     AzureOpenAI = 1 << 2,
-    Ollama = 1 << 3, // we keep ollama here only for connectivity check
+    Ollama = 1 << 3,
     Onnx = 1 << 4,
     Google = 1 << 5,
     HuggingFace = 1 << 6,
@@ -56,7 +58,11 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
             {
                 using (ResetSkipReason(Skip))
                 {
-                    if (HasSkipReason(aiConnectionStringForTesting) == false)
+                    if (string.IsNullOrEmpty(Skip) && aiConnectionStringForTesting.AiConnectorType == AiConnectorType.Ollama)
+                    {
+                        Skip = "Local Ollama integration tests are currently disabled.";
+                    }
+                    else if (HasSkipReason(aiConnectionStringForTesting) == false)
                     {
                         if (aiConnectionStringForTesting.CanConnect.Value == false)
                         {
@@ -69,9 +75,11 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
                         ? aiConnectionStringForTesting.GetAiConfiguration()
                         : null;
 
+                    var effectiveOptions = ModifyOptionsForConnector(aiConnectionStringForTesting, options);
+
                     var row = Data == null || Data.Length == 0
-                        ? new TheoryDataRow(options, aiIntegrationConfiguration)
-                        : new TheoryDataRow(new object[] { options, aiIntegrationConfiguration }.Concat(Data).ToArray());
+                        ? new TheoryDataRow(effectiveOptions, aiIntegrationConfiguration)
+                        : new TheoryDataRow(new object[] { effectiveOptions, aiIntegrationConfiguration }.Concat(Data).ToArray());
 
                     if (string.IsNullOrEmpty(skipReason) == false)
                         row.Skip = skipReason;
@@ -84,6 +92,8 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
     }
 
     private DisposableAction ResetSkipReason(string skip) => new(() => Skip = skip);
+
+    protected virtual RavenTestBase.Options ModifyOptionsForConnector(IAiConnectorForTesting<TConfig> connector, RavenTestBase.Options options) => options;
 
     private bool HasSkipReason(IAiConnectorForTesting<TConfig> aiConnectorForTesting)
     {
@@ -119,6 +129,17 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
 
 public class RavenGenAiDataAttribute : AbstractRavenAiIntegrationDataAttribute<GenAiConfiguration>
 {
+    protected override RavenTestBase.Options ModifyOptionsForConnector(IAiConnectorForTesting<GenAiConfiguration> connector, RavenTestBase.Options options)
+    {
+        if (connector.AiConnectorType != AiConnectorType.Ollama)
+            return options;
+
+        // A local reasoning model needs more than the default 60s per completion.
+        options = options.Clone();
+        options.ModifyDatabaseRecord += record => record.Settings[RavenConfiguration.GetKey(x => x.Ai.GenAiSendToModelTimeout)] = "180";
+        return options;
+    }
+
     public static IEnumerable<IAiConnectorForTesting<GenAiConfiguration>> GetAiConnectionStrings(RavenAiIntegration aiIntegration)
     {
         if (aiIntegration.HasFlag(RavenAiIntegration.OpenAi))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26944

### Additional description

This PR improves AI agent structured-output handling in four areas:

1. Separates streamed reasoning from answer content, preventing reasoning text from being parsed as structured JSON.
2. Preserves reasoning / reasoning_content as a fallback only when no real answer content was produced.
3. Handles invalid, incomplete, and length-truncated structured responses cleanly without leaking low-level JSON parser errors.
4. Improves the related tests and makes them more reliable across slower and less capable models.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
