### PR TITLE
RavenDB-26826: Port of https://github.com/ravendb/ravendb/pull/22993 to v6.2

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -143,18 +143,21 @@ namespace Raven.Server.Documents.Replication.Incoming
                     var configuration = GetConfiguration();
                     var readTimeout = (int)configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds;
 
+                    var sinceLastReceive = Stopwatch.StartNew(); // time since the last REAL read
                     long lastTotalBytesRead = 0;
 
                     while (_cts.IsCancellationRequested == false)
                     {
                         try
                         {
+                            var remaining = readTimeout - (int)sinceLastReceive.ElapsedMilliseconds;
+
                             AddReplicationPulse(ReplicationPulseDirection.IncomingInitiate);
 
                             using (var msg = interruptibleRead.ParseToMemory(
                                 _replicationFromAnotherSource,
                                 "IncomingReplication/read-message",
-                                readTimeout,
+                                remaining,
                                 _copiedBuffer.Buffer,
                                 _cts.Token))
                             {
@@ -167,6 +170,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                                     var currentUsed = _copiedBuffer.Buffer.Used;
                                     if (currentUsed > lastTotalBytesRead)
                                     {
+                                        sinceLastReceive.Restart(); // partial bytes = activity
                                         lastTotalBytesRead = currentUsed;
                                         if (Logger.IsInfoEnabled)
                                             Logger.Info($"Incoming replication from `{FromToString}` timed out ({readTimeout}ms) while reading next batch, " +
@@ -179,10 +183,13 @@ namespace Raven.Server.Documents.Replication.Incoming
                                     throw new TimeoutException($"Incoming replication from `{FromToString}` timed out while reading next batch. Read timeout = {readTimeout} ms. No data received in this interval.");
                                 }
 
-                                lastTotalBytesRead = 0;
-
                                 if (msg.Document != null)
                                 {
+                                    // Only a fully-consumed message resets the partial-read tracker; doing it on the
+                                    // notify branch would make any residual buffered bytes look like fresh growth on the
+                                    // next timeout, which would keep restarting sinceLastReceive and defeat the read-timeout.
+                                    lastTotalBytesRead = 0;
+
                                     EnsureNotDeleted();
 
                                     using (var writer = new BlittableJsonTextWriter(msg.Context, _stream))
@@ -191,6 +198,8 @@ namespace Raven.Server.Documents.Replication.Incoming
                                             msg.Document,
                                             writer);
                                     }
+
+                                    sinceLastReceive.Restart();
                                 }
                                 else // notify peer about new change vector
                                 {

--- a/src/Raven.Server/Documents/Replication/InterruptibleRead.cs
+++ b/src/Raven.Server/Documents/Replication/InterruptibleRead.cs
@@ -51,6 +51,9 @@ namespace Raven.Server.Documents.Replication
             JsonOperationContext.MemoryBuffer buffer,
             CancellationToken token)
         {
+            if (timeout <= 0)
+                return new Result { Timeout = true };
+
             if (_prevCall == null)
             {
                 _prevCall = ReadNextObject(debugTag, buffer, token);

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -310,12 +310,16 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
         private bool WaitForChanges(int timeout, CancellationToken token)
         {
+            var sinceLastReceive = Stopwatch.StartNew();
+
             while (true)
             {
+                var remaining = timeout - (int)sinceLastReceive.ElapsedMilliseconds;
+
                 using (var result = _interruptibleRead.ParseToMemory(
                     _waitForChanges,
                     "replication notify message",
-                    timeout,
+                    remaining,
                     _buffer,
                     token))
                 {

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -16,6 +18,7 @@ using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server.Config;
+using Raven.Server.Documents.Replication.Incoming;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -1282,6 +1285,483 @@ namespace SlowTests.Server.Replication
                 resList.Add(await task);
             }
             return resList;
+        }
+
+        // Reproduces the "zombie pull connection" deadlock on a busy sink.
+        //
+        // RavenDB_25412 proved that when the hub stops sending, the sink's read-timeout
+        // (Replication.ActiveConnectionTimeout) fires, the hung connection is reaped, and the sink reconnects.
+        //
+        // This test adds the one ingredient that was present in the production incident but missing from
+        // that test: OTHER incoming replication traffic on the same sink node. Every time any other incoming
+        // connection receives a batch, ReplicationLoader.OnIncomingReceiveSucceeded calls
+        // OnReplicationFromAnotherSource() on EVERY other incoming handler. That wakes the handler's read loop
+        // (the "notify" branch) and makes InterruptibleRead.ParseToMemory return Interrupted with a brand-new
+        // per-call timeout window. On a busy node these wake-ups arrive faster than the timeout, so msg.Timeout
+        // never fires: before the fix the hung connection became an immortal zombie that was never reaped and
+        // never reconnected, and only a task restart (which disposes it via DropIncomingConnections) cleared it.
+        //
+        // The fix tracks time since the last REAL receive and reaps on that, so the timeout fires regardless of
+        // how many notify wake-ups occur. EXPECTED: this test FAILS on the pre-fix code (reproduces the bug) and
+        // passes with the fix.
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task BusySink_ShouldStillTimeoutAndReconnect_HangingPullConnection()
+        {
+            DoNotReuseServer();
+
+            // keep the read-timeout short so the test is fast
+            var customSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.ActiveConnectionTimeout)] = "5"
+            };
+
+            using var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
+            using var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
+
+            using var hubStore = GetDocumentStore(new Options
+            {
+                Server = hubServer
+            });
+
+            using var sinkStore = GetDocumentStore(new Options
+            {
+                Server = sinkServer
+            });
+
+            var pullReplicationName = $"{hubStore.Database}-pull";
+            var connectionStringName = "ConnectionString-" + hubStore.Database;
+
+            var sinkDb = await GetDatabase(sinkStore.Database, sinkServer);
+
+            // Open = normal, Closed = reads hang (socket stays up, no data arrives).
+            var networkGate = new AsyncGate();
+            var connectionCounter = 0;
+
+            var forTesting = sinkDb.ReplicationLoader.ForTestingPurposesOnly();
+            forTesting.WrapIncomingReplicationStream = innerStream =>
+            {
+                // Hang ONLY the first connection (the one we will strangle). Any reconnection must read
+                // normally, otherwise the global gate would block the recovered connection too and the
+                // second document could never arrive -- on buggy AND fixed code alike.
+                var n = Interlocked.Increment(ref connectionCounter);
+                return n == 1
+                    ? new SmartHangingStreamWrapper(innerStream, networkGate)
+                    : innerStream;
+            };
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(pullReplicationName)));
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Name = connectionStringName,
+                Database = hubStore.Database,
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+            await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+            {
+                Name = pullReplicationName,
+                HubName = pullReplicationName,
+                ConnectionStringName = connectionStringName
+            }));
+
+            // 1. initial replication works
+            using (var session = hubStore.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = "Users/1-A", Name = "Lev" });
+                await session.SaveChangesAsync();
+            }
+            Assert.True(WaitForDocument<User>(sinkStore, "Users/1-A", u => u.Name == "Lev"), "Initial replication failed");
+
+            var initialConnections = connectionCounter;
+
+            // The incoming pull handler must be established before we strangle it.
+            Assert.True(WaitForValue(() => sinkDb.ReplicationLoader.IncomingHandlers.OfType<IncomingReplicationHandler>().Any(), true),
+                "Expected an incoming pull replication handler on the sink");
+
+            // 2. Simulate a busy sink node: keep poking the notify event on every live incoming handler,
+            // exactly as OnIncomingReceiveSucceeded would when sibling connections receive batches.
+            using var pumpCts = new CancellationTokenSource();
+            var pump = NotifyPump(sinkDb, pumpCts.Token);
+
+            // 3. The hub goes silent on this connection (socket up, nothing arrives). The notify wake-ups keep driving
+            // the "notify" branch, so before the fix the read-timeout never fired. The fix must reap it regardless.
+            networkGate.Close();
+
+            using (var session = hubStore.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = "Users/2-A", Name = "Lev" });
+                await session.SaveChangesAsync();
+            }
+
+            // Allow several timeout windows for the zombie to be reaped, the sink to reconnect, and the doc to arrive.
+            var timeout = (int)sinkDb.Configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds * 4;
+
+            // PRIMARY assertion (gates the read-timeout fix): even on a busy sink, the read-timeout must fire, reap the
+            // zombie, and trigger a reconnect. A reconnect creates a new incoming stream, so connectionCounter increments.
+            var reconnected = WaitForValue(() => connectionCounter > initialConnections, true, timeout: timeout, interval: 200);
+            Assert.True(reconnected,
+                $"The hung pull connection was never reaped while the sink was busy. connectionCounter={connectionCounter}, initial={initialConnections}. " +
+                $"The notify wake-ups kept resetting the read-timeout, leaving an immortal zombie incoming handler that only a task restart would clear.");
+
+            // SECONDARY assertion (end-to-end recovery): once reaped, the sink reconnects on a clean stream and the
+            // second document arrives.
+            Assert.True(WaitForDocument<User>(sinkStore, "Users/2-A", u => u.Name == "Lev", timeout), "Second replication failed (end-to-end recovery)");
+
+            pumpCts.Cancel();
+            try
+            { await pump; }
+            catch { /* ignored */ }
+        }
+
+        // The flip side of the read-timeout fix: it must NOT reap a HEALTHY idle connection, EVEN under heavy notify
+        // fan-out. A healthy idle source keeps sending heartbeats (every ReplicationMinimalHeartbeat); the sink RECEIVES
+        // them (the msg.Document != null branch) and restarts the read-timeout. Because the timeout is evaluated only
+        // AFTER the read has had its chance to return, a heartbeat that already arrived is always consumed before any
+        // reap -- so the notify flood cannot reap a live connection. (Before the fix this test FAILED: the read-timeout
+        // was decided at the top of the loop, so under a notify flood a buffered heartbeat could be reaped before it was
+        // consumed.)
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task HealthyIdleConnection_IsNotReaped_UnderNotifyFanOut()
+        {
+            DoNotReuseServer();
+
+            // read-timeout (5s) > heartbeat interval (2s): a healthy idle peer's heartbeats keep the connection alive.
+            var customSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.ActiveConnectionTimeout)] = "5",
+                [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "2"
+            };
+
+            using var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
+            using var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
+
+            using var hubStore = GetDocumentStore(new Options { Server = hubServer });
+            using var sinkStore = GetDocumentStore(new Options { Server = sinkServer });
+
+            var pullReplicationName = $"{hubStore.Database}-pull";
+            var connectionStringName = "ConnectionString-" + hubStore.Database;
+            var sinkDb = await GetDatabase(sinkStore.Database, sinkServer);
+
+            var connectionCounter = 0;
+            var forTesting = sinkDb.ReplicationLoader.ForTestingPurposesOnly();
+            forTesting.WrapIncomingReplicationStream = innerStream =>
+            {
+                // Passthrough: the connection stays healthy; we only count (re)connections.
+                Interlocked.Increment(ref connectionCounter);
+                return innerStream;
+            };
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(pullReplicationName)));
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Name = connectionStringName,
+                Database = hubStore.Database,
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+            await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+            {
+                Name = pullReplicationName,
+                HubName = pullReplicationName,
+                ConnectionStringName = connectionStringName
+            }));
+
+            using (var session = hubStore.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = "Users/1-A", Name = "Lev" });
+                await session.SaveChangesAsync();
+            }
+            Assert.True(WaitForDocument<User>(sinkStore, "Users/1-A", u => u.Name == "Lev"), "Initial replication failed");
+
+            var initialConnections = connectionCounter;
+
+            IncomingReplicationHandler pullHandler = null;
+            Assert.True(WaitForValue(() =>
+            {
+                pullHandler = sinkDb.ReplicationLoader.IncomingHandlers.OfType<IncomingReplicationHandler>().FirstOrDefault();
+                return pullHandler != null;
+            }, true), "Expected an incoming pull replication handler on the sink");
+
+            // Flood the handler with notify wake-ups, exactly as a busy node would. The connection is healthy: the hub
+            // keeps sending heartbeats which the sink receives. It must survive every read-timeout window unchanged.
+            using var pumpCts = new CancellationTokenSource();
+            var pump = NotifyPump(sinkDb, pumpCts.Token);
+
+            var readTimeoutMs = (int)sinkDb.Configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds;
+            for (var i = 0; i < (readTimeoutMs * 3) / 1000; i++)
+            {
+                await Task.Delay(1000);
+                Assert.Equal(initialConnections, connectionCounter); // a reconnect would increment this => reaped
+                var current = sinkDb.ReplicationLoader.IncomingHandlers.OfType<IncomingReplicationHandler>().FirstOrDefault();
+                Assert.True(ReferenceEquals(current, pullHandler),
+                    $"The healthy incoming handler was reaped/replaced while idle under notify fan-out " +
+                    $"(connectionCounter={connectionCounter}, initial={initialConnections}).");
+            }
+
+            // And it still works: a new document flows over the SAME connection (no reconnect).
+            using (var session = hubStore.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = "Users/2-A", Name = "Lev" });
+                await session.SaveChangesAsync();
+            }
+            Assert.True(WaitForDocument<User>(sinkStore, "Users/2-A", u => u.Name == "Lev", 10_000), "Healthy connection stopped replicating");
+            Assert.Equal(initialConnections, connectionCounter);
+
+            pumpCts.Cancel();
+            try
+            { await pump; }
+            catch { /* ignored */ }
+        }
+
+        // Realistic fleet-load check (external replication, same code path as a hub): many sources replicate into one
+        // destination. One source stays idle (the "victim"); the others push continuously, so every batch fires
+        // ReplicationLoader.OnIncomingReceiveSucceeded -> OnReplicationFromAnotherSource on the victim's handler (genuine
+        // notify fan-out). The idle victim keeps sending heartbeats, so with the fix it must NOT be reaped: the timeout
+        // is only evaluated after a read, and received heartbeats reset it. We assert ZERO churn on the destination
+        // (no reconnect of any handler) and that the idle victim keeps replicating.
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task BusyDestination_IdleSource_IsNotReaped_AndKeepsReplicating()
+        {
+            DoNotReuseServer();
+
+            var customSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.ActiveConnectionTimeout)] = "10",
+                [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "2"
+            };
+            using var server = GetNewServer(new ServerCreationOptions { CustomSettings = customSettings });
+
+            using var dest = GetDocumentStore(new Options { Server = server });
+            using var victim = GetDocumentStore(new Options { Server = server });
+            var noisy = new List<DocumentStore>();
+            for (var i = 0; i < 4; i++)
+                noisy.Add((DocumentStore)GetDocumentStore(new Options { Server = server }));
+
+            var destDb = await GetDatabase(dest.Database, server);
+
+            var connectionCounter = 0;
+            destDb.ReplicationLoader.ForTestingPurposesOnly().WrapIncomingReplicationStream = s =>
+            {
+                Interlocked.Increment(ref connectionCounter); // count every incoming (re)connection on the destination
+                return s;
+            };
+
+            var sources = new List<DocumentStore> { victim };
+            sources.AddRange(noisy);
+
+            // external replication: every source -> destination
+            foreach (var src in sources)
+                await SetupReplicationAsync(src, dest);
+
+            // seed one doc per source so all connections establish and replicate
+            for (var i = 0; i < sources.Count; i++)
+            {
+                using var s = sources[i].OpenAsyncSession();
+                await s.StoreAsync(new User { Id = $"seed/{i}", Name = "x" });
+                await s.SaveChangesAsync();
+            }
+            Assert.True(WaitForValue(() => destDb.ReplicationLoader.IncomingHandlers.Count() == sources.Count, true, timeout: 30_000),
+                $"Expected {sources.Count} incoming handlers on the destination, got {destDb.ReplicationLoader.IncomingHandlers.Count()}");
+
+            await Task.Delay(2000); // let things settle
+            var initialConnections = connectionCounter;
+
+            // The noisy sources push continuously -> genuine OnIncomingReceiveSucceeded fan-out onto every handler.
+            using var noiseCts = new CancellationTokenSource();
+            var noiseTasks = noisy.Select((src, idx) => Task.Run(async () =>
+            {
+                var k = 0;
+                while (noiseCts.IsCancellationRequested == false)
+                {
+                    try
+                    {
+                        using var s = src.OpenAsyncSession();
+                        await s.StoreAsync(new User { Id = $"noise/{idx}/{k++}", Name = "n" });
+                        await s.SaveChangesAsync();
+                    }
+                    catch { /* shutting down */ }
+                    try
+                    { await Task.Delay(100, noiseCts.Token); }
+                    catch { /* cancelled */ }
+                }
+            })).ToList();
+
+            // Run under heavy notify fan-out for several read-timeout windows. The idle victim keeps sending heartbeats,
+            // so its connection must never be reaped: no handler on the destination should reconnect (zero churn).
+            var readTimeoutMs = (int)destDb.Configuration.Replication.ActiveConnectionTimeout.AsTimeSpan.TotalMilliseconds;
+            await Task.Delay(readTimeoutMs * 3);
+
+            Assert.Equal(initialConnections, connectionCounter); // any reconnect under load => a healthy connection was reaped
+
+            // The idle victim is still connected and still replicates.
+            Assert.True(destDb.ReplicationLoader.IncomingHandlers.Any(h => h.ConnectionInfo.SourceDatabaseName == victim.Database),
+                "The idle victim's incoming connection was dropped under fleet load.");
+
+            using (var s = victim.OpenAsyncSession())
+            {
+                await s.StoreAsync(new User { Id = "victim/final", Name = "v" });
+                await s.SaveChangesAsync();
+            }
+            Assert.True(WaitForDocument<User>(dest, "victim/final", u => u.Name == "v", 20_000),
+                "The idle victim source stopped replicating under fleet load.");
+
+            noiseCts.Cancel();
+            foreach (var t in noiseTasks)
+            { try { await t; } catch { /* ignored */ } }
+            foreach (var s in noisy)
+                s.Dispose();
+        }
+
+        // Pokes the notify event on every live incoming handler, exactly as ReplicationLoader.OnIncomingReceiveSucceeded
+        // does when sibling connections receive batches. This is the "busy node" ingredient.
+        private static Task NotifyPump(Raven.Server.Documents.DocumentDatabase db, CancellationToken token)
+        {
+            return Task.Run(async () =>
+            {
+                while (token.IsCancellationRequested == false)
+                {
+                    foreach (var handler in db.ReplicationLoader.IncomingHandlers)
+                    {
+                        try
+                        {
+                            (handler as IncomingReplicationHandler)?.OnReplicationFromAnotherSource();
+                        }
+                        catch
+                        {
+                            // handler may be disposed mid-iteration; ignore
+                        }
+                    }
+
+                    try
+                    { await Task.Delay(100, token); }
+                    catch { /* cancelled */ }
+                }
+            });
+        }
+
+        private class AsyncGate
+        {
+            private readonly object _lock = new object();
+            private TaskCompletionSource<object> _openTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private TaskCompletionSource<object> _closeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private volatile bool _isOpen = true;
+
+            public AsyncGate()
+            {
+                _openTcs.SetResult(null);
+            }
+
+            public bool IsOpen => _isOpen;
+
+            public void Close()
+            {
+                lock (_lock)
+                {
+                    if (!_isOpen)
+                        return;
+                    _isOpen = false;
+                    _openTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _closeTcs.TrySetResult(null);
+                }
+            }
+
+            public void Open()
+            {
+                lock (_lock)
+                {
+                    if (_isOpen)
+                        return;
+                    _isOpen = true;
+                    _closeTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _openTcs.TrySetResult(null);
+                }
+            }
+
+            public Task WaitToOpenAsync(CancellationToken token)
+            {
+                lock (_lock)
+                {
+                    if (_isOpen)
+                        return Task.CompletedTask;
+                    return _openTcs.Task.WithCancellation(token);
+                }
+            }
+
+            public Task WaitToCloseAsync(CancellationToken token)
+            {
+                lock (_lock)
+                {
+                    if (!_isOpen)
+                        return Task.CompletedTask;
+                    return _closeTcs.Task.WithCancellation(token);
+                }
+            }
+        }
+
+        private class SmartHangingStreamWrapper : Stream
+        {
+            private readonly Stream _inner;
+            private readonly AsyncGate _gate;
+            private readonly CancellationTokenSource _disposeCts = new CancellationTokenSource();
+
+            public SmartHangingStreamWrapper(Stream inner, AsyncGate gate)
+            {
+                _inner = inner;
+                _gate = gate;
+            }
+
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCts.Token))
+                    {
+                        try
+                        {
+                            await _gate.WaitToOpenAsync(linkedCts.Token);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            if (_disposeCts.IsCancellationRequested)
+                                throw new IOException("Stream disposed");
+                            throw;
+                        }
+
+                        var readTask = _inner.ReadAsync(buffer, offset, count, cancellationToken);
+                        var closeGateTask = _gate.WaitToCloseAsync(linkedCts.Token);
+
+                        var completedTask = await Task.WhenAny(readTask, closeGateTask);
+                        if (completedTask == closeGateTask)
+                        {
+                            continue;
+                        }
+
+                        return await readTask;
+                    }
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _disposeCts.Cancel();
+                    _inner.Dispose();
+                    _disposeCts.Dispose();
+                }
+                base.Dispose(disposing);
+            }
+
+            public override void Flush() => _inner.Flush();
+            public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+            public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+            public override void SetLength(long value) => _inner.SetLength(value);
+            public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+            public override bool CanRead => _inner.CanRead;
+            public override bool CanSeek => _inner.CanSeek;
+            public override bool CanWrite => _inner.CanWrite;
+            public override long Length => _inner.Length;
+            public override long Position { get => _inner.Position; set => _inner.Position = value; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26826/Replication-a-busy-node-never-times-out-a-dead-incoming-connection-blocking-reconnect-notify-wake-ups-reset

### Additional description

https://github.com/ravendb/ravendb/pull/22993

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
