### PR TITLE
RavenDB-27357 Quill: don't parse the message in the AI capability probes

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -368,8 +368,8 @@ public class ChatCompletionClient : IDisposable
             var paramsSchema = GetSchemaForTool(schema: null, sampleObject: "{\"reason\":\"why the tool is being called\"}");
             var tool = GetTool(context, "connection_test_probe", "A probe so the request matches an agent call. Do not call it.", paramsSchema);
 
-            var request = CreateCompletionRequest(context, messages: [userMessage], attachments: null, tools: [context.ReadObject(tool, "probe/tool")], useTools: true, streaming: false, EmptySchema);
-            await CompleteAsync(context, request, new AiUsage(), schema: null, trace: null, token);
+            var request = CreateCompletionRequest(context, messages: [userMessage], attachments: null, tools: [context.ReadObject(tool, "probe/tool")], useTools: true, streaming: false, schema: null);
+            await EnsureRequestAcceptedAsync(context, request, token);
             return true;
         }
         catch (UnsuccessfulAiRequestException e) when (e.StatusCode == HttpStatusCode.BadRequest)
@@ -395,14 +395,24 @@ public class ChatCompletionClient : IDisposable
                 [Constants.RequestFields.Content] = "describe the image"
             }, "probe/user");
 
-            var request = CreateCompletionRequest(context, messages: [userMessage], attachments: [attachment], tools: null, useTools: false, streaming: false, EmptySchema);
-            await CompleteAsync(context, request, new AiUsage(), schema: null, trace: null, token);
+            var request = CreateCompletionRequest(context, messages: [userMessage], attachments: [attachment], tools: null, useTools: false, streaming: false, schema: null);
+            await EnsureRequestAcceptedAsync(context, request, token);
             return true;
         }
-        catch (Exception)
+        catch (UnsuccessfulAiRequestException)
         {
             return false;
         }
+    }
+    
+    private async Task EnsureRequestAcceptedAsync(JsonOperationContext context, HttpRequestMessage request, CancellationToken token)
+    {
+        AddDefaultHeaders(request);
+        using var response = await SendRequestAsync(request, token);
+        var responseContent = await GetResponseContentAsync(context, response, token);
+
+        var responseParser = new AiResponseParser(this, response, responseContent);
+        responseParser.EnsureSuccessfulResponse();
     }
 
     public async Task<AiResponse> CompleteAsync(JsonOperationContext context, HttpRequestMessage request, AiUsage usage, string schema, AiDebugTrace trace, CancellationToken token)

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -399,7 +399,7 @@ public class ChatCompletionClient : IDisposable
             await EnsureRequestAcceptedAsync(context, request, token);
             return true;
         }
-        catch (UnsuccessfulAiRequestException)
+        catch (Exception)
         {
             return false;
         }

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -409,10 +409,11 @@ public class ChatCompletionClient : IDisposable
     {
         AddDefaultHeaders(request);
         using var response = await SendRequestAsync(request, token);
-        var responseContent = await GetResponseContentAsync(context, response, token);
+        if (response.IsSuccessStatusCode)
+            return;
 
-        var responseParser = new AiResponseParser(this, response, responseContent);
-        responseParser.EnsureSuccessfulResponse();
+        var responseContent = await GetResponseContentAsync(context, response, token);
+        HandleUnsuccessfulResponse(response, responseContent);
     }
 
     public async Task<AiResponse> CompleteAsync(JsonOperationContext context, HttpRequestMessage request, AiUsage usage, string schema, AiDebugTrace trace, CancellationToken token)

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887.cs
@@ -235,6 +235,8 @@ public class RavenDB_24887(ITestOutputHelper output) : RavenTestBase(output)
         Assert.NotNull(addToCartArgs);
         // and were able to "solve" it properly
         Assert.Equal(AiConversationResult.Done, result.Status);
-        Assert.Contains("added", result.Answer.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.True(result.Answer.Message.Contains("added", StringComparison.OrdinalIgnoreCase) ||
+                    result.Answer.Message.Contains("already", StringComparison.OrdinalIgnoreCase),
+            result.Answer.Message);
     }
 }

