### PR TITLE
RavenDB-27336, RavenDB-27341: fix Quill table selection and style setup error banners

### DIFF
--- a/src/Raven.Quill.Web/src/components/form/wizard/wizard-error-alert.tsx
+++ b/src/Raven.Quill.Web/src/components/form/wizard/wizard-error-alert.tsx
@@ -1,3 +1,4 @@
+import { CircleAlertIcon } from "lucide-react";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { ErrorDetails } from "@/components/data/error-details";
 import { WizardStepError } from "@/components/form/wizard/wizard-step-error";
@@ -8,6 +9,7 @@ export function WizardErrorAlert({ error, className }: { error: Error; className
 
     return (
         <Alert variant="destructive" className={cn("grid gap-2", className)}>
+            <CircleAlertIcon aria-hidden="true" />
             <span className="whitespace-pre-wrap">{error.message}</span>
             {details && <ErrorDetails details={details} />}
         </Alert>

--- a/src/Raven.Quill.Web/src/components/form/wizard/wizard-error-list.tsx
+++ b/src/Raven.Quill.Web/src/components/form/wizard/wizard-error-list.tsx
@@ -1,8 +1,21 @@
+import { CircleAlertIcon } from "lucide-react";
 import type { WizardError } from "@/api/generated/server-api";
 import { ErrorDetails } from "@/components/data/error-details";
-import { cn } from "@/lib/utils";
+import { Alert, AlertDescription, AlertTitle } from "@/components/shadcn/ui/alert";
 
-export function WizardErrorList({ errors, className }: { errors?: WizardError[]; className?: string }) {
+/**
+ * Page-level banner for the errors a wizard step's server call reported. `title` names what failed,
+ * because the server messages below it describe the cause without saying which call produced them.
+ */
+export function WizardErrorList({
+    errors,
+    title,
+    className,
+}: {
+    errors?: WizardError[];
+    title: string;
+    className?: string;
+}) {
     const visibleErrors = errors?.filter(Boolean) ?? [];
 
     if (visibleErrors.length === 0) {
@@ -10,13 +23,19 @@ export function WizardErrorList({ errors, className }: { errors?: WizardError[];
     }
 
     return (
-        <ul className={cn("grid gap-2 text-sm text-destructive", className)}>
-            {visibleErrors.map((error, index) => (
-                <li key={index} className="grid gap-1">
-                    <span className="whitespace-pre-wrap">{error.message}</span>
-                    {error.details && <ErrorDetails details={error.details} />}
-                </li>
-            ))}
-        </ul>
+        <Alert variant="destructive" className={className}>
+            <CircleAlertIcon aria-hidden="true" />
+            <AlertTitle>{title}</AlertTitle>
+            <AlertDescription>
+                <ul className="grid gap-2">
+                    {visibleErrors.map((error, index) => (
+                        <li key={index} className="grid gap-1">
+                            <span className="whitespace-pre-wrap">{error.message}</span>
+                            {error.details && <ErrorDetails details={error.details} />}
+                        </li>
+                    ))}
+                </ul>
+            </AlertDescription>
+        </Alert>
     );
 }

--- a/src/Raven.Quill.Web/src/components/shadcn/ui/checkbox.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/checkbox.tsx
@@ -2,14 +2,14 @@ import * as React from "react";
 import { Checkbox as CheckboxPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
-import { CheckIcon } from "lucide-react";
+import { CheckIcon, MinusIcon } from "lucide-react";
 
 function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
     return (
         <CheckboxPrimitive.Root
             data-slot="checkbox"
             className={cn(
-                "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:data-checked:bg-primary",
+                "group/checkbox peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary dark:data-[state=indeterminate]:bg-primary",
                 className,
             )}
             {...props}
@@ -18,7 +18,10 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
                 data-slot="checkbox-indicator"
                 className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
             >
-                <CheckIcon />
+                {/* Radix renders the indicator for indeterminate as well as checked, so the two
+                    have to be told apart here - otherwise a partial selection looks complete. */}
+                <CheckIcon className="group-data-[state=indeterminate]/checkbox:hidden" />
+                <MinusIcon className="hidden group-data-[state=indeterminate]/checkbox:block" />
             </CheckboxPrimitive.Indicator>
         </CheckboxPrimitive.Root>
     );

--- a/src/Raven.Quill.Web/src/components/shadcn/ui/field.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/field.tsx
@@ -92,7 +92,7 @@ function FieldLabel({ className, ...props }: React.ComponentProps<typeof Label>)
         <Label
             data-slot="field-label"
             className={cn(
-                "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+                "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-[state=checked]:border-primary/30 has-data-[state=checked]:bg-primary/5 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 dark:has-data-[state=checked]:border-primary/20 dark:has-data-[state=checked]:bg-primary/10",
                 "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
                 className,
             )}

--- a/src/Raven.Quill.Web/src/components/table/row-range-selection.test.ts
+++ b/src/Raven.Quill.Web/src/components/table/row-range-selection.test.ts
@@ -1,0 +1,129 @@
+import type { Row, RowSelectionState, Table } from "@tanstack/react-table";
+import { describe, expect, it } from "vitest";
+import { getRangeSelection, setRowsSelected } from "@/components/table/row-range-selection";
+
+/**
+ * The range helpers only read the row model and the selection state, and write the selection back,
+ * so a stub covering those three is enough to pin the range rules without standing up react-table.
+ */
+function createTable(rowIds: string[], selectedRowIds: string[] = []) {
+    let rowSelection: RowSelectionState = Object.fromEntries(selectedRowIds.map((id) => [id, true]));
+    const rows = rowIds.map((id) => ({ id }) as Row<unknown>);
+
+    const table = {
+        getRowModel: () => ({ rows }),
+        getState: () => ({ rowSelection }),
+        setRowSelection: (next: RowSelectionState) => {
+            rowSelection = next;
+        },
+    } as unknown as Table<unknown>;
+
+    return {
+        table,
+        selectedIds: () => Object.keys(rowSelection).filter((id) => rowSelection[id]),
+    };
+}
+
+const ROWS = ["a", "b", "c", "d", "e"];
+const rangeIds = <TData>(range: { rows: Row<TData>[] }) => range.rows.map((row) => row.id);
+
+describe("getRangeSelection", () => {
+    it("selects the range when the clicked row is unselected, even with nothing selected yet", () => {
+        const { table } = createTable(ROWS);
+
+        const range = getRangeSelection(table, "a", "c");
+
+        expect(rangeIds(range)).toEqual(["a", "b", "c"]);
+        expect(range.isSelecting).toBe(true);
+    });
+
+    it("clears the range when the clicked row is already selected", () => {
+        const { table } = createTable(ROWS, ["a", "b", "c"]);
+
+        const range = getRangeSelection(table, "a", "c");
+
+        expect(rangeIds(range)).toEqual(["a", "b", "c"]);
+        expect(range.isSelecting).toBe(false);
+    });
+
+    it("covers the range in display order whichever side the anchor is on", () => {
+        const { table } = createTable(ROWS);
+
+        expect(rangeIds(getRangeSelection(table, "d", "b"))).toEqual(["b", "c", "d"]);
+    });
+
+    it("runs from the top row when no anchor has been recorded yet", () => {
+        const { table } = createTable(ROWS);
+
+        expect(rangeIds(getRangeSelection(table, null, "c"))).toEqual(["a", "b", "c"]);
+    });
+
+    it("runs from the top row once a filter has hidden the anchor", () => {
+        const { table } = createTable(ROWS);
+
+        expect(rangeIds(getRangeSelection(table, "missing", "c"))).toEqual(["a", "b", "c"]);
+    });
+
+    it("takes no range for a target that is not in the row model", () => {
+        const { table } = createTable(ROWS);
+
+        expect(rangeIds(getRangeSelection(table, "a", "missing"))).toEqual([]);
+    });
+
+    it("takes no range in an empty table", () => {
+        const { table } = createTable([]);
+
+        expect(rangeIds(getRangeSelection(table, null, "a"))).toEqual([]);
+    });
+
+    it("trims a selecting range to the limit", () => {
+        const { table } = createTable(ROWS, ["a"]);
+
+        const range = getRangeSelection(table, "b", "e", 3);
+
+        // "a" already holds one of the three slots, leaving room for "b" and "c" only.
+        expect(rangeIds(range)).toEqual(["b", "c"]);
+    });
+
+    it("never trims a clearing range, so a full range can always be cleared", () => {
+        const { table } = createTable(ROWS, ROWS);
+
+        const range = getRangeSelection(table, "a", "e", 3);
+
+        expect(rangeIds(range)).toEqual(ROWS);
+        expect(range.isSelecting).toBe(false);
+    });
+});
+
+describe("setRowsSelected", () => {
+    it("adds the range to the existing selection", () => {
+        const { table, selectedIds } = createTable(ROWS, ["e"]);
+        const range = getRangeSelection(table, "a", "b");
+
+        setRowsSelected(table, range.rows, range.isSelecting);
+
+        expect(selectedIds().sort()).toEqual(["a", "b", "e"]);
+    });
+
+    it("removes the range and leaves the rest of the selection alone", () => {
+        const { table, selectedIds } = createTable(ROWS, ["a", "b", "e"]);
+        const range = getRangeSelection(table, "a", "b");
+
+        setRowsSelected(table, range.rows, range.isSelecting);
+
+        expect(selectedIds()).toEqual(["e"]);
+    });
+
+    it("stops selecting at the limit", () => {
+        const { table, selectedIds } = createTable(ROWS);
+
+        setRowsSelected(
+            table,
+            [...Array(5).keys()].map((i) => ({ id: ROWS[i]! }) as Row<unknown>),
+            true,
+            2,
+        );
+
+        expect(selectedIds()).toEqual(["a", "b"]);
+    });
+});

--- a/src/Raven.Quill.Web/src/components/table/row-range-selection.ts
+++ b/src/Raven.Quill.Web/src/components/table/row-range-selection.ts
@@ -8,36 +8,49 @@ export function countSelectedRows(selection: RowSelectionState): number {
     return Object.values(selection).filter(Boolean).length;
 }
 
-export function isRowSelected<TData>(table: Table<TData>, rowId: string | null): boolean {
+function isRowSelected<TData>(table: Table<TData>, rowId: string | null): boolean {
     return rowId !== null && Boolean(table.getState().rowSelection[rowId]);
 }
 
 /**
- * The rows a shift-click on `targetRowId` would apply the anchor row's state to, already trimmed to
- * the selection limit. Empty when there is no range to take, e.g. before the first click or once a
- * filter has removed the anchor; the click then falls back to toggling the row it landed on.
+ * The rows a shift-click on `targetRowId` would cover, and the state it would give them, already
+ * trimmed to the selection limit.
+ *
+ * `isSelecting` follows the row the click lands on, so the range takes the same toggle that row's
+ * own checkbox would: a shift-click on an unselected row extends the selection over the range, and
+ * one on a selected row clears it. Reading it off the anchor instead would strand the gesture -
+ * with nothing selected the anchor is unselected too, so the click would clear an already empty
+ * range and do nothing at all.
+ *
+ * The range runs from the top of the table when there is no usable anchor. Only a plain click on a
+ * row records one, so a selection that arrived some other way - seeded from a stored configuration,
+ * taken with the header checkbox, cleared through "Deselect all" - has none, and a filter can hide
+ * the row that held it. Without a fallback endpoint the shift-click in those states would collapse
+ * into a plain toggle, which reads as Shift doing nothing at all.
  */
-export function getRangeSelectionRows<TData>(
+export function getRangeSelection<TData>(
     table: Table<TData>,
     anchorRowId: string | null,
     targetRowId: string,
     maxSelectedCount: number = Infinity,
-): Row<TData>[] {
-    if (anchorRowId === null) {
-        return [];
-    }
-
+): { rows: Row<TData>[]; isSelecting: boolean } {
+    const isSelecting = !isRowSelected(table, targetRowId);
     const rows = table.getRowModel().rows;
-    const anchorIndex = rows.findIndex((row) => row.id === anchorRowId);
     const targetIndex = rows.findIndex((row) => row.id === targetRowId);
 
-    if (anchorIndex === -1 || targetIndex === -1) {
-        return [];
+    if (targetIndex === -1) {
+        return { rows: [], isSelecting };
     }
 
+    // findIndex reports -1 for both a missing and a null anchor, which the clamp turns into the
+    // first row; the empty-table case is already ruled out by the target lookup above.
+    const anchorIndex = Math.max(
+        rows.findIndex((row) => row.id === anchorRowId),
+        0,
+    );
     const rangeRows = rows.slice(Math.min(anchorIndex, targetIndex), Math.max(anchorIndex, targetIndex) + 1);
 
-    return takeWithinLimit(table, rangeRows, isRowSelected(table, anchorRowId), maxSelectedCount);
+    return { rows: takeWithinLimit(table, rangeRows, isSelecting, maxSelectedCount), isSelecting };
 }
 
 /** Selects or clears `rows`, in display order, without letting the selection pass the limit. */
@@ -127,7 +140,7 @@ export function useRowRangeSelection<TData>(maxSelectedCount: number = Infinity)
             }
 
             return new Set(
-                getRangeSelectionRows(table, anchorRowIdRef.current, hoveredRowId, maxSelectedCount).map(
+                getRangeSelection(table, anchorRowIdRef.current, hoveredRowId, maxSelectedCount).rows.map(
                     (row) => row.id,
                 ),
             );

--- a/src/Raven.Quill.Web/src/mocks/setup-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/setup-mocks.ts
@@ -379,3 +379,21 @@ export const sampleMappingTest: TestMappingResponse = {
     errors: [],
     warnings: [],
 };
+
+export const failedMappingTest: TestMappingResponse = {
+    results: [],
+    errors: [
+        {
+            message: 'Could not project column "Preferences" into the mapped document: the value is not valid JSON.',
+            details:
+                "System.Text.Json.JsonException: '{' is an invalid start of a value. Path: $ | LineNumber: 0\n" +
+                "   at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack&, JsonReaderException)\n" +
+                "   at Raven.Quill.Setup.MappingTester.ProjectColumn(DiscoverColumnResponse, Object)",
+        },
+        {
+            message: "Fix the column mapping or exclude the column, then run the preview again.",
+            details: null,
+        },
+    ],
+    warnings: [],
+};

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
@@ -12,6 +12,7 @@ import {
     discoveryWithAllStates,
     failedCdcVerification,
     failedDiscovery,
+    failedMappingTest,
     manyTablesDiscovery,
     sampleDiscovery,
     setupMocks,
@@ -355,4 +356,23 @@ export const MapTablesSuggesting: Story = {
 
 export const Preview: Story = {
     render: () => <AppWizardAtStep initialStep="preview" />,
+};
+
+// The mapping ran but reported errors, so the preview shows the destructive banner instead of documents.
+export const PreviewMappingErrors: Story = {
+    parameters: {
+        msw: { handlers: { setup: [setupMocks.testMapping(failedMappingTest), ...defaultApiMocks.setup] } },
+    },
+    render: () => <AppWizardAtStep initialStep="preview" />,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await waitFor(() => expect(canvas.getByText("Testing the mapping failed")).toBeInTheDocument());
+
+        // The banner is one alert, not an alert nested in another one.
+        expect(canvasElement.querySelectorAll('[data-slot="alert"]')).toHaveLength(1);
+
+        await userEvent.click(canvas.getByRole("button", { name: /show details/i }));
+        expect(canvas.getByText(/is an invalid start of a value/i)).toBeInTheDocument();
+    },
 };

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
@@ -159,6 +159,25 @@ function AppWizardStepBody({ initialStep }: { initialStep: AppStepId }) {
     );
 }
 
+/**
+ * What the select-all box actually draws. `aria-checked` was already correct while a partial
+ * selection still rendered the same checkmark as a complete one, so the mark is the part worth
+ * asserting: "check" for every row, "dash" for some, "empty" for none.
+ */
+function readSelectAllMark(canvasElement: HTMLElement): "check" | "dash" | "empty" {
+    const box = within(canvasElement).getByRole("checkbox", { name: "Select all" });
+    const marks = [...box.querySelectorAll("svg")].filter((svg) => getComputedStyle(svg).display !== "none");
+
+    if (marks.length === 0) {
+        return "empty";
+    }
+    if (marks.length > 1) {
+        throw new Error(`Expected one visible mark in the select-all box, found ${marks.length}`);
+    }
+
+    return marks[0]!.classList.contains("lucide-minus") ? "dash" : "check";
+}
+
 export const ChooseDataSource: Story = {
     render: () => <AppWizardAtStep initialStep="dataSource" />,
 };
@@ -254,6 +273,13 @@ export const ConnectSourceError: Story = {
 export const VerifySchema: Story = {
     parameters: { msw: { handlers: discoverHandlers(discoveryWithAllStates) } },
     render: () => <AppWizardAtStep initialStep="verifySchema" discovery={discoveryWithAllStates} />,
+    // Every verified table starts selected, so the header draws a check rather than a partial dash.
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await waitFor(() => expect(canvas.getByRole("checkbox", { name: "Select all" })).toBeInTheDocument());
+        expect(readSelectAllMark(canvasElement)).toBe("check");
+    },
 };
 
 // Discovery failed: only the destructive error banner is shown, no tables.
@@ -287,10 +313,13 @@ export const VerifySchemaSelectionLimit: Story = {
         // which would drop the held shift key before the range click.
         const user = userEvent.setup();
         const rowCheckboxes = () => canvas.getAllByRole("checkbox", { name: "Select row" });
+        const selectAll = () => canvas.getByRole("checkbox", { name: "Select all" });
         const limitNotice = () => canvas.queryByText(/one app processes at most 64 tables/i);
         const previewedRows = () => canvasElement.querySelectorAll(`.${RANGE_PREVIEW_ROW_CLASSNAME}`);
+        const selectAllMark = () => readSelectAllMark(canvasElement);
 
-        expect(canvas.getByText(/while clicking to select a range of tables/i)).toBeInTheDocument();
+        expect(canvas.getByText(/to select a range of tables/i)).toBeInTheDocument();
+        expect(selectAllMark()).toBe("empty");
 
         await user.click(rowCheckboxes()[0]);
 
@@ -304,14 +333,80 @@ export const VerifySchemaSelectionLimit: Story = {
         await waitFor(() => expect(canvas.getByText(/4 out of 80 tables selected/)).toBeInTheDocument());
         await waitFor(() => expect(previewedRows()).toHaveLength(0));
         expect(limitNotice()).not.toBeInTheDocument();
+        // 4 of 80 is a partial selection, so the header must not claim everything is selected.
+        expect(selectAll()).toHaveAttribute("aria-checked", "mixed");
+        expect(selectAllMark()).toBe("dash");
 
-        const selectAll = canvas.getByRole("checkbox", { name: "Select all" });
-        await user.click(selectAll);
+        await user.click(selectAll());
         await waitFor(() => expect(canvas.getByText(/64 out of 80 tables selected/)).toBeInTheDocument());
         expect(limitNotice()).toBeInTheDocument();
+        // The limit stops select-all short of every row, so the selection stays partial.
+        expect(selectAllMark()).toBe("dash");
 
-        await user.click(selectAll);
+        await user.click(selectAll());
         await waitFor(() => expect(limitNotice()).not.toBeInTheDocument());
+        expect(selectAllMark()).toBe("empty");
+    },
+};
+
+// A shift-click has to be able to start a multi-selection from an empty one. The range used to
+// inherit the anchor row's own state, so with nothing selected the click cleared an already empty
+// range - and suppressed the plain toggle on the way - leaving the click with no effect at all.
+export const VerifySchemaShiftSelectFromEmpty: Story = {
+    parameters: { msw: { handlers: discoverHandlers(manyTablesDiscovery) } },
+    render: () => (
+        <AppWizardAtStep initialStep="verifySchema" discovery={manyTablesDiscovery} hasSelectedTables={false} />
+    ),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const user = userEvent.setup();
+        const rowCheckboxes = () => canvas.getAllByRole("checkbox", { name: "Select row" });
+        const selectedCount = () => rowCheckboxes().filter((box) => box.getAttribute("aria-checked") === "true").length;
+
+        // Leaves an anchor behind on an empty selection - where an operator lands after picking a
+        // table and changing their mind.
+        await user.click(rowCheckboxes()[0]);
+        await waitFor(() => expect(selectedCount()).toBe(1));
+        await user.click(rowCheckboxes()[0]);
+        await waitFor(() => expect(selectedCount()).toBe(0));
+
+        await user.keyboard("{Shift>}");
+        await user.click(rowCheckboxes()[4]);
+        await user.keyboard("{/Shift}");
+
+        await waitFor(() => expect(canvas.getByText(/5 out of 80 tables selected/)).toBeInTheDocument());
+
+        // Shift-clicking inside the range it just took clears it again.
+        await user.keyboard("{Shift>}");
+        await user.click(rowCheckboxes()[4]);
+        await user.keyboard("{/Shift}");
+
+        await waitFor(() => expect(selectedCount()).toBe(0));
+    },
+};
+
+// The anchor is only ever recorded by clicking a row, so a selection that arrived any other way -
+// seeded from a stored configuration, or cleared through "Deselect all" - used to leave the first
+// shift-click with no second endpoint, degrading it to a plain single toggle.
+export const VerifySchemaShiftSelectWithoutClicking: Story = {
+    parameters: { msw: { handlers: discoverHandlers(discoveryWithAllStates) } },
+    render: () => <AppWizardAtStep initialStep="verifySchema" discovery={discoveryWithAllStates} />,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const user = userEvent.setup();
+        const rowCheckboxes = () => canvas.getAllByRole("checkbox", { name: "Select row" });
+        const selectedCount = () => rowCheckboxes().filter((box) => box.getAttribute("aria-checked") === "true").length;
+
+        // Clears the seeded selection without ever clicking a row, so no anchor is recorded.
+        await user.click(canvas.getByRole("button", { name: /deselect all/i }));
+        await waitFor(() => expect(selectedCount()).toBe(0));
+
+        // The range still opens, counted from the top of the table.
+        await user.keyboard("{Shift>}");
+        await user.click(rowCheckboxes()[2]);
+        await user.keyboard("{/Shift}");
+
+        await waitFor(() => expect(selectedCount()).toBe(3));
     },
 };
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/edit-app-wizard.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/edit-app-wizard.tsx
@@ -51,7 +51,9 @@ function EditAppWizardForm({ app, cdc }: { app: ApplianceAppResponse; cdc: AppCd
                         {seed.error}
                         <div className="mt-3">
                             <Button asChild type="button" variant="outline" size="sm">
-                                <Link to={appRoutes.app(app.slug)}>Back to the application</Link>
+                                <Link to={appRoutes.app(app.slug)} className="!no-underline">
+                                    Back to the application
+                                </Link>
                             </Button>
                         </div>
                     </AlertDescription>

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/preview/preview-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/preview/preview-step.tsx
@@ -7,11 +7,14 @@ import { FormInput } from "@/components/form/form-input";
 import { ConfirmDialog } from "@/components/shadcn/ui/confirm-dialog";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
-import { Alert } from "@/components/shadcn/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/shadcn/ui/alert";
 import { WizardErrorList } from "@/components/form/wizard/wizard-error-list";
 import AceEditor from "@/components/ace-editor/ace-editor";
-import { DownloadIcon, MessageSquareWarningIcon } from "lucide-react";
+import { CircleAlertIcon, DownloadIcon, MessageSquareWarningIcon } from "lucide-react";
 import { buildConfigExport, downloadConfig } from "@/pages/setup/add-app-wizard/config-io";
+
+// Both failure paths report the same thing: the request itself failed, or it came back with errors.
+const MAPPING_TEST_ERROR_TITLE = "Testing the mapping failed";
 
 export function PreviewStep() {
     const { control, getValues } = useFormContext<AppFormData>();
@@ -102,8 +105,11 @@ function PreviewResult() {
     if (testMappingQuery.isError) {
         return (
             <Alert variant="destructive" className="mb-4">
-                Error testing mapping:{" "}
-                {testMappingQuery.error instanceof Error ? testMappingQuery.error.message : "Unknown error"}
+                <CircleAlertIcon aria-hidden="true" />
+                <AlertTitle>{MAPPING_TEST_ERROR_TITLE}</AlertTitle>
+                <AlertDescription>
+                    {testMappingQuery.error instanceof Error ? testMappingQuery.error.message : "Unknown error"}
+                </AlertDescription>
             </Alert>
         );
     }
@@ -114,9 +120,7 @@ function PreviewResult() {
 
     if (testMappingQuery.data.errors?.length) {
         return (
-            <Alert variant="destructive" className="mb-4">
-                <WizardErrorList errors={testMappingQuery.data.errors} />
-            </Alert>
+            <WizardErrorList errors={testMappingQuery.data.errors} title={MAPPING_TEST_ERROR_TITLE} className="mb-4" />
         );
     }
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verified-tables-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verified-tables-table.tsx
@@ -77,7 +77,6 @@ export function VerifiedTablesTable({
                 columnCount={columns.length}
                 emptyMessage="No tables match the current filter."
                 maxHeight="fill"
-                className="mb-4"
                 getRowState={(rowId) => (rowSelection[rowId] ? "selected" : "")}
                 getRowClassName={(rowId) => (rangePreviewRowIds.has(rowId) ? RANGE_PREVIEW_ROW_CLASSNAME : "")}
                 onRowHoverChange={rangeSelection.onRowHoverChange}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-columns.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-columns.tsx
@@ -7,6 +7,7 @@ import type { RefObject } from "react";
 import type { ColumnDef, Table } from "@tanstack/react-table";
 import { TriangleAlertIcon } from "lucide-react";
 import type { DiscoverTableResponse } from "@/api/generated/server-api";
+import { InfoHint } from "@/components/data/info-hint";
 import { Checkbox } from "@/components/shadcn/ui/checkbox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
 import {
@@ -58,6 +59,10 @@ const COLUMNS_COUNT_COLUMN: ColumnDef<DiscoverTableResponse> = {
     cell: ({ getValue }) => <span className="tabular-nums">{getValue<number>()}</span>,
 };
 
+// Lives in the select column header rather than the toolbar: the accelerator belongs to the
+// checkboxes right below it, and an icon keeps the hint quieter than the table it explains.
+const RANGE_SELECTION_HINT = "Hold Shift while clicking to select a range of tables";
+
 /**
  * Columns of the verified tables table. Built per mounted table rather than shared as a constant so
  * the select column can write the row of the last plain click into `anchorRowIdRef`: a shift-click
@@ -67,7 +72,12 @@ export function createVerifiedColumns(anchorRowIdRef: RefObject<string | null>):
     return [
         {
             id: "select",
-            header: ({ table }) => <SelectAllCheckbox table={table} />,
+            header: ({ table }) => (
+                <span className="flex items-center gap-1.5">
+                    <SelectAllCheckbox table={table} />
+                    <InfoHint content={RANGE_SELECTION_HINT} />
+                </span>
+            ),
             cell: ({ row, table }) => (
                 <Checkbox
                     checked={row.getIsSelected()}
@@ -101,7 +111,8 @@ export function createVerifiedColumns(anchorRowIdRef: RefObject<string | null>):
             enableSorting: false,
             enableHiding: false,
             enableResizing: false,
-            size: 40,
+            // Cell padding plus the checkbox and the hint icon sitting next to it in the header.
+            size: 48,
         },
         TABLE_NAME_COLUMN,
         PRIMARY_KEY_COLUMN,

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-columns.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-columns.tsx
@@ -7,15 +7,9 @@ import type { RefObject } from "react";
 import type { ColumnDef, Table } from "@tanstack/react-table";
 import { TriangleAlertIcon } from "lucide-react";
 import type { DiscoverTableResponse } from "@/api/generated/server-api";
-import { InfoHint } from "@/components/data/info-hint";
 import { Checkbox } from "@/components/shadcn/ui/checkbox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
-import {
-    countSelectedRows,
-    getRangeSelectionRows,
-    isRowSelected,
-    setRowsSelected,
-} from "@/components/table/row-range-selection";
+import { countSelectedRows, getRangeSelection, setRowsSelected } from "@/components/table/row-range-selection";
 import { getTableLabel, MAX_SELECTED_TABLES } from "@/pages/setup/add-app-wizard/discover-utils";
 import { Button } from "@/components/shadcn/ui/button";
 
@@ -59,46 +53,33 @@ const COLUMNS_COUNT_COLUMN: ColumnDef<DiscoverTableResponse> = {
     cell: ({ getValue }) => <span className="tabular-nums">{getValue<number>()}</span>,
 };
 
-// Lives in the select column header rather than the toolbar: the accelerator belongs to the
-// checkboxes right below it, and an icon keeps the hint quieter than the table it explains.
-const RANGE_SELECTION_HINT = "Hold Shift while clicking to select a range of tables";
-
 /**
  * Columns of the verified tables table. Built per mounted table rather than shared as a constant so
  * the select column can write the row of the last plain click into `anchorRowIdRef`: a shift-click
- * applies that row's state to everything in between, and the table previews the same range on hover.
+ * spans the rows between that anchor and the clicked row, and the table previews the same span on
+ * hover. The clicked row decides whether the span is selected or cleared - see `getRangeSelection`.
  */
 export function createVerifiedColumns(anchorRowIdRef: RefObject<string | null>): ColumnDef<DiscoverTableResponse>[] {
     return [
         {
             id: "select",
-            header: ({ table }) => (
-                <span className="flex items-center gap-1.5">
-                    <SelectAllCheckbox table={table} />
-                    <InfoHint content={RANGE_SELECTION_HINT} />
-                </span>
-            ),
+            header: ({ table }) => <SelectAllCheckbox table={table} />,
             cell: ({ row, table }) => (
                 <Checkbox
                     checked={row.getIsSelected()}
                     // Radix skips its own toggle once a click handler prevents the default, which is
                     // what turns a shift-click into a range selection instead of a single toggle.
                     onClick={(event) => {
-                        const rangeRows = event.shiftKey
-                            ? getRangeSelectionRows(table, anchorRowIdRef.current, row.id, MAX_SELECTED_TABLES)
-                            : [];
+                        const range = event.shiftKey
+                            ? getRangeSelection(table, anchorRowIdRef.current, row.id, MAX_SELECTED_TABLES)
+                            : null;
 
-                        if (rangeRows.length === 0) {
+                        if (range === null || range.rows.length === 0) {
                             return;
                         }
 
                         event.preventDefault();
-                        setRowsSelected(
-                            table,
-                            rangeRows,
-                            isRowSelected(table, anchorRowIdRef.current),
-                            MAX_SELECTED_TABLES,
-                        );
+                        setRowsSelected(table, range.rows, range.isSelecting, MAX_SELECTED_TABLES);
                     }}
                     onCheckedChange={(value) => {
                         row.toggleSelected(!!value);
@@ -111,8 +92,7 @@ export function createVerifiedColumns(anchorRowIdRef: RefObject<string | null>):
             enableSorting: false,
             enableHiding: false,
             enableResizing: false,
-            // Cell padding plus the checkbox and the hint icon sitting next to it in the header.
-            size: 48,
+            size: 40,
         },
         TABLE_NAME_COLUMN,
         PRIMARY_KEY_COLUMN,

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-columns.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-columns.tsx
@@ -23,7 +23,7 @@ const TABLE_NAME_COLUMN: ColumnDef<DiscoverTableResponse> = {
             {row.original.warnings.length > 0 && (
                 <Tooltip>
                     <TooltipTrigger asChild>
-                        <Button variant="link" aria-label="Table warnings">
+                        <Button variant="link" aria-label="Table warnings" className="cursor-default px-0">
                             <TriangleAlertIcon
                                 className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400"
                                 aria-hidden="true"

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-step.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from "react";
 import type { RowSelectionState } from "@tanstack/react-table";
 import { useFormContext, useFormState } from "react-hook-form";
-import { CheckIcon, PlusIcon, SearchIcon, TriangleAlertIcon } from "lucide-react";
+import { CheckIcon, CircleAlertIcon, PlusIcon, SearchIcon, TriangleAlertIcon } from "lucide-react";
 import type { DiscoverResponse, DiscoverTableResponse } from "@/api/generated/server-api";
 import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
 import { WizardErrorAlert } from "@/components/form/wizard/wizard-error-alert";
-import { Alert } from "@/components/shadcn/ui/alert";
+import { Alert, AlertTitle } from "@/components/shadcn/ui/alert";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/shadcn/ui/input-group";
@@ -108,7 +108,7 @@ export function VerifySchemaStep({ isBusy }: WizardBodyComponentProps) {
         <div className="flex min-h-0 flex-1 flex-col gap-4">
             <div className="grid shrink-0 gap-4">
                 <LockedConfigAlert />
-                <WizardErrorList errors={discoverResult?.errors} />
+                <WizardErrorList errors={discoverResult?.errors} title="Schema discovery failed" />
                 <MessageList messages={discoverResult?.warnings} tone="warning" />
             </div>
 
@@ -128,13 +128,6 @@ export function VerifySchemaStep({ isBusy }: WizardBodyComponentProps) {
                                 type="search"
                             />
                         </InputGroup>
-                        {currentTab === "verified" && (
-                            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                                Hold
-                                <kbd className="rounded border px-1 py-0.5 font-mono text-[10px]">Shift</kbd>
-                                while clicking to select a range of tables
-                            </span>
-                        )}
                         <Button
                             type="button"
                             variant="outline"
@@ -205,7 +198,8 @@ export function VerifySchemaStep({ isBusy }: WizardBodyComponentProps) {
                 overflow, so a shrinkable alert collapses into an unreadable sliver. */}
             {tablesError && (
                 <Alert variant="destructive" className="shrink-0">
-                    {tablesError.message}
+                    <CircleAlertIcon aria-hidden="true" />
+                    <AlertTitle>{tablesError.message}</AlertTitle>
                 </Alert>
             )}
             {cdcError && <WizardErrorAlert error={cdcError} className="shrink-0" />}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-step.tsx
@@ -177,15 +177,22 @@ export function VerifySchemaStep({ isBusy }: WizardBodyComponentProps) {
                     )}
 
                     {currentTab === "verified" ? (
-                        <VerifiedTablesTable
-                            tables={verifiedTables}
-                            totalTableCount={allTables.length}
-                            search={search}
-                            rowSelection={rowSelection}
-                            onRowSelectionChange={handleRowSelectionChange}
-                            disabled={isLocked || isVerifyCdcRunning}
-                            isBusy={isBusy}
-                        />
+                        <>
+                            <VerifiedTablesTable
+                                tables={verifiedTables}
+                                totalTableCount={allTables.length}
+                                search={search}
+                                rowSelection={rowSelection}
+                                onRowSelectionChange={handleRowSelectionChange}
+                                disabled={isLocked || isVerifyCdcRunning}
+                                isBusy={isBusy}
+                            />
+                            <small className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+                                Hold
+                                <kbd className="rounded border px-1 py-0.5 font-mono text-[10px]">Shift</kbd>
+                                to select a range of tables
+                            </small>
+                        </>
                     ) : (
                         <NeedsConfigTablesTable tables={needsConfigTables} search={search} />
                     )}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27336
https://issues.hibernatingrhinos.com/issue/RavenDB-27341

### Additional description

Two findings from the Quill Beta UX audit, both on `/app/add` (and the equivalent edit wizard).

**RavenDB-27336 — demote the Shift-select hint.** The hint sat in the verify step's toolbar as a
full sentence, level with the search field and louder than the table it explains. It keeps its
wording and styling and only moves, to below the table. The ticket's other suggestion was the
checkbox column header, but that column is 40px wide, so only an icon fits and the sentence would
have had to become a tooltip.

Reviewing the table underneath it turned up three defects in the selection itself, all fixed here:

- **The select-all box could not show a partial selection.** Its checked styling was written as
  `data-checked:*`, but Radix emits `data-state="checked"` — Tailwind generated no rules at all for
  those utilities, so a checked box had no fill, just a bare checkmark on a transparent background.
  Radix also renders the indicator for `indeterminate` as well as `checked`, and the indicator
  always drew `CheckIcon`, so 5 of 6 rows selected looked identical to all 6. The variants now
  target `data-state`, indeterminate shares the filled treatment, and indeterminate draws
  `MinusIcon`. `aria-checked` was already reporting `"mixed"` correctly, so the regression was
  purely visual — the tests assert which mark the box draws, not its ARIA state.
- **A Shift-click did nothing when nothing was selected.** The range applied the *anchor row's*
  current selection state, and with an empty selection the anchor is unselected too, so the click
  cleared an already empty range — and because the range was non-empty it also called
  `preventDefault()`, suppressing the single-row toggle Radix would have done. The range now takes
  the toggle the clicked row itself is about to receive: shift-clicking an unselected row selects
  the span, shift-clicking a selected one clears it.
- **The anchor was often absent entirely.** It is written only by a plain click on a row checkbox,
  so a selection that arrived any other way had none — seeded from a stored configuration (how the
  edit wizard opens), taken with the header checkbox, or cleared through "Deselect all". With no
  second endpoint the first Shift-click collapsed into a single toggle. The range now starts at the
  first row whenever the anchor is missing or a filter has hidden it.

Both Shift fixes also made the hover preview honest: it used to highlight the rows a click was
about to take while the click took none of them. Click and preview now derive the range and its
direction from one function, so they cannot disagree.

**RavenDB-27341 — style page-level error banners.** `WizardErrorList` rendered a bare `<ul>` of
destructive-coloured text — no border, background, or icon — while its sibling `WizardErrorAlert`
wrapped the same content in `<Alert variant="destructive">`. It now uses the same destructive Alert
with an icon, a caller-supplied title, and the server messages in the description, following the
`unmapped-tables-alert` convention. Two notes for reviewers:

- `preview-step.tsx` already wrapped the list in its own `<Alert>`, so making the component an
  Alert would have nested two banners. That outer wrapper is gone; a story test asserts exactly one
  `[data-slot="alert"]` on the page.
- `title` is a required prop rather than a generic error count, because the server messages describe
  the cause but never say which call produced them (`failedDiscovery` is a failure plus remediation
  advice, with no header). The bare sibling alerts — the verify step's `tablesError`, the preview
  step's request failure, and `WizardErrorAlert` — pick up the same icon, so the flow reads
  consistently instead of the mismatch simply moving.

`alert.tsx` itself is deliberately untouched: its `destructive` variant supplies `bg-card` and red
text on a *neutral* border, which is why `login.tsx` compensates locally with
`border-destructive/30 bg-destructive/5`. Moving that tint into the variant would restyle every
destructive alert in the app, well beyond these tickets.

**Three smaller fixes in the same surfaces**, in the last commit:

- `field.tsx` carried the *same* dead-variant bug as `checkbox.tsx`: the selected field-label tint
  was written as `has-data-checked:*`, which resolves to `:has([data-checked])` — an attribute Radix
  never sets. Those four utilities have always been a no-op and now target
  `has-data-[state=checked]:*`. I sampled nine default story states and none currently has a field
  label wrapping a checked switch or checkbox (every `FormSwitch` sits behind a sheet, dialog or
  collapsible), so this turns a dead rule live without changing any default view.
- The table's warning-icon button kept the default size's `px-2.5`, pushing the icon away from the
  table name it belongs to. `px-0` on the `Button` — not the `svg`, since the padding is the
  button's and the icon has none — takes it from 34px wide to 16px.
- The edit wizard's "Back to the application" button sits inside an `AlertDescription`, and
  `alert.tsx` styles `[&_a]:underline` for prose links in alerts, so a button-shaped link was being
  underlined. `!no-underline` opts that one link out.

Each state can be seen in Storybook (`pnpm storybook` in `src/Raven.Quill.Web`; MSW serves the
failures, no backend needed): `VerifySchemaDiscoveryFailed`, `PreviewMappingErrors`,
`VerifySchemaWithoutSelection`, `VerifySchemaCdcVerificationFailed`, `ConnectSourceError`,
`VerifySchemaSelectionLimit`, `VerifySchemaShiftSelectFromEmpty`,
`VerifySchemaShiftSelectWithoutClicking`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

Frontend only, and no behaviour outside the tables changes — but two shared components are touched,
so the visual blast radius is wider than the two wizard steps. See the behaviour-change section
below.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

Added `row-range-selection.test.ts` (12 unit tests covering the range rules, both trim behaviours,
and the no-anchor / hidden-anchor / empty-table fallbacks) plus four stories:
`PreviewMappingErrors`, `VerifySchemaShiftSelectFromEmpty`, `VerifySchemaShiftSelectWithoutClicking`,
and select-all mark assertions on `VerifySchema` / `VerifySchemaSelectionLimit`. Each fix was written
test-first and the test confirmed failing against the old code before the fix landed. 98 unit + 76
story tests pass; `typecheck`, `lint` and `format:check` are clean. Every state was checked manually
in both light and dark themes.

The "internal classes" item is left unchecked as it does not apply to a frontend-only change.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Two shared components change appearance app-wide. Neither changes behaviour:

- `components/shadcn/ui/checkbox.tsx` — **every checkbox in the app**. Checked boxes now actually
  render their `bg-primary` fill, which the dead `data-checked:*` variants never produced, so they
  will look different (correct per the design system, but different) everywhere they appear. The
  indeterminate state gains a dash; nothing previously relied on it being a checkmark.
- `components/form/wizard/wizard-error-alert.tsx` — gains a leading icon at its five call sites:
  the connect step's test-connection error, the import-config dialog, two in the map-tables step,
  and the wizard footer's advance error (shared with the add-capability wizard).
- `components/shadcn/ui/field.tsx` — **every `FieldLabel` wrapping a checkbox, radio or switch**.
  Its selected tint (`border-primary/30` + `bg-primary/5`) has never rendered because it targeted an
  attribute Radix does not emit; it now will. No default view in the nine stories I sampled contains
  such a label, so the practical change is limited to opened sheets, dialogs and collapsibles — but
  it is the widest surface in this PR and worth a look during review.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
