### PR TITLE
RavenDB-27286 Add pattern matching and wildcard support in Corax queries

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Runtime.CompilerServices;
 using Sparrow;
 using Sparrow.Server;
@@ -133,7 +134,11 @@ namespace Corax
         
         public static class Search
         {
-            public const byte Wildcard = (byte)'*';
+            public const byte Asterisk = (byte)'*';
+
+            public const byte QuestionMark = (byte)'?';
+
+            public static readonly SearchValues<byte> PatternSymbols = SearchValues.Create([Asterisk, QuestionMark]);
 
             [Flags]
             public enum SearchMatchOptions
@@ -142,7 +147,8 @@ namespace Corax
                 StartsWith = 1,
                 EndsWith = 1 << 1,
                 Exists = 1 << 2,
-                Contains = StartsWith | EndsWith
+                Contains = StartsWith | EndsWith,
+                PatternMatch = 1 << 3
             }
 
             public enum Operator

--- a/src/Corax/Querying/IndexSearcher.Search.cs
+++ b/src/Corax/Querying/IndexSearcher.Search.cs
@@ -10,9 +10,9 @@ using Corax.Mappings;
 using Corax.Pipeline;
 using Corax.Querying.Matches;
 using Corax.Querying.Matches.Meta;
+using Sparrow;
 using Sparrow.Server;
 using Voron;
-using Voron.Data.PostingLists;
 using Voron.Util;
 
 namespace Corax.Querying;
@@ -403,11 +403,12 @@ public partial class IndexSearcher
                     Constants.Search.SearchMatchOptions.Contains => (1, -1),
                     Constants.Search.SearchMatchOptions.TermMatch => (0, 0),
                     Constants.Search.SearchMatchOptions.Exists => (0, 0),
+                    Constants.Search.SearchMatchOptions.PatternMatch => (0, 0),
                     _ => throw new InvalidExpressionException("Unknown flag inside Search match.")
                 };
-                
+
                 //Rewrite term without asterisks.
-                if (termType is not (Constants.Search.SearchMatchOptions.Exists or Constants.Search.SearchMatchOptions.TermMatch))
+                if (termType is not (Constants.Search.SearchMatchOptions.Exists or Constants.Search.SearchMatchOptions.TermMatch or Constants.Search.SearchMatchOptions.PatternMatch))
                 {
                     Slice.From(Allocator, valueAsSpan.Slice(startIncrement, valueAsSpan.Length - startIncrement + lengthIncrement), ByteStringType.Immutable, out value);
                 }
@@ -425,6 +426,7 @@ public partial class IndexSearcher
                         $"{nameof(TermMatch)} is handled in different part of evaluator. This is a bug."),
                     Constants.Search.SearchMatchOptions.Exists => ExistsQuery(field, token: cancellationToken),
                     Constants.Search.SearchMatchOptions.StartsWith => StartWithQuery(field, value, token: cancellationToken),
+                    Constants.Search.SearchMatchOptions.PatternMatch => PatternQuery(field, value, token: cancellationToken),
                     Constants.Search.SearchMatchOptions.EndsWith => EndsWithQuery(field, value, token: cancellationToken),
                     Constants.Search.SearchMatchOptions.Contains => ContainsQuery(field, value, token: cancellationToken),
                     _ => throw new ArgumentOutOfRangeException(nameof(termType), termType.ToString())
@@ -437,10 +439,10 @@ public partial class IndexSearcher
                     (_, Constants.Search.Operator.Or) => Or(searchQuery, query),
                     _ => throw new ArgumentOutOfRangeException(nameof(@operator), @operator, null)
                 };
-                
+
                 continue;
             }
-            
+
             // Phrase query part (wildcards are not supported in phrase queries).
             var hs = new HashSet<Slice>(SliceComparer.Instance);
             for (var i = 0; i < terms.Count; ++i)
