### PR TITLE
RavenDB-27363: rebuild the appliance certificate with its issuer chai…

### DIFF
--- a/docker/quill/Dockerfile
+++ b/docker/quill/Dockerfile
@@ -109,9 +109,11 @@ COPY docker/quill/nginx.conf /etc/nginx/nginx.conf
 
 COPY docker/quill/s6-rc.d/ /etc/s6-overlay/s6-rc.d/
 COPY docker/quill/scripts/proxy-certs.sh /usr/local/bin/proxy-certs
+COPY docker/quill/scripts/cert-chain.sh /usr/local/bin/cert-chain
 COPY docker/quill/scripts/svc-log.sh /usr/local/bin/svc-log
 RUN chmod +x /etc/s6-overlay/s6-rc.d/*/run \
              /usr/local/bin/proxy-certs \
+             /usr/local/bin/cert-chain \
              /usr/local/bin/svc-log
 
 EXPOSE 443

--- a/docker/quill/Dockerfile.source
+++ b/docker/quill/Dockerfile.source
@@ -151,10 +151,12 @@ COPY docker/quill/nginx.conf /etc/nginx/nginx.conf
 COPY docker/quill/s6-rc.d/ /etc/s6-overlay/s6-rc.d/
 COPY docker/quill/scripts/update-dns.sh /usr/local/bin/update-dns
 COPY docker/quill/scripts/proxy-certs.sh /usr/local/bin/proxy-certs
+COPY docker/quill/scripts/cert-chain.sh /usr/local/bin/cert-chain
 COPY docker/quill/scripts/svc-log.sh /usr/local/bin/svc-log
 RUN chmod +x /etc/s6-overlay/s6-rc.d/*/run \
              /usr/local/bin/update-dns \
              /usr/local/bin/proxy-certs \
+             /usr/local/bin/cert-chain \
              /usr/local/bin/svc-log
 
 EXPOSE 443

--- a/docker/quill/s6-rc.d/01-ravendb/run
+++ b/docker/quill/s6-rc.d/01-ravendb/run
@@ -38,8 +38,6 @@ if [ -f "$SETUP_SETTINGS" ]; then
     PFX="$(basename "$(ls "$SETUP_DIR"/A/cluster.server.certificate.*.pfx | head -n1)")"
     [ -f "$CERT_DIR/$PFX" ] || cp "$SETUP_DIR/A/$PFX" "$CERT_DIR/"
 
-    cert-chain "$CERT_DIR/$PFX"
-
     sed -i "s#\"$PFX\"#\"$CERT_DIR/$PFX\"#" /app/ravendb/settings.json
 
     if [ -f "$SETUP_DIR/admin-thumbprint" ]; then

--- a/docker/quill/s6-rc.d/01-ravendb/run
+++ b/docker/quill/s6-rc.d/01-ravendb/run
@@ -38,6 +38,8 @@ if [ -f "$SETUP_SETTINGS" ]; then
     PFX="$(basename "$(ls "$SETUP_DIR"/A/cluster.server.certificate.*.pfx | head -n1)")"
     [ -f "$CERT_DIR/$PFX" ] || cp "$SETUP_DIR/A/$PFX" "$CERT_DIR/"
 
+    cert-chain "$CERT_DIR/$PFX"
+
     sed -i "s#\"$PFX\"#\"$CERT_DIR/$PFX\"#" /app/ravendb/settings.json
 
     if [ -f "$SETUP_DIR/admin-thumbprint" ]; then

--- a/docker/quill/s6-rc.d/04-certwatch/run
+++ b/docker/quill/s6-rc.d/04-certwatch/run
@@ -11,8 +11,17 @@ done
 
 PFX="$(ls "$CERT_DIR"/cluster.server.certificate.*.pfx | head -n1)"
 
+pfx_serial() {
+    openssl pkcs12 -in "$PFX" -nokeys -clcerts -passin pass: 2>/dev/null | openssl x509 -noout -serial 2>/dev/null
+}
+
+pem_serial() {
+    openssl x509 -in /var/lib/quill/proxy/leaf.pem -noout -serial 2>/dev/null
+}
+
 while sleep 60; do
