### PR TITLE
RavenDB-27195 Add several unsupported SQL shapes and small fixes to the SQL translator

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
@@ -60,6 +60,9 @@ namespace Raven.Server.Integrations.PostgreSQL
                 if (PgVirtualInterpreter.TryExecute(queryText, new VirtualQueryContext { Database = documentDatabase, Username = username }, out var virtualTable))
                     return new VirtualInterpreterQuery(queryText, parametersDataTypes, virtualTable);
 
+                if (PgSqlToRqlTranslator.TryParseScalarCount(queryText, documentDatabase, out var countRql, out var countColumns))
+                    return new PgScalarCountQuery(countRql, parametersDataTypes, documentDatabase, countColumns);
+
                 if (PgSqlToRqlTranslator.TryParse(queryText, parametersDataTypes, documentDatabase, out var rql, out var hasExplicitProjection))
                 {
                     return hasExplicitProjection

--- a/src/Raven.Server/Integrations/PostgreSQL/Translation/PgScalarCountQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Translation/PgScalarCountQuery.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Integrations.PostgreSQL.Messages;
+using Raven.Server.Integrations.PostgreSQL.Types;
+using Raven.Server.ServerWide;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Integrations.PostgreSQL.Translation
+{
+    // Answers `SELECT count(*) FROM t [WHERE ...]` with a single int8 row (what PostgreSQL's count()
+    // returns). Page size 0 makes the engine drain the whole filtered enumerator and report the exact
+    // TotalResults - the same mechanism as IDocumentQueryBase.Count(). The buffered ExecuteQuery path
+    // is mandatory: ExecuteStreamQuery never surfaces TotalResults.
+    internal sealed class PgScalarCountQuery : PgQuery
+    {
+        private readonly DocumentDatabase _documentDatabase;
+        private readonly string[] _columnNames;
+        private readonly List<PgColumn> _columns = new();
+
+        public PgScalarCountQuery(string rql, int[] parametersDataTypes, DocumentDatabase documentDatabase, string[] columnNames)
+            : base(rql, parametersDataTypes)
+        {
+            _documentDatabase = documentDatabase;
+            _columnNames = columnNames;
+        }
+
+        public override Task<ICollection<PgColumn>> Init()
+        {
+            var resultsFormat = GetDefaultResultsFormat();
+
+            _columns.Clear();
+            for (int i = 0; i < _columnNames.Length; i++)
+                _columns.Add(new PgColumn(_columnNames[i], (short)i, PgInt8.Default, resultsFormat));
+
+            return Task.FromResult<ICollection<PgColumn>>(_columns);
+        }
+
+        public override async Task Execute(MessageBuilder builder, PipeWriter writer, CancellationToken token)
+        {
+            if (_columns.Count == 0)
+                await Init();
+
+            var count = await GetCount(token);
+
+            var row = new ReadOnlyMemory<byte>?[_columns.Count];
+            for (int i = 0; i < row.Length; i++)
+                row[i] = PgInt8.Default.ToBytes(count, _columns[i].FormatCode);
+
+            await writer.WriteAsync(builder.DataRow(row), token);
+            await writer.WriteAsync(builder.CommandComplete("SELECT 1"), token);
+        }
+
+        private async Task<long> GetCount(CancellationToken token)
+        {
+            using var queryOperationContext = QueryOperationContext.Allocate(_documentDatabase);
+
+            var parameters = DynamicJsonValue.Convert(Parameters);
+            var queryParameters = queryOperationContext.Documents.ReadObject(parameters, "query/parameters");
+
+            var indexQuery = new IndexQueryServerSide(QueryString, queryParameters)
+            {
+                Start = 0,
+                PageSize = 0,
+                Offset = 0,
+                Limit = 0
+            };
+
+            using var cancelToken = new OperationCancelToken(_documentDatabase.DatabaseShutdown, token);
+            var result = await _documentDatabase.QueryRunner.ExecuteQuery(indexQuery, queryOperationContext, null, cancelToken);
+
+            return result.TotalResults;
+        }
+
+        public override void Dispose()
+        {
+        }
+    }
+}

--- a/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
@@ -1148,13 +1148,12 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             // when present — PowerBI always emits one (`as "a0"`/`as "a1"`/…) — so the
             // RQL becomes `select Freight, sum(Freight) as a0` and the implicit alias
             // never matters.
-            if (string.IsNullOrWhiteSpace(sqlAlias) == false &&
-                string.Equals(sqlAlias, expr, StringComparison.OrdinalIgnoreCase) == false)
-            {
-                if (IsSafeRqlIdentifier(sqlAlias) == false)
-                    throw UnsupportedGroupBy();
-                projection = $"{expr} as {sqlAlias}";
-            }
+            // Superset labels adhoc metrics COUNT(*) / SUM(col) / COUNT_DISTINCT(col) and uses the label
+            // verbatim as the alias, so quote it rather than reject it. An alias that merely matches the
+            // expression text still has to be emitted: RQL's implicit name for `sum(Freight)` is
+            // `Freight`, so dropping `as "SUM(Freight)"` would rename the column out from under the client.
+            if (string.IsNullOrWhiteSpace(sqlAlias) == false)
+                projection = $"{expr} as {EscapeProjectionField(sqlAlias)}";
 
             return new GroupByAggregate(projection, expr, string.IsNullOrWhiteSpace(sqlAlias) ? funcName : sqlAlias, orderField, ordering);
         }

--- a/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
@@ -119,6 +119,90 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             }
         }
 
+        // `SELECT count(*) FROM t [WHERE ...]` is the one scalar aggregate RQL answers exactly: a count
+        // query (page size 0) drains the filtered enumerator and reports TotalResults. Kept out of
+        // TryParse because its other callers (PowerBI) discard the count shape and must keep rejecting it.
+        public static bool TryParseScalarCount(string sql, DocumentDatabase documentDatabase, out string rql, out string[] columnNames)
+        {
+            rql = null;
+            columnNames = null;
+
+            try
+            {
+                var parseResult = SqlAstCache.GetOrParse(sql);
+                if (parseResult.IsSuccess == false || parseResult.Value?.Stmts is not { Count: > 0 } stmts)
+                    return false;
+
+                if (stmts[0]?.Stmt?.SelectStmt is not { } selectStmt)
+                    return false;
+
+                if (TryGetScalarCountColumns(selectStmt, out columnNames) == false)
+                    return false;
+
+                rql = TranslateSelectStatement(selectStmt, documentDatabase, asScalarCount: true);
+                return LogSuccess(sql, rql);
+            }
+            catch (NotSupportedException)
+            {
+                rql = null;
+                columnNames = null;
+                return false;
+            }
+        }
+
+        // Only count(*) qualifies: count(x) counts non-null values and count(distinct x) needs dedup,
+        // neither of which TotalResults reports. Everything else - other aggregates, a bare column,
+        // DISTINCT, GROUP BY - keeps falling through to ScalarAggregateWithoutGroupBy.
+        private static bool TryGetScalarCountColumns(SelectStmt selectStmt, out string[] columnNames)
+        {
+            columnNames = null;
+
+            if (selectStmt.GroupClause is { Count: > 0 } ||
+                selectStmt.DistinctClause is { Count: > 0 } ||
+                selectStmt.SortClause is { Count: > 0 } ||
+                selectStmt.HavingClause != null ||
+                selectStmt.WithClause != null ||
+                selectStmt.LimitOffset != null)
+                return false;
+
+            // SQL `LIMIT 0` returns no rows at all, which this always-one-row path can't express.
+            if (selectStmt.LimitCount != null &&
+                (PgSqlAstHelpers.TryReadNonNegativeIntConst(selectStmt.LimitCount, out var limit) == false || limit == 0))
+                return false;
+
+            if (selectStmt.FromClause is not [{ RangeVar: not null }])
+                return false;
+
+            if (selectStmt.TargetList is not { Count: > 0 } targets)
+                return false;
+
+            var names = new string[targets.Count];
+            for (int i = 0; i < targets.Count; i++)
+            {
+                var resTarget = targets[i]?.ResTarget;
+                if (IsCountStar(resTarget?.Val?.FuncCall) == false)
+                    return false;
+
+                names[i] = string.IsNullOrWhiteSpace(resTarget.Name) ? "count" : resTarget.Name;
+            }
+
+            columnNames = names;
+            return true;
+        }
+
+        private static bool IsCountStar(FuncCall func)
+        {
+            if (func == null || func.AggStar == false || func.AggDistinct || func.AggFilter != null || func.Over != null)
+                return false;
+
+            if (func.Args is { Count: > 0 })
+                return false;
+
+            // Match the last name segment so PowerBI's `pg_catalog.count(*)` is recognized too.
+            var name = func.Funcname is { Count: > 0 } ? func.Funcname[^1]?.String?.Sval : null;
+            return string.Equals(name, "count", StringComparison.OrdinalIgnoreCase);
+        }
+
         private static bool LogSuccess(string sql, string rql)
         {
             if (Logger.IsInfoEnabled)
@@ -133,7 +217,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             return false;
         }
 
-        private static string TranslateSelectStatement(SelectStmt selectStmt, DocumentDatabase documentDatabase = null)
+        private static string TranslateSelectStatement(SelectStmt selectStmt, DocumentDatabase documentDatabase = null, bool asScalarCount = false)
         {
             if (selectStmt.FromClause is [{ JoinExpr: not null }])
                 return TranslateSimpleJoin(selectStmt);
@@ -160,6 +244,12 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             if (isGroupBy)
             {
                 ApplyGroupBy(q, selectStmt, fromAlias);
+            }
+            else if (asScalarCount)
+            {
+                // The caller runs this as an RQL count query, so neither the projection nor the SQL
+                // bounds may be emitted: in SQL they cap the single output row, not the count.
+                return BuildRql(q);
             }
             else
             {
@@ -196,6 +286,11 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 q.Take(limit.Value);
             }
 
+            return BuildRql(q);
+        }
+
+        private static string BuildRql(AsyncDocumentQuery<JObject> q)
+        {
             // Prefer the official query text emitted by IndexQuery when possible.
             // Falls back to ToString() which also returns pure RQL.
             var indexQuery = q.GetIndexQuery();

--- a/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
@@ -30,6 +30,15 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
         // ad-hoc throws elsewhere still use NotSupportedException(string) until migrated.
         private static PgTranslationException UnsupportedSelectAggregate() =>
             new(TranslationFailureCategory.Aggregate, "Unsupported SELECT aggregate");
+        // DISTINCT / FILTER / OVER each change which values the aggregate sees, and RQL's grouped
+        // select can express none of them — emitting the plain aggregate returns the whole group's
+        // value instead, with no error.
+        private static PgTranslationException UnsupportedAggregateModifier(string modifier) =>
+            new(TranslationFailureCategory.Aggregate, $"Aggregate {modifier} is not supported");
+        // RQL's count() is the group's row count and ignores its argument, so it cannot express
+        // SQL's count(<column>) (which counts non-null values only).
+        private static PgTranslationException UnsupportedCountArgument() =>
+            new(TranslationFailureCategory.Aggregate, "count(<column>) is not supported");
         // Scalar aggregate (all-aggregate SELECT with no GROUP BY) and avg() have no RQL form —
         // bail so PgQuery falls through to UnhandledQueryDiagnoser for a user-facing explanation
         // instead of emitting RQL the engine rejects at execution time with an opaque error.
@@ -664,6 +673,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
 
             var projections = new List<string>(capacity: targets.Count);
             var aggregates = new List<GroupByAggregate>(capacity: targets.Count);
+            var groupKeyProjected = false;
             foreach (var t in targets)
             {
                 var val = t.ResTarget?.Val;
@@ -672,7 +682,8 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
 
                 if (val.FuncCall == null)
                 {
-                    projections.Add(BuildProjectionForGroupByTarget(val, groupFieldName, fromAlias));
+                    projections.Add(BuildProjectionForGroupByTarget(val, groupFieldName, t.ResTarget?.Name, fromAlias));
+                    groupKeyProjected = true;
                     continue;
                 }
 
@@ -685,7 +696,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             q.SelectFields<JObject>(projections.ToArray());
 
             if (selectStmt.SortClause != null && selectStmt.SortClause.Count > 0)
-                TranslateOrderByForGroupBy(q, selectStmt.SortClause, groupFieldName, projections, aggregates, fromAlias);
+                TranslateOrderByForGroupBy(q, selectStmt.SortClause, groupFieldName, groupKeyProjected, aggregates, fromAlias);
         }
 
         // True iff every column referenced by the WHERE predicate is in <paramref name="allowed"/>.
@@ -742,7 +753,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             AsyncDocumentQuery<JObject> q,
             Google.Protobuf.Collections.RepeatedField<Node> sortClause,
             string groupFieldName,
-            IReadOnlyList<string> projections,
+            bool groupKeyProjected,
             IReadOnlyList<GroupByAggregate> aggregates,
             string fromAlias = null)
         {
@@ -763,10 +774,11 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
 
                     if (string.Equals(fieldName, groupFieldName, StringComparison.OrdinalIgnoreCase))
                     {
-                        if (projections.Any(p => string.Equals(p, groupFieldName, StringComparison.OrdinalIgnoreCase)) == false)
+                        if (groupKeyProjected == false)
                             throw UnsupportedOrderByForGroupBy();
 
-                        orderField = projections.First(p => string.Equals(p, groupFieldName, StringComparison.OrdinalIgnoreCase));
+                        // RQL sorts by the reduced field, so the key's SELECT alias is irrelevant here.
+                        orderField = groupFieldName;
                         ordering = OrderingType.String;
                     }
                     else
@@ -1018,24 +1030,30 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             return funcCall.Args[0];
         }
 
