### PR TITLE
HRINT-5009 add policy to retry fetch the setup package

### DIFF
--- a/src/Raven.Quill/AiHelper/LicenseHttpClient.cs
+++ b/src/Raven.Quill/AiHelper/LicenseHttpClient.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using Polly;
+using Polly.Retry;
 using Raven.Server.Commercial;
 
 namespace Raven.Quill.AiHelper;
@@ -13,7 +16,7 @@ public sealed class LicenseHttpClient : ILicenseClient
         HttpResponseMessage response;
         try
         {
-            response = await ApiHttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, shouldRetry: false, ct);
+            response = await ApiHttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, SetupPackageRetryPolicy, token: ct);
         }
         catch (HttpRequestException e)
         {
@@ -33,4 +36,16 @@ public sealed class LicenseHttpClient : ILicenseClient
             await SetupPackageDownload.CopyCappedAsync(source, destination, ct);
         }
     }
+
+    private static readonly AsyncRetryPolicy<HttpResponseMessage> SetupPackageRetryPolicy = Policy
+        .HandleResult<HttpResponseMessage>(r => r.StatusCode is HttpStatusCode.ServiceUnavailable && r.Headers.RetryAfter != null)
+        .WaitAndRetryAsync(
+            retryCount: 5,
+            sleepDurationProvider: (_, result, _) => result.Result.Headers.RetryAfter.Delta.Value,
+            onRetryAsync: (outcome, _, _, _) =>
+            {
+                // ResponseHeadersRead holds the connection until the message is disposed
+                using (outcome.Result)
+                    return Task.CompletedTask;
+            });
 }

--- a/src/Raven.Server/Commercial/ApiHttpClient.cs
+++ b/src/Raven.Server/Commercial/ApiHttpClient.cs
@@ -94,12 +94,10 @@ namespace Raven.Server.Commercial
             return RetryPolicy.ExecuteAsync(t => Instance.GetAsync(relativeUri, t), token, continueOnCapturedContext: false);
         }
 
-        public static Task<HttpResponseMessage> GetAsync(string relativeUri, HttpCompletionOption completionOption, bool shouldRetry = true, CancellationToken token = default)
+        public static Task<HttpResponseMessage> GetAsync(string relativeUri, HttpCompletionOption completionOption, AsyncRetryPolicy<HttpResponseMessage> policy = null, CancellationToken token = default)
         {
-            if (shouldRetry == false)
-                return Instance.GetAsync(relativeUri, completionOption, token);
-
-            return RetryPolicy.ExecuteAsync(t => Instance.GetAsync(relativeUri, completionOption, t), token, continueOnCapturedContext: false);
+            policy ??= RetryPolicy;
+            return policy.ExecuteAsync(t => Instance.GetAsync(relativeUri, completionOption, t), token, continueOnCapturedContext: false);
         }
 
         static ApiHttpClient()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRINT-5009

### Additional description

add policy to retry fetch the setup package

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