@@ -511,24 +513,31 @@ public partial class IndexSearcher
     
     private Constants.Search.SearchMatchOptions GetTermType(ReadOnlySpan<byte> termValue)
     {
-        if (termValue.IsEmpty)
+        if (termValue.IsEmpty || termValue.ContainsAny(Constants.Search.PatternSymbols) == false)
             return Constants.Search.SearchMatchOptions.TermMatch;
-            
-        Constants.Search.SearchMatchOptions mode = default;
-            
-        if (termValue[0] == '*')
-            mode |= Constants.Search.SearchMatchOptions.EndsWith;
 
-        if (termValue[^1] == '*')
-        {
-            if (termValue.Length <= 2 || termValue[^2] != '\\')
-                mode |= Constants.Search.SearchMatchOptions.StartsWith;
-        }
-            
-        if (mode == Constants.Search.SearchMatchOptions.Contains && termValue.Count((byte)'*') == termValue.Length)
+        bool hasPrefixAsterisk = termValue[0] == '*';
+        bool hasSuffixAsterisk = termValue[^1] == '*' && (termValue.Length <= 2 || termValue[^2] != '\\');
+        
+        if (hasPrefixAsterisk & hasSuffixAsterisk && termValue.Count((byte)'*') == termValue.Length)
             return Constants.Search.SearchMatchOptions.Exists;
+        
+        var len = termValue.Length - hasSuffixAsterisk.ToInt32();
+        var leftTerm = termValue[hasPrefixAsterisk.ToInt32()..len];
+        var hasLeftTermAnyPatterns = leftTerm.ContainsAny(Constants.Search.PatternSymbols);
+        
+        if (hasPrefixAsterisk && hasLeftTermAnyPatterns)
+            return Constants.Search.SearchMatchOptions.PatternMatch;
 
-        return mode;
+        if (hasSuffixAsterisk && hasPrefixAsterisk)
+            return Constants.Search.SearchMatchOptions.Contains;
+
+        if (hasPrefixAsterisk)
+            return Constants.Search.SearchMatchOptions.EndsWith;
+
+        return hasSuffixAsterisk
+            ? Constants.Search.SearchMatchOptions.StartsWith
+            : Constants.Search.SearchMatchOptions.TermMatch;
     }
     
     private Analyzer CreateWildcardAnalyzer(in FieldMetadata field, ref Analyzer analyzer)

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.PatternTerm.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.PatternTerm.cs
@@ -18,26 +18,31 @@ public struct PatternTermProvider<TLookupIterator> : ITermProvider
     private readonly IndexSearcher _searcher;
     private readonly FieldMetadata _field;
     private readonly CompactKey _pattern;
+    private readonly CompactKey _seekLimitForBackward;
     private readonly int _seekPrefixLength;
     private readonly CancellationToken _token;
     private CompactTree.Iterator<TLookupIterator> _iterator;
-    
+    private bool _firstRun;
+
     private readonly string _patternString;
     private readonly ByteString _termBuffer;
-
-    public PatternTermProvider(IndexSearcher searcher, CompactTree tree, in FieldMetadata field, CompactKey pattern, CancellationToken token)
+    private readonly CompactKey _compactKey;
+    
+    public PatternTermProvider(IndexSearcher searcher, CompactTree tree, in FieldMetadata field, CompactKey pattern, CompactKey seekLimitForBackward, CancellationToken token)
     {
         _searcher = searcher;
         _field = field;
         _pattern = pattern;
+        _seekLimitForBackward = seekLimitForBackward;
         _token = token;
         _tree = tree;
 
         var patternSpan = pattern.Decoded();
 
         // The literal run before the first wildcard character lets us seek instead of scanning the whole field.
-        var firstPatternCharacter = patternSpan.IndexOfAny(Constants.Search.PatternSymbols);
-        _seekPrefixLength = firstPatternCharacter == -1 ? patternSpan.Length : firstPatternCharacter;
+        _seekPrefixLength = patternSpan.IndexOfAny(Constants.Search.PatternSymbols);
+        if (_seekPrefixLength < 0)
+            throw new InvalidOperationException($"{nameof(PatternTermProvider<TLookupIterator>)} must be used with at least with one pattern symbol (? or *).");
 
         _patternString = null;
         _termBuffer = default;
@@ -48,6 +53,10 @@ public struct PatternTermProvider<TLookupIterator> : ITermProvider
         }
 
         _iterator = tree.Iterate<TLookupIterator>();
