### PR TITLE
RavenDB-27345 Abort the transport when disposing a compressed duplex stream, instead of flushing into it

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2935,18 +2935,19 @@ namespace Raven.Server
             try
             {
                 using (var context = JsonOperationContext.ShortTermSingleUse())
-                await using (var errorWriter = new AsyncBlittableJsonTextWriter(context, tcpStream))
                 {
-                    context.Write(errorWriter, new DynamicJsonValue
+                    await using (var errorWriter = new AsyncBlittableJsonTextWriter(context, tcpStream))
                     {
-                        ["Type"] = "Error",
-                        ["Exception"] = e.ToString(),
-                        ["Message"] = e.Message
-                    });
+                        context.Write(errorWriter, new DynamicJsonValue
+                        {
+                            ["Type"] = "Error",
+                            ["Exception"] = e.ToString(),
+                            ["Message"] = e.Message
+                        });
+                    }
 
-                    await errorWriter.FlushAsync();
+                    await tcpStream.FlushAsync();
                 }
-
             }
             catch (Exception inner)
             {

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -15,6 +15,7 @@ namespace Sparrow.Json
         // PERF: Cache the RecyclableMemoryStream reference to avoid repeated casting
         private readonly RecyclableMemoryStream _innerStream;
         private readonly bool _continueOnCapturedContext;
+        private bool _wroteToOutputStream;
 
         internal static readonly AsyncLocal<bool> CaptureContextOnAwait = new();
 
@@ -67,6 +68,7 @@ namespace Sparrow.Json
             if (bytesCount == 0)
                 return new ValueTask<long>(0);
 
+            _wroteToOutputStream = true;
             _innerStream.Position = 0;
             // bufferSize is required by the netstandard2.0 overload but is unused by RecyclableMemoryStream.CopyToAsync, which writes each internal block directly.
             var copyTask = _innerStream.CopyToAsync(_outputStream, bufferSize: 4096, token);
@@ -98,8 +100,8 @@ namespace Sparrow.Json
             if (flushTask.IsCompletedSuccessfully)
             {
                 // Fast synchronous path
-                var bytesWritten = flushTask.Result;
-                if (bytesWritten > 0)
+                flushTask.GetAwaiter().GetResult();
+                if (_wroteToOutputStream)
                 {
                     var outputFlushTask = _outputStream.FlushAsync(_cancellationToken);
                     if (outputFlushTask.IsCompleted)
@@ -123,8 +125,8 @@ namespace Sparrow.Json
 
         private async ValueTask DisposeAsyncSlow(ValueTask<long> flushTask)
         {
-            var bytesWritten = await flushTask.ConfigureAwait(_continueOnCapturedContext);
-            if (bytesWritten > 0)
+            await flushTask.ConfigureAwait(_continueOnCapturedContext);
+            if (_wroteToOutputStream)
                 await _outputStream.FlushAsync(_cancellationToken).ConfigureAwait(_continueOnCapturedContext);
 
             await DisposeStreamAsync().ConfigureAwait(_continueOnCapturedContext);

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -95,47 +95,57 @@ namespace Sparrow.Json
         {
             DisposeInternal();
 
-            // PERF: Check if flush completed synchronously to avoid async state machine
-            var flushTask = FlushAsync(_cancellationToken);
-            if (flushTask.IsCompletedSuccessfully)
+            try
             {
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = FlushAsync(_cancellationToken);
+                if (flushTask.IsCompletedSuccessfully == false)
+                    return DisposeAsyncSlow(flushTask);
+
                 // Fast synchronous path
                 flushTask.GetAwaiter().GetResult();
                 if (_wroteToOutputStream)
                 {
                     var outputFlushTask = _outputStream.FlushAsync(_cancellationToken);
-                    if (outputFlushTask.IsCompleted)
-                    {
-                        outputFlushTask.GetAwaiter().GetResult();
-                        return DisposeStreamAsync();
-                    }
-                    else
-                    {
+                    if (outputFlushTask.IsCompleted == false)
                         return DisposeAsyncSlow(outputFlushTask);
-                    }
-                }
-                else
-                {
-                    return DisposeStreamAsync();
+
+                    outputFlushTask.GetAwaiter().GetResult();
                 }
             }
-            
-            return DisposeAsyncSlow(flushTask);
+            catch
+            {
+                _stream.Dispose();
+                throw;
+            }
+
+            return DisposeStreamAsync();
         }
 
         private async ValueTask DisposeAsyncSlow(ValueTask<long> flushTask)
         {
-            await flushTask.ConfigureAwait(_continueOnCapturedContext);
-            if (_wroteToOutputStream)
-                await _outputStream.FlushAsync(_cancellationToken).ConfigureAwait(_continueOnCapturedContext);
-
-            await DisposeStreamAsync().ConfigureAwait(_continueOnCapturedContext);
+            try
+            {
+                await flushTask.ConfigureAwait(_continueOnCapturedContext);
+                if (_wroteToOutputStream)
+                    await _outputStream.FlushAsync(_cancellationToken).ConfigureAwait(_continueOnCapturedContext);
+            }
+            finally
+            {
+                await DisposeStreamAsync().ConfigureAwait(_continueOnCapturedContext);
+            }
         }
 
         private async ValueTask DisposeAsyncSlow(Task outputFlushTask)
         {
-            await outputFlushTask.ConfigureAwait(_continueOnCapturedContext);
-            await DisposeStreamAsync().ConfigureAwait(_continueOnCapturedContext);
+            try
+            {
+                await outputFlushTask.ConfigureAwait(_continueOnCapturedContext);
+            }
+            finally
+            {
+                await DisposeStreamAsync().ConfigureAwait(_continueOnCapturedContext);
+            }
         }
 
         private ValueTask DisposeStreamAsync()

--- a/src/Sparrow/Utils/ReadWriteCompressedStream.cs
+++ b/src/Sparrow/Utils/ReadWriteCompressedStream.cs
@@ -193,11 +193,22 @@ namespace Sparrow.Utils
         private bool _disposing;
         private void DisposeInternal()
         {
-            Flush();
             base.Dispose(_disposing);
-            _output?.Dispose();
-            _inner?.Dispose();
-            _input?.Dispose();
+
+            // Callers are expected to call Flush() before Dispose(), if they don't, that is on them.
+            // We first dispose the inner stream, (typically a network one), so any pending operations on that will
+            // fail, and then we dispose the compression streams, without flushing, so we won't try to write to the
+            // inner stream (which was already disposed).
+            try
+            {
+                _inner?.Dispose();
+            }
+            finally
+            {
+                // We explicitly dispose the inner stream first, so we cannot flush
+                _output?.DisposeWithoutFlushing();
+                _input?.Dispose();
+            }
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Sparrow/Utils/ZstdStream.cs
+++ b/src/Sparrow/Utils/ZstdStream.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.IO;
 using System.IO.Compression;
@@ -279,6 +279,20 @@ namespace Sparrow.Utils
 
         protected override void Dispose(bool disposing)
         {
+            DisposeInternal(flush: true);
+        }
+
+        /// <summary>
+        /// Use this when the transport underneath is already gone, so there is no point to try to write to the inner stream,
+        /// and we'll skip flushing.
+        /// </summary>
+        internal void DisposeWithoutFlushing()
+        {
+            DisposeInternal(flush: false);
+        }
+
+        private void DisposeInternal(bool flush)
+        {
             if (_disposed)
                 return;
 
@@ -289,7 +303,7 @@ namespace Sparrow.Utils
 
                 _disposed = true;
 
-                if (_compressContext != null)
+                if (flush && _compressContext != null)
                 {
                     if (_compression)
                         FlushInternal();

--- a/test/FastTests/Sparrow/ReadWriteCompressedStreamTests.cs
+++ b/test/FastTests/Sparrow/ReadWriteCompressedStreamTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Sparrow.Utils;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Sparrow
+{
+    public class ReadWriteCompressedStreamTests : NoDisposalNeeded
+    {
+        public ReadWriteCompressedStreamTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        /// <summary>
+        /// <see cref="ReadWriteCompressedStream"/> multiplexes an independent read side and write side over a single
+        /// inner stream, and in production that inner stream is an <see cref="System.Net.Security.SslStream"/>, which
+        /// rejects a write issued while another write is still pending. Disposal therefore may not write to the inner
+        /// stream at all: on a live replication connection the sender can be parked inside a write (a full socket send
+        /// buffer toward a dying node) while the server shutdown token fires a cancellation callback that disposes that
+        /// same stream - JsonOperationContext.ParseToMemoryAsync registers stream.Dispose() to unblock a pending read.
+        /// </summary>
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task DisposeMustNotWriteToInnerStreamWhileAWriteIsPending()
+        {
+            var inner = new SocketLikeStream();
+            var compressed = new ReadWriteCompressedStream(inner);
+
+            var payload = Incompressible(1024 * 1024);
+            var write = Task.Run(() => compressed.Write(payload, 0, payload.Length));
+
+            Assert.True(inner.WriteEntered.Wait(TimeSpan.FromSeconds(30)), "The writer never reached the inner stream.");
+
+            inner.RecordWritesFromNowOn();
+            compressed.Dispose();
+
+            await Assert.ThrowsAnyAsync<Exception>(() => write);
+
+            Assert.Null(inner.ConcurrentWriteRejectedAt);
+            Assert.Equal(0, inner.WritesAfterDisposalStarted);
+            Assert.True(inner.Disposed, "The inner stream was not disposed, so the connection leaked.");
+        }
+
+        /// <summary>
+        /// Disposal aborts the transport instead of waiting for a write that may never drain: disposing the inner
+        /// stream fails the pending write straight away, so the writer unwinds and releases the compression stream's
+        /// dispose lock. Without that, disposal would block for as long as the socket takes to give up on the send -
+        /// inside a cancellation callback on the server shutdown path.
+        /// </summary>
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task DisposeAbortsAWritePendingOnTheInnerStream()
+        {
+            var inner = new SocketLikeStream();
+            var compressed = new ReadWriteCompressedStream(inner);
+
+            var payload = Incompressible(1024 * 1024);
+            var write = Task.Run(() => compressed.Write(payload, 0, payload.Length));
+
+            Assert.True(inner.WriteEntered.Wait(TimeSpan.FromSeconds(30)), "The writer never reached the inner stream.");
+
+            // Nothing here ever releases the parked write - disposal has to break it loose on its own.
+            var dispose = Task.Run(() => compressed.Dispose());
+
+            Assert.True(await Task.WhenAny(dispose, Task.Delay(TimeSpan.FromSeconds(15))) == dispose,
+                "Dispose() blocked on the pending write instead of aborting the inner stream.");
+            await dispose;
+
+            // The writer has to learn the connection is gone, and it has to learn it that way: a NullReferenceException
+            // would mean the compression buffer was released from under it while it was still writing.
+            var error = await Assert.ThrowsAnyAsync<Exception>(() => write);
+            Assert.IsType<ObjectDisposedException>(error);
+        }
+
+        private static byte[] Incompressible(int size)
+        {
+            // Random bytes, and more than one zstd block worth of them, so that compression actually produces output
+            // and reaches the inner stream instead of being buffered inside zstd.
+            var buffer = new byte[size];
+            new Random(1337).NextBytes(buffer);
+            return buffer;
+        }
+
+        /// <summary>
+        /// Models the two traits of the <see cref="System.Net.Security.SslStream"/> over a socket that this test class
+        /// depends on: a write issued while another write is pending is rejected rather than serialized, and disposing
+        /// the stream fails a pending write instead of leaving it parked. The first write parks until the stream is
+        /// disposed, which is the window a concurrent disposal has to hit.
+        /// </summary>
+        private sealed class SocketLikeStream : Stream
+        {
+            public readonly ManualResetEventSlim WriteEntered = new ManualResetEventSlim(false);
+
+            public string ConcurrentWriteRejectedAt;
+            public int WritesAfterDisposalStarted;
+            public bool Disposed;
+
+            private readonly ManualResetEventSlim _writeParked = new ManualResetEventSlim(false);
+            private int _writePending;
+            private bool _parked;
+            private bool _recordWrites;
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            /// <summary>
+            /// Starts counting writes, so that a test can tell writes issued by disposal apart from the ones the parked
+            /// writer had already made on its way in.
+            /// </summary>
+            public void RecordWritesFromNowOn() => _recordWrites = true;
+
+            public override void Write(byte[] buffer, int offset, int count) => WriteCore();
+
+            public override void Write(ReadOnlySpan<byte> buffer) => WriteCore();
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                WriteCore();
+                return Task.CompletedTask;
+            }
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                WriteCore();
+                return ValueTask.CompletedTask;
+            }
+
+            private void WriteCore()
+            {
+                if (_recordWrites)
+                    Interlocked.Increment(ref WritesAfterDisposalStarted);
+
+                if (Disposed)
+                    throw new ObjectDisposedException(nameof(SocketLikeStream));
+
+                if (Interlocked.CompareExchange(ref _writePending, 1, 0) != 0)
+                {
+                    ConcurrentWriteRejectedAt = Environment.StackTrace;
+                    throw new NotSupportedException(" This method may not be called when another write operation is pending.");
+                }
+
+                try
+                {
+                    if (_parked)
+                        return;
+
+                    _parked = true;
+                    WriteEntered.Set();
+                    _writeParked.Wait();
+
+                    throw new ObjectDisposedException(nameof(SocketLikeStream));
+                }
+                finally
+                {
+                    Interlocked.Exchange(ref _writePending, 0);
+                }
+            }
+
+            public override void Flush()
+            {
+            }
+
+            public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public override int Read(byte[] buffer, int offset, int count) => 0;
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            protected override void Dispose(bool disposing)
+            {
+                Disposed = true;
+
+                // A real socket fails whatever send was in flight when it is closed, rather than holding the caller.
+                _writeParked.Set();
+
+                base.Dispose(disposing);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27345

### Additional description

`ReadWriteCompressedStream` carries a duplex connection whose read side and write side share a single inner stream, an `SslStream` in production. Disposal used to flush, which put a write on that shared stream while the write side could still have one in flight, and an `SslStream` rejects a write issued while another is pending.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

Disposal semantics change for every user of the compressed TCP stream: replication, subscriptions, the cluster state machine and cluster maintenance.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

No final flush or zstd end-of-frame marker is written when the stream is disposed. The connection is being closed at that point, so the peer observes a closed connection either way, and the marker was already not written whenever the old flush threw.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Anything using `ReadWriteCompressedStream` over TCP - replication, subscriptions, `ClusterStateMachine`, `ClusterMaintenanceSupervisor` - no longer flushes when that stream is disposed, and has its transport aborted first. Callers that need bytes delivered must flush before disposing; all of them already do.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
