### PR TITLE
RavenDB-27337 RavenDB-27331 RavenDB-27312 RavenDB-27311 Quill: Sections, headers and empty states fixes

### DIFF
--- a/src/Raven.Quill.Web/src/pages/apps/agents-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/agents-section.tsx
@@ -13,96 +13,90 @@ import { DeleteAgentDialog } from "@/pages/apps/agents/delete-agent-dialog";
 import { SectionCard, SectionTable } from "@/pages/apps/section-card";
 
 export function AgentsSection({ slug }: { slug: string }) {
-    const agentsQuery = useQuery(api.queries.agents.list(slug));
-
     return (
-        <SectionCard title="Agents" action={<AddAgentButton slug={slug} />}>
-            <ApiState
-                isLoading={agentsQuery.isPending}
-                isError={agentsQuery.isError}
-                errorTitle="Could not load agents"
-                onRetry={() => void agentsQuery.refetch()}
-                loadingLabel="Loading agents..."
-            >
-                {agentsQuery.data && (
-                    <SectionTable
-                        headers={[
-                            "Agent name",
-                            "Status",
-                            "Model",
-                            "Last run",
-                            "Conversations",
-                            "Messages",
-                            "Tokens",
-                            "",
-                        ]}
-                        isEmpty={agentsQuery.data.length === 0}
-                        emptyMessage="No agents yet."
-                    >
-                        {agentsQuery.data.map((agent) => (
-                            <TableRow key={agent.agentId}>
-                                <TableCell className="font-medium">{agent.name}</TableCell>
-                                <TableCell>
-                                    <StatusIndicator
-                                        tone={agent.disabled ? "muted" : "positive"}
-                                        label={agent.disabled ? "Disabled" : "Active"}
-                                    />
-                                </TableCell>
-                                <TableCell className="font-mono text-xs text-muted-foreground">
-                                    {agent.model ?? "—"}
-                                </TableCell>
-                                <TableCell className="whitespace-nowrap text-muted-foreground">
-                                    {agent.lastInvokedAt ? formatDateTime(agent.lastInvokedAt) : "—"}
-                                </TableCell>
-                                <TableCell className="tabular-nums">{formatCompact(agent.conversations)}</TableCell>
-                                <TableCell className="tabular-nums">{formatCompact(agent.messages)}</TableCell>
-                                <TableCell className="tabular-nums">{formatCompact(agent.tokens)}</TableCell>
-                                <TableCell className="text-right">
-                                    <div className="flex items-center justify-end gap-1">
-                                        <Button
-                                            asChild
-                                            variant="ghost"
-                                            size="icon-sm"
-                                            aria-label={`Edit ${agent.name}`}
-                                            title="Edit agent"
-                                        >
-                                            <Link
-                                                to={appRoutes.app(
-                                                    slug,
-                                                    `agents/${encodeURIComponent(agent.agentId)}/edit`,
-                                                )}
-                                            >
-                                                <Pencil className="size-3.5" aria-hidden="true" />
-                                            </Link>
-                                        </Button>
-                                        <DeleteAgentDialog
-                                            slug={slug}
-                                            agent={agent}
-                                            trigger={
-                                                <Button
-                                                    variant="ghost"
-                                                    size="icon-sm"
-                                                    aria-label={`Delete ${agent.name}`}
-                                                    title="Delete agent"
-                                                >
-                                                    <Trash2 className="size-3.5" aria-hidden="true" />
-                                                </Button>
-                                            }
-                                        />
-                                    </div>
-                                </TableCell>
-                            </TableRow>
-                        ))}
-                    </SectionTable>
-                )}
-            </ApiState>
+        <SectionCard title="Agents" action={<AddAgentButton slug={slug} variant="outline" />}>
+            <AgentsTable slug={slug} />
         </SectionCard>
     );
 }
 