+        
+        _compactKey = _searcher._transaction.LowLevelTransaction.AcquireCompactKey();
+        _compactKey.Initialize(_searcher._transaction.LowLevelTransaction);
+        
         Reset();
     }
 
@@ -55,31 +64,62 @@ public struct PatternTermProvider<TLookupIterator> : ITermProvider
 
     public int Fill(Span<long> containers) => throw new NotImplementedException();
 
+    /// <summary>
+    /// The forward iterator seeks the literal prefix itself, the backward one seeks the term right after the prefix
+    /// range and walks down towards it, so it is bounded only when that term was prepared for us.
+    /// </summary>
+    private bool IsBoundedByPrefix => default(TLookupIterator).IsForward
+        ? _seekPrefixLength > 0
+        : _seekLimitForBackward != null;
+
     public void Reset()
     {
         _iterator = _tree.Iterate<TLookupIterator>();
+        _firstRun = true;
 
-        // Only the forward iterator can seek to the prefix; the backward iterator falls back to a full scan.
-        if (_seekPrefixLength > 0 && default(TLookupIterator).IsForward)
-            _iterator.Seek(_pattern.Decoded()[.._seekPrefixLength]);
-        else
+        if (IsBoundedByPrefix == false)
+        {
+            // There is no prefix to seek to (e.g. '*ab'), we've to scan the whole field.
             _iterator.Reset();
+            return;
+        }
+
+        if (default(TLookupIterator).IsForward)
+        {
+            _iterator.Seek(_pattern.Decoded()[.._seekPrefixLength]);
+            return;
+        }
+
+        // Backward iteration starts at the first term *after* the prefix range (for 'ab?c*' we seek 'ac'),
+        // exactly like the backward startsWith does.
+        _iterator.Seek(_seekLimitForBackward);
     }
 
     public bool Next(out TermMatch term)
     {
         var pattern = _pattern.Decoded();
-        var prefix = default(TLookupIterator).IsForward ? pattern[.._seekPrefixLength] : default;
+        var prefix = IsBoundedByPrefix ? pattern[.._seekPrefixLength] : default;
 
-        while (_iterator.MoveNext(out var compactKey, out _, out _))
+        while (_iterator.MoveNext(_compactKey, out _, out _))
         {
             _token.ThrowIfCancellationRequested();
 
-            var key = compactKey.Decoded();
+            var key = _compactKey.Decoded();
+            var isFirstTerm = _firstRun;
+            _firstRun = false;
 
             // Terms are sorted, so once we move past the prefix range there is nothing left to match.
             if (prefix.IsEmpty == false && key.StartsWith(prefix) == false)
+            {
+                // The backward iterator starts at the first term after our range (for prefix 'ab' we've seeked
+                // a['b'+1]), so that very first term is allowed to miss - it's either that boundary term or, when
+                // the boundary doesn't exist in the tree, a term below the whole range. Any further miss means
+                // we've walked out of the range for good.
+                if (default(TLookupIterator).IsForward == false && isFirstTerm)
+                    continue;
+
                 break;
+            }
 
             var isMatch = _patternString != null && StandardParsers.IsAscii(key) == false
                 ? IsMatchUtf8(key)
@@ -88,14 +128,14 @@ public struct PatternTermProvider<TLookupIterator> : ITermProvider
             if (isMatch == false)
                 continue;
 
-            term = _searcher.TermQuery(_field, compactKey, _tree);
+            term = _searcher.TermQuery(_field, _compactKey, _tree);
             return true;
         }
 
         term = TermMatch.CreateEmpty(_searcher, _searcher.Allocator);
         return false;
     }
