### PR TITLE
RavenDB-27350 Fix setup wizard stuck on 'Configuration in progress'

### DIFF
--- a/src/Raven.Studio/typescript/commands/operations/getServerOperationStateCommand.ts
+++ b/src/Raven.Studio/typescript/commands/operations/getServerOperationStateCommand.ts
@@ -1,0 +1,20 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+
+class getServerOperationStateCommand extends commandBase {
+
+    constructor(private operationId: number) {
+        super();
+    }
+
+    execute(): JQueryPromise<Raven.Client.Documents.Operations.OperationState> {
+        const args = {
+            id: this.operationId
+        }
+        const url = endpoints.global.operationsServer.operationsState + this.urlEncodeArgs(args);
+
+        return this.query<Raven.Client.Documents.Operations.OperationState>(url, null);
+    }
+}
+
+export = getServerOperationStateCommand;

--- a/src/Raven.Studio/typescript/components/services/SetupWizardService.ts
+++ b/src/Raven.Studio/typescript/components/services/SetupWizardService.ts
@@ -11,6 +11,7 @@ import checkDomainAvailabilityCommand from "commands/wizard/checkDomainAvailabil
 import claimDomainCommand from "commands/wizard/claimDomainCommand";
 import continueSecureClusterConfigurationCommand from "commands/wizard/continueSecureClusterConfigurationCommand";
 import loadAgreementCommand from "commands/wizard/loadAgreementCommand";
