### PR TITLE
RavenDB-26893 & RavenDB-27012 - Run CoraxAndLuceneAlphanumericalSortResultMustBeIdentical and Streaming_Projection_Query_On_Encrypted_Db_Aborted_MidStream_Does_Not_Throw on 64-bit only

### DIFF
--- a/test/StressTests/Issues/RavenDB-26721.cs
+++ b/test/StressTests/Issues/RavenDB-26721.cs
@@ -37,7 +37,7 @@ public class RavenDB_26721 : RavenTestBase
         public string Body { get; set; }
     }
 
-    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Encryption | RavenTestCategory.Indexes)]
+    [RavenMultiplatformFact(RavenTestCategory.Querying | RavenTestCategory.Encryption | RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
     public async Task Streaming_Projection_Query_On_Encrypted_Db_Aborted_MidStream_Does_Not_Throw()
     {
         // Repro for RavenDB-26721: during a streaming projection query over an encrypted database, the index read

--- a/test/StressTests/Issues/RavenDB_24423.cs
+++ b/test/StressTests/Issues/RavenDB_24423.cs
@@ -14,7 +14,7 @@ namespace StressTests.Issues;
 
 public class RavenDB_24423(ITestOutputHelper output) : SlowTests.Issues.RavenDB_24423(output)
 {
-    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [InlineData(1, 0x007F)]
     [InlineData(0x0080, 0x07FF)]
     [InlineData(0x0800, 0xFFFF)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26893/StressTests.Issues.RavenDB24423.CoraxAndLuceneAlphanumericalSortResultMustBeIdenticalfrom-65536-toInclusive-1114111
https://issues.hibernatingrhinos.com/issue/RavenDB-27012/StressTests.Issues.RavenDB26721.StreamingProjectionQueryOnEncryptedDbAbortedMidStreamDoesNotThrow

### Additional description

Run CoraxAndLuceneAlphanumericalSortResultMustBeIdentical and Streaming_Projection_Query_On_Encrypted_Db_Aborted_MidStream_Does_Not_Throw on 64-bit only.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