-    
+
     private bool IsMatchUtf8(ReadOnlySpan<byte> term)
     {
         var termChars = _termBuffer.ToSpan<char>();
@@ -188,7 +228,8 @@ public struct PatternTermProvider<TLookupIterator> : ITermProvider
             parameters: new Dictionary<string, string>()
             {
                 { Constants.QueryInspectionNode.FieldName, _field.ToString() },
-                { Constants.QueryInspectionNode.Term, _pattern.ToString()}
+                { Constants.QueryInspectionNode.Term, _pattern.ToString()},
+                { Constants.QueryInspectionNode.IteratorDirection, Constants.QueryInspectionNode.IterationDirectionName<TLookupIterator>()}
             });
     }
 }

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.Wildcard.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.Wildcard.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Corax.Mappings;
+using Corax.Pipeline.Parsing;
+using Corax.Querying.Matches.Meta;
+using Sparrow.Server;
+using Voron.Data.CompactTrees;
+using Voron.Data.Lookups;
+
+namespace Corax.Querying.Matches.TermProviders;
+
+public struct PatternTermProvider<TLookupIterator> : ITermProvider
+    where TLookupIterator : struct, ILookupIterator
+{
+    private readonly CompactTree _tree;
+    private readonly IndexSearcher _searcher;
+    private readonly FieldMetadata _field;
+    private readonly CompactKey _pattern;
+    private readonly int _seekPrefixLength;
+    private readonly CancellationToken _token;
+    private CompactTree.Iterator<TLookupIterator> _iterator;
+    
+    private readonly string _patternString;
+    private readonly ByteString _termBuffer;
+
+    public PatternTermProvider(IndexSearcher searcher, CompactTree tree, in FieldMetadata field, CompactKey pattern, CancellationToken token)
+    {
+        _searcher = searcher;
+        _field = field;
+        _pattern = pattern;
+        _token = token;
+        _tree = tree;
+
+        var patternSpan = pattern.Decoded();
+
+        // The literal run before the first wildcard character lets us seek instead of scanning the whole field.
+        var firstPatternCharacter = patternSpan.IndexOfAny(Constants.Search.PatternSymbols);
+        _seekPrefixLength = firstPatternCharacter == -1 ? patternSpan.Length : firstPatternCharacter;
+
+        _patternString = null;
+        _termBuffer = default;
+        if (patternSpan.Contains(Constants.Search.QuestionMark))
+        {
+            _patternString = Encoding.UTF8.GetString(patternSpan);
+            searcher.Allocator.Allocate(Constants.Terms.MaxLength * sizeof(char), out _termBuffer);
+        }
+
+        _iterator = tree.Iterate<TLookupIterator>();
+        Reset();
+    }
+
+    public bool IsFillSupported => false;
+
+    public int Fill(Span<long> containers) => throw new NotImplementedException();
+
+    public void Reset()
+    {
+        _iterator = _tree.Iterate<TLookupIterator>();
+
+        // Only the forward iterator can seek to the prefix; the backward iterator falls back to a full scan.
+        if (_seekPrefixLength > 0 && default(TLookupIterator).IsForward)
+            _iterator.Seek(_pattern.Decoded()[.._seekPrefixLength]);
+        else
+            _iterator.Reset();
+    }
+
+    public bool Next(out TermMatch term)
+    {
+        var pattern = _pattern.Decoded();
+        var prefix = default(TLookupIterator).IsForward ? pattern[.._seekPrefixLength] : default;
+
+        while (_iterator.MoveNext(out var compactKey, out _, out _))
+        {
+            _token.ThrowIfCancellationRequested();
+
+            var key = compactKey.Decoded();
+
+            // Terms are sorted, so once we move past the prefix range there is nothing left to match.
+            if (prefix.IsEmpty == false && key.StartsWith(prefix) == false)
+                break;
+
+            var isMatch = _patternString != null && StandardParsers.IsAscii(key) == false
+                ? IsMatchUtf8(key)
+                : IsMatch(pattern, key, Constants.Search.Asterisk, Constants.Search.QuestionMark);
+
+            if (isMatch == false)
+                continue;
+
+            term = _searcher.TermQuery(_field, compactKey, _tree);
+            return true;
+        }
+
+        term = TermMatch.CreateEmpty(_searcher, _searcher.Allocator);
+        return false;
+    }
+    
+    private bool IsMatchUtf8(ReadOnlySpan<byte> term)
+    {
+        var termChars = _termBuffer.ToSpan<char>();
+        if (Encoding.UTF8.TryGetChars(term, termChars, out var charsWritten) == false)
+            throw new InvalidOperationException(
+                $"A term did not fit into {termChars.Length} chars during wildcard matching. Corax terms are limited to {Constants.Terms.MaxLength} bytes.");
+
+        return IsMatch(_patternString, termChars[..charsWritten],
+            (char)Constants.Search.Asterisk, (char)Constants.Search.QuestionMark);
+    }
+    
+    private static bool IsMatch<T>(ReadOnlySpan<T> pattern, ReadOnlySpan<T> term, T asterisk, T question)
+        where T : struct, IEquatable<T>
+    {
+        var wildcardPos = pattern.IndexOf(asterisk);
+
+        // No '*' at all: the pattern must cover the term exactly.
+        if (wildcardPos == -1)
+            return pattern.Length == term.Length && Consume(pattern, term, question);
+
+        // Consume prefix (if exists)
+        var prefix = pattern[..wildcardPos];
+        if (prefix.Length > term.Length || Consume(prefix, term, question) == false)
+            return false;
+
+        pattern = pattern[(wildcardPos + 1)..];
+        term = term[prefix.Length..];
+
+        while (pattern.IsEmpty == false)
+        {
+            //search for next wildcard
+            wildcardPos = pattern.IndexOf(asterisk);
+
+            // State: [*]patte?rn. So basically, we've to check if there is suffix that accepts our left pattern.
+            if (wildcardPos == -1)
+            {
+                if (pattern.Length > term.Length)
+                    return false;
+
+                var suffix = term[^pattern.Length..]; //takes pattern.Length elements from the end
+                return Consume(pattern, suffix, question);
+            }
+
+            // State [*]pa?t*ern, so we've to find first occurrence of "pa?t"
+            var currentSubpattern = pattern[..wildcardPos];
+            var subpatternPos = Seek(currentSubpattern, term, question);
+            if (subpatternPos == -1)
+                return false;
+
+            pattern = pattern[(wildcardPos + 1)..];
+            term = term[(subpatternPos + currentSubpattern.Length)..];
+        }
+
+        // Pattern ended with '*', which absorbs whatever is left of the term.
+        return true;
+    }
+
+    // Consumes a fixed-shape piece at the start of the window ('?' matches any single symbol).
+    private static bool Consume<T>(ReadOnlySpan<T> pattern, ReadOnlySpan<T> term, T questionMark)
+        where T : struct, IEquatable<T>
+    {
+        for (var i = 0; i < pattern.Length; i++)
+        {
+            if (pattern[i].Equals(term[i]) == false && pattern[i].Equals(questionMark) == false)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static int Seek<T>(ReadOnlySpan<T> pattern, ReadOnlySpan<T> term, T questionMark)
+        where T : struct, IEquatable<T>
+    {
+        // Shortcut, if we do not have question marks, search for the pattern directly.
+        if (pattern.Contains(questionMark) == false)
+            return term.IndexOf(pattern);
+
+        for (var pos = 0; pos + pattern.Length <= term.Length; pos++)
+        {
+            if (Consume(pattern, term.Slice(pos, pattern.Length), questionMark))
+                return pos;
+        }
+
+        return -1;
+    }
+
+    public QueryInspectionNode Inspect()
+    {
+        return new QueryInspectionNode($"{nameof(PatternTermProvider<TLookupIterator>)}",
+            parameters: new Dictionary<string, string>()
+            {
+                { Constants.QueryInspectionNode.FieldName, _field.ToString() },
+                { Constants.QueryInspectionNode.Term, _pattern.ToString()}
+            });
+    }
+}

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
@@ -68,6 +68,14 @@ public partial class IndexSearcher
     }
 
     
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public MultiTermMatch PatternQuery(in FieldMetadata field, Slice pattern, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
+    {
+        return forward
+            ? MultiTermMatchBuilder<PatternTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, pattern, streamingEnabled, validatePostfixLen: false, token: token)
+            : MultiTermMatchBuilder<PatternTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, pattern, streamingEnabled, validatePostfixLen: false, token: token);
+    }
+
     public MultiTermMatch RegexQuery(in FieldMetadata field, Regex regex, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
     {
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
@@ -71,19 +71,31 @@ public partial class IndexSearcher
     private bool TryRewriteTermWhenPerformingBackwardStreaming<TTermProvider>(bool streamingEnabled, Slice termSlice, out Slice termForSeek)
         where TTermProvider : struct, ITermProvider
     {
-        var shouldRewrite = typeof(TTermProvider) == typeof(StartsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>);
+        termForSeek = default;
 
-        if (streamingEnabled == false || shouldRewrite == false || termSlice.Size == 0)
-        {
-            termForSeek = default;
+        if (streamingEnabled == false || termSlice.Size == 0)
             return false;
+
+        if (typeof(TTermProvider) == typeof(StartsWithTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>))
+            return TryGetBackwardSeekTermForPrefix(termSlice.AsSpan(), out termForSeek);
+
+        if (typeof(TTermProvider) == typeof(PatternTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>))
+        {
+            var pattern = termSlice.AsSpan();
+            var prefixLength = pattern.IndexOfAny(Constants.Search.PatternSymbols);
+
+            return prefixLength > 0
+                   && TryGetBackwardSeekTermForPrefix(pattern[..prefixLength], out termForSeek);
         }
 
-        var originalTerm = termSlice.AsSpan();
+        return false;
+    }
 
+    private bool TryGetBackwardSeekTermForPrefix(ReadOnlySpan<byte> originalTerm, out Slice termForSeek)
+    {
         if (originalTerm[^1] < byte.MaxValue)
         {
-            Slice.From(Allocator, termSlice.AsSpan(), out termForSeek);
+            Slice.From(Allocator, originalTerm, out termForSeek);
             //When we have eg startsWith("ab") we have to seek into "ac"
             termForSeek.AsSpan()[^1]++;
             return true;
@@ -144,10 +156,10 @@ public partial class IndexSearcher
             return (TTermProvider)(object)new ContainsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term);
         
         if (typeof(TTermProvider) == typeof(PatternTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>))
-            return (TTermProvider)(object)new PatternTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field, term, token);
+            return (TTermProvider)(object)new PatternTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field, term, seekTerm, token);
 
         if (typeof(TTermProvider) == typeof(PatternTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>))
-            return (TTermProvider)(object)new PatternTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term, token);
+            return (TTermProvider)(object)new PatternTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term, seekTerm, token);
 
         if (typeof(TTermProvider) == typeof(ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>))
             return (TTermProvider)(object)new ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field);

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
@@ -143,6 +143,12 @@ public partial class IndexSearcher
         if (typeof(TTermProvider) == typeof(ContainsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>))
             return (TTermProvider)(object)new ContainsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term);
         
