### PR TITLE
RavenDB-27334, RavenDB-27315, RavenDB-27314 Quill navigation fixes: disable AI Assistant, remove dashboard link, add correct link to docs

### DIFF
--- a/src/Raven.Quill.Web/src/app.tsx
+++ b/src/Raven.Quill.Web/src/app.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet, useLocation, useMatches, useParams } from "react-router";
+import { Link, Outlet, useMatches, useParams } from "react-router";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { MessageCircle, Sparkles } from "lucide-react";
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { RavenLogo } from "@/components/brand/raven-logo";
 import { ContactSheet } from "@/components/layout/contact-sheet";
 import { Button } from "@/components/shadcn/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
 
 const compactSidebarMediaQuery = "(max-width: 63.999rem)";
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "sidebar-collapsed";
@@ -24,7 +25,6 @@ function readStoredSidebarCollapsed() {
 
 function App() {
     const { slug } = useParams();
-    const { pathname } = useLocation();
     const isCompactSidebarViewport = useMediaQuery(compactSidebarMediaQuery);
     const activeRoute = [...useMatches()]
         .reverse()
@@ -96,19 +96,8 @@ function App() {
                 <CommandPalette slug={slug} appName={activeAppLabel} />
 
                 <nav className="ml-4 flex shrink-0 items-center gap-4 text-sm" aria-label="Top navigation">
-                    <Link
-                        to={appRoutes.dashboard()}
-                        className={cn(
-                            "transition-colors",
-                            pathname === appRoutes.dashboard()
-                                ? "font-semibold text-foreground"
-                                : "text-muted-foreground hover:text-foreground",
-                        )}
-                    >
-                        Dashboard
-                    </Link>
                     <a
-                        href="https://docs.ravendb.net/"
+                        href="https://docs.ravendb.net/quill"
                         target="_blank"
                         rel="noreferrer"
                         className="text-muted-foreground transition-colors hover:text-foreground"
@@ -123,13 +112,20 @@ function App() {
                             </Button>
                         }
                     />
-                    <Link
-                        to="/ai"
-                        className="text-primary [filter:drop-shadow(0_0_6px_var(--brand-400))] transition-colors hover:text-primary/80"
-                        aria-label="AI assistant"
-                    >
-                        <Sparkles className="size-4" aria-hidden="true" />
-                    </Link>
+                    <TooltipProvider>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <span
+                                    aria-disabled="true"
+                                    aria-label="AI assistant (coming soon)"
+                                    className="cursor-default text-primary/50 [filter:drop-shadow(0_0_6px_var(--brand-400))]"
+                                >
+                                    <Sparkles className="size-4" aria-hidden="true" />
+                                </span>
+                            </TooltipTrigger>
+                            <TooltipContent>AI assistant (coming soon)</TooltipContent>
+                        </Tooltip>
+                    </TooltipProvider>
                     <UserMenu />
                 </nav>
             </header>

--- a/src/Raven.Quill.Web/src/components/layout/command-palette.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/command-palette.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { useQuery } from "@tanstack/react-query";
-import { AppWindow, BookOpen, Plus, Search, Sparkles } from "lucide-react";
+import { AppWindow, BookOpen, Plus, Search } from "lucide-react";
 import { api } from "@/api/api";
 import { useTheme } from "@/components/shadcn/theme-provider";
 import {
@@ -18,7 +18,7 @@ import { appRoutes } from "@/lib/app-routes";
 import { THEME_OPTIONS } from "@/lib/theme-options";
 
 const IS_MAC = typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC");
-const DOCS_URL = "https://docs.ravendb.net/";
+const DOCS_URL = "https://docs.ravendb.net/quill";
 
 type CommandPaletteProps = {
     slug?: string;
@@ -29,10 +29,7 @@ export function CommandPalette({ slug, appName }: CommandPaletteProps) {
     // Built in render, not at module scope: this module is part of the
     // routes -> app -> command-palette import cycle, and the routes exports
     // are still in their temporal dead zone while the cycle initializes.
-    const navigationCommands: NavigationItem[] = [
-        ...navigationItems,
-        { label: "AI assistant", to: "/ai", icon: Sparkles },
-    ];
+    const navigationCommands: NavigationItem[] = [...navigationItems];
     const appPageCommands = appNavigationSections.flatMap((section) =>
         section.items.filter((item) => !item.isComingSoon),
     );

--- a/src/Raven.Quill.Web/src/components/layout/command-palette.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/command-palette.tsx
@@ -13,7 +13,7 @@ import {
     CommandItem,
     CommandList,
 } from "@/components/shadcn/ui/command";
-import { appNavigationSections, navigationItems, type NavigationItem } from "@/routes";
+import { appNavigationSections, navigationItems } from "@/routes";
 import { appRoutes } from "@/lib/app-routes";
 import { THEME_OPTIONS } from "@/lib/theme-options";
 
@@ -26,10 +26,9 @@ type CommandPaletteProps = {
 };
 
 export function CommandPalette({ slug, appName }: CommandPaletteProps) {
-    // Built in render, not at module scope: this module is part of the
+    // Read in render, not at module scope: this module is part of the
     // routes -> app -> command-palette import cycle, and the routes exports
     // are still in their temporal dead zone while the cycle initializes.
-    const navigationCommands: NavigationItem[] = [...navigationItems];
     const appPageCommands = appNavigationSections.flatMap((section) =>
         section.items.filter((item) => !item.isComingSoon),
     );
@@ -103,7 +102,7 @@ export function CommandPalette({ slug, appName }: CommandPaletteProps) {
                             </CommandGroup>
                         )}
                         <CommandGroup heading="Navigation">
-                            {navigationCommands.map((item) => (
+                            {navigationItems.map((item) => (
                                 <CommandItem key={item.label} onSelect={() => runCommand(() => navigate(item.to))}>
                                     <item.icon aria-hidden="true" />
                                     <span>{item.label}</span>

--- a/src/Raven.Quill.Web/src/routes.tsx
+++ b/src/Raven.Quill.Web/src/routes.tsx
@@ -39,7 +39,6 @@ import { DashboardLicense } from "@/pages/dashboard/license";
 import { DashboardUsage } from "@/pages/dashboard/usage";
 import { appRoutes as appRouteBuilders, ROUTE_PATTERNS } from "@/lib/app-routes";
 import { RequireApp } from "@/pages/apps/require-app";
-import { AiPage } from "@/pages/utility/ai-page";
 import { AppScopedNotFoundPage, NotFoundPage } from "@/pages/utility/not-found-page";
 import { RouteErrorBoundary } from "@/pages/utility/route-error-boundary";
 import { SimpleInfoPage } from "@/pages/utility/simple-info-page";
@@ -382,13 +381,6 @@ const utilityRoutes: RouteObject[] = [
         element: <SimpleInfoPage title="Docs" description="Open RavenDB documentation from the top navigation." />,
         handle: {
             title: "Docs",
-        } satisfies AppRouteHandle,
-    },
-    {
-        path: "ai",
-        element: <AiPage />,
-        handle: {
-            title: "AI",
         } satisfies AppRouteHandle,
     },
 ];


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27334
https://issues.hibernatingrhinos.com/issue/RavenDB-27315
https://issues.hibernatingrhinos.com/issue/RavenDB-27314


### Additional description

- **Docs link → Quill docs (RavenDB-27314)** The Docs link pointed at the generic https://docs.ravendb.net/. It now resolves to https://docs.ravendb.net/quill. Updated in both the top nav and the command palette's DOCS_URL so the two stay consistent.
- **AI Assistant → coming soon (RavenDB-27315)** The AI Assistant was a full screen whose only content was a "coming soon" message. The nav icon is now a disabled Sparkles glyph with an "AI assistant (coming soon)" tooltip, mirroring the existing coming-soon pattern in the sidebar. The /ai route is retired (removed from routes.tsx and dropped from the command palette) until there's something behind it. The ai-page.tsx component is kept on disk for later reuse.
- **Remove redundant Dashboard link (RavenDB-27334)** The Dashboard link in the top nav resolved the same route as the My apps sidebar item, so it's removed. The now-unused pathname/useLocation were cleaned up along with it.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

**Command palette (command-palette.tsx)** — the "AI assistant" entry is removed, and the "Documentation" action now opens https://docs.ravendb.net/quill instead of the generic docs root. This keeps the palette consistent with the nav changes.

**/ai route** — deregistered from the router. Navigating directly to /ai (e.g. a bookmark or hand-typed URL) now falls through to the not-found handling instead of rendering the "coming soon" page. Intended, since the route is retired until the feature exists. The AiPage component itself is kept on disk for later reuse.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