--- a/test/SlowTests/Server/Documents/AI/RavenDB-27357.cs
+++ b/test/SlowTests/Server/Documents/AI/RavenDB-27357.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.AI;
+using Raven.Server.Documents.AI.Settings;
+using Raven.Server.Logging;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Logging;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI
+{
+    public class RavenDB_27357 : RavenTestBase
+    {
+        public RavenDB_27357(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const string RefusalInsteadOfContentResponse = """
+                                                               {
+                                                                 "id": "chatcmpl-",
+                                                                 "object": "chat.completion",
+                                                                 "created": 1785734451,
+                                                                 "model": "gpt-4.1-2025-04-14",
+                                                                 "choices": [
+                                                                   {
+                                                                     "index": 0,
+                                                                     "message": { "role": "assistant", "content": null, "refusal": "Hello! How can I help you today?", "annotations": [] },
+                                                                     "logprobs": null,
+                                                                     "finish_reason": "stop"
+                                                                   }
+                                                                 ],
+                                                                 "usage": { "prompt_tokens": 115, "completion_tokens": 50, "total_tokens": 165 },
+                                                                 "service_tier": "default",
+                                                                 "system_fingerprint": ""
+                                                               }
+                                                               """;
+
+        private const string BadRequestResponse = """
+                                                  {
+                                                    "error": { "message": "Unrecognized request argument supplied: tools", "type": "invalid_request_error", "param": null, "code": null }
+                                                  }
+                                                  """;
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task SupportsToolsProbe_ShouldNotFail_WhenModelAnswersWithRefusalInsteadOfContent()
+        {
+            using var contextPool = NewContextPool();
+            using var client = CannedResponseClient(contextPool, HttpStatusCode.OK, RefusalInsteadOfContentResponse);
+
+            Assert.True(await client.TestSupportsToolsAsync(default));
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task AcceptsImageInputProbe_ShouldNotReportFalse_WhenModelAnswersWithRefusalInsteadOfContent()
+        {
+            using var contextPool = NewContextPool();
+            using var client = CannedResponseClient(contextPool, HttpStatusCode.OK, RefusalInsteadOfContentResponse);
+
+            Assert.True(await client.TestAcceptsImageInputAsync(default));
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task SupportsToolsProbe_ShouldReportFalse_WhenProviderRejectsTheRequest()
+        {
+            using var contextPool = NewContextPool();
+            using var client = CannedResponseClient(contextPool, HttpStatusCode.BadRequest, BadRequestResponse);
+
+            Assert.False(await client.TestSupportsToolsAsync(default));
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task AcceptsImageInputProbe_ShouldReportFalse_WhenProviderRejectsTheRequest()
+        {
+            using var contextPool = NewContextPool();
+            using var client = CannedResponseClient(contextPool, HttpStatusCode.BadRequest, BadRequestResponse);
+
+            Assert.False(await client.TestAcceptsImageInputAsync(default));
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task Completion_ShouldStillThrow_WhenModelAnswersWithRefusalInsteadOfContent()
+        {
+            using var contextPool = NewContextPool();
+            using var client = CannedResponseClient(contextPool, HttpStatusCode.OK, RefusalInsteadOfContentResponse);
+
+            var schema = ChatCompletionClient.GetSchemaFromSampleObject("{\"answer\":\"the answer to the user's prompt\"}");
+
+            await Assert.ThrowsAsync<RefusedToAnswerException>(() => client.TestCompleteAsync("system", "hi", schema, default));
+        }
+
+        private static TransactionContextPool NewContextPool() =>
+            new(RavenLogManager.Instance.CreateNullLogger(), new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnlyForTests()));
+
+        private static CannedResponseChatCompletionClient CannedResponseClient(IMemoryContextPool contextPool, HttpStatusCode statusCode, string responseJson)
+        {
+            var connection = new AiConnectionString
+            {
+                ModelType = AiModelType.Chat,
+                Name = "test-connection",
+                OpenAiSettings = new OpenAiSettings(apiKey: "test-key", endpoint: null, model: "gpt-4.1")
+            };
+
+            Assert.True(AbstractChatCompletionClientSettings.TryGetParameters(connection, out var settings));
+
+            return new CannedResponseChatCompletionClient(contextPool, settings, statusCode, responseJson);
+        }
+
+        private sealed class CannedResponseChatCompletionClient(
+            IMemoryContextPool contextPool,
+            AbstractChatCompletionClientSettings settings,
+            HttpStatusCode statusCode,
+            string responseJson)
+            : ChatCompletionClient(contextPool, settings, ChatCompletionClient.ConventionsToUse)
+        {
+            protected override Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token)
+            {
+                return Task.FromResult(new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27357/Quill-Connection-string-test-occasionally-throws-RefusedToAnswerException

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