+        if (typeof(TTermProvider) == typeof(PatternTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>))
+            return (TTermProvider)(object)new PatternTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field, term, token);
+
+        if (typeof(TTermProvider) == typeof(PatternTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>))
+            return (TTermProvider)(object)new PatternTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>(this, termTree, field, term, token);
+
         if (typeof(TTermProvider) == typeof(ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>))
             return (TTermProvider)(object)new ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>(this, termTree, field);
         

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -1353,7 +1353,8 @@ namespace FastTests.Corax
                 new IndexSingleEntry {Id = "entry/6", Content = "a"},
                 new IndexSingleEntry {Id = "entry/7", Content = "b-ab"},
                 new IndexSingleEntry {Id = "entry/8", Content = "x-ab-b"},
-                new IndexSingleEntry {Id = "entry/9", Content = "a\u00e9b"}
+                new IndexSingleEntry {Id = "entry/9", Content = "a\u00e9b"},
+                new IndexSingleEntry {Id = "entry/10", Content = "ac"}
             };
 
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
@@ -1368,7 +1369,6 @@ namespace FastTests.Corax
                 ("**a**b", 5),
                 ("ab*cd", 2),
                 ("ab*x*d", 1),
-                ("abcd", 1),
                 ("a*a", 0),
                 ("*ab*b", 1),
                 ("*a*b*c*d", 2),