-    if [ "$PFX" -nt /var/lib/quill/proxy/leaf.pem ]; then
+    if [ "$(pfx_serial)" != "$(pem_serial)" ]; then
+        cert-chain "$PFX"
         proxy-certs
         s6-svc -h /run/service/03-proxy
         echo "04-certwatch: certificate renewed; nginx reloaded."

--- a/docker/quill/s6-rc.d/04-certwatch/run
+++ b/docker/quill/s6-rc.d/04-certwatch/run
@@ -4,6 +4,7 @@ set -e
 exec 2>&1
 
 CERT_DIR=/var/lib/quill/certs
+PROXY_DIR=/var/lib/quill/proxy
 
 while [ -z "$(ls "$CERT_DIR"/cluster.server.certificate.*.pfx 2>/dev/null)" ]; do
     sleep 10
@@ -16,12 +17,23 @@ pfx_serial() {
 }
 
 pem_serial() {
-    openssl x509 -in /var/lib/quill/proxy/leaf.pem -noout -serial 2>/dev/null
+    openssl x509 -in "$PROXY_DIR/leaf.pem" -noout -serial 2>/dev/null
 }
 
+unreadable=""
+
 while sleep 60; do
-    if [ "$(pfx_serial)" != "$(pem_serial)" ]; then
-        cert-chain "$PFX"
+    # An unreadable pfx would compare equal to an unreadable leaf.pem and look like "no change", so
+    # say so instead - once, rather than every minute
+    serial="$(pfx_serial)"
+    if [ -z "$serial" ]; then
+        [ -n "$unreadable" ] || echo "04-certwatch: cannot read a serial from $PFX; renewal detection is paused." >&2
+        unreadable=yes
+        continue
+    fi
+    unreadable=""
+
+    if [ "$serial" != "$(pem_serial)" ]; then
         proxy-certs
         s6-svc -h /run/service/03-proxy
         echo "04-certwatch: certificate renewed; nginx reloaded."

--- a/docker/quill/s6-rc.d/04-certwatch/run
+++ b/docker/quill/s6-rc.d/04-certwatch/run
@@ -10,32 +10,51 @@ while [ -z "$(ls "$CERT_DIR"/cluster.server.certificate.*.pfx 2>/dev/null)" ]; d
     sleep 10
 done
 
-PFX="$(ls "$CERT_DIR"/cluster.server.certificate.*.pfx | head -n1)"
-
 pfx_serial() {
-    openssl pkcs12 -in "$PFX" -nokeys -clcerts -passin pass: 2>/dev/null | openssl x509 -noout -serial 2>/dev/null
+    openssl pkcs12 -in "$1" -nokeys -clcerts -passin pass: 2>/dev/null | openssl x509 -noout -serial 2>/dev/null
 }
 
 pem_serial() {
     openssl x509 -in "$PROXY_DIR/leaf.pem" -noout -serial 2>/dev/null
 }
 
+chain_ok() {
+    if [ -s "$PROXY_DIR/chain.pem" ]; then
+        openssl verify -untrusted "$PROXY_DIR/chain.pem" "$PROXY_DIR/leaf.pem" >/dev/null 2>&1
+    else
+        openssl verify "$PROXY_DIR/leaf.pem" >/dev/null 2>&1
+    fi
+}
+
+rebuild() {
+    proxy-certs
+    s6-svc -h /run/service/03-proxy
+    echo "04-certwatch: $1; nginx reloaded."
+}
+
 unreadable=""
+retry=0
 
 while sleep 60; do
-    # An unreadable pfx would compare equal to an unreadable leaf.pem and look like "no change", so
-    # say so instead - once, rather than every minute
-    serial="$(pfx_serial)"
-    if [ -z "$serial" ]; then
-        [ -n "$unreadable" ] || echo "04-certwatch: cannot read a serial from $PFX; renewal detection is paused." >&2
+    PFX="$(ls "$CERT_DIR"/cluster.server.certificate.*.pfx 2>/dev/null | head -n1)"
+
+    if ! serial="$(pfx_serial "$PFX")" || [ -z "$serial" ]; then
+        [ -n "$unreadable" ] || echo "04-certwatch: cannot read a serial from '$PFX'; renewal detection is paused." >&2
         unreadable=yes
         continue
     fi
     unreadable=""
 
     if [ "$serial" != "$(pem_serial)" ]; then
