### PR TITLE
RavenDB-27302 Don't report OperationCanceledException as an unexpected ETL error

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2352,6 +2352,8 @@ namespace Raven.Server.Documents
 
             internal Action<EtlProcess, ExtractedItem, int> OnEtlItemExtracted; // (process, item, batchId == EtlPerformanceStats.Id)
 
+            internal Action<EtlProcess> OnEtlBatchCompleted;
+
             internal Action<ConversationDocument> BeforeAiAgentTalk;
 
             internal Func<AiAgentConfiguration, LazyStringValue, bool> ShouldAiAgentAddMutualParameterForSubAgentReq;

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -930,6 +930,9 @@ namespace Raven.Server.Documents.ETL
                         }
 
                         Database.EtlLoader.OnBatchCompleted(ConfigurationName, TransformationName, Statistics);
+
+                        Database.ForTestingPurposes?.OnEtlBatchCompleted?.Invoke(this);
+
                         continue;
                     }
                     try
@@ -992,6 +995,14 @@ namespace Raven.Server.Documents.ETL
                     {
                         return;
                     }
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
                 }
                 catch (Exception e)
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-27302.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27302.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Documents.TasksErrors;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27302 : RavenTestBase
+{
+    public RavenDB_27302(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public async Task CancellationOfEtlProcessIsNotRecordedAsUnknownError()
+    {
+        using (var src = GetDocumentStore())
+        using (var dest = GetDocumentStore())
+        {
+            var database = await GetDatabase(src.Database);
+
+            var batchCompleted = new ManualResetEventSlim();
+
+            database.ForTestingPurposesOnly().OnEtlBatchCompleted = _ =>
+            {
+                batchCompleted.Set();
+                throw new OperationCanceledException("The operation was canceled.");
+            };
+
+            Etl.AddEtl(src, dest, "Users", script: "loadToUsers(this);");
+
+            using (var session = src.OpenSession())
+            {
+                session.Store(new User { Name = "Joe Doe" }, "users/1");
+                session.SaveChanges();
+            }
+
+            Assert.True(batchCompleted.Wait(TimeSpan.FromSeconds(30)));
+
+            var unknownErrors = await WaitForValueAsync(
+                () => database.TaskErrorsStorage.ReadAllProcessErrors(TaskCategory.Etl).Count(x => x.Step == (long)TaskErrorStep.Unknown),
+                expectedVal: 1, timeout: 5000, interval: 100);
+
+            Assert.Equal(0, unknownErrors);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27302

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