@@ -1376,22 +1376,63 @@ namespace FastTests.Corax
                 ("*a?b", 2),
                 ("*a??b", 2),
                 ("*?at*", 2),
-                ("a?cd", 1), 
+                ("a?cd", 1),
                 ("a?b", 1),
                 ("*\u00e9*", 1),
                 ("*?\u00e9*", 1),
             };
 
+            //The backward iterator seeks to the end of the pattern's prefix range when streaming is enabled and
+            //scans the whole field otherwise. Both have to return exactly the same terms as the forward one.
+            (bool Forward, bool Streaming)[] directions = [(true, false), (false, true), (false, false)];
+
             Span<long> ids = stackalloc long[16];
             foreach (var (pattern, expected) in cases)
             {
                 using var _ = Slice.From(bsc, pattern, out var patternSlice);
-                var match = searcher.PatternQuery(contentMetadata, patternSlice);
+                foreach (var (forward, streaming) in directions)
+                {
+                    var match = searcher.PatternQuery(contentMetadata, patternSlice, forward: forward, streamingEnabled: streaming);
 
-                Assert.Equal(expected, match.Fill(ids));
-                if (expected > 0)
-                    Assert.Equal(0, match.Fill(ids));
+                    Assert.Equal(expected, match.Fill(ids));
+                    if (expected > 0)
+                        Assert.Equal(0, match.Fill(ids));
+                }
             }
