### PR TITLE
RavenDB-26860 Validate Storage.IoRingQueueSize is -1 or >= 3

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -181,7 +181,7 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Storage.LowPriorityFlushAndSync", ConfigurationEntryScope.ServerWideOnly)]
         public bool LowPriorityFlushAndSync { get; set; }
         
-        [Description("EXPERT: The queue size to use for I/O ring operations. Use -1 to disable I/O ring entirely, which is only honored when Storage.WriteMode=Auto.")]
+        [Description("EXPERT: The queue size to use for I/O ring operations, minimum 3. Use -1 to disable I/O ring entirely, which is only honored when Storage.WriteMode=Auto.")]
         [DefaultValue(1024)]
         [ConfigurationEntry("Storage.IoRingQueueSize", ConfigurationEntryScope.ServerWideOnly)]
         public int IoRingQueueSize { get; set; }
@@ -209,14 +209,22 @@ namespace Raven.Server.Config.Categories
 
         private void ValidateIoRingConfiguration()
         {
+            var sizeKey = RavenConfiguration.GetKey(x => x.Storage.IoRingQueueSize);
+            var modeKey = RavenConfiguration.GetKey(x => x.Storage.WriteMode);
+
+            if (IoRingQueueSize != -1 && IoRingQueueSize < 3)
+            {
+                throw new InvalidOperationException(
+                    $"'{sizeKey}' is set to {IoRingQueueSize}, which is not a valid I/O ring queue size. " +
+                    $"Use -1 to disable I/O ring (only supported with '{modeKey}={Pal.RvnWriteMode.Auto}') or a value of at least 3.");
+            }
+
             if (WriteMode == Pal.RvnWriteMode.IoRing && IoRingQueueSize == -1)
             {
-                var sizeKey = RavenConfiguration.GetKey(x => x.Storage.IoRingQueueSize);
-                var modeKey = RavenConfiguration.GetKey(x => x.Storage.WriteMode);
                 throw new InvalidOperationException(
                     $"'{modeKey}' is set to '{Pal.RvnWriteMode.IoRing}' but '{sizeKey}' is -1, which disables I/O ring. " +
                     $"Disabling I/O ring is only supported with '{modeKey}={Pal.RvnWriteMode.Auto}'. " +
-                    $"Either set '{modeKey}={Pal.RvnWriteMode.Auto}' or use a positive '{sizeKey}'.");
+                    $"Either set '{modeKey}={Pal.RvnWriteMode.Auto}' or use a '{sizeKey}' of at least 3.");
             }
         }
     }

--- a/src/Sparrow.Server/Platform/PalHelper.cs
+++ b/src/Sparrow.Server/Platform/PalHelper.cs
@@ -49,7 +49,14 @@ namespace Sparrow.Server.Platform
                 throw new FileNotFoundException(txt);
 
             if ((specialErrnoCodes & PalFlags.ErrnoSpecialCodes.NoSpc) != 0)
