### PR TITLE
RavenDB-27261 Improve connection string UX and fix cdc EP

### DIFF
--- a/src/Raven.Quill.Web/src/components/form/form-toggle-group.tsx
+++ b/src/Raven.Quill.Web/src/components/form/form-toggle-group.tsx
@@ -3,8 +3,8 @@ import { type FieldPath, type FieldValues, type UseControllerProps, useControlle
 import { Field, FieldDescription, FieldLabel } from "@/components/shadcn/ui/field";
 import { ToggleGroup, ToggleGroupItem } from "@/components/shadcn/ui/toggle-group";
 
-export type FormToggleGroupOption = {
-    value: string;
+export type FormToggleGroupOption<TValue extends string = string> = {
+    value: TValue;
     label: ReactNode;
     ariaLabel?: string;
 };
@@ -13,6 +13,8 @@ type FormToggleGroupProps<TFieldValues extends FieldValues, TName extends FieldP
     TFieldValues,
     TName
 > & {
+    /** When false, clicking the selected item keeps it selected instead of clearing to null. */
+    canDeselect?: boolean;
     className?: string;
     description?: ReactNode;
     disabled?: boolean;
@@ -22,6 +24,7 @@ type FormToggleGroupProps<TFieldValues extends FieldValues, TName extends FieldP
 
 /** Single-select toggle group; clicking the selected item again clears the value back to null. */
 export function FormToggleGroup<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>({
+    canDeselect = true,
     className,
     control,
     defaultValue,
@@ -48,7 +51,13 @@ export function FormToggleGroup<TFieldValues extends FieldValues, TName extends 
                 type="single"
                 variant="outline"
                 value={typeof value === "string" ? value : ""}
-                onValueChange={(next) => onChange(next === "" ? null : next)}
+                onValueChange={(next) => {
+                    if (next !== "") {
+                        onChange(next);
+                    } else if (canDeselect) {
+                        onChange(null);
+                    }
+                }}
                 disabled={disabled || formState.isSubmitting}
                 aria-invalid={invalid}
             >

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
@@ -58,7 +58,7 @@ function buildSeed(discovery: DiscoverResponse): AppFormData {
                 database: "acme_shop",
                 username: "admin",
                 password: "secret",
-                isSecured: false,
+                ssl: "disable",
             },
             connectionString: "",
         },

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.tsx
@@ -22,7 +22,7 @@ function getDefaultValues(): AppFormData {
                 database: "",
                 username: "",
                 password: "",
-                isSecured: true,
+                ssl: "default",
             },
             connectionString: "",
         },

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
@@ -197,13 +197,16 @@ export const tablesSchema = z
 
 export const connectionModeSchema = z.union([z.literal("fields"), z.literal("raw")]);
 
+/** "default" leaves the choice to the driver: the connection string then carries no SSL keyword. */
+export const sslModeSchema = z.enum(["default", "require", "disable"]);
+
 const connectionFieldsShape = {
     host: z.string(),
     port: z.number().nullable(),
     database: z.string(),
     username: z.string(),
     password: z.string(),
-    isSecured: z.boolean(),
+    ssl: sslModeSchema,
 };
 
 const filledConnectionFieldsSchema = z.object({

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
@@ -214,7 +214,8 @@ const filledConnectionFieldsSchema = z.object({
         .int("Port must be a whole number")
         .min(1, "Port must be between 1 and 65535")
         .max(65535, "Port must be between 1 and 65535")
-        .nullable(),
+        .nullable()
+        .refine((port) => port !== null, "Port is required"),
     database: z.string().trim().min(1, "Database name is required"),
     username: z.string().trim().min(1, "Username is required"),
 });

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.test.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.test.ts
@@ -13,7 +13,7 @@ function values(overrides: Partial<ConnectionValues> = {}): ConnectionValues {
         database: "acme_shop",
         username: "admin",
         password: "secret",
-        isSecured: false,
+        ssl: "disable",
         ...overrides,
     };
 }
@@ -42,11 +42,19 @@ describe("buildConnectionString", () => {
     });
 
     it("asks for an encrypted transport with the keyword each provider expects", () => {
-        expect(buildConnectionString("Npgsql", values({ isSecured: true }))).toContain("SSL Mode=Require");
-        expect(buildConnectionString("SqlClient", values({ isSecured: true }))).toContain("Encrypt=True");
-        expect(buildConnectionString("MySqlConnectorFactory", values({ isSecured: true }))).toContain(
+        expect(buildConnectionString("Npgsql", values({ ssl: "require" }))).toContain("SSL Mode=Require");
+        expect(buildConnectionString("SqlClient", values({ ssl: "require" }))).toContain("Encrypt=True");
+        expect(buildConnectionString("MySqlConnectorFactory", values({ ssl: "require" }))).toContain(
             "SslMode=Required",
         );
+    });
+
+    it("leaves the SSL choice to the driver by omitting the keyword", () => {
+        expect(buildConnectionString("Npgsql", values({ ssl: "default" }))).toBe(
+            "Host=localhost;Port=5432;Database=acme_shop;Username=admin;Password=secret",
+        );
+        expect(buildConnectionString("SqlClient", values({ ssl: "default" }))).not.toContain("Encrypt");
+        expect(buildConnectionString("MySqlConnectorFactory", values({ ssl: "default" }))).not.toContain("SslMode");
     });
 
     it("omits the port and password when not provided", () => {
@@ -62,7 +70,7 @@ describe("buildConnectionString", () => {
         const empty = values({ host: "", port: null, database: "", username: "", password: "" });
 
         expect(buildConnectionString("Npgsql", empty)).toBe("");
-        expect(buildConnectionString("Npgsql", { ...empty, isSecured: true })).toBe("");
+        expect(buildConnectionString("Npgsql", { ...empty, ssl: "require" })).toBe("");
     });
 
     it("quotes values containing separators or quotes", () => {
@@ -78,7 +86,6 @@ describe("parseConnectionString", () => {
     it("parses a PostgreSQL connection string", () => {
         expect(
             parseConnectionString(
-                "Npgsql",
                 "Host=localhost;Port=5432;Database=acme_shop;Username=admin;Password=secret;SSL Mode=Disable",
             ),
         ).toEqual({ values: values(), droppedKeywords: [], hasRecognizedKeywords: true });
@@ -87,7 +94,6 @@ describe("parseConnectionString", () => {
     it("parses a connection string with one keyword per line", () => {
         expect(
             parseConnectionString(
-                "Npgsql",
                 lines(
                     "Host=localhost",
                     "Port=5432",
@@ -103,7 +109,6 @@ describe("parseConnectionString", () => {
     it("parses keyword aliases case-insensitively", () => {
         expect(
             parseConnectionString(
-                "MySqlConnectorFactory",
                 "server=db.example.com;PORT=3306;Initial Catalog=shop;Uid=root;Pwd=secret;sslmode=none",
             ).values,
         ).toEqual(values({ host: "db.example.com", port: 3306, database: "shop", username: "root" }));
@@ -111,76 +116,62 @@ describe("parseConnectionString", () => {
 
     it("extracts the SQL Server port from the server value", () => {
         expect(
-            parseConnectionString(
-                "SqlClient",
-                "Server=db.example.com,1433;Database=shop;User ID=sa;Password=secret;Encrypt=False",
-            ).values,
+            parseConnectionString("Server=db.example.com,1433;Database=shop;User ID=sa;Password=secret;Encrypt=False")
+                .values,
         ).toEqual(values({ host: "db.example.com", port: 1433, database: "shop", username: "sa" }));
     });
 
     it("splits the host and port whichever provider's dialect wrote them", () => {
         const parsed = parseConnectionString(
-            "SqlClient",
             "Server=localhost,5432;Database=acme_shop;User ID=admin;Password=secret;Encrypt=True",
         );
 
-        expect(parsed.values).toEqual(values({ isSecured: true }));
+        expect(parsed.values).toEqual(values({ ssl: "require" }));
         expect(parsed.droppedKeywords).toEqual([]);
     });
 
     it("leaves a multi-host value alone", () => {
         expect(
-            parseConnectionString("Npgsql", "Host=primary.example.com,replica.example.com;Database=shop").values,
+            parseConnectionString("Host=primary.example.com,replica.example.com;Database=shop").values,
         ).toMatchObject({ host: "primary.example.com,replica.example.com", port: null });
     });
 
-    it("reads the secured flag from each provider's SSL keyword", () => {
-        expect(parseConnectionString("Npgsql", "Host=h;SSL Mode=Require").values.isSecured).toBe(true);
-        expect(parseConnectionString("Npgsql", "Host=h;SSL Mode=Disable").values.isSecured).toBe(false);
-        expect(parseConnectionString("SqlClient", "Server=h;Encrypt=True").values.isSecured).toBe(true);
-        expect(parseConnectionString("SqlClient", "Server=h;Encrypt=False").values.isSecured).toBe(false);
-        expect(parseConnectionString("MySqlConnectorFactory", "Server=h;SslMode=Required").values.isSecured).toBe(true);
-        expect(parseConnectionString("MySqlConnectorFactory", "Server=h;SslMode=None").values.isSecured).toBe(false);
+    it("reads the SSL mode from each provider's keyword", () => {
+        expect(parseConnectionString("Host=h;SSL Mode=Require").values.ssl).toBe("require");
+        expect(parseConnectionString("Host=h;SSL Mode=Disable").values.ssl).toBe("disable");
+        expect(parseConnectionString("Server=h;Encrypt=True").values.ssl).toBe("require");
+        expect(parseConnectionString("Server=h;Encrypt=False").values.ssl).toBe("disable");
+        expect(parseConnectionString("Server=h;SslMode=Required").values.ssl).toBe("require");
+        expect(parseConnectionString("Server=h;SslMode=None").values.ssl).toBe("disable");
     });
 
-    it("reads an opportunistic SSL value as not secured", () => {
-        expect(parseConnectionString("Npgsql", "Host=h;SSL Mode=Prefer").values.isSecured).toBe(false);
-        expect(parseConnectionString("MySqlConnectorFactory", "Server=h;SslMode=Preferred").values.isSecured).toBe(
-            false,
-        );
+    it("reads an opportunistic SSL value as the driver default", () => {
+        expect(parseConnectionString("Host=h;SSL Mode=Prefer").values.ssl).toBe("default");
+        expect(parseConnectionString("Server=h;SslMode=Preferred").values.ssl).toBe("default");
     });
 
-    it("maps a missing SSL keyword to what the driver does by default", () => {
-        expect(parseConnectionString("Npgsql", "Host=h;Database=d;Username=u;Password=p").values.isSecured).toBe(false);
-        expect(
-            parseConnectionString("MySqlConnectorFactory", "Server=h;Database=d;User ID=u;Password=p").values.isSecured,
-        ).toBe(false);
-        // Microsoft.Data.SqlClient encrypts unless the string says otherwise.
-        expect(parseConnectionString("SqlClient", "Server=h;Database=d;User ID=u;Password=p").values.isSecured).toBe(
-            true,
-        );
+    it("maps a missing SSL keyword to the driver default", () => {
+        expect(parseConnectionString("Host=h;Database=d;Username=u;Password=p").values.ssl).toBe("default");
     });
 
     it("keeps a SQL Server named instance intact when there is no port", () => {
-        expect(
-            parseConnectionString("SqlClient", "Server=host\\SQLEXPRESS;Database=shop;User ID=sa;Password=x").values
-                .host,
-        ).toBe("host\\SQLEXPRESS");
+        expect(parseConnectionString("Server=host\\SQLEXPRESS;Database=shop;User ID=sa;Password=x").values.host).toBe(
+            "host\\SQLEXPRESS",
+        );
     });
 
     it("reports when nothing in the string maps to a connection value", () => {
-        const parsed = parseConnectionString("Npgsql", "somevalue");
+        const parsed = parseConnectionString("somevalue");
 
         expect(parsed.hasRecognizedKeywords).toBe(false);
         expect(parsed.droppedKeywords).toEqual(["somevalue"]);
-        expect(parseConnectionString("Npgsql", "Application Name=quill").hasRecognizedKeywords).toBe(false);
-        expect(parseConnectionString("Npgsql", "Host=h").hasRecognizedKeywords).toBe(true);
+        expect(parseConnectionString("Application Name=quill").hasRecognizedKeywords).toBe(false);
+        expect(parseConnectionString("Host=h").hasRecognizedKeywords).toBe(true);
     });
 
     it("names the keywords no input represents", () => {
         expect(
             parseConnectionString(
-                "SqlClient",
                 "Server=localhost;Database=shop;User ID=sa;Password=x;TrustServerCertificate=True;Connect Timeout=30",
             ).droppedKeywords,
         ).toEqual(["TrustServerCertificate", "Connect Timeout"]);
@@ -188,24 +179,22 @@ describe("parseConnectionString", () => {
 
     it("drops nothing from a string the values fully express", () => {
         expect(
-            parseConnectionString("Npgsql", "Host=h;Port=5432;Database=d;Username=u;Password=p;SSL Mode=Require")
-                .droppedKeywords,
+            parseConnectionString("Host=h;Port=5432;Database=d;Username=u;Password=p;SSL Mode=Require").droppedKeywords,
         ).toEqual([]);
     });
 
     it("unquotes values containing separators", () => {
         expect(
-            parseConnectionString("Npgsql", "Host=localhost;Database=shop;Username=admin;Password='p;a=''s'").values
-                .password,
+            parseConnectionString("Host=localhost;Database=shop;Username=admin;Password='p;a=''s'").values.password,
         ).toBe("p;a='s");
     });
 
     it("round-trips through build for every provider", () => {
         for (const provider of ["Npgsql", "SqlClient", "MySqlConnectorFactory"] as const) {
-            for (const isSecured of [true, false]) {
-                const original = values({ password: "we;ird'pa=ss", isSecured });
+            for (const ssl of ["default", "require", "disable"] as const) {
+                const original = values({ password: "we;ird'pa=ss", ssl });
 
-                expect(parseConnectionString(provider, buildConnectionString(provider, original))).toEqual({
+                expect(parseConnectionString(buildConnectionString(provider, original))).toEqual({
                     values: original,
                     droppedKeywords: [],
                     hasRecognizedKeywords: true,

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.test.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.test.ts
@@ -18,8 +18,12 @@ function values(overrides: Partial<ConnectionValues> = {}): ConnectionValues {
     };
 }
 
+function lines(...pairs: string[]): string {
+    return pairs.map((pair) => `${pair};`).join("\n");
+}
+
 describe("buildConnectionString", () => {
-    it("builds a PostgreSQL connection string", () => {
+    it("builds a single-line PostgreSQL connection string", () => {
         expect(buildConnectionString("Npgsql", values())).toBe(
             "Host=localhost;Port=5432;Database=acme_shop;Username=admin;Password=secret;SSL Mode=Disable",
         );
@@ -54,10 +58,11 @@ describe("buildConnectionString", () => {
         );
     });
 
-    it("leaves out empty values instead of emitting a bare keyword", () => {
-        expect(buildConnectionString("Npgsql", values({ host: "", database: "", username: "", password: "" }))).toBe(
-            "Port=5432;SSL Mode=Disable",
-        );
+    it("returns an empty string when every field is empty", () => {
+        const empty = values({ host: "", port: null, database: "", username: "", password: "" });
+
+        expect(buildConnectionString("Npgsql", empty)).toBe("");
+        expect(buildConnectionString("Npgsql", { ...empty, isSecured: true })).toBe("");
     });
 
     it("quotes values containing separators or quotes", () => {
@@ -73,14 +78,32 @@ describe("parseConnectionString", () => {
     it("parses a PostgreSQL connection string", () => {
         expect(
             parseConnectionString(
+                "Npgsql",
                 "Host=localhost;Port=5432;Database=acme_shop;Username=admin;Password=secret;SSL Mode=Disable",
             ),
-        ).toEqual({ values: values(), droppedKeywords: [] });
+        ).toEqual({ values: values(), droppedKeywords: [], hasRecognizedKeywords: true });
+    });
+
+    it("parses a connection string with one keyword per line", () => {
+        expect(
+            parseConnectionString(
+                "Npgsql",
+                lines(
+                    "Host=localhost",
+                    "Port=5432",
+                    "Database=acme_shop",
+                    "Username=admin",
+                    "Password=secret",
+                    "SSL Mode=Disable",
+                ),
+            ),
+        ).toEqual({ values: values(), droppedKeywords: [], hasRecognizedKeywords: true });
     });
 
     it("parses keyword aliases case-insensitively", () => {
         expect(
             parseConnectionString(
+                "MySqlConnectorFactory",
                 "server=db.example.com;PORT=3306;Initial Catalog=shop;Uid=root;Pwd=secret;sslmode=none",
             ).values,
         ).toEqual(values({ host: "db.example.com", port: 3306, database: "shop", username: "root" }));
@@ -88,13 +111,16 @@ describe("parseConnectionString", () => {
 
     it("extracts the SQL Server port from the server value", () => {
         expect(
-            parseConnectionString("Server=db.example.com,1433;Database=shop;User ID=sa;Password=secret;Encrypt=False")
-                .values,
+            parseConnectionString(
+                "SqlClient",
+                "Server=db.example.com,1433;Database=shop;User ID=sa;Password=secret;Encrypt=False",
+            ).values,
         ).toEqual(values({ host: "db.example.com", port: 1433, database: "shop", username: "sa" }));
     });
 
     it("splits the host and port whichever provider's dialect wrote them", () => {
         const parsed = parseConnectionString(
+            "SqlClient",
             "Server=localhost,5432;Database=acme_shop;User ID=admin;Password=secret;Encrypt=True",
         );
 
@@ -104,32 +130,57 @@ describe("parseConnectionString", () => {
 
     it("leaves a multi-host value alone", () => {
         expect(
-            parseConnectionString("Host=primary.example.com,replica.example.com;Database=shop").values,
+            parseConnectionString("Npgsql", "Host=primary.example.com,replica.example.com;Database=shop").values,
         ).toMatchObject({ host: "primary.example.com,replica.example.com", port: null });
     });
 
     it("reads the secured flag from each provider's SSL keyword", () => {
-        expect(parseConnectionString("Host=h;SSL Mode=Require").values.isSecured).toBe(true);
-        expect(parseConnectionString("Host=h;SSL Mode=Disable").values.isSecured).toBe(false);
-        expect(parseConnectionString("Server=h;Encrypt=True").values.isSecured).toBe(true);
-        expect(parseConnectionString("Server=h;Encrypt=False").values.isSecured).toBe(false);
-        expect(parseConnectionString("Server=h;SslMode=Required").values.isSecured).toBe(true);
-        expect(parseConnectionString("Server=h;SslMode=None").values.isSecured).toBe(false);
+        expect(parseConnectionString("Npgsql", "Host=h;SSL Mode=Require").values.isSecured).toBe(true);
+        expect(parseConnectionString("Npgsql", "Host=h;SSL Mode=Disable").values.isSecured).toBe(false);
+        expect(parseConnectionString("SqlClient", "Server=h;Encrypt=True").values.isSecured).toBe(true);
+        expect(parseConnectionString("SqlClient", "Server=h;Encrypt=False").values.isSecured).toBe(false);
+        expect(parseConnectionString("MySqlConnectorFactory", "Server=h;SslMode=Required").values.isSecured).toBe(true);
+        expect(parseConnectionString("MySqlConnectorFactory", "Server=h;SslMode=None").values.isSecured).toBe(false);
     });
 
-    it("treats a missing SSL keyword as secured", () => {
-        expect(parseConnectionString("Host=h;Database=d;Username=u;Password=p").values.isSecured).toBe(true);
+    it("reads an opportunistic SSL value as not secured", () => {
+        expect(parseConnectionString("Npgsql", "Host=h;SSL Mode=Prefer").values.isSecured).toBe(false);
+        expect(parseConnectionString("MySqlConnectorFactory", "Server=h;SslMode=Preferred").values.isSecured).toBe(
+            false,
+        );
+    });
+
+    it("maps a missing SSL keyword to what the driver does by default", () => {
+        expect(parseConnectionString("Npgsql", "Host=h;Database=d;Username=u;Password=p").values.isSecured).toBe(false);
+        expect(
+            parseConnectionString("MySqlConnectorFactory", "Server=h;Database=d;User ID=u;Password=p").values.isSecured,
+        ).toBe(false);
+        // Microsoft.Data.SqlClient encrypts unless the string says otherwise.
+        expect(parseConnectionString("SqlClient", "Server=h;Database=d;User ID=u;Password=p").values.isSecured).toBe(
+            true,
+        );
     });
 
     it("keeps a SQL Server named instance intact when there is no port", () => {
-        expect(parseConnectionString("Server=host\\SQLEXPRESS;Database=shop;User ID=sa;Password=x").values.host).toBe(
-            "host\\SQLEXPRESS",
-        );
+        expect(
+            parseConnectionString("SqlClient", "Server=host\\SQLEXPRESS;Database=shop;User ID=sa;Password=x").values
+                .host,
+        ).toBe("host\\SQLEXPRESS");
+    });
+
+    it("reports when nothing in the string maps to a connection value", () => {
+        const parsed = parseConnectionString("Npgsql", "somevalue");
+
+        expect(parsed.hasRecognizedKeywords).toBe(false);
+        expect(parsed.droppedKeywords).toEqual(["somevalue"]);
+        expect(parseConnectionString("Npgsql", "Application Name=quill").hasRecognizedKeywords).toBe(false);
+        expect(parseConnectionString("Npgsql", "Host=h").hasRecognizedKeywords).toBe(true);
     });
 
     it("names the keywords no input represents", () => {
         expect(
             parseConnectionString(
+                "SqlClient",
                 "Server=localhost;Database=shop;User ID=sa;Password=x;TrustServerCertificate=True;Connect Timeout=30",
             ).droppedKeywords,
         ).toEqual(["TrustServerCertificate", "Connect Timeout"]);
@@ -137,24 +188,29 @@ describe("parseConnectionString", () => {
 
     it("drops nothing from a string the values fully express", () => {
         expect(
-            parseConnectionString("Host=h;Port=5432;Database=d;Username=u;Password=p;SSL Mode=Require").droppedKeywords,
+            parseConnectionString("Npgsql", "Host=h;Port=5432;Database=d;Username=u;Password=p;SSL Mode=Require")
+                .droppedKeywords,
         ).toEqual([]);
     });
 
     it("unquotes values containing separators", () => {
         expect(
-            parseConnectionString("Host=localhost;Database=shop;Username=admin;Password='p;a=''s'").values.password,
+            parseConnectionString("Npgsql", "Host=localhost;Database=shop;Username=admin;Password='p;a=''s'").values
+                .password,
         ).toBe("p;a='s");
     });
 
     it("round-trips through build for every provider", () => {
-        const original = values({ password: "we;ird'pa=ss", isSecured: true });
-
         for (const provider of ["Npgsql", "SqlClient", "MySqlConnectorFactory"] as const) {
-            expect(parseConnectionString(buildConnectionString(provider, original))).toEqual({
-                values: original,
-                droppedKeywords: [],
-            });
+            for (const isSecured of [true, false]) {
+                const original = values({ password: "we;ird'pa=ss", isSecured });
+
+                expect(parseConnectionString(provider, buildConnectionString(provider, original))).toEqual({
+                    values: original,
+                    droppedKeywords: [],
+                    hasRecognizedKeywords: true,
+                });
+            }
         }
     });
 });

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.ts
@@ -3,13 +3,15 @@ import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-valida
 type ExternalConnection = AppFormData["externalConnection"];
 type Provider = ExternalConnection["provider"];
 
+export type SslMode = ExternalConnection["fields"]["ssl"];
+
 export type ConnectionValues = {
     host: string;
     port: number | null;
     database: string;
     username: string;
     password: string;
-    isSecured: boolean;
+    ssl: SslMode;
 };
 
 export type ParsedConnectionString = {
@@ -42,10 +44,10 @@ const KEYWORDS_BY_PROVIDER: Record<
     },
 };
 
-const SSL_BY_PROVIDER: Record<Provider, { keyword: string; secured: string; insecure: string }> = {
-    Npgsql: { keyword: "SSL Mode", secured: "Require", insecure: "Disable" },
-    SqlClient: { keyword: "Encrypt", secured: "True", insecure: "False" },
-    MySqlConnectorFactory: { keyword: "SslMode", secured: "Required", insecure: "None" },
+const SSL_BY_PROVIDER: Record<Provider, { keyword: string; require: string; disable: string }> = {
+    Npgsql: { keyword: "SSL Mode", require: "Require", disable: "Disable" },
+    SqlClient: { keyword: "Encrypt", require: "True", disable: "False" },
+    MySqlConnectorFactory: { keyword: "SslMode", require: "Required", disable: "None" },
 };
 
 export function buildConnectionString(provider: Provider, values: ConnectionValues): string {
@@ -77,8 +79,10 @@ export function buildConnectionString(provider: Provider, values: ConnectionValu
         return "";
     }
 
-    const ssl = SSL_BY_PROVIDER[provider];
-    pairs.push(`${ssl.keyword}=${values.isSecured ? ssl.secured : ssl.insecure}`);
+    if (values.ssl !== "default") {
+        const ssl = SSL_BY_PROVIDER[provider];
+        pairs.push(`${ssl.keyword}=${values.ssl === "require" ? ssl.require : ssl.disable}`);
+    }
 
     return pairs.join(";");
 }
@@ -116,35 +120,38 @@ const FIELD_BY_KEYWORD: Record<string, keyof ConnectionValues> = {
     uid: "username",
     password: "password",
     pwd: "password",
-    "ssl mode": "isSecured",
-    sslmode: "isSecured",
-    encrypt: "isSecured",
+    "ssl mode": "ssl",
+    sslmode: "ssl",
+    encrypt: "ssl",
 };
 
-// "prefer"/"preferred" are the Npgsql/MySqlConnector defaults - no SSL guarantee, so the toggle
-// cannot show them as secured.
-const INSECURE_SSL_VALUES = new Set(["disable", "disabled", "none", "false", "0", "no", "prefer", "preferred"]);
+const DISABLE_SSL_VALUES = new Set(["disable", "disabled", "none", "false", "0", "no"]);
 
-/**
- * What the driver does when the string does not mention SSL: Microsoft.Data.SqlClient encrypts
- * (Encrypt defaults to True), Npgsql and MySqlConnector only opportunistically try SSL with no
- * guarantee. The toggle must mirror that, or a round trip through the details editor would
- * silently flip the connection's security.
- */
-const IS_SECURED_WHEN_UNSPECIFIED: Record<Provider, boolean> = {
-    Npgsql: false,
-    SqlClient: true,
-    MySqlConnectorFactory: false,
-};
+// "prefer"/"preferred" are what Npgsql/MySqlConnector do anyway when the keyword is absent.
+const DEFAULT_SSL_VALUES = new Set(["prefer", "preferred"]);
 
-export function parseConnectionString(provider: Provider, connectionString: string): ParsedConnectionString {
+function toSslMode(value: string): SslMode {
+    const normalized = value.trim().toLowerCase();
+
+    if (DISABLE_SSL_VALUES.has(normalized)) {
+        return "disable";
+    }
+
+    if (DEFAULT_SSL_VALUES.has(normalized)) {
+        return "default";
+    }
+
+    return "require";
+}
+
+export function parseConnectionString(connectionString: string): ParsedConnectionString {
     const values: ConnectionValues = {
         host: "",
         port: null,
         database: "",
         username: "",
         password: "",
-        isSecured: IS_SECURED_WHEN_UNSPECIFIED[provider],
+        ssl: "default",
     };
     const droppedKeywords: string[] = [];
     let hasRecognizedKeywords = false;
@@ -170,8 +177,8 @@ export function parseConnectionString(provider: Provider, connectionString: stri
 
         if (field === "port") {
             values.port = parsePort(value);
-        } else if (field === "isSecured") {
-            values.isSecured = !INSECURE_SSL_VALUES.has(value.trim().toLowerCase());
+        } else if (field === "ssl") {
+            values.ssl = toSslMode(value);
         } else if (field === "host") {
             const { host, port } = splitHostAndPort(value);
             values.host = host;

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.ts
@@ -15,6 +15,8 @@ export type ConnectionValues = {
 export type ParsedConnectionString = {
     values: ConnectionValues;
     droppedKeywords: string[];
+    /** False when no keyword mapped to a connection value - the values are then all defaults. */
+    hasRecognizedKeywords: boolean;
 };
 
 export const DEFAULT_PROVIDER: Provider = "Npgsql";
@@ -70,6 +72,11 @@ export function buildConnectionString(provider: Provider, values: ConnectionValu
         }
     }
 
+    // Empty details produce an empty string - an SSL keyword alone is never a usable connection.
+    if (pairs.length === 0) {
+        return "";
+    }
+
     const ssl = SSL_BY_PROVIDER[provider];
     pairs.push(`${ssl.keyword}=${values.isSecured ? ssl.secured : ssl.insecure}`);
 
@@ -85,7 +92,7 @@ export function resolveConnectionString(
 }
 
 function escapeValue(value: string): string {
-    if (value !== "" && !/[;'"=]/.test(value) && value === value.trim()) {
+    if (value !== "" && !/[;'"=\r\n]/.test(value) && value === value.trim()) {
         return value;
     }
 
@@ -114,18 +121,33 @@ const FIELD_BY_KEYWORD: Record<string, keyof ConnectionValues> = {
     encrypt: "isSecured",
 };
 
-const INSECURE_SSL_VALUES = new Set(["disable", "disabled", "none", "false", "0", "no"]);
+// "prefer"/"preferred" are the Npgsql/MySqlConnector defaults - no SSL guarantee, so the toggle
+// cannot show them as secured.
+const INSECURE_SSL_VALUES = new Set(["disable", "disabled", "none", "false", "0", "no", "prefer", "preferred"]);
 
-export function parseConnectionString(connectionString: string): ParsedConnectionString {
+/**
+ * What the driver does when the string does not mention SSL: Microsoft.Data.SqlClient encrypts
+ * (Encrypt defaults to True), Npgsql and MySqlConnector only opportunistically try SSL with no
+ * guarantee. The toggle must mirror that, or a round trip through the details editor would
+ * silently flip the connection's security.
+ */
+const IS_SECURED_WHEN_UNSPECIFIED: Record<Provider, boolean> = {
+    Npgsql: false,
+    SqlClient: true,
+    MySqlConnectorFactory: false,
+};
+
+export function parseConnectionString(provider: Provider, connectionString: string): ParsedConnectionString {
     const values: ConnectionValues = {
         host: "",
         port: null,
         database: "",
         username: "",
         password: "",
-        isSecured: true,
+        isSecured: IS_SECURED_WHEN_UNSPECIFIED[provider],
     };
     const droppedKeywords: string[] = [];
+    let hasRecognizedKeywords = false;
 
     for (const segment of splitSegments(connectionString)) {
         const separatorIndex = segment.indexOf("=");
@@ -141,7 +163,12 @@ export function parseConnectionString(connectionString: string): ParsedConnectio
 
         if (!field) {
             droppedKeywords.push(keyword);
-        } else if (field === "port") {
+            continue;
+        }
+
+        hasRecognizedKeywords = true;
+
+        if (field === "port") {
             values.port = parsePort(value);
         } else if (field === "isSecured") {
             values.isSecured = !INSECURE_SSL_VALUES.has(value.trim().toLowerCase());
@@ -154,7 +181,7 @@ export function parseConnectionString(connectionString: string): ParsedConnectio
         }
     }
 
-    return { values, droppedKeywords };
+    return { values, droppedKeywords, hasRecognizedKeywords };
 }
 
 function splitHostAndPort(value: string): { host: string; port: number | null } {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/edit-app-values.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/edit-app-values.ts
@@ -75,13 +75,13 @@ function buildConnectionSeed(provider: Provider, connectionString: string): Conn
                 database: "",
                 username: "",
                 password: "",
-                isSecured: true,
+                ssl: "default",
             },
             connectionString: "",
         };
     }
 
-    const { values: fields, droppedKeywords } = parseConnectionString(provider, connectionString);
+    const { values: fields, droppedKeywords } = parseConnectionString(connectionString);
 
     return { mode: droppedKeywords.length === 0 ? "fields" : "raw", fields, connectionString };
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/edit-app-values.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/edit-app-values.ts
@@ -81,7 +81,7 @@ function buildConnectionSeed(provider: Provider, connectionString: string): Conn
         };
     }
 
-    const { values: fields, droppedKeywords } = parseConnectionString(connectionString);
+    const { values: fields, droppedKeywords } = parseConnectionString(provider, connectionString);
 
     return { mode: droppedKeywords.length === 0 ? "fields" : "raw", fields, connectionString };
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connection-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connection-editor.tsx
@@ -1,10 +1,10 @@
 import { useFormContext, useWatch } from "react-hook-form";
 import { FormInput } from "@/components/form/form-input";
-import { FormSwitch } from "@/components/form/form-switch";
 import { FormTextarea } from "@/components/form/form-textarea";
+import { FormToggleGroup, type FormToggleGroupOption } from "@/components/form/form-toggle-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/ui/tabs";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
-import { DEFAULT_PORT_BY_PROVIDER } from "@/pages/setup/add-app-wizard/connection-string";
+import { DEFAULT_PORT_BY_PROVIDER, type SslMode } from "@/pages/setup/add-app-wizard/connection-string";
 import { useConnectionSync } from "@/pages/setup/add-app-wizard/steps/connect/use-connection-sync";
 
 type Provider = AppFormData["externalConnection"]["provider"];
@@ -13,6 +13,18 @@ const CONNECTION_STRING_PLACEHOLDER_BY_PROVIDER: Record<Provider, string> = {
     Npgsql: "Host=localhost;Port=5432;Database=my_db;Username=admin;Password=pass",
     SqlClient: "Server=localhost,1433;Database=my_db;User ID=sa;Password=pass",
     MySqlConnectorFactory: "Server=localhost;Port=3306;Database=my_db;User ID=admin;Password=pass",
+};
+
+const SSL_OPTIONS: FormToggleGroupOption<SslMode>[] = [
+    { value: "default", label: "Driver default" },
+    { value: "require", label: "Require" },
+    { value: "disable", label: "Disable" },
+];
+
+const SSL_DEFAULT_DESCRIPTION_BY_PROVIDER: Record<Provider, string> = {
+    Npgsql: "Driver default tries SSL first and falls back to an unencrypted connection.",
+    SqlClient: "Driver default requires an encrypted connection.",
+    MySqlConnectorFactory: "Driver default tries SSL first and falls back to an unencrypted connection.",
 };
 
 export function ConnectionEditor({ isDisabled }: { isDisabled: boolean }) {
@@ -86,10 +98,13 @@ function ConnectionFieldsEditor({ isDisabled }: { isDisabled: boolean }) {
                     disabled={isDisabled}
                 />
             </div>
-            <FormSwitch
+            <FormToggleGroup
                 control={control}
-                name="externalConnection.fields.isSecured"
-                label="Secured connection (SSL/TLS)"
+                name="externalConnection.fields.ssl"
+                label="SSL/TLS"
+                options={SSL_OPTIONS}
+                canDeselect={false}
+                description={SSL_DEFAULT_DESCRIPTION_BY_PROVIDER[provider]}
                 disabled={isDisabled}
             />
         </>

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connection-sync.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connection-sync.ts
@@ -24,7 +24,6 @@ export function useConnectionSync() {
             // A blank string has nothing to read - wiping the details with it would throw away
             // whatever was already typed there.
             const { values, droppedKeywords, hasRecognizedKeywords } = parseConnectionString(
-                connection.provider,
                 connection.connectionString,
             );
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connection-sync.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connection-sync.ts
@@ -12,14 +12,27 @@ export function useConnectionSync() {
         const connection = getValues("externalConnection");
 
         if (mode === "raw") {
-            setValue(
-                "externalConnection.connectionString",
-                buildConnectionString(connection.provider, connection.fields),
+            // Half-filled details would overwrite the string with a fragment, so it only
+            // regenerates once every field is in.
+            if (hasCompleteFields(connection.fields)) {
+                setValue(
+                    "externalConnection.connectionString",
+                    buildConnectionString(connection.provider, connection.fields),
+                );
+            }
+        } else if (connection.connectionString.trim() !== "") {
+            // A blank string has nothing to read - wiping the details with it would throw away
+            // whatever was already typed there.
+            const { values, droppedKeywords, hasRecognizedKeywords } = parseConnectionString(
+                connection.provider,
+                connection.connectionString,
             );
-        } else {
-            const { values, droppedKeywords } = parseConnectionString(connection.connectionString);
 
-            setValue("externalConnection.fields", values);
+            // Same protection when nothing in the string maps to a detail field: the details
+            // keep what was typed, and the warning names what could not be carried over.
+            if (hasRecognizedKeywords) {
+                setValue("externalConnection.fields", values);
+            }
             warnAboutDroppedKeywords(droppedKeywords);
         }
 
@@ -27,6 +40,16 @@ export function useConnectionSync() {
     };
 
     return { changeMode };
+}
+
+function hasCompleteFields(fields: ExternalConnection["fields"]): boolean {
+    return (
+        fields.host.trim() !== "" &&
+        fields.port != null &&
+        fields.database.trim() !== "" &&
+        fields.username.trim() !== "" &&
+        fields.password.trim() !== ""
+    );
 }
 
 function warnAboutDroppedKeywords(droppedKeywords: string[]) {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
@@ -123,7 +123,7 @@ export function useImportConfig() {
                 sourceTableName: table.sourceTableName ?? "",
             }));
 
-            const { values: fields, droppedKeywords } = parseConnectionString(config.connectionString);
+            const { values: fields, droppedKeywords } = parseConnectionString(config.provider, config.connectionString);
 
             setValue("externalConnection.provider", config.provider);
             setValue("externalConnection.mode", droppedKeywords.length === 0 ? "fields" : "raw");

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
@@ -123,7 +123,7 @@ export function useImportConfig() {
                 sourceTableName: table.sourceTableName ?? "",
             }));
 
-            const { values: fields, droppedKeywords } = parseConnectionString(config.provider, config.connectionString);
+            const { values: fields, droppedKeywords } = parseConnectionString(config.connectionString);
 
             setValue("externalConnection.provider", config.provider);
             setValue("externalConnection.mode", droppedKeywords.length === 0 ? "fields" : "raw");

--- a/src/Raven.Quill/Endpoints/AppsEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/AppsEndpoints.cs
@@ -294,15 +294,32 @@ public static class AppsEndpoints
         if (app is null)
             return Results.NotFound(new ApiErrorResponse($"no app with slug '{slug}'"));
 
-        var wizardId = WizardState.DocumentIdFor(slug);
-        using (var session = store.OpenAsyncSession())
-        {
-            var state = await session.LoadAsync<WizardState>(wizardId, ct);
-            if (state?.LastMapConfiguration is null)
-                return Results.NotFound(new ApiErrorResponse($"no cdc config for {slug} found"));
+        // The app database is the source of truth: the wizard's state document is scratch space
+        // that a later setup run for the same slug may reset.
+        var task = await store.Maintenance.ForDatabase(app.Database).SendAsync(
+            new GetOngoingTaskInfoOperation(app.CdcTaskName, OngoingTaskType.CdcSink), ct);
+        if (task is not OngoingTaskCdcSink cdc)
+            return Results.NotFound(new ApiErrorResponse($"no cdc config for {slug} found"));
 
-            return Results.Ok(new AppCdcConfigurationResponse(state.LastMapConfiguration, state.SourceConnectionString));
-        }
+        return Results.Ok(new AppCdcConfigurationResponse(
+            cdc.Configuration,
+            await LoadSourceConnectionStringAsync(store, app.Database, cdc.Configuration.ConnectionStringName, ct)));
+    }
+
+    private static async Task<string?> LoadSourceConnectionStringAsync(
+        IDocumentStore store,
+        string database,
+        string? connectionStringName,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(connectionStringName))
+            return null;
+
+        var result = await store.Maintenance.ForDatabase(database).SendAsync(
+            new GetConnectionStringsOperation(connectionStringName, ConnectionStringType.Sql), ct);
+        return result.SqlConnectionStrings.TryGetValue(connectionStringName, out var source)
+            ? source.ConnectionString
+            : null;
     }
 
     private static async Task SetupTryAsync(

--- a/test/QuillTests/CdcGetEndpointTests.cs
+++ b/test/QuillTests/CdcGetEndpointTests.cs
@@ -2,7 +2,7 @@ using System.Net;
 using QuillTests.E2E.Fixtures;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.CdcSink;
-using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Quill.Wizard;
 using Tests.Infrastructure;
 using Xunit;
@@ -25,15 +25,32 @@ public class CdcGetEndpointTests(ITestOutputHelper output) : QuillTestBase(outpu
     }
 
     [RavenFact(RavenTestCategory.Quill)]
-    public async Task CdcGet_returns_404_when_no_cdc_configured()
+    public async Task CdcGet_survives_a_wizard_state_reset()
     {
         await using var app = await NewAppAsync();
 
+        // A later setup run for the same slug may wipe the wizard's scratch document (e.g. a
+        // re-connect with a reformatted connection string); the provisioned app must not care.
         var session = Host.Config.OpenAsyncSession();
         var wizard = await session.LoadAsync<WizardState>(WizardState.DocumentIdFor(app.Slug));
         wizard.LastMapConfiguration = null;
+        wizard.SourceConnectionString = null;
         await session.SaveChangesAsync();
-        
+
+        var cdc = await app.GetCdcAsync();
+        Assert.Equal($"{app.Slug}-cdc", cdc.Configuration.Name);
+        Assert.Equal("Host=localhost;Database=src", cdc.ConnectionString);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task CdcGet_returns_404_when_the_cdc_task_is_gone()
+    {
+        await using var app = await NewAppAsync();
+
+        var task = await app.Store.Maintenance.SendAsync(
+            new GetOngoingTaskInfoOperation($"{app.Slug}-cdc", OngoingTaskType.CdcSink));
+        await app.Store.Maintenance.SendAsync(new DeleteOngoingTaskOperation(task.TaskId, OngoingTaskType.CdcSink));
+
         var ex = await Assert.ThrowsAsync<QuillHttpException>(() => app.GetCdcAsync());
         Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
     }


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27261

### Additional description

**Tri-state SSL control**
- The SSL toggle is replaced with **Driver default / Require / Disable**, with "Driver default" selected initially.
- "Driver default" omits the SSL keyword entirely, so editing an app never silently rewrites its security. A per-provider hint explains what the driver does then: PostgreSQL/MySQL try SSL and fall back to plaintext, SQL Server requires encryption.
- Parsing maps a missing SSL keyword and opportunistic values (`Prefer`/`Preferred`) to "Driver default", explicit insecure values to "Disable", everything else to "Require".

**Sync no longer clears user input**
- Details -> string: the raw string only regenerates once every field is filled; a half-filled form never overwrites it.
- String -> details: the fields are only overwritten when the string contains at least one recognized keyword; unrecognized-only input (or a blank string) leaves them untouched, with a toast naming what could not be carried over.

**CDC GET endpoint**
- Now reads the configuration from the app database's ongoing CDC task instead of the wizard state document. The wizard state is scratch space that a later setup run for the same slug may reset, so the provisioned task is the only reliable source of truth.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