+import getServerOperationStateCommand from "commands/operations/getServerOperationStateCommand";
 
 export default class SetupWizardService {
     async getEula() {
@@ -66,5 +67,9 @@ export default class SetupWizardService {
 
     async getLetsEncryptAgreement(...args: ConstructorParameters<typeof loadAgreementCommand>) {
         return new loadAgreementCommand(...args).execute();
+    }
+
+    async getOperationState(...args: ConstructorParameters<typeof getServerOperationStateCommand>) {
+        return new getServerOperationStateCommand(...args).execute();
     }
 }

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardFinishStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardFinishStep.tsx
@@ -3,7 +3,7 @@ import { SetupWizardFormData } from "../setupWizardValidation";
 import { Switch } from "components/common/Checkbox";
 import { FormGroup } from "components/common/Form";
 import useBoolean from "components/hooks/useBoolean";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useServices } from "components/hooks/useServices";
 import serverNotificationCenterClient from "common/serverNotificationCenterClient";
 import { ThemeColor } from "components/models/common";
@@ -37,6 +37,11 @@ interface Logs {
     color?: ThemeColor;
 }
 
+const webSocketConnectionTimeoutMs = 5000;
+const operationStatePollIntervalMs = 2000;
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
 export function SetupWizardFinishStep() {
     const { control, setValue } = useFormContext<SetupWizardFormData>();
     const { reportEvent } = useEventsCollector();
@@ -46,8 +51,6 @@ export function SetupWizardFinishStep() {
 
     const { setupMethodStep, usePackageStep, finishStep } = useWatch({ control });
 
-    const websocket = useMemo(() => new serverNotificationCenterClient(), []);
-
     const { databasesService, setupWizardService } = useServices();
 
     const [logs, setLogs] = useState<Logs[]>([]);
@@ -55,61 +58,70 @@ export function SetupWizardFinishStep() {
     const [configurationProcess, setConfigurationProcess] =
         useState<Raven.Server.Commercial.SetupProgressAndResult>(null);
 
+    const lastStatusRef = useRef<OperationStatus>(null);
+    const isOperationFinishedRef = useRef(false);
+
     const handleSetFinishStatus = (status: OperationStatus) => {
         dispatch(setupWizardActions.finishStepStatusSet(status));
         setValue("finishStep.finishingStatus", status);
         reportEvent(setupWizardGA4Prefixes.finalStep, "status", status);
     };
 
+    const applyOperationState = (state: Raven.Client.Documents.Operations.OperationState) => {
+        if (isOperationFinishedRef.current) {
+            return;
+        }
+
+        let dto: Raven.Server.Commercial.SetupProgressAndResult = state.Progress;
+
+        switch (state.Status) {
+            case "Completed":
+                dto = state.Result as Raven.Server.Commercial.SetupProgressAndResult;
+                setConfigurationProcess(dto);
+                break;
+            case "InProgress":
+                dto = state.Progress as Raven.Server.Commercial.SetupProgressAndResult;
+                setConfigurationProcess(dto);
+                break;
+            case "Faulted": {
+                setConfigurationProcess(state.Progress);
+                const failure = state.Result as Raven.Client.Documents.Operations.OperationExceptionResult;
+
+                setLogs((prev) => [...prev, { message: failure.Message, color: "danger" }]);
+                setLogs((prev) => [...prev, { message: state.Result.Error, color: "danger" }]);
+                setErrorLogs((prev) => [...prev, { message: failure.Error, color: "danger" }]);
+                break;
+            }
+            case "Canceled":
+                dto = state.Result as Raven.Server.Commercial.SetupProgressAndResult;
+                setConfigurationProcess(dto);
+                break;
+        }
+
+        if (dto?.Messages) {
+            setLogs(dto.Messages.map((message) => ({ message })));
+        }
+
+        if (lastStatusRef.current !== state.Status) {
+            lastStatusRef.current = state.Status;
+            handleSetFinishStatus(state.Status);
+        }
+
+        if (state.Status !== "InProgress") {
+            isOperationFinishedRef.current = true;
+        }
+    };
+
     const handleWebSocketOperation = (operation: Raven.Server.NotificationCenter.Notifications.OperationChanged) => {
         if (operation.TaskType === "Setup") {
-            let dto: Raven.Server.Commercial.SetupProgressAndResult = operation.State.Progress;
-
-            switch (operation.State.Status) {
-                case "Completed":
-                    dto = operation.State.Result as Raven.Server.Commercial.SetupProgressAndResult;
-                    setConfigurationProcess(operation.State.Result);
-                    handleSetFinishStatus("Completed");
-                    break;
-                case "InProgress":
-                    dto = operation.State.Progress as Raven.Server.Commercial.SetupProgressAndResult;
-                    setConfigurationProcess(operation.State.Progress);
-                    handleSetFinishStatus("InProgress");
-                    break;
-                case "Faulted": {
-                    setConfigurationProcess(operation.State.Progress);
-                    const failure = operation.State
-                        .Result as Raven.Client.Documents.Operations.OperationExceptionResult;
-
-                    setLogs((prev) => [...prev, { message: failure.Message, color: "danger" }]);
-                    setLogs((prev) => [...prev, { message: operation.State.Result.Error, color: "danger" }]);
-                    setErrorLogs((prev) => [...prev, { message: failure.Error, color: "danger" }]);
-
-                    handleSetFinishStatus("Faulted");
-                    break;
-                }
-                case "Canceled":
-                    dto = operation.State.Result as Raven.Server.Commercial.SetupProgressAndResult;
-                    setConfigurationProcess(operation.State.Result);
-                    handleSetFinishStatus("Canceled");
-                    break;
-            }
-
-            if (dto) {
-                switch (operation.TaskType) {
-                    case "Setup":
-                        setLogs(dto.Messages.map((message) => ({ message })));
-                        break;
-                }
-            }
+            applyOperationState(operation.State);
         }
     };
 
     const { getRegularDto, getContinueWithPackageDto, getSubmitUrlBase, downloadConfigurationLog } =
         useSetupWizardFinishUtils();
 
-    const regularFinish = async () => {
-        const operationId = await databasesService.getNextOperationId(null);
+    const regularFinish = (operationId: number) => {
         const operationPart = "?operationId=" + operationId;
         const urlBase = getSubmitUrlBase();
 
@@ -121,15 +133,9 @@ export function SetupWizardFinishStep() {
         form.action = urlBase + operationPart;
         optionsInput.value = JSON.stringify(dto);
         form.submit();
-
-        websocket.watchOperation(operationId, handleWebSocketOperation);
     };
 
-    const continueWithPackageFinish = async () => {
-        const operationId = await databasesService.getNextOperationId(null);
-
-        websocket.watchOperation(operationId, handleWebSocketOperation);
-
+    const continueWithPackageFinish = async (operationId: number) => {
         const dto = getContinueWithPackageDto();
 
         if (usePackageStep.isZipSecure) {
@@ -140,20 +146,62 @@ export function SetupWizardFinishStep() {
     };
 
     useEffect(() => {
+        let disposed = false;
+        const websocket = new serverNotificationCenterClient();
+
+        const waitForWebSocketConnection = (): Promise<void> =>
+            Promise.race([
+                new Promise<void>((resolve) => websocket.connectToWebSocketTask.always(() => resolve())),
+                delay(webSocketConnectionTimeoutMs),
+            ]);
+
+        const pollOperationState = async (operationId: number) => {
+            while (!disposed && !isOperationFinishedRef.current) {
+                await delay(operationStatePollIntervalMs);
+
+                if (disposed || isOperationFinishedRef.current) {
+                    return;
+                }
+
+                try {
+                    applyOperationState(await setupWizardService.getOperationState(operationId));
+                } catch {
+
+                }
+            }
+        };
+
         const finish = async () => {
             reportEvent(
                 setupWizardGA4Prefixes.finalStep,
                 "start-setup",
                 setupMethodStep.method === "usePackage" ? "usePackage" : "regular"
             );
-            if (setupMethodStep.method === "usePackage") {
-                await continueWithPackageFinish();
-            } else {
-                await regularFinish();
+
+            const operationId = await databasesService.getNextOperationId(null);
+
+            websocket.watchOperation(operationId, handleWebSocketOperation);
+            await waitForWebSocketConnection();
+
+            if (disposed) {
+                return;
             }
+
+            if (setupMethodStep.method === "usePackage") {
+                await continueWithPackageFinish(operationId);
+            } else {
+                regularFinish(operationId);
+            }
+
+            pollOperationState(operationId);
         };
 
         finish();
+
+        return () => {
+            disposed = true;
+            websocket.dispose();
+        };
     }, []);
 
     return (

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardFinishStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardFinishStep.tsx
@@ -31,6 +31,7 @@ import Code from "components/common/Code";
 import { useAppDispatch } from "components/store";
 import { setupWizardActions } from "components/setupWizard/store/setupWizardSlice";
 import OperationStatus = Raven.Client.Documents.Operations.OperationStatus;
+import { delay } from "components/utils/common";
 
 interface Logs {
     message: string;
@@ -39,8 +40,7 @@ interface Logs {
 
 const webSocketConnectionTimeoutMs = 5000;
 const operationStatePollIntervalMs = 2000;
-
-const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+const maxConsecutivePollFailures = 15;
 
 export function SetupWizardFinishStep() {
     const { control, setValue } = useFormContext<SetupWizardFormData>();
@@ -65,6 +65,19 @@ export function SetupWizardFinishStep() {
         dispatch(setupWizardActions.finishStepStatusSet(status));
         setValue("finishStep.finishingStatus", status);
         reportEvent(setupWizardGA4Prefixes.finalStep, "status", status);
+    };
+
+    const failSetup = (message: string) => {
+        if (isOperationFinishedRef.current) {
+            return;
+        }
+
+        isOperationFinishedRef.current = true;
+        lastStatusRef.current = "Faulted";
+
+        setLogs((prev) => [...prev, { message, color: "danger" }]);
+        setErrorLogs((prev) => [...prev, { message, color: "danger" }]);
+        handleSetFinishStatus("Faulted");
     };
 
     const applyOperationState = (state: Raven.Client.Documents.Operations.OperationState) => {
@@ -149,13 +162,17 @@ export function SetupWizardFinishStep() {
         let disposed = false;
         const websocket = new serverNotificationCenterClient();
 
-        const waitForWebSocketConnection = (): Promise<void> =>
+        const waitForWebSocketConnection = (): Promise<boolean> =>
             Promise.race([
-                new Promise<void>((resolve) => websocket.connectToWebSocketTask.always(() => resolve())),
-                delay(webSocketConnectionTimeoutMs),
+                new Promise<boolean>((resolve) =>
+                    websocket.connectToWebSocketTask.done(() => resolve(true)).fail(() => resolve(false))
+                ),
+                delay(webSocketConnectionTimeoutMs).then(() => false),
             ]);
 
         const pollOperationState = async (operationId: number) => {
+            let consecutiveFailures = 0;
+
             while (!disposed && !isOperationFinishedRef.current) {
                 await delay(operationStatePollIntervalMs);
 
@@ -165,8 +182,18 @@ export function SetupWizardFinishStep() {
 
                 try {
                     applyOperationState(await setupWizardService.getOperationState(operationId));
-                } catch {
+                    consecutiveFailures = 0;
+                } catch (e) {
+                    consecutiveFailures++;
+                    console.warn(`Failed to read state of setup operation ${operationId}`, e);
 
+                    if (consecutiveFailures >= maxConsecutivePollFailures) {
+                        failSetup(
+                            "The server stopped responding to setup status queries. " +
+                                "The setup might still be running - check the server log."
+                        );
+                        return;
+                    }
                 }
             }
         };
@@ -181,10 +208,14 @@ export function SetupWizardFinishStep() {
             const operationId = await databasesService.getNextOperationId(null);
 
             websocket.watchOperation(operationId, handleWebSocketOperation);
-            await waitForWebSocketConnection();
+            const isWebSocketConnected = await waitForWebSocketConnection();
 
             if (disposed) {
                 return;
+            }
+
+            if (!isWebSocketConnected) {
+                console.warn("Notification websocket is not connected, relying on operation state polling only");
             }
 
             if (setupMethodStep.method === "usePackage") {
@@ -193,10 +224,16 @@ export function SetupWizardFinishStep() {
                 regularFinish(operationId);
             }
 
-            pollOperationState(operationId);
+            await pollOperationState(operationId);
         };
 
-        finish();
+        finish().catch((e) => {
+            console.error("Setup failed", e);
+
+            if (!disposed) {
+                failSetup("Setup failed: " + genUtils.trimMessage(e?.responseJSON?.Message ?? e));
+            }
+        });
 
         return () => {
             disposed = true;

--- a/src/Raven.Studio/typescript/components/utils/common.ts
+++ b/src/Raven.Studio/typescript/components/utils/common.ts
@@ -45,7 +45,7 @@ export function createFailureState(error?: string): loadableData<any> {
 }
 
 export async function delay(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
 export function databaseLocationComparator(lhs: databaseLocationSpecifier, rhs: databaseLocationSpecifier) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27350

### Additional description

The wizard's finish step learned the setup operation outcome only from notification-center websocket pushes, and started the operation without waiting for the socket to connect. Operation notifications are not persistent and are replayed on connect only for still-active operations, so a handshake slower than the (sub-second) setup lost every notification unrecoverably, leaving the wizard on its default 'InProgress' state with an empty log.

- register the operation watcher and wait (bounded) for the socket before starting setup
- poll /operations/state as a fallback so a missed notification cannot wedge the wizard
- apply operation state idempotently, since websocket and polling now feed the same handler
- dispose the notification-center client on unmount and fetch the operation id once

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