+            {
+                // ENOSPC from io-ring creation is the native 'queue too small' sentinel, not a disk-full condition
+                if (rc == PalFlags.FailCodes.FailCreateIoRing)
+                    throw new InvalidOperationException(
+                        $"Failed to create I/O ring, most likely because the requested queue size is too small. Check the 'Storage.IoRingQueueSize' configuration option. {txt}");
+
                 throw new DiskFullException(txt);
+            }
 
             if (PlatformDetails.RunningOnWindows)
             {

--- a/test/FastTests/Issues/RavenDB_26859.cs
+++ b/test/FastTests/Issues/RavenDB_26859.cs
@@ -25,9 +25,9 @@ namespace FastTests.Issues
         [RavenTheory(RavenTestCategory.Configuration | RavenTestCategory.Voron)]
         [InlineData("IoRing", "1024")]
         [InlineData("Auto", "-1")]
-        [InlineData("Auto", "0")]
+        [InlineData("Auto", "3")]
         [InlineData("FileIo", "-1")]
-        [InlineData("FileIo", "0")]
+        [InlineData("FileIo", "3")]
         public void ValidIoRingConfigurationInitializes(string writeMode, string queueSize)
         {
             var configuration = RavenConfiguration.CreateForServer(null);

--- a/test/FastTests/Issues/RavenDB_26860.cs
+++ b/test/FastTests/Issues/RavenDB_26860.cs
@@ -1,0 +1,83 @@
+using System;
+using Raven.Server.Config;
+using Sparrow.Server.Exceptions;
+using Sparrow.Server.Platform;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_26860 : NoDisposalNeeded
+    {
+        public RavenDB_26860(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Configuration | RavenTestCategory.Voron)]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("2")]
+        public void TooSmallIoRingQueueSizeUnderExplicitIoRingWriteModeFailsWithClearError(string queueSize)
+        {
+            var configuration = RavenConfiguration.CreateForServer(null);
+            configuration.SetSetting(RavenConfiguration.GetKey(x => x.Storage.WriteMode), "IoRing");
+            configuration.SetSetting(RavenConfiguration.GetKey(x => x.Storage.IoRingQueueSize), queueSize);
+
+            var error = Assert.ThrowsAny<Exception>(() => configuration.Initialize());
+            Assert.Contains("IoRingQueueSize", error.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Configuration | RavenTestCategory.Voron)]
+        [InlineData("IoRing", "-2")]
+        [InlineData("IoRing", "-100")]
+        [InlineData("Auto", "1")]
+        [InlineData("FileIo", "2")]
+        public void InvalidIoRingQueueSizeIsRejectedRegardlessOfWriteMode(string writeMode, string queueSize)
+        {
+            var configuration = RavenConfiguration.CreateForServer(null);
+            configuration.SetSetting(RavenConfiguration.GetKey(x => x.Storage.WriteMode), writeMode);
+            configuration.SetSetting(RavenConfiguration.GetKey(x => x.Storage.IoRingQueueSize), queueSize);
+
+            var error = Assert.ThrowsAny<Exception>(() => configuration.Initialize());
+            Assert.Contains("IoRingQueueSize", error.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Configuration | RavenTestCategory.Voron)]
+        [InlineData("IoRing", "3")]
+        [InlineData("IoRing", "1024")]
+        [InlineData("Auto", "-1")]
+        [InlineData("Auto", "1024")]
+        public void ValidIoRingQueueSizePassesValidation(string writeMode, string queueSize)
+        {
+            var configuration = RavenConfiguration.CreateForServer(null);
+            configuration.SetSetting(RavenConfiguration.GetKey(x => x.Storage.WriteMode), writeMode);
+            configuration.SetSetting(RavenConfiguration.GetKey(x => x.Storage.IoRingQueueSize), queueSize);
+
+            configuration.Initialize();
+
+            Assert.Equal(int.Parse(queueSize), configuration.Storage.IoRingQueueSize);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void FailCreateIoRingWithNoSpcErrnoThrowsConfigurationErrorNotDiskFull()
+        {
+            // 112 = ERROR_DISK_FULL on Windows, 28 = ENOSPC on Posix - both map to the NoSpc special code
+            var noSpcErrno = global::Sparrow.Platform.PlatformDetails.RunningOnWindows ? 112 : 28;
+
+            var error = Assert.ThrowsAny<Exception>(() =>
+                PalHelper.ThrowLastError(PalFlags.FailCodes.FailCreateIoRing, noSpcErrno, "failed to create io ring"));
+
+            Assert.IsNotType<DiskFullException>(error);
+            Assert.Contains("IoRingQueueSize", error.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void GenuineDiskFullStillMapsToDiskFullException()
+        {
+            var noSpcErrno = global::Sparrow.Platform.PlatformDetails.RunningOnWindows ? 112 : 28;
+
+            Assert.Throws<DiskFullException>(() =>
+                PalHelper.ThrowLastError(PalFlags.FailCodes.FailWriteFile, noSpcErrno, "failed to write"));
+        }
+    }
+}


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26860

### Additional description

- reject invalid queue sizes (0/1/2, < -1) at config init on all platforms and write modes, with an error naming the setting
- map `FailCreateIoRing` + `ENOSPC` sentinel to a configuration error instead of a misleading `DiskFullException`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
