### PR TITLE
RavenDB-27291 Delete on compressed tree must be aware of page's deletion in rebalancing mechanism.

### DIFF
--- a/src/Voron/Data/BTrees/Tree.Compressed.cs
+++ b/src/Voron/Data/BTrees/Tree.Compressed.cs
@@ -295,8 +295,6 @@ namespace Voron.Data.BTrees
             }
 
             var decompressed = DecompressPage(page, usage: DecompressionUsage.Write, skipCache: false);
-            var rebalancingFreedThePage = false;
-
             try
             {
                 decompressed.Search(_llt, keyToDelete);
@@ -310,27 +308,22 @@ namespace Voron.Data.BTrees
 
                 using (var cursor = cursorConstructor.Build(keyToDelete))
                 {
-                    var treeRebalancer = new TreeRebalancer(_llt, this, cursor, watchedPageNumber: decompressed.PageNumber);
+                    var treeRebalancer = new TreeRebalancer(_llt, this, cursor);
                     var changedPage = (TreePage)decompressed;
                     while (changedPage != null)
                     {
                         changedPage = treeRebalancer.Execute(changedPage);
                     }
-
-                    rebalancingFreedThePage = treeRebalancer.WatchedPageWasFreed;
                 }
 
 #if DEBUG
-                // validate only existing pages
-                if (rebalancingFreedThePage == false)
+                if (decompressed.IsInvalidated == false)
                     page.DebugValidate(this, ReadHeader().RootPageNumber);
 #endif
             }
             finally
             {
-                // the rebalancing may have taken this page out of the tree and freed it
-                if (rebalancingFreedThePage == false)
-                    decompressed.CopyToOriginal(_llt, defragRequired: true, wasModified: true, this);
+                decompressed.CopyToOriginal(_llt, defragRequired: true, wasModified: true, this);
             }
         }
 

--- a/src/Voron/Data/BTrees/Tree.Compressed.cs
+++ b/src/Voron/Data/BTrees/Tree.Compressed.cs
@@ -295,6 +295,7 @@ namespace Voron.Data.BTrees
             }
 
             var decompressed = DecompressPage(page, usage: DecompressionUsage.Write, skipCache: false);
+            var rebalancingFreedThePage = false;
 
             try
             {
@@ -309,19 +310,27 @@ namespace Voron.Data.BTrees
 
                 using (var cursor = cursorConstructor.Build(keyToDelete))
                 {
-                    var treeRebalancer = new TreeRebalancer(_llt, this, cursor);
+                    var treeRebalancer = new TreeRebalancer(_llt, this, cursor, watchedPageNumber: decompressed.PageNumber);
                     var changedPage = (TreePage)decompressed;
                     while (changedPage != null)
                     {
                         changedPage = treeRebalancer.Execute(changedPage);
                     }
+
+                    rebalancingFreedThePage = treeRebalancer.WatchedPageWasFreed;
                 }
 
-                page.DebugValidate(this, ReadHeader().RootPageNumber);
+#if DEBUG
+                // validate only existing pages
+                if (rebalancingFreedThePage == false)
+                    page.DebugValidate(this, ReadHeader().RootPageNumber);
+#endif
             }
             finally
             {
-                decompressed.CopyToOriginal(_llt, defragRequired: true, wasModified: true, this);
+                // the rebalancing may have taken this page out of the tree and freed it
+                if (rebalancingFreedThePage == false)
+                    decompressed.CopyToOriginal(_llt, defragRequired: true, wasModified: true, this);
             }
         }
 

--- a/src/Voron/Data/BTrees/TreeRebalancer.cs
+++ b/src/Voron/Data/BTrees/TreeRebalancer.cs
@@ -20,15 +20,12 @@ namespace Voron.Data.BTrees
         private readonly TreeCursor _cursor;
 
         private bool _ancestorsChanged;
-        private readonly long _watchedPageNumber;
-        public bool WatchedPageWasFreed { get; private set; }
 
-        public TreeRebalancer(LowLevelTransaction tx, Tree tree, TreeCursor cursor, long watchedPageNumber = -1L)
+        public TreeRebalancer(LowLevelTransaction tx, Tree tree, TreeCursor cursor)
         {
             _tx = tx;
             _tree = tree;
             _cursor = cursor;
-            _watchedPageNumber = watchedPageNumber;
         }
         
         private FreeSpaceHandlingDisabler DisableFreeSpaceUsageIfSplittingRootTree()
@@ -543,7 +540,9 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void FreePage(TreePage page)
         {
-            WatchedPageWasFreed |= page.PageNumber == _watchedPageNumber;
+            if (page is DecompressedLeafPage dlp)
+                dlp.Invalidate();
+                
             _tree.FreePage(page);
         }
 

--- a/src/Voron/Data/BTrees/TreeRebalancer.cs
+++ b/src/Voron/Data/BTrees/TreeRebalancer.cs
@@ -20,14 +20,17 @@ namespace Voron.Data.BTrees
         private readonly TreeCursor _cursor;
 
         private bool _ancestorsChanged;