+
+            using (Slice.From(bsc, "abcd", out var termWithoutPattern))
+                Assert.Throws<InvalidOperationException>(() => { searcher.PatternQuery(contentMetadata, termWithoutPattern); });
+        }
+
+        [RavenFact(RavenTestCategory.Corax)]
+        public void PatternQueryCanBeAndedMoreThanOnce()
+        {
+            var entries = new[]
+            {
+                new IndexSingleEntry {Id = "entry/1", Content = "ab-x-cd"},
+                new IndexSingleEntry {Id = "entry/2", Content = "abcd"},
+                new IndexSingleEntry {Id = "entry/3", Content = "b-cat-a"}
+            };
+
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+            IndexEntries(bsc, entries, CreateKnownFields(bsc));
+
+            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
+            var contentMetadata = searcher.FieldMetadataBuilder("Content", ContentIndex);
+            using var _ = Slice.From(bsc, "ab*cd", out var patternSlice);
+
+            var match = searcher.PatternQuery(contentMetadata, patternSlice);
+            var allEntries = searcher.AllEntries();
+
+            Span<long> ids = stackalloc long[16];
+            Span<long> incoming = stackalloc long[16];
+            var total = allEntries.Fill(incoming);
+
+            incoming[..total].CopyTo(ids);
+            Assert.Equal(2, match.AndWith(ids, total));
+
+            incoming[..total].CopyTo(ids);
+            Assert.Equal(2, match.AndWith(ids, total));
         }
 
         [RavenFact(RavenTestCategory.Corax)]

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -1341,6 +1341,60 @@ namespace FastTests.Corax
         }
 
         [RavenFact(RavenTestCategory.Corax)]