-function AddAgentButton({ slug }: { slug: string }) {
+export function AgentsTable({ slug }: { slug: string }) {
+    const agentsQuery = useQuery(api.queries.agents.list(slug));
+
     return (
-        <Button asChild size="sm" variant="outline">
+        <ApiState
+            isLoading={agentsQuery.isPending}
+            isError={agentsQuery.isError}
+            errorTitle="Could not load agents"
+            onRetry={() => void agentsQuery.refetch()}
+            loadingLabel="Loading agents..."
+        >
+            {agentsQuery.data && (
+                <SectionTable
+                    headers={["Agent name", "Status", "Model", "Last run", "Conversations", "Messages", "Tokens", ""]}
+                    isEmpty={agentsQuery.data.length === 0}
+                    emptyMessage="No agents yet."
+                >
+                    {agentsQuery.data.map((agent) => (
+                        <TableRow key={agent.agentId}>
+                            <TableCell className="font-medium">{agent.name}</TableCell>
+                            <TableCell>
+                                <StatusIndicator
+                                    tone={agent.disabled ? "muted" : "positive"}
+                                    label={agent.disabled ? "Disabled" : "Active"}
+                                />
+                            </TableCell>
+                            <TableCell className="font-mono text-xs text-muted-foreground">
+                                {agent.model ?? "—"}
+                            </TableCell>
+                            <TableCell className="whitespace-nowrap text-muted-foreground">
+                                {agent.lastInvokedAt ? formatDateTime(agent.lastInvokedAt) : "—"}
+                            </TableCell>
+                            <TableCell className="tabular-nums">{formatCompact(agent.conversations)}</TableCell>
+                            <TableCell className="tabular-nums">{formatCompact(agent.messages)}</TableCell>
+                            <TableCell className="tabular-nums">{formatCompact(agent.tokens)}</TableCell>
+                            <TableCell className="text-right">
+                                <div className="flex items-center justify-end gap-1">
+                                    <Button
+                                        asChild
+                                        variant="ghost"
+                                        size="icon-sm"
+                                        aria-label={`Edit ${agent.name}`}
+                                        title="Edit agent"
+                                    >
+                                        <Link
+                                            to={appRoutes.app(slug, `agents/${encodeURIComponent(agent.agentId)}/edit`)}
+                                        >
+                                            <Pencil className="size-3.5" aria-hidden="true" />
+                                        </Link>
+                                    </Button>
+                                    <DeleteAgentDialog
+                                        slug={slug}
+                                        agent={agent}
+                                        trigger={
+                                            <Button
+                                                variant="ghost"
+                                                size="icon-sm"
+                                                aria-label={`Delete ${agent.name}`}
+                                                title="Delete agent"
+                                            >
+                                                <Trash2 className="size-3.5" aria-hidden="true" />
+                                            </Button>
+                                        }
+                                    />
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </SectionTable>
+            )}
+        </ApiState>
+    );
+}
+
+export function AddAgentButton({ slug, variant = "default" }: { slug: string; variant?: "default" | "outline" }) {
+    return (
+        <Button asChild variant={variant} size="sm">
             <Link to={appRoutes.addCapability(slug, "agent")}>
                 <Plus className="size-3.5" aria-hidden="true" />
                 Add agent

--- a/src/Raven.Quill.Web/src/pages/apps/app-agents.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-agents.tsx
@@ -1,8 +1,16 @@
 import { useParams } from "react-router";
-import { AgentsSection } from "@/pages/apps/agents-section";
+import { AddAgentButton, AgentsTable } from "@/pages/apps/agents-section";
 
 export function AppAgents() {
     const { slug = "" } = useParams();
 
-    return <AgentsSection slug={slug} />;
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between gap-3">
+                <h1 className="text-2xl font-semibold tracking-tight">Agents</h1>
+                <AddAgentButton slug={slug} />
+            </div>
+            <AgentsTable slug={slug} />
+        </div>
+    );
 }

--- a/src/Raven.Quill.Web/src/pages/apps/app-analytics.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-analytics.tsx
@@ -7,7 +7,7 @@ import { ApiState } from "@/components/data/api-state";
 import { SeriesBarChart } from "@/components/data/charts";
 import { DatePeriodPicker } from "@/components/data/date-period-picker";
 import { PagePanel } from "@/components/data/page-panel";
-import { canDrillInto, drillInto, getDefaultDatePeriod } from "@/lib/date-period";
+import { canDrillInto, drillInto, getDefaultDatePeriod, type DatePeriod } from "@/lib/date-period";
 import { useAppStartDate } from "@/lib/use-start-date";
 import { TableCell, TableRow } from "@/components/shadcn/ui/table";
 import { formatCompact } from "@/lib/format";
@@ -36,9 +36,6 @@ export function AppAnalytics() {
 
     return (
         <PagePanel>
-            <div className="mb-6 flex items-center justify-end">
-                <DatePeriodPicker value={period} earliest={appStartDate} onChange={setPeriod} />
-            </div>
             <ApiState
                 isLoading={appUsageQuery.isPending}
                 isError={appUsageQuery.isError}
@@ -48,7 +45,12 @@ export function AppAnalytics() {
             >
                 {appUsageQuery.data && (
                     <div className="space-y-8">
-                        <AnalyticsMetricCards usage={appUsageQuery.data} />
+                        <AnalyticsMetricCards
+                            usage={appUsageQuery.data}
+                            period={period}
+                            earliest={appStartDate}
+                            onPeriodChange={setPeriod}
+                        />
                         <AnalyticsSeriesSection
                             title="Tokens by capability"
                             series={appUsageQuery.data.tokensByCapability}
@@ -72,7 +74,17 @@ export function AppAnalytics() {
     );
 }
 
-function AnalyticsMetricCards({ usage }: { usage: AppUsageResponse }) {
+function AnalyticsMetricCards({
+    usage,
+    period,
+    earliest,
+    onPeriodChange,
+}: {
+    usage: AppUsageResponse;
+    period: DatePeriod;
+    earliest: Date | undefined;
+    onPeriodChange: (value: DatePeriod) => void;
+}) {
     const { conversations, tokens } = usage.metrics;
     const cards: DashboardStatCard[] = [
         {
@@ -85,7 +97,12 @@ function AnalyticsMetricCards({ usage }: { usage: AppUsageResponse }) {
         { label: "Tokens", value: tokens.value, isLoading: false, delta: tokens.delta, series: tokens.sparkline },
     ];
 
-    return <StatCardsSection cards={cards} />;
+    return (
+        <StatCardsSection
+            cards={cards}
+            action={<DatePeriodPicker value={period} earliest={earliest} onChange={onPeriodChange} />}
+        />
+    );
 }
 
 function AnalyticsSeriesSection({

--- a/src/Raven.Quill.Web/src/pages/apps/app-channels.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-channels.tsx
@@ -15,12 +15,15 @@ export function AppChannels() {
     ];
 
     return (
-        <div className="space-y-8">
-            <div className="flex items-start justify-between gap-4">
-                <p className="max-w-prose text-sm text-muted-foreground">
-                    Channels are the surfaces end users reach your agents through.
-                </p>
-                <AddChannelMenu slug={slug} label="New channel" />
+        <div className="space-y-6">
+            <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Channels</h1>
+                    <p className="max-w-prose text-sm text-muted-foreground">
+                        Channels are the surfaces end users reach your agents through.
+                    </p>
+                </div>
+                <AddChannelMenu slug={slug} label="New channel" variant="default" />
             </div>
             <DashboardStatCards cards={cards} />
             <ChannelGroups slug={slug} />

--- a/src/Raven.Quill.Web/src/pages/apps/app-conversations.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-conversations.tsx
@@ -1,7 +1,5 @@
 import { useState } from "react";
 import { useParams } from "react-router";
-import { DatePeriodPicker } from "@/components/data/date-period-picker";
-import { PagePanel } from "@/components/data/page-panel";
 import { getDefaultDatePeriod } from "@/lib/date-period";
 import { useAppStartDate } from "@/lib/use-start-date";
 import { ConversationStatsCards, ConversationsSection } from "@/pages/apps/conversations-section";
@@ -12,14 +10,20 @@ export function AppConversations() {
     const appStartDate = useAppStartDate(slug);
 
     return (
-        <PagePanel>
-            <div className="space-y-8">
-                <div className="flex justify-end">
-                    <DatePeriodPicker value={period} earliest={appStartDate} onChange={setPeriod} />
+        <div className="space-y-8">
+            <div className="space-y-6">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Conversations</h1>
+                    <p className="text-sm text-muted-foreground">Live and historical chats across all channels.</p>
                 </div>
-                <ConversationStatsCards slug={slug} period={period} />
-                <ConversationsSection slug={slug} period={period} />
+                <ConversationStatsCards
+                    slug={slug}
+                    period={period}
+                    earliest={appStartDate}
+                    onPeriodChange={setPeriod}
+                />
             </div>
-        </PagePanel>
+            <ConversationsSection slug={slug} period={period} />
+        </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/apps/channels/add-channel-menu.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/add-channel-menu.tsx
@@ -56,10 +56,12 @@ export function AddChannelMenu({
     slug,
     agent,
     label = "Add channel",
+    variant = "outline",
 }: {
     slug: string;
     agent?: FixedAgent;
     label?: string;
+    variant?: "default" | "outline";
 }) {
     const [isSheetOpen, setIsSheetOpen] = useState(false);
 
@@ -67,7 +69,7 @@ export function AddChannelMenu({
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button size="sm" variant="outline">
+                    <Button size="sm" variant={variant}>
                         <Plus className="size-3.5" aria-hidden="true" />
                         {label}
                     </Button>

--- a/src/Raven.Quill.Web/src/pages/apps/conversations-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/conversations-section.tsx
@@ -3,6 +3,7 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import type { ConversationDto } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
+import { DatePeriodPicker } from "@/components/data/date-period-picker";
 import { TablePagination } from "@/components/table/table-pagination";
 import type { DatePeriod } from "@/lib/date-period";
 import { StatCardsSection, type DashboardStatCard } from "@/pages/dashboard/dashboard-stat-cards";
@@ -19,7 +20,12 @@ interface ConversationsSectionProps {
     period: DatePeriod;
 }
 
-export function ConversationStatsCards({ slug, period }: ConversationsSectionProps) {
+export function ConversationStatsCards({
+    slug,
+    period,
+    earliest,
+    onPeriodChange,
+}: ConversationsSectionProps & { earliest: Date | undefined; onPeriodChange: (value: DatePeriod) => void }) {
     const conversationStatsQuery = useQuery(api.queries.stats.conversationStats(slug, period));
     const stats = conversationStatsQuery.data;
 
@@ -29,7 +35,12 @@ export function ConversationStatsCards({ slug, period }: ConversationsSectionPro
         { label: "Tokens", value: stats?.tokens, isLoading: conversationStatsQuery.isPending },
     ];
 
-    return <StatCardsSection cards={cards} />;
+    return (
+        <StatCardsSection
+            cards={cards}
+            action={<DatePeriodPicker value={period} earliest={earliest} onChange={onPeriodChange} />}
+        />
+    );
 }
 
 const EMPTY_CONVERSATIONS: ConversationDto[] = [];
@@ -69,8 +80,11 @@ export function ConversationsSection({ slug, period }: ConversationsSectionProps
         [conversations, search, status, agent, channel],
     );
 
+    const emptyMessage =
+        conversations.length === 0 ? "No conversations yet." : "No conversations match the current filters.";
+
     return (
-        <SectionCard title="Conversations" description="Live and historical chats across all channels.">
+        <SectionCard>
             <ApiState
                 isLoading={conversationsQuery.isPending}
                 isError={conversationsQuery.isError}
@@ -94,7 +108,11 @@ export function ConversationsSection({ slug, period }: ConversationsSectionProps
                             onChannelChange={setChannel}
                             channelOptions={channelOptions}
                         />
-                        <ConversationsTable slug={slug} conversations={filteredConversations} />
+                        <ConversationsTable
+                            slug={slug}
+                            conversations={filteredConversations}
+                            emptyMessage={emptyMessage}
+                        />
                         <TablePagination
                             pageIndex={pageIndex}
                             pageSize={PAGE_SIZE}

--- a/src/Raven.Quill.Web/src/pages/apps/conversations/conversations-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/conversations/conversations-table.tsx
@@ -7,7 +7,15 @@ import type { ConversationDto } from "@/api/generated/server-api";
 import { VirtualDataTable } from "@/components/table/virtual-data-table";
 import { createConversationColumns } from "@/pages/apps/conversations/conversations-columns";
 
-export function ConversationsTable({ slug, conversations }: { slug: string; conversations: ConversationDto[] }) {
+export function ConversationsTable({
+    slug,
+    conversations,
+    emptyMessage,
+}: {
+    slug: string;
+    conversations: ConversationDto[];
+    emptyMessage: string;
+}) {
     // react-table (and its row models) want stable references across renders; "use no memo" opts this
     // file out of the React Compiler, so the columns are memoized explicitly. The parent memoizes the
     // filtered `conversations` array.
@@ -24,7 +32,7 @@ export function ConversationsTable({ slug, conversations }: { slug: string; conv
         <VirtualDataTable
             table={table}
             columnCount={columns.length}
-            emptyMessage="No conversations match the current filters."
+            emptyMessage={emptyMessage}
             maxHeight={520}
             rowHeightInPx={60}
             className="bg-card"

--- a/src/Raven.Quill.Web/src/pages/apps/section-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/section-card.tsx
@@ -7,20 +7,22 @@ export function SectionCard({
     action,
     children,
 }: {
-    title: ReactNode;
+    title?: ReactNode;
     description?: ReactNode;
     action?: ReactNode;
     children: ReactNode;
 }) {
     return (
         <section className="min-w-0">
-            <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="space-y-0.5">
-                    <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
-                    {description && <p className="text-sm text-muted-foreground">{description}</p>}
+            {(title || action) && (
+                <div className="mb-2 flex items-center justify-between gap-3">
+                    <div className="space-y-0.5">
+                        {title && <h2 className="text-lg font-semibold tracking-tight">{title}</h2>}
+                        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+                    </div>
+                    {action}
                 </div>
-                {action}
-            </div>
+            )}
             {children}
         </section>
     );

--- a/src/Raven.Quill.Web/src/pages/apps/welcome-panel.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/welcome-panel.tsx
@@ -1,13 +1,12 @@
 import { useState } from "react";
 import { Link } from "react-router";
-import { Check, ExternalLink, X } from "lucide-react";
+import { Check, X } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import { Button } from "@/components/shadcn/ui/button";
 import { appRoutes } from "@/lib/app-routes";
 import { cn } from "@/lib/utils";
 
-const QUICKSTART_GUIDE_URL = "https://docs.ravendb.net/";
 const DISMISSED_STORAGE_KEY_PREFIX = "quill-welcome-dismissed:";
 
 function dismissedStorageKey(slug: string) {
@@ -32,15 +31,6 @@ export function WelcomePanel({ slug }: { slug: string }) {
         setIsDismissed(readDismissed(slug));
     }
 
-    if (isDismissed) {
-        return null;
-    }
-
-    const dismiss = () => {
-        localStorage.setItem(dismissedStorageKey(slug), "true");
-        setIsDismissed(true);
-    };
-
     const steps = [
         { label: "Connect a data source", isComplete: Boolean(appQuery.data?.database) },
         {
@@ -55,6 +45,17 @@ export function WelcomePanel({ slug }: { slug: string }) {
         },
     ];
 
+    const isConfigured = steps.every((step) => step.isComplete);
+
+    if (isDismissed || isConfigured) {
+        return null;
+    }
+
+    const dismiss = () => {
+        localStorage.setItem(dismissedStorageKey(slug), "true");
+        setIsDismissed(true);
+    };
+
     return (
         <section className="rounded-lg border bg-card p-4">
             <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
@@ -64,18 +65,10 @@ export function WelcomePanel({ slug }: { slug: string }) {
                         Three steps to get your first agent answering questions in production.
                     </p>
                 </div>
-                <div className="flex items-center gap-1">
-                    <Button asChild size="sm" variant="outline">
-                        <a href={QUICKSTART_GUIDE_URL} target="_blank" rel="noreferrer">
-                            <ExternalLink className="size-3.5" aria-hidden="true" />
-                            Quickstart Guide
-                        </a>
-                    </Button>
-                    <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={dismiss}>
-                        Dismiss
-                        <X className="size-3.5" aria-hidden="true" />
-                    </Button>
-                </div>
+                <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={dismiss}>
+                    Dismiss
+                    <X className="size-3.5" aria-hidden="true" />
+                </Button>
             </div>
 
             <ol className="flex flex-wrap items-center gap-x-8 gap-y-3">

--- a/src/Raven.Quill.Web/src/pages/dashboard/dashboard-home.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/dashboard-home.tsx
@@ -25,13 +25,12 @@ export function DashboardHome() {
             </header>
 
             {appsQuery.data && appsQuery.data.length > 0 && (
-                // The period also drives the apps table below, so the picker stays at page level.
-                <div className="space-y-4">
-                    <div className="flex justify-end">
-                        <DatePeriodPicker value={period} earliest={setupStartDate} onChange={setPeriod} />
-                    </div>
-                    <StatCardsSection cards={cards} />
-                </div>
+                // The period lives here because it also drives the apps table below, but the
+                // picker itself renders inline with the "Activity" header via the action slot.
+                <StatCardsSection
+                    cards={cards}
+                    action={<DatePeriodPicker value={period} earliest={setupStartDate} onChange={setPeriod} />}
+                />
             )}
 
             <ApiState

--- a/src/Raven.Quill.Web/src/routes.tsx
+++ b/src/Raven.Quill.Web/src/routes.tsx
@@ -195,6 +195,7 @@ const appPages: AppRouteDefinition[] = [
             icon: Bot,
             section: "database",
         },
+        isPageTitleHidden: true,
         element: <AppAgents />,
     },
     {
@@ -212,6 +213,7 @@ const appPages: AppRouteDefinition[] = [
             icon: MessagesSquare,
             section: "database",
         },
+        isPageTitleHidden: true,
         element: <AppConversations />,
     },
     {
@@ -242,6 +244,7 @@ const appPages: AppRouteDefinition[] = [
             icon: Cable,
             section: "settings",
         },
+        isPageTitleHidden: true,
         element: <AppChannels />,
     },
     {


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27337
https://issues.hibernatingrhinos.com/issue/RavenDB-27331
https://issues.hibernatingrhinos.com/issue/RavenDB-27312
https://issues.hibernatingrhinos.com/issue/RavenDB-27311

### Additional description

- **Duplicate headers**: Agents, Conversations, and Channels now render their own page-level H1; the duplicate global title is hidden for these routes and SectionCard titles are optional. The date-period picker moved inline into the "Activity" header.
- **Primary actions**: Add agent / Add channel now render as primary buttons in their page headers (one primary action per view).
- **Empty states**: Conversations shows "No conversations yet." on a fresh app, and "No conversations match the current filters." only when filters exclude results.
- **Onboarding panel**: removed the link to the non-existent Quickstart guide, and the panel now auto-hides once setup is complete.
- **Spacing**: aligned app views to space-y-6, with the conversations table separated by space-y-8.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

- **Dashboard home & App analytics** — the date-period picker moved from its own row into the "Activity" section header (action slot). Same functionality, new placement. 
- **SectionCard component** — title is now optional. Existing callers pass a title and are unchanged; the new behavior only applies where title is omitted (conversations table).
- **App overview welcome panel** — now also hides automatically once setup is complete, in addition to manual dismissal.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
