### PR TITLE
RavenDB-27359 Quill: populate the sidebar Help center

### DIFF
--- a/src/Raven.Quill.Web/src/app.tsx
+++ b/src/Raven.Quill.Web/src/app.tsx
@@ -96,14 +96,6 @@ function App() {
                 <CommandPalette slug={slug} appName={activeAppLabel} />
 
                 <nav className="ml-4 flex shrink-0 items-center gap-4 text-sm" aria-label="Top navigation">
-                    <a
-                        href="https://docs.ravendb.net/quill"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-muted-foreground transition-colors hover:text-foreground"
-                    >
-                        Docs
-                    </a>
                     <ContactSheet
                         trigger={
                             <Button variant="outline" size="sm">

--- a/src/Raven.Quill.Web/src/components/layout/app-sidebar.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/app-sidebar.tsx
@@ -1,7 +1,8 @@
 import { NavLink, useMatch } from "react-router";
 import type { ReactNode } from "react";
-import { CircleHelp, PanelLeftClose, PanelLeftOpen, Users } from "lucide-react";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { appNavigationSections, dashboardNavigationSections, navigationItems, type NavigationItem } from "@/routes";
+import { HelpMenu } from "@/components/layout/help-menu";
 import { ThemeSwitcher } from "@/components/layout/theme-switcher";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
@@ -58,14 +59,7 @@ export function AppSidebar({ slug, hasActiveApp, isCollapsed, isToggleVisible, o
                         ))}
                 </nav>
                 <div className={cn("flex flex-col gap-0.5 py-2", isCollapsed ? "items-center" : "px-2")}>
-                    <SidebarNavLink
-                        item={{ label: "Community", to: "/community", icon: Users, isComingSoon: true }}
-                        isCollapsed={isCollapsed}
-                    />
-                    <SidebarNavLink
-                        item={{ label: "Help", to: "/help", icon: CircleHelp, isComingSoon: true }}
-                        isCollapsed={isCollapsed}
-                    />
+                    <HelpMenu variant={isCollapsed ? "dropdown" : "inline"} />
                     <div
                         className={cn(
                             "flex",

--- a/src/Raven.Quill.Web/src/components/layout/help-menu.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/help-menu.tsx
@@ -1,0 +1,111 @@
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, CircleHelp } from "lucide-react";
+import { api } from "@/api/api";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/shadcn/ui/collapsible";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "@/components/shadcn/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
+import { getHelpLinks } from "@/lib/help-links";
+import { cn } from "@/lib/utils";
+
+/**
+ * Help center links with two layouts, mirroring the ThemeSwitcher split:
+ *
+ * - `inline` (expanded sidebar): a collapsible group that pushes the links into
+ *   the sidebar itself.
+ *
+ * - `dropdown` (collapsed rail): a single icon button opening a menu, since a
+ *   narrow rail has no room to indent a nested list.
+ *
+ * Every item leaves the product, so the rows carry no per-item external-link
+ * glyph - it would repeat the same signal on every line.
+ */
+export function HelpMenu({ variant = "inline" }: { variant?: "inline" | "dropdown" }) {
+    // Shares the query key with the license and dashboard views, so this is
+    // usually a cache hit rather than an extra request.
+    const licenseQuery = useQuery(api.queries.settings.license());
+    const helpLinks = getHelpLinks(licenseQuery.data?.response.id);
+
+    if (variant === "dropdown") {
+        return (
+            <DropdownMenu>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <DropdownMenuTrigger
+                            aria-label="Help center"
+                            className={cn(
+                                "flex size-8 items-center justify-center rounded-md text-sidebar-foreground/85 transition-colors",
+                                "hover:bg-sidebar-accent hover:text-sidebar-foreground",
+                                "focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:outline-none",
+                            )}
+                        >
+                            <CircleHelp className="size-4" aria-hidden="true" />
+                        </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">Help center</TooltipContent>
+                </Tooltip>
+                <DropdownMenuContent side="right" align="end" className="w-48">
+                    <DropdownMenuLabel>Help center</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {helpLinks.map(({ label, href, icon: Icon }) => (
+                        <DropdownMenuItem key={label} asChild>
+                            <a href={href} target="_blank" rel="noreferrer">
+                                <Icon aria-hidden="true" />
+                                <span>{label}</span>
+                            </a>
+                        </DropdownMenuItem>
+                    ))}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        );
+    }
+
+    return (
+        <Collapsible>
+            <CollapsibleTrigger
+                className={cn(
+                    "group flex h-8 w-full items-center gap-2 rounded-md px-2 text-sm transition-colors",
+                    "text-sidebar-foreground/85 hover:bg-sidebar-accent/60 hover:text-sidebar-foreground",
+                    "focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:outline-none",
+                )}
+            >
+                <CircleHelp className="size-4 shrink-0" aria-hidden="true" />
+                <span className="truncate">Help center</span>
+                <ChevronDown
+                    className="ml-auto size-4 shrink-0 transition-transform duration-200 group-data-[state=open]:rotate-180"
+                    aria-hidden="true"
+                />
+            </CollapsibleTrigger>
+            <CollapsibleContent
+                className={cn(
+                    "overflow-hidden",
+                    "data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down",
+                )}
+            >
+                <div className="flex flex-col gap-0.5 pt-0.5">
+                    {helpLinks.map(({ label, href, icon: Icon }) => (
+                        <a
+                            key={label}
+                            href={href}
+                            target="_blank"
+                            rel="noreferrer"
+                            className={cn(
+                                "flex h-8 items-center gap-2 rounded-md pr-2 pl-8 text-sm transition-colors",
+                                "text-sidebar-foreground/85 hover:bg-sidebar-accent/60 hover:text-sidebar-foreground",
+                            )}
+                        >
+                            <Icon className="size-4 shrink-0" aria-hidden="true" />
+                            <span className="truncate">{label}</span>
+                        </a>
+                    ))}
+                </div>
+            </CollapsibleContent>
+        </Collapsible>
+    );
+}

--- a/src/Raven.Quill.Web/src/lib/help-links.ts
+++ b/src/Raven.Quill.Web/src/lib/help-links.ts
@@ -1,0 +1,22 @@
+import { Activity, BookOpen, LifeBuoy, Users, type LucideIcon } from "lucide-react";
+
+const SUPPORT_URL = "https://ravendb.net/support";
+
+// Support carries the license id so the request arrives already identified. The id is
+// missing until the license query resolves, which just means a plain support link.
+export function getHelpLinks(licenseId: string | undefined): { label: string; href: string; icon: LucideIcon }[] {
+    return [
+        { label: "Support", href: getSupportUrl(licenseId), icon: LifeBuoy },
+        { label: "Documentation", href: "https://docs.ravendb.net/quill", icon: BookOpen },
+        { label: "Community", href: "https://ravendb.net/community", icon: Users },
+        { label: "Service status", href: "https://status.ravendb.net", icon: Activity },
+    ];
+}
+
+function getSupportUrl(licenseId: string | undefined) {
+    if (!licenseId) {
+        return SUPPORT_URL;
+    }
+
+    return `${SUPPORT_URL}?${new URLSearchParams({ licenseId })}`;
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27359

### Additional description

The sidebar bottom block held two dead `isComingSoon` placeholders, **Community** and **Help**. Both are replaced by a single collapsible **Help center** group, following the RavenDB Cloud portal pattern:

* **Support** — `https://ravendb.net/support?licenseId={licenseId}`
* **Documentation** — `https://docs.ravendb.net/quill`
* **Community** — `https://ravendb.net/community`
* **Service status** — `https://status.ravendb.net`

Community folds into the group, so the block goes from two dead entries to one working section.

Notes for reviewers:

* **Two layouts, mirroring `ThemeSwitcher`.** Expanded sidebar gets a shadcn `Collapsible` with the links indented under the trigger; the collapsed rail gets a dropdown, since a narrow rail has no room for a nested list. `HelpMenu` takes the same `inline | dropdown` variant prop.
* **Animation reuses `tw-animate-css`.** `collapsible-down` / `collapsible-up` are already available through the existing `index.css` import, so no new keyframes. The layout classes sit on an inner `div` rather than on `CollapsibleContent` — padding on the animated element corrupts Radix's height measurement.
* **No per-item external-link glyph.** Every item leaves the product, so a glyph per row repeats the same signal four times. Links keep `target="_blank" rel="noreferrer"`.
* **Support is identified.** The license id comes from `api.queries.settings.license()`, sharing its query key with the license and dashboard views, so it is normally a cache hit rather than an extra request. Before the query resolves the link falls back to plain `/support` instead of sending `licenseId=undefined`.
* **The docs link leaves the top navigation** (`app.tsx`), since Help center is now its home. Heads-up for anyone else in that nav block.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

Not manually verified in a running app — `tsc -b`, ESLint and Prettier are clean, but the collapse animation and the collapsed-rail dropdown placement still want an eyeball.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

The **Docs** link is gone from the top navigation bar; the documentation link now lives in the sidebar Help center. The command palette keeps its own documentation entry, unchanged.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
