### PR TITLE
RavenDB-27293 Explain how to recover a failed shared journals root

### DIFF
--- a/src/Raven.Server/Documents/Indexes/SharedIndexJournals.cs
+++ b/src/Raven.Server/Documents/Indexes/SharedIndexJournals.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using Raven.Server.Config.Categories;
 using Raven.Server.Logging;
+using Raven.Server.Storage.Layout;
 using Raven.Server.Utils;
 using Sparrow.Logging;
 using Sparrow;
@@ -58,7 +59,7 @@ public class SharedIndexJournals : IJournalMerger, IDisposable
         options.OnIntegrityErrorOfAlreadySyncedData += (s, e) => documentDatabase.HandleOnIndexIntegrityErrorOfAlreadySyncedData(IndexingConfiguration.SharedJournalsStorageName, s, e);
         options.OnRecoverableFailure += documentDatabase.HandleRecoverableFailure;
 
-        _env = new StorageEnvironment(options);
+        _env = StorageLoader.OpenEnvironment(options, StorageEnvironmentWithType.StorageEnvironmentType.SharedJournals);
         _logger = RavenLogManager.Instance.GetLoggerForDatabase<SharedIndexJournals>(documentDatabase);
         _env.Journal.BranchJournalMerger = this;
         _env.Journal.OnBranchHardLinkLimitReached = OnBranchHardLinkLimitReached;

--- a/src/Raven.Server/Storage/Layout/StorageLoader.cs
+++ b/src/Raven.Server/Storage/Layout/StorageLoader.cs
@@ -89,6 +89,13 @@ namespace Raven.Server.Storage.Layout
                                            "This switch is meant to be use only for recovery purposes. Please make sure that you won't use it after you manage to recover your data. " +
                                            $"Eventually you should delete the system storage at '{basePath.FullPath}', start the server and create your databases again with the usage of existing data.";
                                 break;
+                            case StorageEnvironmentWithType.StorageEnvironmentType.SharedJournals:
+                                message += "This is the shared index-journals storage: it holds journal bookkeeping shared by all indexes of the " +
+                                           "database, so the database cannot be loaded without it even though it contains no index data of its own. " +
+                                           "You can start the server in dangerous mode temporarily so it will ignore invalid journals on startup:" +
+                                           $"{Environment.NewLine}{ravenServer} --{RavenConfiguration.GetKey(x => x.Storage.IgnoreInvalidJournalErrors)}=true{Environment.NewLine}" +
+                                           "This switch is meant to be use only for recovery purposes. Please make sure that you won't use it after you manage to recover your data.";
+                                break;
                             default:
                                 throw new ArgumentException($"Unknown storage type: {type}", nameof(type));
 

--- a/test/SlowTests/Voron/Issues/RavenDB_27293.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27293.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+// A missing journal file in Indexes/@SharedJournals/Journals fails the WHOLE database load, because
+// GetJournalFileInfo checks file presence unconditionally regardless of sync state. That is recoverable with
+// Storage.Dangerous.IgnoreInvalidJournalErrors, but the shared root used to be opened with a bare
+// `new StorageEnvironment(options)`, bypassing StorageLoader - so the operator got a raw Voron
+// "No such journal" with no indication that a remedy exists. Found as RavenDB-24520 finding F-9.
+public class RavenDB_27293(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class Item
+    {
+        public string Name { get; set; }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task SharedJournalsRootMustReportTheRemedyWhenItsJournalIsMissing()
+    {
+        using var store = GetDocumentStore(new Options { RunInMemory = false });
+
+        await store.Maintenance.SendAsync(new PutIndexesOperation(new IndexDefinition
+        {
+            Name = "Idx/A",
+            Maps = { "from i in docs.Items select new { i.Name }" }
+        }));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Item { Name = "a" }, "items/1");
+            await session.SaveChangesAsync();
+        }
+        Indexes.WaitForIndexing(store);
+
+        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        Assert.NotNull(database.IndexStore.SharedJournals);
+
+        var rootEnv = database.IndexStore.SharedJournals.Env;
+        string journalsDir = Path.Combine(rootEnv.Options.BasePath.FullPath, "Journals");
+
+        // the journal recovery must start from - deleting a LATER one is tolerated as a torn tail
+        long lastSynced = rootEnv.HeaderAccessor.CopyHeader().Journal.LastSyncedJournal;
+        string victim = Path.Combine(journalsDir, StorageEnvironmentOptions.JournalName(lastSynced < 0 ? 0 : lastSynced));
+        Output.WriteLine($"LastSyncedJournal={lastSynced}, deleting {Path.GetFileName(victim)}");
+
+        await store.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(store.Database, disable: true));
+
+        Assert.True(File.Exists(victim), $"expected {victim} to exist before deleting it");
+        await DeleteWithRetryAsync(victim); // the toggle returns before the unloaded database releases its handles
+
+        // re-enabling already fails, because the toggle waits for the database to load - so both the toggle and
+        // the explicit load have to be inside the assertion, whichever surfaces the failure first
+        var e = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await store.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(store.Database, disable: false));
+            await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+        });
+
+        // ToString() carries the whole inner-exception and AggregateException chain
+        string message = e.ToString();
+
+        Assert.Contains("No such journal", message);
+        Assert.Contains(RavenConfiguration.GetKey(x => x.Storage.IgnoreInvalidJournalErrors), message);
+        Assert.Contains("shared index-journals storage", message);
+    }
+
+    private static async Task DeleteWithRetryAsync(string path)
+    {
+        for (int i = 0; ; i++)
+        {
+            try
+            {
+                File.Delete(path);
+                return;
+            }
+            catch (IOException) when (i < 100)
+            {
+                await Task.Delay(100);
+            }
+        }
+    }
+}


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27293

### Additional description

The shared root was opened with a bare `new StorageEnvironment(options)`, bypassing StorageLoader, so a missing or invalid journal surfaced as a raw Voron "No such journal" with no remedy. It now goes through StorageLoader with the existing but previously unhandled StorageEnvironmentType.SharedJournals, and the switch needs that case in the same change because its default arm throws ArgumentException("Unknown storage type") and would mask the real error. Side effect: options are now disposed on a failed open, which SharedIndexJournals did not do.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