-        proxy-certs
-        s6-svc -h /run/service/03-proxy
-        echo "04-certwatch: certificate renewed; nginx reloaded."
+        rebuild "certificate renewed"
+        retry=0
+    elif chain_ok; then
+        retry=0
+    elif [ "$retry" -gt 0 ]; then
+        # An unreachable CA would otherwise refetch every minute.
+        retry=$((retry - 1))
+    else
+        rebuild "chain was incomplete, rebuilt"
+        retry=30
     fi
 done

--- a/docker/quill/scripts/cert-chain.sh
+++ b/docker/quill/scripts/cert-chain.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -e
+
+# Let's Encrypt sends the issuers along with the leaf, but the PFX RavenDB writes keeps only the
+# leaf, so clients get no path to a trusted root. Rebuild the PFX with the issuers fetched from
+# each certificate's Authority Information Access extension.
+
+PFX="$1"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+certs() {
+    openssl pkcs12 -in "$PFX" -nokeys -passin pass: 2>/dev/null | grep -c 'BEGIN CERTIFICATE'
+}
+
+trusted() {
+    openssl verify -untrusted "$WORK/chain.pem" "$WORK/leaf.pem" >/dev/null 2>&1
+}
+
+issuer_url() {
+    openssl x509 -in "$1" -noout -text | sed -n 's#.*CA Issuers - URI:##p' | head -n1
+}
+
+if [ "$(certs)" -gt 1 ]; then
+    exit 0
+fi
+
+openssl pkcs12 -in "$PFX" -nokeys -clcerts -passin pass: -out "$WORK/leaf.pem"
+openssl pkcs12 -in "$PFX" -nocerts -nodes  -passin pass: -out "$WORK/key.pem"
+
+touch "$WORK/chain.pem"
+last="$WORK/leaf.pem"
+hops=0
+
+# Stopping on `trusted` rather than on a known issuer name keeps this working when Let's Encrypt
+# rotates intermediates, and drops the extra hop once their new root ships in trust stores.
+while [ "$hops" -lt 4 ] && ! trusted; do
+    url="$(issuer_url "$last")"
+    [ -n "$url" ] || break
+
+    hops=$((hops + 1))
+    curl -fsS --max-time 15 "$url" -o "$WORK/issuer.der" || break
+    openssl x509 -inform DER -in "$WORK/issuer.der" -out "$WORK/issuer-$hops.pem"
+
+    cat "$WORK/issuer-$hops.pem" >> "$WORK/chain.pem"
+    last="$WORK/issuer-$hops.pem"
+done
+
+if ! trusted; then
+    echo "cert-chain: could not build a trusted chain; leaving $(basename "$PFX") as it is." >&2
+    exit 0
+fi
+
+openssl pkcs12 -export -passout pass: \
+    -inkey "$WORK/key.pem" -in "$WORK/leaf.pem" -certfile "$WORK/chain.pem" \
+    -out "$WORK/new.pfx"
+
+cp "$WORK/new.pfx" "$PFX.tmp"
+chmod 600 "$PFX.tmp"
+mv "$PFX.tmp" "$PFX"
+
+echo "cert-chain: added $hops issuer(s) to $(basename "$PFX")."