+        private readonly long _watchedPageNumber;
+        public bool WatchedPageWasFreed { get; private set; }
 
-        public TreeRebalancer(LowLevelTransaction tx, Tree tree, TreeCursor cursor)
+        public TreeRebalancer(LowLevelTransaction tx, Tree tree, TreeCursor cursor, long watchedPageNumber = -1L)
         {
             _tx = tx;
             _tree = tree;
             _cursor = cursor;
+            _watchedPageNumber = watchedPageNumber;
         }
-
+        
         private FreeSpaceHandlingDisabler DisableFreeSpaceUsageIfSplittingRootTree()
         {
             if (_tree == _tx.RootObjects)
@@ -104,7 +107,7 @@ namespace Voron.Data.BTrees
                         parentPage.RemoveNode(parentPage.LastSearchPositionOrLastEntry);
                     }
 
-                    _tree.FreePage(page);
+                    FreePage(page);
 
                     return parentPage;
                 }
@@ -184,7 +187,7 @@ namespace Voron.Data.BTrees
 
             nodeHeader->PageNumber = pageRefNumber;
 
-            _tree.FreePage(page);
+            FreePage(page);
         }
 
         private bool TryMergePages(TreePage parentPage, TreePage left, TreePage right)
@@ -224,7 +227,7 @@ namespace Voron.Data.BTrees
                     $"About to unlink the wrong node from parent page {parentPage.PageNumber} (node {parentPage.LastSearchPositionOrLastEntry} references {parentPage.GetNode(parentPage.LastSearchPositionOrLastEntry)->PageNumber} instead of the merged right page {right.PageNumber}), tree: {_tree.Name}");
 
             parentPage.RemoveNode(parentPage.LastSearchPositionOrLastEntry); // unlink the right sibling
-            _tree.FreePage(right);
+            FreePage(right);
 
             return true;
         }
@@ -534,6 +537,13 @@ namespace Voron.Data.BTrees
             _cursor.Pop();
             _cursor.Push(rootPage);
 
+            FreePage(page);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void FreePage(TreePage page)
+        {
+            WatchedPageWasFreed |= page.PageNumber == _watchedPageNumber;
             _tree.FreePage(page);
         }
 

--- a/src/Voron/Data/Compression/DecompressedLeafPage.cs
+++ b/src/Voron/Data/Compression/DecompressedLeafPage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Sparrow;
 using Sparrow.Server;
@@ -29,6 +30,13 @@ namespace Voron.Data.Compression
 
         public DecompressionUsage Usage;
 