+        public void WildcardQueryStatement()
+        {
+            var entries = new[]
+            {
+                new IndexSingleEntry {Id = "entry/1", Content = "a-cat-b"},
+                new IndexSingleEntry {Id = "entry/2", Content = "xa*b"},
+                new IndexSingleEntry {Id = "entry/3", Content = "b-cat-a"},
+                new IndexSingleEntry {Id = "entry/4", Content = "ab-x-cd"},
+                new IndexSingleEntry {Id = "entry/5", Content = "abcd"},
+                new IndexSingleEntry {Id = "entry/6", Content = "a"},
+                new IndexSingleEntry {Id = "entry/7", Content = "b-ab"},
+                new IndexSingleEntry {Id = "entry/8", Content = "x-ab-b"},
+                new IndexSingleEntry {Id = "entry/9", Content = "a\u00e9b"}
+            };
+
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+            IndexEntries(bsc, entries, CreateKnownFields(bsc));
+
+            using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
+            var contentMetadata = searcher.FieldMetadataBuilder("Content", ContentIndex);
+
+            var cases = new (string Pattern, int Expected)[]
+            {
+                ("*a*b", 5),
+                ("**a**b", 5),
+                ("ab*cd", 2),
+                ("ab*x*d", 1),
+                ("abcd", 1),
+                ("a*a", 0),
+                ("*ab*b", 1),
+                ("*a*b*c*d", 2),
+                ("*a*c*b*d", 0),
+                ("*a?b", 2),
+                ("*a??b", 2),
+                ("*?at*", 2),
+                ("a?cd", 1), 
+                ("a?b", 1),
+                ("*\u00e9*", 1),
+                ("*?\u00e9*", 1),
+            };
+
+            Span<long> ids = stackalloc long[16];
+            foreach (var (pattern, expected) in cases)
+            {
+                using var _ = Slice.From(bsc, pattern, out var patternSlice);
+                var match = searcher.PatternQuery(contentMetadata, patternSlice);
+
+                Assert.Equal(expected, match.Fill(ids));
+                if (expected > 0)
+                    Assert.Equal(0, match.Fill(ids));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Corax)]
         public void SimpleBetweenCompareStatement()
         {
             var entry1 = new IndexSingleEntry {Id = "entry/1", Content = "3"};

--- a/test/SlowTests/Issues/RavenDB_27286.cs
+++ b/test/SlowTests/Issues/RavenDB_27286.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27286(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["*a*b", 4])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["*a*b*", 4])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["a*b", 1])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["a*b*", 1])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["*b*a", 1])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["*a?b", 3])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["*?at*", 2])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["a?b", 0])]
+    public void SearchWithWildcardInsideTermBehavesTheSameOnBothEngines(Options options, string pattern, int expectedCount)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item { Name = "a-cat-b" });
+            session.Store(new Item { Name = "xaéb" });
+            session.Store(new Item { Name = "xa*b" });
+            session.Store(new Item { Name = "a*b" });
+            session.Store(new Item { Name = "b-cat-a" });
+            session.SaveChanges();
+        }
+
+        new ItemsIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<Item, ItemsIndex>().Search(x => x.Name, pattern).ToList();
+            Assert.Equal(expectedCount, results.Count);
+        }
+    }
+
+    private class Item
+    {
+        public string Name { get; set; }
+    }
+
+    private class ItemsIndex : AbstractIndexCreationTask<Item>
+    {
+        public ItemsIndex()
+        {
+            Map = items => from item in items select new { item.Name };
+            Index(x => x.Name, FieldIndexing.Search);
+            Analyze(x => x.Name, "LowerCaseKeywordAnalyzer");
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_27286.cs
+++ b/test/SlowTests/Issues/RavenDB_27286.cs
@@ -43,6 +43,34 @@ public class RavenDB_27286(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["a?b", 1])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["a*b", 1])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["?axb", 0])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, Data = ["*a?b", 4])]
+    public void PatternTermMatcherIsCompatibileAcrossSearchEngines(Options options, string pattern, int expectedCount)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item { Name = "axb" });
+            session.Store(new Item { Name = "a?b" });
+            session.Store(new Item { Name = "a*b" });
+            session.Store(new Item { Name = "zaxb" });
+            session.SaveChanges();
+        }
+
+        new ItemsIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<Item, ItemsIndex>().Search(x => x.Name, pattern).ToList();
+            Assert.Equal(expectedCount, results.Count);
+        }
+    }
+
     private class Item
     {
         public string Name { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27286

### Additional description

Support for queries like:
`where search(Field, "m*ej")`
`where search(Field, "?aciej")`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