+        private static void RejectUnsupportedAggregateModifiers(FuncCall funcCall)
+        {
+            if (funcCall.AggDistinct)
+                throw UnsupportedAggregateModifier("DISTINCT");
+
+            if (funcCall.AggFilter != null)
+                throw UnsupportedAggregateModifier("FILTER (WHERE ...)");
+
+            if (funcCall.Over != null)
+                throw UnsupportedAggregateModifier("OVER (window function)");
+        }
+
         private static string BuildCountProjection(FuncCall funcCall, string fromAlias = null)
         {
+            RejectUnsupportedAggregateModifiers(funcCall);
+
             if (funcCall.AggStar)
                 return "count()";
 
             var countArg = GetSingleArgOrThrow(funcCall);
             if (countArg.ColumnRef != null)
-            {
-                var countFieldName = ExtractFieldName(countArg, fromAlias);
-                if (string.IsNullOrWhiteSpace(countFieldName))
-                    throw UnsupportedSelectAggregate();
-                // Aggregate args go into a verbatim RQL string that is also matched for order-by, so
-                // restrict to bare identifiers rather than quoting.
-                if (IsSafeRqlFieldPath(countFieldName) == false)
-                    throw UnsupportedSelectAggregate();
-                return $"count({countFieldName})";
-            }
+                throw UnsupportedCountArgument();
 
+            // count(1) / count('x') count every row, which is exactly count(*).
             if (countArg.AConst != null)
                 return "count()";
 
@@ -1044,6 +1062,8 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
 
         private static string BuildSingleColumnAggregateProjection(string funcName, FuncCall funcCall, string fromAlias = null)
         {
+            RejectUnsupportedAggregateModifiers(funcCall);
+
             var arg0 = GetSingleArgOrThrow(funcCall);
             if (arg0?.ColumnRef == null)
                 throw UnsupportedSelectAggregate();
@@ -1058,7 +1078,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             return $"{funcName}({fieldName})";
         }
 
-        private static string BuildProjectionForGroupByTarget(Node val, string groupFieldName, string fromAlias = null)
+        private static string BuildProjectionForGroupByTarget(Node val, string groupFieldName, string sqlAlias, string fromAlias = null)
         {
             if (val.ColumnRef == null)
                 throw UnsupportedGroupBy();
@@ -1070,7 +1090,14 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             if (IsSafeRqlFieldPath(groupFieldName) == false)
                 throw UnsupportedGroupBy();
 
-            return groupFieldName;
+            if (string.IsNullOrWhiteSpace(sqlAlias) ||
+                string.Equals(sqlAlias, groupFieldName, StringComparison.OrdinalIgnoreCase))
+                return groupFieldName;
+
+            if (IsSafeRqlIdentifier(sqlAlias) == false)
+                throw UnsupportedGroupBy();
+
+            return $"{groupFieldName} as {sqlAlias}";
         }
 
         // OrderField/Ordering describe how RQL refers to the aggregate in an `order by` clause:

--- a/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
@@ -262,7 +262,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             }
             else
             {
-                ApplySelectProjection(q, selectStmt, fromAlias);
+                var aliasToField = ApplySelectProjection(q, selectStmt, fromAlias);
 
                 // Build ORDER BY clause. Type-infer sort fields from a doc sample (when the
                 // database is available) so numeric fields sort numerically instead of falling
@@ -270,8 +270,8 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 // have a "first document" in the collection-sampling sense.
                 if (selectStmt.SortClause != null && selectStmt.SortClause.Count > 0)
                 {
-                    var sortTypeMap = isIndex ? null : TryBuildSortTypeMap(documentDatabase, relname, selectStmt.SortClause, fromAlias);
-                    TranslateOrderBy(q, selectStmt.SortClause, fromAlias, sortTypeMap);
+                    var sortTypeMap = isIndex ? null : TryBuildSortTypeMap(documentDatabase, relname, selectStmt.SortClause, fromAlias, aliasToField);
+                    TranslateOrderBy(q, selectStmt.SortClause, fromAlias, sortTypeMap, aliasToField);
                 }
             }
 
@@ -826,14 +826,14 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             return (aggregate.OrderField, aggregate.Ordering);
         }
 
-        private static void ApplySelectProjection(AsyncDocumentQuery<JObject> q, SelectStmt selectStmt, string fromAlias)
+        private static IReadOnlyDictionary<string, string> ApplySelectProjection(AsyncDocumentQuery<JObject> q, SelectStmt selectStmt, string fromAlias)
         {
             var targets = selectStmt.TargetList;
             if (targets == null || targets.Count == 0)
-                return;
+                return null;
 
             if (IsSelectStar(targets))
-                return;
+                return null;
 
             var isDistinct = selectStmt.DistinctClause is { Count: > 0 };
             var anyAgg = targets.Any(IsAggregateTarget);
@@ -853,17 +853,19 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 throw ScalarAggregateWithoutGroupBy();
             }
 
-            var (projectionFields, projectionAliases) = BuildColumnProjections(targets, fromAlias);
+            var (projectionFields, projectionAliases, aliasToField) = BuildColumnProjections(targets, fromAlias);
             if (isDistinct && projectionFields.Length != 1)
                 throw UnsupportedDistinct();
 
             if (projectionFields.Length == 0)
-                return;
+                return null;
 
             // Distinct Fields vs Projections preserves `1 as "c0"`-style aliases (see BuildColumnProjections).
             q.SelectFields<JObject>(new QueryData(projectionFields, projectionAliases) { IsProjectInto = true });
             if (isDistinct)
                 q.Distinct();
+
+            return aliasToField;
         }
 
         private static bool IsSelectStar(IReadOnlyList<Node> targetList)
@@ -896,10 +898,11 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
         // `<field> as <alias>` when the two differ — which is the only way to preserve
         // PowerBI's aliases for constant projections like `1 as "c0"` (their row-preview
         // queries emit those and would otherwise produce a column-count mismatch).
-        private static (string[] Fields, string[] Aliases) BuildColumnProjections(IReadOnlyList<Node> targetList, string fromAlias)
+        private static (string[] Fields, string[] Aliases, Dictionary<string, string> AliasToField) BuildColumnProjections(IReadOnlyList<Node> targetList, string fromAlias)
         {
             var projectionFields = new List<string>(capacity: targetList.Count);
             var projectionAliases = new List<string>(capacity: targetList.Count);
+            var aliasToField = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var t in targetList)
             {
@@ -921,16 +924,26 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 if (string.IsNullOrWhiteSpace(alias))
                 {
                     projectionAliases.Add(fieldName);
+                    continue;
                 }
-                else
+
+                // SelectFields splices the `as <alias>` name verbatim; quote when needed. PowerBI
+                // aliases columns to the synthetic id()/json() names, which are known tokens.
+                projectionAliases.Add(EscapeProjectionField(alias));
+
+                string sortableField = null;
+                if (val.ColumnRef != null)
                 {
-                    // SelectFields splices the `as <alias>` name verbatim; quote when needed. PowerBI
-                    // aliases columns to the synthetic id()/json() names, which are known tokens.
-                    projectionAliases.Add(EscapeProjectionField(alias));
+                    var raw = ExtractFieldName(val, fromAlias);
+                    if (PgSyntheticColumns.IsDocumentIdColumn(raw) == false)
+                        sortableField = raw;
                 }
+
+                // A null marks an alias over a constant or id(): there is no document field to sort on.
+                aliasToField[alias] = sortableField;
             }
 
-            return (projectionFields.ToArray(), projectionAliases.ToArray());
+            return (projectionFields.ToArray(), projectionAliases.ToArray(), aliasToField);
         }
 
         private static string TranslateSelectTargetValue(Node val, string fromAlias)
@@ -1375,7 +1388,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 ? new PgBoundParameterReference((int)value.Raw)
                 : value.Raw;
 
-        private static void TranslateOrderBy(AsyncDocumentQuery<JObject> q, Google.Protobuf.Collections.RepeatedField<Node> sortClause, string fromAlias, IReadOnlyDictionary<string, OrderingType> sortTypeMap = null)
+        private static void TranslateOrderBy(AsyncDocumentQuery<JObject> q, Google.Protobuf.Collections.RepeatedField<Node> sortClause, string fromAlias, IReadOnlyDictionary<string, OrderingType> sortTypeMap = null, IReadOnlyDictionary<string, string> aliasToField = null)
         {
             // Fail the translation rather than silently dropping a sort key we can't map to a column -
             // a missing ORDER BY term returns mis-ordered rows with no error (caller falls through to the diagnoser).
@@ -1387,6 +1400,11 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 var fieldName = ExtractFieldName(sortBy.Node, fromAlias);
                 if (string.IsNullOrEmpty(fieldName))
                     throw new NotSupportedException("Unsupported ORDER BY expression (only column sort keys are supported)");
+
+                if (TryResolveOrderByField(fieldName, aliasToField, out var resolved) == false)
+                    throw new NotSupportedException($"Unsupported ORDER BY target \"{fieldName}\" (the SELECT alias does not name a document field)");
+
+                fieldName = resolved;
 
                 // Pick the right ordering: type-inferred from the sampled doc when we have it,
                 // otherwise PG-style default (String / alphabetic).
@@ -1410,11 +1428,27 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
         // find `Freight` and will fall back to String ordering — the same surface area issue users
         // hit with unquoted WHERE clauses. Quoting (`ORDER BY "Freight"`) preserves case and the
         // type inference kicks in.
+        // ORDER BY may name a SELECT alias instead of a field. RQL sorts on the underlying document
+        // field, so the alias has to be resolved back or the sort targets a field that does not exist.
+        // False means the alias names a constant or id(), which has no field to sort on.
+        private static bool TryResolveOrderByField(string fieldName, IReadOnlyDictionary<string, string> aliasToField, out string resolved)
+        {
+            if (aliasToField == null || aliasToField.TryGetValue(fieldName, out var aliased) == false)
+            {
+                resolved = fieldName;
+                return true;
+            }
+
+            resolved = aliased;
+            return aliased != null;
+        }
+
         private static Dictionary<string, OrderingType> TryBuildSortTypeMap(
             DocumentDatabase documentDatabase,
             string collection,
             Google.Protobuf.Collections.RepeatedField<Node> sortClause,
-            string fromAlias)
+            string fromAlias,
+            IReadOnlyDictionary<string, string> aliasToField = null)
         {
             if (documentDatabase == null || string.IsNullOrWhiteSpace(collection))
                 return null;
@@ -1429,7 +1463,9 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 var name = ExtractFieldName(sortNode.SortBy.Node, fromAlias);
                 if (string.IsNullOrEmpty(name))
                     continue;
-                fieldNames.Add(name);
+                if (TryResolveOrderByField(name, aliasToField, out var resolved) == false)
+                    continue;
+                fieldNames.Add(resolved);
             }
 
             if (fieldNames.Count == 0)