+        private bool _invalidated = false;
+        public void Invalidate() => _invalidated = true;
+        
+#if DEBUG
+        public bool IsInvalidated => _invalidated;
+#endif
+        
         public void Dispose()
         {
             if (Cached)
@@ -39,15 +47,12 @@ namespace Voron.Data.Compression
 
         public void CopyToOriginal(LowLevelTransaction tx, bool defragRequired, bool wasModified, Tree tree)
         {
-#if DEBUG
-            if (tx.DirtyPageStillBelongsTo(Original.Base, PageNumber) == false)
+            if (_invalidated)
             {
-                VoronUnrecoverableErrorException.Raise(tx,
-                    $"Attempt to write decompressed page #{PageNumber} back into scratch memory that no longer belongs to it - " +
-                    $"the page was freed and its scratch slot re-issued (the slot's header now claims page #{Original.PageNumber}). " +
-                    $"Writing would corrupt the new owner's writable copy, tree: {tree.Name}");
+                tree.DecompressionsCache.Invalidate(PageNumber, DecompressionUsage.Write);
+                return;
             }
-#endif
+            
             if (CalcSizeUsed() < Original.PageMaxSpace)
             {
                 // no need to compress
@@ -97,6 +102,7 @@ namespace Voron.Data.Compression
 
         private void SplitPage(LowLevelTransaction tx, Tree tree)
         {
+            Debug.Assert(_invalidated == false);
             // let's take a node from the middle and add it again with the page splitting
             // this way we'll copy half of the page to a new page
 

--- a/src/Voron/Data/Compression/DecompressedLeafPage.cs
+++ b/src/Voron/Data/Compression/DecompressedLeafPage.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using Sparrow;
 using Sparrow.Server;
 using Voron.Data.BTrees;
+using Voron.Exceptions;
 using Voron.Global;
 using Voron.Impl;
 
@@ -38,6 +39,15 @@ namespace Voron.Data.Compression
 
         public void CopyToOriginal(LowLevelTransaction tx, bool defragRequired, bool wasModified, Tree tree)
         {
+#if DEBUG
+            if (tx.DirtyPageStillBelongsTo(Original.Base, PageNumber) == false)
+            {
+                VoronUnrecoverableErrorException.Raise(tx,
+                    $"Attempt to write decompressed page #{PageNumber} back into scratch memory that no longer belongs to it - " +
+                    $"the page was freed and its scratch slot re-issued (the slot's header now claims page #{Original.PageNumber}). " +
+                    $"Writing would corrupt the new owner's writable copy, tree: {tree.Name}");
+            }
+#endif
             if (CalcSizeUsed() < Original.PageMaxSpace)
             {
                 // no need to compress

--- a/src/Voron/Data/Compression/DecompressedLeafPage.cs
+++ b/src/Voron/Data/Compression/DecompressedLeafPage.cs
@@ -52,7 +52,15 @@ namespace Voron.Data.Compression
                 tree.DecompressionsCache.Invalidate(PageNumber, DecompressionUsage.Write);
                 return;
             }
-            
+
+#if DEBUG
+            if (tx.DirtyPageStillBelongsTo(Original.Base, PageNumber) == false)
+            {
+                VoronUnrecoverableErrorException.Raise(tx,
+                    $"Attempt to write decompressed page #{PageNumber} back into scratch memory that no longer belongs to it - the page was freed and its scratch slot re-issued (the slot's header now claims page #{Original.PageNumber}). The page should have been invalidated when it was freed, tree: {tree.Name}");
+            }
+#endif
+
             if (CalcSizeUsed() < Original.PageMaxSpace)
             {
                 // no need to compress

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -611,6 +611,14 @@ namespace Voron.Impl
             return page;
         }
 
+        // once the page is freed the same memory can be handed out to a different page, and the pointer
+        // stops representing the modification of this one
+        internal bool DirtyPageStillBelongsTo(byte* dirtyPagePointer, long pageNumber)
+        {
+            return _scratchPagesInUse.TryGetValue(pageNumber, out var scratchPage) &&
+                   scratchPage.ReadWritableRawPagePointer(ref PagerTransactionState) == dirtyPagePointer;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private T GetPageHeaderFromDataFile<T>(long pageNumber) where T : unmanaged
         {

--- a/test/SlowTests/Voron/Issues/RavenDB_27291.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27291.cs
@@ -1,0 +1,73 @@
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron.Data.BTrees;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_27291(ITestOutputHelper output) : StorageTest(output)
+{
+    private const string TreeName = "reduce-tree";
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Compression)]
+    public void DeletingTheLastEntryOfASaturatedCompressedPageMustNotCorruptTheTree()
+    {
+        using (var tx = Env.WriteTransaction())
+        {
+            // the shape MapReduceResultsStore builds for a reduce tree on 64 bits
+            tx.CreateTree(TreeName, flags: TreeFlags.LeafsCompressed);
+            tx.Commit();
+        }
+
+        for (int batch = 0; batch < 8_250; batch += 250)
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree(TreeName);
+
+                for (int id = batch; id < batch + 250; id++)
+                {
+                    var value = new byte[250 + id % 41 * 11];
+                    for (int i = 0; i < value.Length; i++)
+                        value[i] = (byte)('a' + (id + i / 16) % 26);
+
+                    tree.Add(Key(id), value);
+                }
+
+                tx.Commit();
+            }
+        }
+
+        using (var tx = Env.ReadTransaction())
+            Assert.Equal(3, tx.ReadTree(TreeName).ReadHeader().Depth);
+
+        using (var tx = Env.WriteTransaction())
+        {
+            var tree = tx.ReadTree(TreeName);
+
+            for (int id = 8; id < 115; id++)
+                tree.Delete(Key(id));
+
+            for (int i = 0; i < 32; i++)
+            {
+                tree.Add(Key(i % 8) + "#" + i / 8, new byte[1]);
+                tree.Delete(Key(i % 8) + "#" + i / 8);
+            }
+
+            for (int id = 1; id < 8; id++)
+                tree.Delete(Key(id));
+
+            tree.Delete(Key(0));
+
+            tx.Commit();
+        }
+
+        using (var tx = Env.ReadTransaction())
+        {
+            var tree = tx.ReadTree(TreeName);
+            tree.ValidateTree_Forced(tree.ReadHeader().RootPageNumber);
+        }
+        
+        string Key(int id) => $"{id:D8}{new string('x', 92)}";
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27291

### Additional description

The actual issue is the following:
1) page = ModifyPage(page); // assigns PTR_0 from the scratch buffers as page N_0
.
.
.
2) Code decided we need to rebalance the tree via `TreeRebalancer`
3) TreeRebalancer calls FreePage on page N_0
4) FreePage returns PTR_0 to the available pool
5) TreeRebalancer keeps looping and calls ModifyPage on page N_1. From LLT it receives memory at address PTR_0. The parent of N_0 is modified before N_0 is freed, but its grandparent after it - that is why the recycled buffer lands on the grandparent, and why the tree has to be at least 3 levels deep to hit this
6) decompressed.CopyToOriginal writes data into PTR_0 (which no longer belongs to N_0, because we removed the whole page)

This is an old issue, however it is not reproducible on earlier versions of Voron since we did not call `FreeImmediately` on the actual buffer, so it was not recycled and the copy went into memory nobody else was using.

Such corruption survives the commit - the broken tree is what the database is left with.

https://github.com/ravendb/ravendb/blob/9a3ec41358d41da2ff05727f0300b4f0d0205ee9/src/Voron/Data/BTrees/Tree.Compressed.cs#L282-L326

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
