### PR TITLE
RavenDB-27156 Query indexes directly for entry count in e2e test

### DIFF
--- a/test/SlowTests/Voron/Issues/RavenDB_27156_e2e.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27156_e2e.cs
@@ -100,7 +100,12 @@ public class RavenDB_27156_e2e(ITestOutputHelper output) : RavenTestBase(output)
         Assert.Equal(750, docCount);
         Assert.Equal(3, finalStats.Length);
         Assert.All(finalStats, s => Assert.Equal(IndexState.Normal, s.State));
-        Assert.All(finalStats, s => Assert.Equal(docCount, s.EntriesCount));
+
+        foreach (var name in new[] { "Idx/A", "Idx/B", "Idx/C" })
+        {
+            using var session = store.OpenAsyncSession();
+            Assert.Equal(docCount, await session.Query<Item>(name).Customize(x => x.WaitForNonStaleResults()).CountAsync());
+        }
     }
 
     private static async Task InsertItems(IDocumentStore store, int start, int count)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27156

### Additional description

`IndexStats.EntriesCount` is persisted after the batch tx and can trail the last processed etag

### Type of change

- [ ] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