--- a/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
@@ -643,12 +643,12 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                     if (string.IsNullOrWhiteSpace(field) || groupSet.Contains(field) == false)
                         throw UnsupportedGroupBy();
 
-                    projected.Add(field);
+                    projected.Add(BuildDistinctRowProjection(field, t.ResTarget?.Name));
                 }
 
                 if (groupFieldNames.Count == 1)
                 {
-                    q.SelectFields<JObject>(projected.Select(EscapeProjectionField).ToArray());
+                    q.SelectFields<JObject>(projected.ToArray());
                     q.Distinct();
                 }
                 else
@@ -660,7 +660,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                         ? groupFieldNames.GetRange(1, groupFieldNames.Count - 1).ToArray()
                         : Array.Empty<string>();
                     q.GroupBy(firstKey, restKeys);
-                    q.SelectFields<JObject>(projected.Select(EscapeProjectionField).ToArray());
+                    q.SelectFields<JObject>(projected.ToArray());
                 }
                 return;
             }
@@ -1076,6 +1076,17 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 throw UnsupportedSelectAggregate();
 
             return $"{funcName}({fieldName})";
+        }
+
+        // An alias equal to the key adds nothing and would make RQL reject the duplicate alias.
+        private static string BuildDistinctRowProjection(string field, string sqlAlias)
+        {
+            var projection = EscapeProjectionField(field);
+            if (string.IsNullOrWhiteSpace(sqlAlias) ||
+                string.Equals(sqlAlias, field, StringComparison.OrdinalIgnoreCase))
+                return projection;
+
+            return $"{projection} as {EscapeProjectionField(sqlAlias)}";
         }
 
         private static string BuildProjectionForGroupByTarget(Node val, string groupFieldName, string sqlAlias, string fromAlias = null)

--- a/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslator.cs
@@ -763,6 +763,8 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 if (sortBy == null)
                     continue;
 
+                RejectUnsupportedSortModifiers(sortNode);
+
                 string orderField;
                 OrderingType ordering;
 
@@ -1397,6 +1399,8 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 var sortBy = sortNode.SortBy
                              ?? throw new NotSupportedException("Unsupported ORDER BY clause (only column sort keys are supported)");
 
+                RejectUnsupportedSortModifiers(sortNode);
+
                 var fieldName = ExtractFieldName(sortBy.Node, fromAlias);
                 if (string.IsNullOrEmpty(fieldName))
                     throw new NotSupportedException("Unsupported ORDER BY expression (only column sort keys are supported)");
@@ -1419,15 +1423,21 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             }
         }
 
-        // Samples the first document of the collection to learn the blittable token type of each
-        // ORDER BY field, mapped to RQL OrderingType. Returns null if the database isn't available
-        // or the collection is empty — callers fall back to OrderingType.String in that case.
-        //
-        // Field lookups are case-sensitive against the document's stored property names. This
-        // means an unquoted `ORDER BY Freight` (case-folded to `freight` by libpg_query) won't
-        // find `Freight` and will fall back to String ordering — the same surface area issue users
-        // hit with unquoted WHERE clauses. Quoting (`ORDER BY "Freight"`) preserves case and the
-        // type inference kicks in.
+        // RQL has no NULLS FIRST / NULLS LAST and no operator-driven sort, and its own null ordering is
+        // not guaranteed to match what was asked for, so an approximation would sort by something else.
+        private static void RejectUnsupportedSortModifiers(Node sortNode)
+        {
+            var sortBy = sortNode.SortBy;
+            if (sortBy == null)
+                return;
+
+            if (sortBy.SortbyNulls is SortByNulls.First or SortByNulls.Last)
+                throw new NotSupportedException("Unsupported ORDER BY clause (NULLS FIRST / NULLS LAST is not supported)");
+
+            if (sortBy.SortbyDir == SortByDir.SortbyUsing)
+                throw new NotSupportedException("Unsupported ORDER BY clause (ORDER BY ... USING is not supported)");
+        }
+
         // ORDER BY may name a SELECT alias instead of a field. RQL sorts on the underlying document
         // field, so the alias has to be resolved back or the sort targets a field that does not exist.
         // False means the alias names a constant or id(), which has no field to sort on.
@@ -1443,6 +1453,15 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             return aliased != null;
         }
 
+        // Samples the first document of the collection to learn the blittable token type of each
+        // ORDER BY field, mapped to RQL OrderingType. Returns null if the database isn't available
+        // or the collection is empty — callers fall back to OrderingType.String in that case.
+        //
+        // Field lookups are case-sensitive against the document's stored property names. This
+        // means an unquoted `ORDER BY Freight` (case-folded to `freight` by libpg_query) won't
+        // find `Freight` and will fall back to String ordering — the same surface area issue users
+        // hit with unquoted WHERE clauses. Quoting (`ORDER BY "Freight"`) preserves case and the
+        // type inference kicks in.
         private static Dictionary<string, OrderingType> TryBuildSortTypeMap(
             DocumentDatabase documentDatabase,
             string collection,

--- a/src/Raven.Server/Integrations/PostgreSQL/Translation/SqlWhereTranslation.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Translation/SqlWhereTranslation.cs
@@ -239,6 +239,12 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 return true;
             }
 
+            // IS [NOT] DISTINCT FROM, NULLIF and the ANY/ALL forms are all built as an A_Expr whose
+            // operator name is a plain "=", so without this gate they pass IsKnownBinaryOp and become
+            // an ordinary equality test — the inverse of what IS DISTINCT FROM means.
+            if (IsAExprKind(aExpr, A_Expr_Kind.AexprOp) == false)
+                return false;
+
             if (IsKnownBinaryOp(op) == false)
                 return false;
 

--- a/src/Raven.Server/Integrations/PostgreSQL/Translation/SqlWhereTranslation.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Translation/SqlWhereTranslation.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 using PgSqlParser;
 using Sparrow.Extensions;
 
@@ -328,6 +329,9 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
             if (TryExtractTimestampLiteral(node, out value))
                 return true;
 
+            if (TryExtractTimestampFunction(node, out value))
+                return true;
+
             var c = node.AConst;
             if (c == null)
                 return false;
@@ -444,6 +448,97 @@ namespace Raven.Server.Integrations.PostgreSQL.Translation
                 return false;
 
             value = new ParsedValue(dt.GetDefaultRavenFormat(), ParsedValueKind.Timestamp);
+            return true;
+        }
+
+        // Superset's Time Range filter emits every datetime bound as to_timestamp(<literal>, <format>).
+        private static bool TryExtractTimestampFunction(Node node, out ParsedValue value)
+        {
+            value = null;
+
+            if (node?.FuncCall?.Funcname is not { Count: > 0 } names)
+                return false;
+
+            var funcName = names[names.Count - 1]?.String?.Sval;
+            var dateOnly = string.Equals(funcName, "to_date", StringComparison.OrdinalIgnoreCase);
+            if (dateOnly == false && string.Equals(funcName, "to_timestamp", StringComparison.OrdinalIgnoreCase) == false)
+                return false;
+
+            // The single-argument to_timestamp(epoch) overload takes no format string; only the
+            // two-literal form is recognised, everything else falls through to rejection.
+            if (node.FuncCall.Args is not { Count: 2 } args)
+                return false;
+
+            var raw = args[0]?.AConst?.Sval?.Sval;
+            var format = args[1]?.AConst?.Sval?.Sval;
+            if (raw == null || format == null)
+                return false;
+
+            if (TryConvertPgDateFormat(format, out var netFormat) == false)
+                return false;
+
+            if (DateTime.TryParseExact(raw, netFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt) == false)
+                return false;
+
+            if (dateOnly)
+                dt = dt.Date;
+
+            value = new ParsedValue(dt.GetDefaultRavenFormat(), ParsedValueKind.Timestamp);
+            return true;
+        }
+
+        private static readonly (string Pg, string Net)[] PgDateFormatTokens =
+        {
+            ("YYYY", "yyyy"),
+            ("HH24", "HH"),
+            ("MM", "MM"),
+            ("DD", "dd"),
+            ("MI", "mm"),
+            ("SS", "ss"),
+            ("US", "ffffff"),
+            ("MS", "fff"),
+        };
+
+        private const string PgDateFormatSeparators = "-/:. ,T";
+
+        // Only the subset of PG's format language listed above translates; an unrecognised token has to
+        // fail the whole format rather than be passed through as a literal, which would shift the value.
+        private static bool TryConvertPgDateFormat(string format, out string netFormat)
+        {
+            netFormat = null;
+            if (string.IsNullOrWhiteSpace(format))
+                return false;
+
+            var builder = new StringBuilder(format.Length * 2);
+            var i = 0;
+            while (i < format.Length)
+            {
+                var matched = false;
+                foreach (var (pg, net) in PgDateFormatTokens)
+                {
+                    if (i + pg.Length > format.Length)
+                        continue;
+
+                    if (string.Compare(format, i, pg, 0, pg.Length, StringComparison.OrdinalIgnoreCase) != 0)
+                        continue;
+
+                    builder.Append(net);
+                    i += pg.Length;
+                    matched = true;
+                    break;
+                }
+
+                if (matched)
+                    continue;
+
+                if (PgDateFormatSeparators.IndexOf(format[i]) < 0)
+                    return false;
+
+                builder.Append('\\').Append(format[i]);
+                i++;
+            }
+
+            netFormat = builder.ToString();
             return true;
         }
     }

--- a/src/Raven.Server/Integrations/PostgreSQL/UnhandledQueryDiagnoser.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/UnhandledQueryDiagnoser.cs
@@ -74,6 +74,26 @@ namespace Raven.Server.Integrations.PostgreSQL
                 return true;
             }
 
+            if (TryGetUnsupportedAggregateModifier(outer, out var modifier))
+            {
+                message = $"An aggregate with {modifier} is not supported. RavenDB's map-reduce aggregates every row that falls into a group, so there is no way to de-duplicate, pre-filter or window the values being aggregated — `count(DISTINCT x)`, `sum(DISTINCT x)`, `count(*) FILTER (WHERE ...)` and `count(*) OVER (...)` would all silently return the plain count/sum over the whole group. De-duplicate or filter client-side, or group by the column so each group already holds only the values you want.";
+                return true;
+            }
+
+            if (HasCountOverColumn(outer))
+            {
+                message = "count(<column>) is not supported — only count(*). PostgreSQL counts the non-NULL values of the named column, while RavenDB's count() returns the group's total row count and ignores the argument, so the two disagree for every document that is missing the field. Use count(*) for the row count, or compute the non-null count client-side.";
+                return true;
+            }
+
+            // Before the scalar-aggregate check: these predicates make `SELECT count(*) ... WHERE x IS
+            // DISTINCT FROM y` fail translation, and blaming the aggregate would hide the real cause.
+            if (HasDistinctFromPredicate(outer))
+            {
+                message = "IS DISTINCT FROM / IS NOT DISTINCT FROM (and NULLIF used as a predicate) are not supported. PostgreSQL builds them from a plain `=` operator that differs only in how it treats NULL, and RavenDB does not distinguish a stored null from a missing field, so neither form can be translated without changing which documents match. Combine `=` / `!=` with an explicit `IS NULL` / `IS NOT NULL` check, or run the query as RQL.";
+                return true;
+            }
+
             if (IsScalarAggregateWithoutGroupBy(outer))
             {
                 message = "Scalar aggregate without GROUP BY is supported for `count(*)` only. RavenDB's sum() is a map-reduce aggregation that requires a GROUP BY, so `SELECT sum(...) FROM t` with no grouping has no RQL form — compute the aggregate client-side from the underlying rows.";
@@ -395,6 +415,99 @@ namespace Raven.Server.Integrations.PostgreSQL
                     return true;
             }
             return false;