--- a/docker/quill/scripts/cert-chain.sh
+++ b/docker/quill/scripts/cert-chain.sh
@@ -18,14 +18,24 @@ umask 077
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
-# openssl treats an empty -untrusted file as an error rather than as "no intermediates", so only
-# pass it once we have something to put in it.
+CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 trusted() {
     if [ -s "$WORK/chain.pem" ]; then
-        openssl verify -untrusted "$WORK/chain.pem" "$WORK/leaf.pem" >/dev/null 2>&1
+        openssl verify -CAfile "$CA_BUNDLE" -untrusted "$WORK/chain.pem" "$WORK/leaf.pem" >/dev/null 2>&1
     else
-        openssl verify "$WORK/leaf.pem" >/dev/null 2>&1
+        openssl verify -CAfile "$CA_BUNDLE" "$WORK/leaf.pem" >/dev/null 2>&1
     fi
+}
+
+extract_certs() {
+    openssl x509 -inform DER -in "$1" -out "$2" 2>/dev/null \
+        || openssl x509 -in "$1" -out "$2" 2>/dev/null \
+        || openssl pkcs7 -inform DER -in "$1" -print_certs -out "$2" 2>/dev/null \
+        || openssl pkcs7 -in "$1" -print_certs -out "$2" 2>/dev/null \
+        || return 1
+
+    grep -q "BEGIN CERTIFICATE" "$2"
 }
 
 issuer_urls() {
@@ -42,39 +52,46 @@ last="$WORK/leaf.pem"
 hops=0
 added=0
 
-deadline=$(( $(date +%s) + 30 ))
+now() {
+    cut -d. -f1 /proc/uptime
+}
+
+deadline=$(( $(now) + 30 ))
 
 # Stopping on `trusted` rather than on a known issuer name keeps this working when Let's Encrypt
 # rotates intermediates, and drops the extra hop once their new root ships in trust stores.
-while [ "$hops" -lt 4 ] && [ "$(date +%s)" -lt "$deadline" ] && ! trusted; do
+while [ "$hops" -lt 4 ] && [ "$(now)" -lt "$deadline" ] && ! trusted; do
     hops=$((hops + 1))
     next="$WORK/issuer-$hops.pem"
 
     # Try every caIssuers URI rather than only the first: a mirror can be down. caIssuers is usually
     # DER, but PEM and PKCS#7 are also served in the wild.
     for url in $(issuer_urls "$last"); do
-        curl -fsSL --proto '=http,https' --proto-redir '=http,https' \
-            --retry 1 --max-time 10 "$url" -o "$WORK/fetched" || continue
+        [ "$(now)" -lt "$deadline" ] || break
 
-        if openssl x509 -inform DER -in "$WORK/fetched" -out "$next" 2>/dev/null \
-            || openssl x509 -in "$WORK/fetched" -out "$next" 2>/dev/null \
-            || openssl pkcs7 -inform DER -in "$WORK/fetched" -print_certs -out "$next" 2>/dev/null; then
+        curl -fsSL --proto '=http,https' --proto-redir '=http,https' \
+            --connect-timeout 3 --max-time 10 --max-filesize 1M \
+            "$url" -o "$WORK/fetched" || continue
+
+        if extract_certs "$WORK/fetched" "$next" \
+            && openssl verify -partial_chain -trusted "$next" "$last" >/dev/null 2>&1; then
             break
         fi
+
+        # Discard it, or a rejected certificate would still be sitting there after the sweep.
+        rm -f "$next"
     done
 
-    [ -s "$next" ] || break
+    [ -f "$next" ] || break
 
     cat "$next" >> "$WORK/chain.pem"
     last="$next"
     added=$((added + 1))
 done
 
-# Written either way: whatever we have is at least what the pfx already carried.
 cp "$WORK/chain.pem" "$OUT"
 
-if trusted; then
-    [ "$added" -eq 0 ] || echo "cert-chain: added $added issuer(s) to the chain nginx serves."
-else
-    echo "cert-chain: could not build a trusted chain for $(basename "$PFX")." >&2
+[ "$added" -eq 0 ] || echo "cert-chain: added $added issuer(s) to the chain nginx serves."
+if ! trusted && [ -n "$(issuer_urls "$last")" ]; then
+    echo "cert-chain: chain for $(basename "$PFX") is incomplete; $(basename "$last") still advertises an issuer." >&2
 fi

--- a/docker/quill/scripts/cert-chain.sh
+++ b/docker/quill/scripts/cert-chain.sh
@@ -1,63 +1,80 @@
 #!/bin/sh
 set -e
 
-# Let's Encrypt sends the issuers along with the leaf, but the PFX RavenDB writes keeps only the
-# leaf, so clients get no path to a trusted root. Rebuild the PFX with the issuers fetched from
-# each certificate's Authority Information Access extension.
+# The pfx RavenDB writes keeps only the leaf certificate, so nginx has no path to a trusted root to
+# serve. Collect the issuers by following each certificate's Authority Information Access extension
+# and write them to $2 for proxy-certs to concatenate.
 
 PFX="$1"
+OUT="$2"
+
+if [ ! -f "$PFX" ]; then
+    echo "cert-chain: no pfx at '$PFX'; nothing to do." >&2
+    exit 0
+fi
+
+umask 077
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
-certs() {
-    openssl pkcs12 -in "$PFX" -nokeys -passin pass: 2>/dev/null | grep -c 'BEGIN CERTIFICATE'
-}
-
+# openssl treats an empty -untrusted file as an error rather than as "no intermediates", so only
+# pass it once we have something to put in it.
 trusted() {
-    openssl verify -untrusted "$WORK/chain.pem" "$WORK/leaf.pem" >/dev/null 2>&1
+    if [ -s "$WORK/chain.pem" ]; then
+        openssl verify -untrusted "$WORK/chain.pem" "$WORK/leaf.pem" >/dev/null 2>&1
+    else
+        openssl verify "$WORK/leaf.pem" >/dev/null 2>&1
+    fi
 }
 
-issuer_url() {
-    openssl x509 -in "$1" -noout -text | sed -n 's#.*CA Issuers - URI:##p' | head -n1
+issuer_urls() {
+    openssl x509 -in "$1" -noout -ext authorityInfoAccess 2>/dev/null \
+        | sed -n 's#^ *CA Issuers - URI:##p' \
+        | sed -e 's#[[:space:]]*$##' -e '/^$/d'
 }
-
-if [ "$(certs)" -gt 1 ]; then
-    exit 0
-fi
 
 openssl pkcs12 -in "$PFX" -nokeys -clcerts -passin pass: -out "$WORK/leaf.pem"
-openssl pkcs12 -in "$PFX" -nocerts -nodes  -passin pass: -out "$WORK/key.pem"
-
+openssl pkcs12 -in "$PFX" -nokeys -cacerts -passin pass: -out "$WORK/chain.pem" 2>/dev/null || true
 touch "$WORK/chain.pem"
+
 last="$WORK/leaf.pem"
 hops=0
+added=0
+
+deadline=$(( $(date +%s) + 30 ))
 
 # Stopping on `trusted` rather than on a known issuer name keeps this working when Let's Encrypt
 # rotates intermediates, and drops the extra hop once their new root ships in trust stores.
-while [ "$hops" -lt 4 ] && ! trusted; do
-    url="$(issuer_url "$last")"
-    [ -n "$url" ] || break
-
+while [ "$hops" -lt 4 ] && [ "$(date +%s)" -lt "$deadline" ] && ! trusted; do
     hops=$((hops + 1))
-    curl -fsS --max-time 15 "$url" -o "$WORK/issuer.der" || break
-    openssl x509 -inform DER -in "$WORK/issuer.der" -out "$WORK/issuer-$hops.pem"
+    next="$WORK/issuer-$hops.pem"
 
-    cat "$WORK/issuer-$hops.pem" >> "$WORK/chain.pem"
-    last="$WORK/issuer-$hops.pem"
+    # Try every caIssuers URI rather than only the first: a mirror can be down. caIssuers is usually
+    # DER, but PEM and PKCS#7 are also served in the wild.
+    for url in $(issuer_urls "$last"); do
+        curl -fsSL --proto '=http,https' --proto-redir '=http,https' \
+            --retry 1 --max-time 10 "$url" -o "$WORK/fetched" || continue
+
+        if openssl x509 -inform DER -in "$WORK/fetched" -out "$next" 2>/dev/null \
+            || openssl x509 -in "$WORK/fetched" -out "$next" 2>/dev/null \
+            || openssl pkcs7 -inform DER -in "$WORK/fetched" -print_certs -out "$next" 2>/dev/null; then
+            break
+        fi
+    done
+
+    [ -s "$next" ] || break
+
+    cat "$next" >> "$WORK/chain.pem"
+    last="$next"
+    added=$((added + 1))
 done
 
-if ! trusted; then
-    echo "cert-chain: could not build a trusted chain; leaving $(basename "$PFX") as it is." >&2
-    exit 0
+# Written either way: whatever we have is at least what the pfx already carried.
+cp "$WORK/chain.pem" "$OUT"
+
+if trusted; then
+    [ "$added" -eq 0 ] || echo "cert-chain: added $added issuer(s) to the chain nginx serves."
+else
+    echo "cert-chain: could not build a trusted chain for $(basename "$PFX")." >&2
 fi
-
-openssl pkcs12 -export -passout pass: \
-    -inkey "$WORK/key.pem" -in "$WORK/leaf.pem" -certfile "$WORK/chain.pem" \
-    -out "$WORK/new.pfx"
-
-cp "$WORK/new.pfx" "$PFX.tmp"
-chmod 600 "$PFX.tmp"
-mv "$PFX.tmp" "$PFX"
-
-echo "cert-chain: added $hops issuer(s) to $(basename "$PFX")."

--- a/docker/quill/scripts/proxy-certs.sh
+++ b/docker/quill/scripts/proxy-certs.sh
@@ -8,9 +8,10 @@ mkdir -p "$PROXY_DIR"
 PFX="$(ls "$CERT_DIR"/cluster.server.certificate.*.pfx | head -n1)"
 
 openssl pkcs12 -in "$PFX" -nokeys -clcerts -passin pass: -out "$PROXY_DIR/leaf.pem"
-cert-chain "$PFX" "$PROXY_DIR/chain.pem" || true
-touch "$PROXY_DIR/chain.pem"
-
-cat "$PROXY_DIR/leaf.pem" "$PROXY_DIR/chain.pem" > "$PROXY_DIR/fullchain.pem"
 openssl pkcs12 -in "$PFX" -nocerts -nodes  -passin pass: -out "$PROXY_DIR/privkey.pem"
 chmod 600 "$PROXY_DIR/privkey.pem"
+
+printf '' > "$PROXY_DIR/chain.pem"
+cert-chain "$PFX" "$PROXY_DIR/chain.pem" || true
+
+cat "$PROXY_DIR/leaf.pem" "$PROXY_DIR/chain.pem" > "$PROXY_DIR/fullchain.pem"

--- a/docker/quill/scripts/proxy-certs.sh
+++ b/docker/quill/scripts/proxy-certs.sh
@@ -8,7 +8,9 @@ mkdir -p "$PROXY_DIR"
 PFX="$(ls "$CERT_DIR"/cluster.server.certificate.*.pfx | head -n1)"
 
 openssl pkcs12 -in "$PFX" -nokeys -clcerts -passin pass: -out "$PROXY_DIR/leaf.pem"
-openssl pkcs12 -in "$PFX" -nokeys -cacerts -passin pass: -out "$PROXY_DIR/chain.pem"
+cert-chain "$PFX" "$PROXY_DIR/chain.pem" || true
+touch "$PROXY_DIR/chain.pem"
+
 cat "$PROXY_DIR/leaf.pem" "$PROXY_DIR/chain.pem" > "$PROXY_DIR/fullchain.pem"
 openssl pkcs12 -in "$PFX" -nocerts -nodes  -passin pass: -out "$PROXY_DIR/privkey.pem"
 chmod 600 "$PROXY_DIR/privkey.pem"


### PR DESCRIPTION
…n so non-browser clients can verify it, detect certificate renewal by serial

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27363

### Additional description

The appliance served only its own certificate, without the Let's Encrypt issuers above it, so any client that validates strictly failed with unable to get local issuer certificate. Browsers often hid this by fetching the missing issuer themselves; API clients and embed consumers could not.

cert-chain now follows the certificate's AIA links, stops as soon as openssl verify succeeds, and rewrites the pfx with the issuers. It runs before ravendb starts and again after each renewal, so the three nginx-terminated surfaces (`dashboard.*, public.*, api.*`) serve a complete chain. `db.*/a.*`are unaffected - RavenDB terminates those itself and already assembles the chain at runtime.

Now:
 a failure leaves the pfx untouched, and both call sites use || true, so it can't block RavenDB startup.

Also changes 04-certwatch to detect renewal by certificate serial rather than file timestamp - otherwise rewriting the pfx looks like a renewal and triggers a spurious nginx reload.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [ ] No

docker quill only

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

see comment below !

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
