### PR TITLE
RavenDB-27317 Quill - Fix duplicated capability description

### DIFF
--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/capability-wizard-flow.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/capability-wizard-flow.tsx
@@ -38,6 +38,9 @@ export const useCapabilitySteps = (): WizardSteps<AgentStepId, AgentFormData> =>
             description: "Choose the AI provider connection string your agent will use.",
             bodyComponent: ConnectProviderStep,
             validate: "connection",
+            // Only the AI Agent capability exists today, so there's nothing else to pick on the
+            // previous step; hide Back so users can't land on it and get stuck.
+            canGoBack: false,
             badge: ({ isComplete }: WizardBadgeContext<AgentFormData>) => {
                 if (!isComplete) {
                     return null;

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/capability/capability-options.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/capability/capability-options.tsx
@@ -19,7 +19,7 @@ export const CAPABILITY_OPTIONS: RadioCardOption<"agent" | "embeddings" | "genai
     {
         value: "genai",
         label: "GenAI",
-        description: "Conversational agent grounded in live CDC data. System prompt + RQL tools.",
+        description: "Analyze and enrich your documents using an LLM.",
         disabled: true,
         icon: <Sparkle className="size-5" />,
     },


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27317

### Additional description

Hide the Back button on the connection-string step of the add-capability wizard, since the Choose Capability step currently offers only one enabled option (AI Agent) — there's nothing to go back and re-pick.
Fix the GenAI capability card's description, which was a copy-paste of the AI Agent option's text.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed

This is Quill Web UI, not the Studio 