+        }
+
+        private static bool TryGetUnsupportedAggregateModifier(SelectStmt selectStmt, out string modifier)
+        {
+            modifier = null;
+
+            if (selectStmt.TargetList is not { Count: > 0 } targets)
+                return false;
+
+            foreach (var t in targets)
+            {
+                var funcCall = t?.ResTarget?.Val?.FuncCall;
+                if (funcCall == null)
+                    continue;
+
+                if (funcCall.AggDistinct)
+                    modifier = "DISTINCT";
+                else if (funcCall.AggFilter != null)
+                    modifier = "a FILTER (WHERE ...) clause";
+                else if (funcCall.Over != null)
+                    modifier = "an OVER (...) window clause";
+                else
+                    continue;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool HasCountOverColumn(SelectStmt selectStmt)
+        {
+            if (selectStmt.TargetList is not { Count: > 0 } targets)
+                return false;
+
+            foreach (var t in targets)
+            {
+                var funcCall = t?.ResTarget?.Val?.FuncCall;
+                if (funcCall == null || funcCall.AggStar)
+                    continue;
+
+                var name = funcCall.Funcname is { Count: > 0 }
+                    ? funcCall.Funcname[funcCall.Funcname.Count - 1]?.String?.Sval
+                    : null;
+                if (string.Equals(name, "count", System.StringComparison.OrdinalIgnoreCase) == false)
+                    continue;
+
+                if (funcCall.Args is { Count: 1 } && funcCall.Args[0]?.ColumnRef != null)
+                    return true;
+            }
+
+            return false;
+        }
+
+        // PG parses IS [NOT] DISTINCT FROM and NULLIF into an A_Expr whose operator name is "=", so
+        // only the Kind separates them from real equality.
+        private static bool HasDistinctFromPredicate(SelectStmt selectStmt)
+        {
+            var wheres = new List<Node>();
+            CollectWhereClauses(selectStmt, wheres, depth: 0);
+
+            foreach (var where in wheres)
+            {
+                if (HasDistinctFromPredicate(where, depth: 0))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool HasDistinctFromPredicate(Node node, int depth)
+        {
+            if (node == null || depth >= MaxJoinSearchDepth)
+                return false;
+
+            if (node.BoolExpr?.Args is { } args)
+            {
+                foreach (var arg in args)
+                {
+                    if (HasDistinctFromPredicate(arg, depth + 1))
+                        return true;
+                }
+                return false;
+            }
+
+            if (node.AExpr is not { } aExpr)
+                return false;
+
+            if (aExpr.Kind is A_Expr_Kind.AexprDistinct or A_Expr_Kind.AexprNotDistinct or A_Expr_Kind.AexprNullif)
+                return true;
+
+            return HasDistinctFromPredicate(aExpr.Lexpr, depth + 1)
+                || HasDistinctFromPredicate(aExpr.Rexpr, depth + 1);
         }
 
         // True iff every projection is an aggregate FuncCall (count/sum/avg/min/max) with no GROUP BY key.

--- a/src/Raven.Server/Integrations/PostgreSQL/UnhandledQueryDiagnoser.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/UnhandledQueryDiagnoser.cs
@@ -100,6 +100,11 @@ namespace Raven.Server.Integrations.PostgreSQL
                 return true;
             }
 
+            // count(*) on its own translates, so when a scalar count(*) query still failed the aggregate
+            // is not the cause — blame the WHERE clause when that is what the translator choked on.
+            if (IsSupportedScalarCountStar(outer) && TryDiagnoseWhereClause(outer, out message))
+                return true;
+
             if (IsScalarAggregateWithoutGroupBy(outer))
             {
                 message = "Scalar aggregate without GROUP BY is supported for `count(*)` only. RavenDB's sum() is a map-reduce aggregation that requires a GROUP BY, so `SELECT sum(...) FROM t` with no grouping has no RQL form — compute the aggregate client-side from the underlying rows.";
@@ -449,6 +454,85 @@ namespace Raven.Server.Integrations.PostgreSQL
             }
 
             return false;
+        }
+
+        private static bool IsSupportedScalarCountStar(SelectStmt selectStmt)
+        {
+            if (selectStmt.GroupClause is { Count: > 0 })
+                return false;
+
+            if (selectStmt.TargetList is not { Count: 1 } targets)
+                return false;
+
+            var funcCall = targets[0]?.ResTarget?.Val?.FuncCall;
+            if (funcCall is not { AggStar: true })
+                return false;
+
+            if (funcCall.AggDistinct || funcCall.AggFilter != null || funcCall.Over != null)
+                return false;
+
+            var name = funcCall.Funcname is { Count: > 0 }
+                ? funcCall.Funcname[funcCall.Funcname.Count - 1]?.String?.Sval
+                : null;
+
+            return string.Equals(name, "count", StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Uses the translator's own WHERE parser as the oracle so the diagnoser can't drift from what is
+        // actually supported, then names the offending operator when the AST identifies one.
+        private static bool TryDiagnoseWhereClause(SelectStmt selectStmt, out string message)
+        {
+            message = null;
+
+            if (selectStmt.WhereClause == null)
+                return false;
+
+            if (SqlWhereParser.TryParse(selectStmt.WhereClause, outerAliasToStrip: null, out _))
+                return false;
+
+            message = TryGetUnsupportedPredicateName(selectStmt.WhereClause, depth: 0, out var predicate)
+                ? $"The WHERE clause uses {predicate}, which is not supported. The aggregate itself is fine — `count(*)` translates on its own — so rewrite just the predicate (for example express NOT BETWEEN as `< lower OR > upper`), or run the query as RQL."
+                : "The WHERE clause could not be translated. The aggregate itself is fine — `count(*)` translates on its own — so the unsupported part is the predicate: simplify it to comparisons, IN, BETWEEN, LIKE and IS [NOT] NULL combined with AND / OR / NOT, or run the query as RQL.";
+
+            return true;
+        }
+
+        private static bool TryGetUnsupportedPredicateName(Node node, int depth, out string predicate)
+        {
+            predicate = null;
+            if (node == null || depth >= MaxJoinSearchDepth)
+                return false;
+
+            if (node.BoolExpr?.Args is { } args)
+            {
+                foreach (var arg in args)
+                {
+                    if (TryGetUnsupportedPredicateName(arg, depth + 1, out predicate))
+                        return true;
+                }
+
+                return false;
+            }
+
+            if (node.AExpr is not { } aExpr)
+                return false;
+
+            predicate = aExpr.Kind switch
+            {
+                A_Expr_Kind.AexprNotBetween => "NOT BETWEEN",
+                A_Expr_Kind.AexprBetweenSym => "BETWEEN SYMMETRIC",
+                A_Expr_Kind.AexprNotBetweenSym => "NOT BETWEEN SYMMETRIC",
+                A_Expr_Kind.AexprSimilar => "SIMILAR TO",
+                A_Expr_Kind.AexprOpAny => "an ANY (...) comparison",
+                A_Expr_Kind.AexprOpAll => "an ALL (...) comparison",
+                _ => null
+            };
+
+            if (predicate != null)
+                return true;
+
+            return TryGetUnsupportedPredicateName(aExpr.Lexpr, depth + 1, out predicate)
+                || TryGetUnsupportedPredicateName(aExpr.Rexpr, depth + 1, out predicate);
         }
 
         private static bool TryGetUnsupportedSortModifier(SelectStmt selectStmt, out string modifier)

--- a/src/Raven.Server/Integrations/PostgreSQL/UnhandledQueryDiagnoser.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/UnhandledQueryDiagnoser.cs
@@ -94,6 +94,12 @@ namespace Raven.Server.Integrations.PostgreSQL
                 return true;
             }
 
+            if (TryGetUnsupportedSortModifier(outer, out var sortModifier))
+            {
+                message = $"ORDER BY ... {sortModifier} is not supported. RavenDB orders missing and null values by its own rule, which is not guaranteed to match PostgreSQL's, and RQL cannot express a per-key null placement or a sort driven by an operator — so the clause is rejected rather than silently sorted a different way. Drop the clause if the default ordering will do, or sort the rows client-side.";
+                return true;
+            }
+
             if (IsScalarAggregateWithoutGroupBy(outer))
             {
                 message = "Scalar aggregate without GROUP BY is supported for `count(*)` only. RavenDB's sum() is a map-reduce aggregation that requires a GROUP BY, so `SELECT sum(...) FROM t` with no grouping has no RQL form — compute the aggregate client-side from the underlying rows.";
@@ -436,6 +442,32 @@ namespace Raven.Server.Integrations.PostgreSQL
                     modifier = "a FILTER (WHERE ...) clause";
                 else if (funcCall.Over != null)
                     modifier = "an OVER (...) window clause";
+                else
+                    continue;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetUnsupportedSortModifier(SelectStmt selectStmt, out string modifier)
+        {
+            modifier = null;
+
+            if (selectStmt.SortClause is not { Count: > 0 } sortClause)
+                return false;
+
+            foreach (var sortNode in sortClause)
+            {
+                var sortBy = sortNode?.SortBy;
+                if (sortBy == null)
+                    continue;
+
+                if (sortBy.SortbyNulls is SortByNulls.First or SortByNulls.Last)
+                    modifier = "NULLS FIRST / NULLS LAST";
+                else if (sortBy.SortbyDir == SortByDir.SortbyUsing)
+                    modifier = "USING <operator>";
                 else
                     continue;
 

--- a/src/Raven.Server/Integrations/PostgreSQL/UnhandledQueryDiagnoser.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/UnhandledQueryDiagnoser.cs
@@ -76,7 +76,7 @@ namespace Raven.Server.Integrations.PostgreSQL
 
             if (IsScalarAggregateWithoutGroupBy(outer))
             {
-                message = "Scalar aggregate (e.g. `SELECT sum(...) FROM t` with no GROUP BY) is not yet supported. Wrap the query in a GROUP BY (even a constant key) or compute the aggregate client-side from the underlying rows.";
+                message = "Scalar aggregate without GROUP BY is supported for `count(*)` only. RavenDB's sum() is a map-reduce aggregation that requires a GROUP BY, so `SELECT sum(...) FROM t` with no grouping has no RQL form — compute the aggregate client-side from the underlying rows.";
                 return true;
             }
 

--- a/test/FastTests/Server/Integrations/PostgreSQL/PgDateBoundFilterTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/PgDateBoundFilterTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Server.Documents;
+using Raven.Server.Integrations.PostgreSQL;
+using Raven.Server.Integrations.PostgreSQL.Messages;
+using Tests.Infrastructure;
+using Xunit;
+using static Tests.Infrastructure.PostgreSqlHelper;
+
+namespace FastTests.Server.Integrations.PostgreSQL
+{
+    public sealed class PgDateBoundFilterTests(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        private const string SupersetFormat = "YYYY-MM-DD HH24:MI:SS";
+
+        private const string Select = "SELECT \"Company\" FROM public.\"Orders\" WHERE ";
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task Bound_before_the_range_keeps_every_order()
+        {
+            using var store = GetDocumentStore();
+            var database = await Seed(store);
+
+            Assert.Equal(
+                new[] { "A", "B", "C", "D", "E" },
+                await Companies(Select + Bound(">=", "1996-01-01 00:00:00"), store, database));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task Bound_inside_the_range_filters()
+        {
+            using var store = GetDocumentStore();
+            var database = await Seed(store);
+
+            Assert.Equal(
+                new[] { "C", "D", "E" },
+                await Companies(Select + Bound(">=", "1996-09-01 00:00:00"), store, database));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task Bound_after_the_range_keeps_nothing()
+        {
+            using var store = GetDocumentStore();
+            var database = await Seed(store);
+
+            Assert.Empty(await Companies(Select + Bound(">=", "1999-01-01 00:00:00"), store, database));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task Half_open_window_keeps_only_the_orders_inside_it()
+        {
+            using var store = GetDocumentStore();
+            var database = await Seed(store);
+
+            Assert.Equal(
+                new[] { "A", "B", "C" },
+                await Companies(
+                    Select + Bound(">=", "1996-07-01 00:00:00") + " AND " + Bound("<", "1996-10-01 00:00:00"),
+                    store, database));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task ToDate_bound_filters_on_the_date_alone()
+        {
+            using var store = GetDocumentStore();
+            var database = await Seed(store);
+
+            Assert.Equal(
+                new[] { "C", "D", "E" },
+                await Companies(
+                    Select + "\"OrderedAt\" >= TO_DATE('1996-09-01', 'YYYY-MM-DD')", store, database));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task ToTimestamp_bound_agrees_with_the_equivalent_cast()
+        {
+            using var store = GetDocumentStore();
+            var database = await Seed(store);
+
+            var viaFunction = await Companies(Select + Bound(">=", "1996-09-01 00:00:00"), store, database);
+            var viaCast = await Companies(
+                Select + "\"OrderedAt\" >= '1996-09-01 00:00:00'::timestamp", store, database);
+
+            Assert.Equal(viaCast, viaFunction);
+        }
+
+        private static string Bound(string op, string value) =>
+            $"\"OrderedAt\" {op} TO_TIMESTAMP('{value}', '{SupersetFormat}')";
+
+        private async Task<DocumentDatabase> Seed(IDocumentStore store)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order { Company = "A", OrderedAt = new DateTime(1996, 7, 4) });
+                await session.StoreAsync(new Order { Company = "B", OrderedAt = new DateTime(1996, 8, 15) });
+                await session.StoreAsync(new Order { Company = "C", OrderedAt = new DateTime(1996, 9, 20) });
+                await session.StoreAsync(new Order { Company = "D", OrderedAt = new DateTime(1997, 1, 10) });
+                await session.StoreAsync(new Order { Company = "E", OrderedAt = new DateTime(1998, 5, 6) });
+                await session.SaveChangesAsync();
+            }
+
+            return await Databases.GetDocumentDatabaseInstanceFor(store);
+        }
+
+        private async Task<string[]> Companies(string sql, IDocumentStore store, DocumentDatabase database)
+        {
+            await Run(sql, database);
+            Indexes.WaitForIndexing(store);
+            var rows = await Run(sql, database);
+            return rows.Select(r => r[0]).OrderBy(x => x, StringComparer.Ordinal).ToArray();
+        }
+
+        private static async Task<List<string[]>> Run(string sql, DocumentDatabase database)
+        {
+            using var query = PgQuery.CreateInstance(sql, Array.Empty<int>(), database, session: null);
+            await query.Init();
+
+            var token = TestContext.Current.CancellationToken;
+            var pipe = new Pipe();
+            var builder = new MessageBuilder();
+
+            var readTask = ReadAllAsync(pipe.Reader, token);
+            await query.Execute(builder, pipe.Writer, token);
+            await pipe.Writer.CompleteAsync();
+
+            return ParseDataRows(await readTask);
+        }
+
+        private sealed class Order
+        {
+            public string Company { get; set; }
+            public DateTime OrderedAt { get; set; }
+        }
+    }
+}

--- a/test/FastTests/Server/Integrations/PostgreSQL/PgGroupByOrderByAggregateTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/PgGroupByOrderByAggregateTests.cs
@@ -272,6 +272,63 @@ namespace FastTests.Server.Integrations.PostgreSQL
             Assert.Equal(new[] { "10" }, Assert.Single(equal));
         }
 
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task Aggregate_alias_that_is_not_an_identifier_is_kept()
+        {
+            using var store = GetDocumentStore();
+            await Seed(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var (columns, rows) = await RunWarm(
+                "SELECT \"Company\", COUNT(*) AS \"COUNT(*)\" FROM public.\"Orders\" GROUP BY \"Company\" ORDER BY \"COUNT(*)\" DESC LIMIT 5",
+                store, database);
+
+            Assert.Equal(new[] { "Company", "COUNT(*)" }, columns);
+            Assert.Equal(new[] { "Alpha", "Beta", "Gamma" }, rows.Select(r => r[0]));
+            Assert.Equal(new[] { "10", "9", "2" }, rows.Select(r => r[1]));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task Sum_alias_that_is_not_an_identifier_is_kept()
+        {
+            using var store = GetDocumentStore();
+            await Seed(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var (columns, rows) = await RunWarm(
+                "SELECT \"Company\", SUM(\"Freight\") AS \"SUM(Freight)\" FROM public.\"Orders\" GROUP BY \"Company\" LIMIT 5",
+                store, database);
+
+            Assert.Equal(new[] { "Company", "SUM(Freight)" }, columns);
+            Assert.Equal(new[] { "Alpha", "Beta", "Gamma" }, rows.Select(r => r[0]).OrderBy(x => x));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task Identifier_aggregate_alias_is_unchanged()
+        {
+            using var store = GetDocumentStore();
+            await Seed(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var (columns, rows) = await RunWarm(
+                "SELECT \"Company\", COUNT(*) AS total FROM public.\"Orders\" GROUP BY \"Company\" LIMIT 5", store, database);
+
+            Assert.Equal(new[] { "Company", "total" }, columns);
+            Assert.Equal(new[] { "Alpha", "Beta", "Gamma" }, rows.Select(r => r[0]).OrderBy(x => x));
+        }
+
+        // An alias cannot be allowed to break out of the RQL string literal it is spliced into.
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task Aggregate_alias_with_a_quote_is_still_rejected()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            Assert.Throws<PgErrorException>(() => PgQuery.CreateInstance(
+                "SELECT \"Company\", COUNT(*) AS \"c'x\" FROM public.\"Orders\" GROUP BY \"Company\"",
+                Array.Empty<int>(), database, session: null));
+        }
+
         // Alpha: 10 orders x 1.5 freight, Beta: 9 x 1, Gamma: 2 x 1. The counts (10/9/2) and the
         // sums (15/9/2) both order differently under string comparison than under numeric.
         private static async Task Seed(IDocumentStore store)

--- a/test/FastTests/Server/Integrations/PostgreSQL/PgGroupByOrderByAggregateTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/PgGroupByOrderByAggregateTests.cs
@@ -196,6 +196,82 @@ namespace FastTests.Server.Integrations.PostgreSQL
             Assert.Equal(PgErrorCodes.StatementTooComplex, error.ErrorCode);
         }
 
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task GroupKey_alias_is_used_as_the_column_name()
+        {
+            using var store = GetDocumentStore();
+            await Seed(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var (columns, rows) = await RunWarm(
+                "SELECT \"Company\" AS grp, COUNT(*) AS c FROM public.\"Orders\" GROUP BY \"Company\"", store, database);
+
+            Assert.Equal(new[] { "grp", "c" }, columns);
+            Assert.Equal(new[] { "Alpha", "Beta", "Gamma" }, rows.Select(r => r[0]).OrderBy(x => x));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task GroupKey_alias_with_order_by_the_key_still_works()
+        {
+            using var store = GetDocumentStore();
+            await Seed(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var (columns, rows) = await RunWarm(
+                "SELECT \"Company\" AS grp, COUNT(*) AS c FROM public.\"Orders\" GROUP BY \"Company\" ORDER BY \"Company\" DESC", store, database);
+
+            Assert.Equal(new[] { "grp", "c" }, columns);
+            Assert.Equal(new[] { "Gamma", "Beta", "Alpha" }, rows.Select(r => r[0]));
+        }
+
+        // These used to return the plain count(*)/sum() value for every group with no error at all.
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("SELECT \"Company\", count(distinct \"Freight\") FROM public.\"Orders\" GROUP BY \"Company\"")]
+        [InlineData("SELECT \"Company\", count(\"Freight\") FROM public.\"Orders\" GROUP BY \"Company\"")]
+        [InlineData("SELECT \"Company\", sum(distinct \"Freight\") FROM public.\"Orders\" GROUP BY \"Company\"")]
+        [InlineData("SELECT \"Company\", count(*) FILTER (WHERE \"Freight\" > 1) FROM public.\"Orders\" GROUP BY \"Company\"")]
+        [InlineData("SELECT \"Company\", count(*) OVER () FROM public.\"Orders\" GROUP BY \"Company\"")]
+        public async Task GroupByAggregate_withUnsupportedModifierOrColumnArg_returns_a_pg_error(string sql)
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var error = Assert.Throws<PgErrorException>(() => PgQuery.CreateInstance(
+                sql, Array.Empty<int>(), database, session: null));
+
+            Assert.Equal(PgErrorCodes.FeatureNotSupported, error.ErrorCode);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task IsDistinctFrom_returns_a_pg_error_instead_of_an_equality_match()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var error = Assert.Throws<PgErrorException>(() => PgQuery.CreateInstance(
+                "SELECT count(*) FROM public.\"Orders\" WHERE \"Company\" IS DISTINCT FROM 'Alpha'",
+                Array.Empty<int>(), database, session: null));
+
+            Assert.Equal(PgErrorCodes.FeatureNotSupported, error.ErrorCode);
+            Assert.Contains("IS DISTINCT FROM", error.Message);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task NotEquals_and_equals_still_count_correctly()
+        {
+            using var store = GetDocumentStore();
+            await Seed(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var (_, notEqual) = await RunWarm(
+                "SELECT COUNT(*) FROM public.\"Orders\" WHERE \"Company\" != 'Alpha'", store, database);
+            var (_, equal) = await RunWarm(
+                "SELECT COUNT(*) FROM public.\"Orders\" WHERE \"Company\" = 'Alpha'", store, database);
+
+            Assert.Equal(new[] { "11" }, Assert.Single(notEqual));
+            Assert.Equal(new[] { "10" }, Assert.Single(equal));
+        }
+
         // Alpha: 10 orders x 1.5 freight, Beta: 9 x 1, Gamma: 2 x 1. The counts (10/9/2) and the
         // sums (15/9/2) both order differently under string comparison than under numeric.
         private static async Task Seed(IDocumentStore store)

--- a/test/FastTests/Server/Integrations/PostgreSQL/PgGroupByOrderByAggregateTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/PgGroupByOrderByAggregateTests.cs
@@ -8,6 +8,7 @@ using Raven.Server.Documents;
 using Raven.Server.Integrations.PostgreSQL;
 using Raven.Server.Integrations.PostgreSQL.Exceptions;
 using Raven.Server.Integrations.PostgreSQL.Messages;
+using Raven.Server.Integrations.PostgreSQL.Types;
 using Tests.Infrastructure;
 using Xunit;
 using static Tests.Infrastructure.PostgreSqlHelper;
@@ -124,6 +125,77 @@ namespace FastTests.Server.Integrations.PostgreSQL
             Assert.False(string.IsNullOrWhiteSpace(error.Message));
         }
 
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task ScalarCount_returns_the_collection_count()
+        {
+            using var store = GetDocumentStore();
+            await Seed(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            using var query = PgQuery.CreateInstance(
+                "SELECT COUNT(*) FROM public.\"Orders\"", Array.Empty<int>(), database, session: null);
+
+            var column = Assert.Single(await query.Init());
+            Assert.Equal("count", column.Name);
+            Assert.Equal(PgTypeOIDs.Int8, column.PgType.Oid);
+
+            Assert.Equal(new[] { "21" }, Assert.Single(await Drain(query)));
+        }
+
+        // Superset's exact shape: in SQL the LIMIT caps the aggregate's single output row, so it must
+        // not become the engine's page size (which would return 0 rows, or a capped count).
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task ScalarCount_with_a_sql_limit_is_not_capped()
+        {
+            using var store = GetDocumentStore();
+            await Seed(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var (columns, rows) = await Run(
+                "SELECT COUNT(*) AS \"COUNT(*)\" FROM public.\"Orders\" LIMIT 50000", database);
+
+            Assert.Equal(new[] { "COUNT(*)" }, columns);
+            Assert.Equal(new[] { "21" }, Assert.Single(rows));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task ScalarCount_honours_the_where_clause()
+        {
+            using var store = GetDocumentStore();
+            await Seed(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var (_, rows) = await RunWarm(
+                "SELECT COUNT(*) FROM public.\"Orders\" WHERE \"Company\" = 'Beta'", store, database);
+
+            Assert.Equal(new[] { "9" }, Assert.Single(rows));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task ScalarSum_without_group_by_still_returns_a_pg_error()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var error = Assert.Throws<PgErrorException>(() => PgQuery.CreateInstance(
+                "SELECT SUM(\"Freight\") FROM public.\"Orders\"", Array.Empty<int>(), database, session: null));
+
+            Assert.Equal(PgErrorCodes.FeatureNotSupported, error.ErrorCode);
+            Assert.Contains("Scalar aggregate", error.Message);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task Count_mixed_with_a_bare_column_without_group_by_still_returns_a_pg_error()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var error = Assert.Throws<PgErrorException>(() => PgQuery.CreateInstance(
+                "SELECT \"Company\", COUNT(*) FROM public.\"Orders\"", Array.Empty<int>(), database, session: null));
+
+            Assert.Equal(PgErrorCodes.StatementTooComplex, error.ErrorCode);
+        }
+
         // Alpha: 10 orders x 1.5 freight, Beta: 9 x 1, Gamma: 2 x 1. The counts (10/9/2) and the
         // sums (15/9/2) both order differently under string comparison than under numeric.
         private static async Task Seed(IDocumentStore store)
@@ -150,6 +222,11 @@ namespace FastTests.Server.Integrations.PostgreSQL
             using var query = PgQuery.CreateInstance(sql, Array.Empty<int>(), database, session: null);
             var columns = await query.Init();
 
+            return (columns.Select(c => c.Name).ToList(), await Drain(query));
+        }
+
+        private static async Task<List<string[]>> Drain(PgQuery query)
+        {
             var token = TestContext.Current.CancellationToken;
             var pipe = new Pipe();
             var builder = new MessageBuilder();
@@ -157,9 +234,8 @@ namespace FastTests.Server.Integrations.PostgreSQL
             var readTask = ReadAllAsync(pipe.Reader, token);
             await query.Execute(builder, pipe.Writer, token);
             await pipe.Writer.CompleteAsync();
-            var bytes = await readTask;
 
-            return (columns.Select(c => c.Name).ToList(), ParseDataRows(bytes));
+            return ParseDataRows(await readTask);
         }
 
         private sealed class Order

--- a/test/FastTests/Server/Integrations/PostgreSQL/PgGroupByOrderByAggregateTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/PgGroupByOrderByAggregateTests.cs
@@ -317,6 +317,21 @@ namespace FastTests.Server.Integrations.PostgreSQL
             Assert.Equal(new[] { "Alpha", "Beta", "Gamma" }, rows.Select(r => r[0]).OrderBy(x => x));
         }
 
+        // The distinct-rows path: a GROUP BY with no aggregate at all.
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task GroupKey_alias_without_an_aggregate_is_used_as_the_column_name()
+        {
+            using var store = GetDocumentStore();
+            await Seed(store);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var (columns, rows) = await RunWarm(
+                "SELECT \"Company\" AS grp FROM public.\"Orders\" GROUP BY \"Company\" LIMIT 5", store, database);
+
+            Assert.Equal(new[] { "grp" }, columns);
+            Assert.Equal(new[] { "Alpha", "Beta", "Gamma" }, rows.Select(r => r[0]).OrderBy(x => x));
+        }
+
         // An alias cannot be allowed to break out of the RQL string literal it is spliced into.
         [RavenFact(RavenTestCategory.PostgreSql)]
         public async Task Aggregate_alias_with_a_quote_is_still_rejected()

--- a/test/FastTests/Server/Integrations/PostgreSQL/PgOrderByTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/PgOrderByTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Server.Documents;
+using Raven.Server.Integrations.PostgreSQL;
+using Raven.Server.Integrations.PostgreSQL.Exceptions;
+using Raven.Server.Integrations.PostgreSQL.Messages;
+using Tests.Infrastructure;
+using Xunit;
+using static Tests.Infrastructure.PostgreSqlHelper;
+
+namespace FastTests.Server.Integrations.PostgreSQL
+{
+    // ORDER BY on the non-grouped path.
+    public sealed class PgOrderByTests(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task OrderBy_a_select_alias_matches_ordering_by_the_field()
+        {
+            using var store = GetDocumentStore();
+            var database = await Seed(store);
+
+            var viaAlias = await Freights(
+                "SELECT \"Freight\" AS f FROM public.\"Orders\" ORDER BY f LIMIT 5", store, database);
+            var viaField = await Freights(
+                "SELECT \"Freight\" FROM public.\"Orders\" ORDER BY \"Freight\" LIMIT 5", store, database);
+
+            Assert.Equal(new[] { "2", "10" }, viaField);
+            Assert.Equal(viaField, viaAlias);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task OrderBy_a_select_alias_descending_matches_ordering_by_the_field()
+        {
+            using var store = GetDocumentStore();
+            var database = await Seed(store);
+
+            var viaAlias = await Freights(
+                "SELECT \"Freight\" AS f FROM public.\"Orders\" ORDER BY f DESC LIMIT 5", store, database);
+
+            Assert.Equal(new[] { "10", "2" }, viaAlias);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task OrderBy_an_alias_over_a_constant_returns_a_pg_error()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var error = Assert.Throws<PgErrorException>(() => PgQuery.CreateInstance(
+                "SELECT 1 AS c0 FROM public.\"Orders\" ORDER BY c0", Array.Empty<int>(), database, session: null));
+
+            Assert.False(string.IsNullOrWhiteSpace(error.Message));
+        }
+
+        private async Task<DocumentDatabase> Seed(IDocumentStore store)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order { Company = "Alpha", Freight = 10 });
+                await session.StoreAsync(new Order { Company = "Beta", Freight = 2 });
+                await session.SaveChangesAsync();
+            }
+
+            return await Databases.GetDocumentDatabaseInstanceFor(store);
+        }
+
+        private async Task<string[]> Freights(string sql, IDocumentStore store, DocumentDatabase database)
+        {
+            await Run(sql, database);
+            Indexes.WaitForIndexing(store);
+            var rows = await Run(sql, database);
+            return rows.Select(r => r[0]).ToArray();
+        }
+
+        private static async Task<List<string[]>> Run(string sql, DocumentDatabase database)
+        {
+            using var query = PgQuery.CreateInstance(sql, Array.Empty<int>(), database, session: null);
+            await query.Init();
+
+            var token = TestContext.Current.CancellationToken;
+            var pipe = new Pipe();
+            var builder = new MessageBuilder();
+
+            var readTask = ReadAllAsync(pipe.Reader, token);
+            await query.Execute(builder, pipe.Writer, token);
+            await pipe.Writer.CompleteAsync();
+
+            return ParseDataRows(await readTask);
+        }
+
+        private sealed class Order
+        {
+            public string Company { get; set; }
+            public double Freight { get; set; }
+        }
+    }
+}

--- a/test/FastTests/Server/Integrations/PostgreSQL/PgOrderByTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/PgOrderByTests.cs
@@ -56,6 +56,32 @@ namespace FastTests.Server.Integrations.PostgreSQL
             Assert.False(string.IsNullOrWhiteSpace(error.Message));
         }
 
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("SELECT \"Freight\" FROM public.\"Orders\" ORDER BY \"Freight\" DESC NULLS LAST LIMIT 5", "NULLS")]
+        [InlineData("SELECT \"Freight\" FROM public.\"Orders\" ORDER BY \"Freight\" USING > LIMIT 5", "USING")]
+        public async Task OrderBy_with_an_unsupported_sort_modifier_returns_a_targeted_pg_error(string sql, string expected)
+        {
+            using var store = GetDocumentStore();
+            var database = await Seed(store);
+
+            var error = Assert.Throws<PgErrorException>(() => PgQuery.CreateInstance(
+                sql, Array.Empty<int>(), database, session: null));
+
+            Assert.Equal(PgErrorCodes.FeatureNotSupported, error.ErrorCode);
+            Assert.Contains(expected, error.Message);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql, LicenseRequired = true)]
+        public async Task OrderBy_without_a_sort_modifier_is_unchanged()
+        {
+            using var store = GetDocumentStore();
+            var database = await Seed(store);
+
+            Assert.Equal(
+                new[] { "10", "2" },
+                await Freights("SELECT \"Freight\" FROM public.\"Orders\" ORDER BY \"Freight\" DESC LIMIT 5", store, database));
+        }
+
         private async Task<DocumentDatabase> Seed(IDocumentStore store)
         {
             using (var session = store.OpenAsyncSession())

--- a/test/FastTests/Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslatorTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslatorTests.cs
@@ -934,6 +934,36 @@ namespace FastTests.Server.Integrations.PostgreSQL.Translation
             AssertRejected(sql);
         }
 
+        // The distinct-rows path (GROUP BY used as a DISTINCT, no aggregate) is a separate projection
+        // path from the aggregate one and used to drop the SELECT alias.
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void GroupByKeyWithoutAggregate_KeepsTheAlias()
+        {
+            Assert.Equal("from 'Orders' select distinct Company as grp",
+                Translate("SELECT \"Company\" AS grp FROM \"Orders\" GROUP BY \"Company\""));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void GroupByKeysWithoutAggregate_KeepEachAlias()
+        {
+            Assert.Equal("from 'Orders' group by Company, Freight select Company as grp, Freight as f",
+                Translate("SELECT \"Company\" AS grp, \"Freight\" AS f FROM \"Orders\" GROUP BY \"Company\", \"Freight\""));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void GroupByKeyWithoutAggregate_NonIdentifierAliasIsQuoted()
+        {
+            Assert.Equal("from 'Orders' select distinct Company as 'the company'",
+                Translate("SELECT \"Company\" AS \"the company\" FROM \"Orders\" GROUP BY \"Company\""));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void GroupByKeyWithoutAggregate_AliasEqualToTheKeyOmitsTheAsClause()
+        {
+            Assert.Equal("from 'Orders' select distinct Company",
+                Translate("SELECT \"Company\" AS \"Company\" FROM \"Orders\" GROUP BY \"Company\""));
+        }
+
         private static void AssertRejected(string sql)
         {
             Assert.False(Raven.Server.Integrations.PostgreSQL.Translation.PgSqlToRqlTranslator.TryParse(

--- a/test/FastTests/Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslatorTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslatorTests.cs
@@ -427,13 +427,11 @@ namespace FastTests.Server.Integrations.PostgreSQL.Translation
             Assert.Equal(expected, Translate(sql));
         }
 
-        // PowerBI's Top-N visual fires this shape: alias-qualified projection + alias-qualified
-        // count argument, both needing the `rows.` fromAlias stripped to match the GROUP BY key.
-        // The SQL alias on the aggregate must be preserved too: RQL's implicit alias for
-        // count(Freight) would be `Freight`, colliding with the sibling group-by-key projection
-        // (`Duplicate alias 'Freight'`), so we emit `count(Freight) as a0`.
+        // RQL's count() ignores its argument, so emitting count(Freight) returned the group's row
+        // count while PG counts non-null values only. The PowerBI dispatch path normalises the same
+        // shape to count() on purpose (see PowerBIAstTests); the generic SQL path must not guess.
         [RavenFact(RavenTestCategory.PostgreSql)]
-        public void GroupBy_WithFromAlias_QualifiedProjectionAndAggregateArg_StripsAliasAndPreservesAggregateAlias()
+        public void GroupBy_CountOverAliasQualifiedColumn_IsRejected()
         {
             var sql = """
                 select "rows"."Freight" as "Freight", count("rows"."Freight") as "a0"
@@ -441,9 +439,9 @@ namespace FastTests.Server.Integrations.PostgreSQL.Translation
                 group by "Freight"
                 limit 1000001
                 """;
-            var expected = "from 'Orders' group by Freight select Freight, count(Freight) as a0 limit 0, 1000001";
 
-            Assert.Equal(expected, Translate(sql));
+            Assert.False(Raven.Server.Integrations.PostgreSQL.Translation.PgSqlToRqlTranslator.TryParse(
+                sql, Array.Empty<int>(), out _));
         }
 
         [RavenFact(RavenTestCategory.PostgreSql)]
@@ -780,6 +778,83 @@ namespace FastTests.Server.Integrations.PostgreSQL.Translation
         {
             Assert.False(Raven.Server.Integrations.PostgreSQL.Translation.PgSqlToRqlTranslator.TryParse(
                 sql, Array.Empty<int>(), out _));
+        }
+
+        // DISTINCT / FILTER / OVER and count(<column>) all used to translate to the plain aggregate,
+        // which RQL computes over every row in the group - the same number as count(*)/sum(*).
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("SELECT \"Company\", count(distinct \"ShipVia\") FROM \"Orders\" GROUP BY \"Company\"")]
+        [InlineData("SELECT \"Company\", count(\"ShipVia\") FROM \"Orders\" GROUP BY \"Company\"")]
+        [InlineData("SELECT \"Company\", sum(distinct \"Freight\") FROM \"Orders\" GROUP BY \"Company\"")]
+        [InlineData("SELECT \"Company\", count(*) FILTER (WHERE \"Freight\" > 10) FROM \"Orders\" GROUP BY \"Company\"")]
+        [InlineData("SELECT \"Company\", count(*) OVER () FROM \"Orders\" GROUP BY \"Company\"")]
+        [InlineData("SELECT \"Company\", count(*) FROM \"Orders\" GROUP BY \"Company\" ORDER BY count(distinct \"ShipVia\") DESC")]
+        public void GroupByAggregate_WithUnsupportedModifierOrColumnArg_IsRejected(string sql)
+        {
+            Assert.False(Raven.Server.Integrations.PostgreSQL.Translation.PgSqlToRqlTranslator.TryParse(
+                sql, Array.Empty<int>(), out _));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void GroupByCountStar_AndGroupBySum_StillTranslate()
+        {
+            Assert.Equal("from 'Orders' group by Company select Company, count()",
+                Translate("SELECT \"Company\", count(*) FROM \"Orders\" GROUP BY \"Company\""));
+
+            Assert.Equal("from 'Orders' group by Company select Company, sum(Freight)",
+                Translate("SELECT \"Company\", sum(\"Freight\") FROM \"Orders\" GROUP BY \"Company\""));
+        }
+
+        // count(1) counts every row, so it stays equivalent to count(*).
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void GroupByCountOverConstant_StillTranslatesToCountStar()
+        {
+            Assert.Equal("from 'Orders' group by Company select Company, count()",
+                Translate("SELECT \"Company\", count(1) FROM \"Orders\" GROUP BY \"Company\""));
+        }
+
+        // PG builds IS [NOT] DISTINCT FROM and NULLIF with a literal "=" operator name, so before the
+        // A_Expr kind was checked they became a plain equality - the inverse of IS DISTINCT FROM.
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("SELECT * FROM \"Orders\" WHERE \"Company\" IS DISTINCT FROM 'companies/85-A'")]
+        [InlineData("SELECT * FROM \"Orders\" WHERE \"Company\" IS NOT DISTINCT FROM 'companies/85-A'")]
+        [InlineData("SELECT * FROM \"Orders\" WHERE NULLIF(\"Company\", 'companies/85-A')")]
+        public void DistinctFromPredicate_IsRejected(string sql)
+        {
+            Assert.False(Raven.Server.Integrations.PostgreSQL.Translation.PgSqlToRqlTranslator.TryParse(
+                sql, Array.Empty<int>(), out _));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void EqualityAndInequality_StillTranslate()
+        {
+            Assert.Equal("from 'Orders' where Company = 'companies/85-A'",
+                Translate("SELECT * FROM \"Orders\" WHERE \"Company\" = 'companies/85-A'"));
+
+            Assert.Equal("from 'Orders' where Company != 'companies/85-A'",
+                Translate("SELECT * FROM \"Orders\" WHERE \"Company\" != 'companies/85-A'"));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void GroupByKey_WithAlias_KeepsTheAlias()
+        {
+            Assert.Equal("from 'Orders' group by Company select Company as grp, count() as c",
+                Translate("SELECT \"Company\" AS grp, COUNT(*) AS c FROM \"Orders\" GROUP BY \"Company\""));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void GroupByKey_WithAlias_OrderByTheKeyStillResolves()
+        {
+            Assert.Equal("from 'Orders' group by Company order by Company desc select Company as grp, count() as c",
+                Translate("SELECT \"Company\" AS grp, COUNT(*) AS c FROM \"Orders\" GROUP BY \"Company\" ORDER BY \"Company\" DESC"));
+        }
+
+        // An alias equal to the key adds nothing and would make RQL reject the duplicate alias.
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void GroupByKey_WithAliasEqualToTheKey_OmitsTheAsClause()
+        {
+            Assert.Equal("from 'Orders' group by Company select Company, count() as c",
+                Translate("SELECT \"Company\" AS \"Company\", COUNT(*) AS c FROM \"Orders\" GROUP BY \"Company\""));
         }
     }
 }

--- a/test/FastTests/Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslatorTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslatorTests.cs
@@ -856,5 +856,88 @@ namespace FastTests.Server.Integrations.PostgreSQL.Translation
             Assert.Equal("from 'Orders' group by Company select Company, count() as c",
                 Translate("SELECT \"Company\" AS \"Company\", COUNT(*) AS c FROM \"Orders\" GROUP BY \"Company\""));
         }
+
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("TO_TIMESTAMP('1996-07-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS')", "'1996-07-01 00:00:00'::timestamp")]
+        [InlineData("TO_TIMESTAMP('1996-07-01 13:45:30', 'YYYY-MM-DD HH24:MI:SS')", "'1996-07-01 13:45:30'::timestamp")]
+        [InlineData("TO_TIMESTAMP('1996-07-01 13:45:30.123456', 'YYYY-MM-DD HH24:MI:SS.US')", "'1996-07-01 13:45:30.123456'::timestamp")]
+        [InlineData("TO_TIMESTAMP('1996-07-01', 'YYYY-MM-DD')", "'1996-07-01'::timestamp")]
+        [InlineData("TO_DATE('1996-07-01', 'YYYY-MM-DD')", "'1996-07-01'::timestamp")]
+        public void TimestampFunctionBound_FoldsToTheSameValueAsTheCast(string bound, string cast)
+        {
+            Assert.Equal(
+                Translate($"SELECT * FROM \"Orders\" WHERE \"OrderedAt\" >= {cast}"),
+                Translate($"SELECT * FROM \"Orders\" WHERE \"OrderedAt\" >= {bound}"));
+        }
+
+        // PG's to_date discards the time component even when the format parses one.
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void ToDateBound_DropsTheTimeComponent()
+        {
+            Assert.Equal(
+                Translate("SELECT * FROM \"Orders\" WHERE \"OrderedAt\" >= '1996-07-01'::timestamp"),
+                Translate("SELECT * FROM \"Orders\" WHERE \"OrderedAt\" >= TO_DATE('1996-07-01 13:45:30', 'YYYY-MM-DD HH24:MI:SS')"));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void TimestampFunctionBound_TranslatesBothEndsOfAHalfOpenWindow()
+        {
+            var rql = Translate(
+                """
+                SELECT * FROM "Orders"
+                WHERE "OrderedAt" >= TO_TIMESTAMP('1996-07-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS')
+                  AND "OrderedAt" < TO_TIMESTAMP('1996-10-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS')
+                """);
+
+            Assert.Contains("1996-07-01", rql, StringComparison.Ordinal);
+            Assert.Contains("1996-10-01", rql, StringComparison.Ordinal);
+        }
+
+        // A format token that isn't translated must fail the whole bound; passing it through as a
+        // literal would silently shift the date.
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("TO_TIMESTAMP('1996-Jul-01', 'YYYY-Mon-DD')")]
+        [InlineData("TO_TIMESTAMP('1996-07-01', 'FMYYYY-FMMM-FMDD')")]
+        [InlineData("TO_TIMESTAMP('01/07/1996 01:00 PM', 'DD/MM/YYYY HH12:MI AM')")]
+        [InlineData("TO_DATE('1996 182', 'YYYY DDD')")]
+        [InlineData("TO_TIMESTAMP('1996-07-01', '')")]
+        public void TimestampFunctionBound_WithUnrecognisedFormat_IsRejected(string bound)
+        {
+            AssertRejected($"SELECT * FROM \"Orders\" WHERE \"OrderedAt\" >= {bound}");
+        }
+
+        // Neither argument can be resolved at translate time unless it is a string literal.
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("TO_TIMESTAMP(\"RequireAt\", 'YYYY-MM-DD')")]
+        [InlineData("TO_TIMESTAMP('1996-07-01', $1)")]
+        [InlineData("TO_TIMESTAMP($1, 'YYYY-MM-DD')")]
+        [InlineData("TO_TIMESTAMP(820454400)")]
+        [InlineData("TO_TIMESTAMP('1996-07-01')")]
+        public void TimestampFunctionBound_WithNonLiteralArgument_IsRejected(string bound)
+        {
+            AssertRejected($"SELECT * FROM \"Orders\" WHERE \"OrderedAt\" >= {bound}");
+        }
+
+        // The format is recognised but the value does not match it.
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void TimestampFunctionBound_WithValueNotMatchingTheFormat_IsRejected()
+        {
+            AssertRejected("SELECT * FROM \"Orders\" WHERE \"OrderedAt\" >= TO_TIMESTAMP('not-a-date', 'YYYY-MM-DD')");
+        }
+
+        // to_timestamp is a WHERE-bound shape only.
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("SELECT TO_TIMESTAMP('1996-07-01', 'YYYY-MM-DD') FROM \"Orders\"")]
+        [InlineData("SELECT \"Company\", COUNT(*) FROM \"Orders\" GROUP BY TO_TIMESTAMP('1996-07-01', 'YYYY-MM-DD')")]
+        public void TimestampFunction_OutsideAWhereBound_IsRejected(string sql)
+        {
+            AssertRejected(sql);
+        }
+
+        private static void AssertRejected(string sql)
+        {
+            Assert.False(Raven.Server.Integrations.PostgreSQL.Translation.PgSqlToRqlTranslator.TryParse(
+                sql, Array.Empty<int>(), out _));
+        }
     }
 }

--- a/test/FastTests/Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslatorTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslatorTests.cs
@@ -996,6 +996,24 @@ namespace FastTests.Server.Integrations.PostgreSQL.Translation
             AssertRejected(sql);
         }
 
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("SELECT \"Freight\" FROM \"Orders\" ORDER BY \"Freight\" DESC NULLS LAST")]
+        [InlineData("SELECT \"Freight\" FROM \"Orders\" ORDER BY \"Freight\" NULLS FIRST")]
+        [InlineData("SELECT \"Freight\" FROM \"Orders\" ORDER BY \"Freight\" USING >")]
+        [InlineData("SELECT \"Company\", COUNT(*) FROM \"Orders\" GROUP BY \"Company\" ORDER BY \"Company\" NULLS LAST")]
+        public void OrderByWithAnUnsupportedSortModifier_IsRejected(string sql)
+        {
+            AssertRejected(sql);
+        }
+
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("SELECT \"Freight\" FROM \"Orders\" ORDER BY \"Freight\" DESC", "from 'Orders' order by Freight desc select Freight")]
+        [InlineData("SELECT \"Freight\" FROM \"Orders\" ORDER BY \"Freight\" ASC", "from 'Orders' order by Freight select Freight")]
+        public void OrderByWithoutASortModifier_IsUnchanged(string sql, string expected)
+        {
+            Assert.Equal(expected, Translate(sql));
+        }
+
         private static void AssertRejected(string sql)
         {
             Assert.False(Raven.Server.Integrations.PostgreSQL.Translation.PgSqlToRqlTranslator.TryParse(

--- a/test/FastTests/Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslatorTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/Translation/PgSqlToRqlTranslatorTests.cs
@@ -964,6 +964,38 @@ namespace FastTests.Server.Integrations.PostgreSQL.Translation
                 Translate("SELECT \"Company\" AS \"Company\" FROM \"Orders\" GROUP BY \"Company\""));
         }
 
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void OrderBySelectAlias_ResolvesToTheUnderlyingField()
+        {
+            Assert.Equal("from 'Orders' order by Freight select Freight as f",
+                Translate("SELECT \"Freight\" AS f FROM \"Orders\" ORDER BY f"));
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void OrderByQuotedSelectAlias_ResolvesToTheUnderlyingField()
+        {
+            Assert.Equal("from 'Orders' order by Freight desc select Freight as 'the freight'",
+                Translate("SELECT \"Freight\" AS \"the freight\" FROM \"Orders\" ORDER BY \"the freight\" DESC"));
+        }
+
+        // A sort key that is a real field rather than an alias keeps resolving as a field.
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void OrderByRealFieldAlongsideAnAlias_IsUnchanged()
+        {
+            Assert.Equal("from 'Orders' order by Company select Freight as f",
+                Translate("SELECT \"Freight\" AS f FROM \"Orders\" ORDER BY \"Company\""));
+        }
+
+        // An alias over a constant or id() has no document field behind it, so there is nothing to
+        // sort on - reject instead of emitting a sort on a field that does not exist.
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("SELECT 1 AS c0 FROM \"Orders\" ORDER BY c0")]
+        [InlineData("SELECT \"id\" AS docid FROM \"Orders\" ORDER BY docid")]
+        public void OrderByAliasOverANonField_IsRejected(string sql)
+        {
+            AssertRejected(sql);
+        }
+
         private static void AssertRejected(string sql)
         {
             Assert.False(Raven.Server.Integrations.PostgreSQL.Translation.PgSqlToRqlTranslator.TryParse(

--- a/test/FastTests/Server/Integrations/PostgreSQL/UnhandledQueryDiagnoserTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/UnhandledQueryDiagnoserTests.cs
@@ -436,6 +436,37 @@ namespace FastTests.Server.Integrations.PostgreSQL
             Assert.False(UnhandledQueryDiagnoser.TryDiagnose(sql, out _));
         }
 
+        // The WHERE-clause check takes priority over the scalar-aggregate check for count(*).
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("""SELECT count(*) FROM "public"."Orders" WHERE "Freight" NOT BETWEEN 1 AND 10""", "NOT BETWEEN")]
+        [InlineData("""SELECT count(*) FROM "public"."Orders" WHERE "Company" SIMILAR TO 'A%'""", "SIMILAR TO")]
+        public void ScalarCountStar_WithUnsupportedWhere_BlamesTheWhereClause(string sql, string predicate)
+        {
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.Contains(predicate, message);
+            Assert.DoesNotContain("Scalar aggregate", message);
+        }
+
+        // sum() has no scalar form at all, so the aggregate message is still the right one there.
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void ScalarSum_WithUnsupportedWhere_StillBlamesTheAggregate()
+        {
+            var sql = """SELECT sum("Freight") FROM "public"."Orders" WHERE "Freight" NOT BETWEEN 1 AND 10""";
+
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.Contains("Scalar aggregate", message);
+        }
+
+        // A translatable WHERE must not be blamed.
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void ScalarCountStar_WithSupportedWhere_IsNotBlamedOnTheWhereClause()
+        {
+            var sql = """SELECT count(*) FROM "public"."Orders" WHERE "Freight" BETWEEN 1 AND 10""";
+
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.DoesNotContain("WHERE clause", message);
+        }
+
         [RavenTheory(RavenTestCategory.PostgreSql)]
         [InlineData("""SELECT "Freight" FROM "public"."Orders" ORDER BY "Freight" DESC NULLS LAST""", "NULLS")]
         [InlineData("""SELECT "Freight" FROM "public"."Orders" ORDER BY "Freight" NULLS FIRST""", "NULLS")]

--- a/test/FastTests/Server/Integrations/PostgreSQL/UnhandledQueryDiagnoserTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/UnhandledQueryDiagnoserTests.cs
@@ -357,5 +357,113 @@ namespace FastTests.Server.Integrations.PostgreSQL
             Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
             Assert.Contains("min()", message);
         }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void CountDistinct_Detected()
+        {
+            var sql = """
+                SELECT "Company", count(distinct "ShipVia")
+                FROM "public"."Orders"
+                GROUP BY "Company"
+                """;
+
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.Contains("DISTINCT", message);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void SumDistinct_Detected()
+        {
+            var sql = """
+                SELECT "Company", sum(distinct "Freight")
+                FROM "public"."Orders"
+                GROUP BY "Company"
+                """;
+
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.Contains("DISTINCT", message);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void AggregateFilterClause_Detected()
+        {
+            var sql = """
+                SELECT "Company", count(*) FILTER (WHERE "Freight" > 10)
+                FROM "public"."Orders"
+                GROUP BY "Company"
+                """;
+
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.Contains("FILTER", message);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void WindowFunction_Detected()
+        {
+            var sql = """
+                SELECT "Company", count(*) OVER ()
+                FROM "public"."Orders"
+                GROUP BY "Company"
+                """;
+
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.Contains("OVER", message);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void CountOverColumn_DetectedWithCountStarHint()
+        {
+            var sql = """
+                SELECT "Company", count("ShipVia")
+                FROM "public"."Orders"
+                GROUP BY "Company"
+                """;
+
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.Contains("count(<column>)", message);
+            Assert.Contains("count(*)", message);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void CountStar_IsNotReportedAsCountOverColumn()
+        {
+            var sql = """
+                SELECT "Company", count(*)
+                FROM "public"."Orders"
+                GROUP BY "Company"
+                """;
+
+            Assert.False(UnhandledQueryDiagnoser.TryDiagnose(sql, out _));
+        }
+
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("""SELECT * FROM "public"."Orders" WHERE "Company" IS DISTINCT FROM 'companies/85-A' """)]
+        [InlineData("""SELECT * FROM "public"."Orders" WHERE "Company" IS NOT DISTINCT FROM 'companies/85-A' """)]
+        [InlineData("""SELECT * FROM "public"."Orders" WHERE NULLIF("Company", 'companies/85-A') """)]
+        public void DistinctFromPredicate_Detected(string sql)
+        {
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.Contains("IS DISTINCT FROM", message);
+        }
+
+        // The predicate check has to win over the scalar-aggregate check here: the aggregate is
+        // count(*), which is supported, so blaming it would point at the wrong half of the query.
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void DistinctFromPredicate_WithCountStar_IsNotReportedAsScalarAggregate()
+        {
+            var sql = """SELECT count(*) FROM "public"."Orders" WHERE "Company" IS DISTINCT FROM 'companies/85-A' """;
+
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.Contains("IS DISTINCT FROM", message);
+            Assert.DoesNotContain("Scalar aggregate", message);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public void PlainEqualityPredicate_NoClassification()
+        {
+            var sql = """SELECT * FROM "public"."Orders" WHERE "Company" != 'companies/85-A' """;
+
+            Assert.False(UnhandledQueryDiagnoser.TryDiagnose(sql, out _));
+        }
     }
 }

--- a/test/FastTests/Server/Integrations/PostgreSQL/UnhandledQueryDiagnoserTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/UnhandledQueryDiagnoserTests.cs
@@ -437,6 +437,25 @@ namespace FastTests.Server.Integrations.PostgreSQL
         }
 
         [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("""SELECT "Freight" FROM "public"."Orders" ORDER BY "Freight" DESC NULLS LAST""", "NULLS")]
+        [InlineData("""SELECT "Freight" FROM "public"."Orders" ORDER BY "Freight" NULLS FIRST""", "NULLS")]
+        [InlineData("""SELECT "Freight" FROM "public"."Orders" ORDER BY "Freight" USING >""", "USING")]
+        public void UnsupportedSortModifier_Detected(string sql, string expected)
+        {
+            Assert.True(UnhandledQueryDiagnoser.TryDiagnose(sql, out var message));
+            Assert.Contains(expected, message);
+        }
+
+        [RavenTheory(RavenTestCategory.PostgreSql)]
+        [InlineData("""SELECT "Freight" FROM "public"."Orders" ORDER BY "Freight" DESC""")]
+        [InlineData("""SELECT "Freight" FROM "public"."Orders" ORDER BY "Freight" ASC""")]
+        [InlineData("""SELECT "Freight" FROM "public"."Orders" ORDER BY "Freight" """)]
+        public void PlainSortDirection_NoClassification(string sql)
+        {
+            Assert.False(UnhandledQueryDiagnoser.TryDiagnose(sql, out _));
+        }
+
+        [RavenTheory(RavenTestCategory.PostgreSql)]
         [InlineData("""SELECT * FROM "public"."Orders" WHERE "Company" IS DISTINCT FROM 'companies/85-A' """)]
         [InlineData("""SELECT * FROM "public"."Orders" WHERE "Company" IS NOT DISTINCT FROM 'companies/85-A' """)]
         [InlineData("""SELECT * FROM "public"."Orders" WHERE NULLIF("Company", 'companies/85-A') """)]

--- a/test/FastTests/Server/Integrations/PostgreSQL/VirtualCatalog/PgCatalogTests.cs
+++ b/test/FastTests/Server/Integrations/PostgreSQL/VirtualCatalog/PgCatalogTests.cs
@@ -68,6 +68,45 @@ namespace FastTests.Server.Integrations.PostgreSQL.VirtualCatalog
             Assert.Equal(new[] { "Companies", "Employees", "Orders" }, ColumnValues(table, column: 0).OrderBy(n => n, StringComparer.Ordinal));
         }
 
+        // SQLAlchemy 1.4's PGDialect.get_view_names() / get_sequence_names(), with the :schema bind
+        // substituted. RavenDB has neither views nor sequences and pg_class reports relkind 'r' for every
+        // collection, so both must resolve and return no rows rather than failing the reflection call.
+        private const string SqlAlchemyGetViewNames =
+            "SELECT c.relname FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace " +
+            "WHERE n.nspname = 'public' AND c.relkind IN ('v', 'm')";
+
+        private const string SqlAlchemyGetSequenceNames =
+            "SELECT relname FROM pg_class c join pg_namespace n on n.oid=c.relnamespace " +
+            "where relkind='S' and n.nspname='public'";
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task SqlAlchemy_get_view_names_shape_reports_no_views()
+        {
+            using var store = GetDocumentStore();
+            StoreThreeCollections(store);
+
+            var ctx = await CtxFor(store);
+            Assert.True(PgVirtualInterpreter.TryExecute(SqlAlchemyGetViewNames, ctx, out var table));
+
+            Assert.Single(table.Columns);
+            Assert.Equal("relname", table.Columns[0].Name);
+            Assert.Empty(table.Data);
+        }
+
+        [RavenFact(RavenTestCategory.PostgreSql)]
+        public async Task SqlAlchemy_get_sequence_names_shape_reports_no_sequences()
+        {
+            using var store = GetDocumentStore();
+            StoreThreeCollections(store);
+
+            var ctx = await CtxFor(store);
+            Assert.True(PgVirtualInterpreter.TryExecute(SqlAlchemyGetSequenceNames, ctx, out var table));
+
+            Assert.Single(table.Columns);
+            Assert.Equal("relname", table.Columns[0].Name);
+            Assert.Empty(table.Data);
+        }
+
         [RavenFact(RavenTestCategory.PostgreSql)]
         public async Task Pg_class_and_information_schema_tables_report_the_same_names()
         {


### PR DESCRIPTION
…unt query

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27195

### Additional description

RavenDB rejected SELECT COUNT(*) FROM t with no GROUP BY. Fixed by running it in the engine's built-in count mode instead of treating it like an unsupported aggregate. Also fixed the error message, which suggested a workaround that didn't actually work.

Also fixed, all found while testing the fix against Superset:

* COUNT(DISTINCT col), SUM(DISTINCT col), and COUNT(col) silently returned the group's row count instead of erroring or counting correctly. Now rejected with a clear message.
* IS DISTINCT FROM was translated as if it were =, the opposite of what it means. Now rejected instead of silently returning wrong rows.
* Aliasing a GROUP BY key (SELECT x AS grp GROUP BY x) silently dropped the alias, with or without an aggregate. Now preserved.
* Aliasing an aggregate with anything other than a plain identifier (COUNT(*) AS "COUNT(*)", which is what Superset actually sends) was rejected outright. Now quoted and accepted.
* ORDER BY on a SELECT alias in a non-grouped query silently sorted by a nonexistent field. Now resolves correctly or rejects.
* NULLS FIRST/LAST and ORDER BY ... USING were silently ignored. Now rejected instead of silently sorting wrong.
* TO_TIMESTAMP/TO_DATE in a WHERE clause were rejected outright — this is how Superset sends every Time Range filter, so no chart with a time filter worked at all. Now accepted.
* A count(*) query with an unsupported WHERE clause blamed the aggregate in the error message instead of the WHERE clause. Fixed.
* Added test coverage for get_view_names/get_sequence_names, previously untested.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
