### PR TITLE
RavenDB-27349 Introduce constant scoring for exists queries in Corax.

### DIFF
--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -12,6 +12,7 @@ using Corax.Utils;
 using Sparrow;
 using Sparrow.Compression;
 using Sparrow.Server;
+using Sparrow.Server.Collections;
 using Sparrow.Server.Utils;
 using Sparrow.Server.Utils.VxSort;
 using Voron;
@@ -26,9 +27,18 @@ namespace Corax.Querying.Matches
     public struct MultiTermMatch<TTermProvider> : IQueryMatch
         where TTermProvider : ITermProvider
     {
+        internal enum ScoringMode : byte
+        {
+            None,
+            Bm25,
+            ConstantScore
+        }
+
         private const int InitialFrequencyHolders = 64;
+        private const int ConstantScoreBufferSize = 4096;
         private readonly CancellationToken _token;
-        private readonly bool _isBoosting;
+        private readonly ScoringMode _scoringMode;
+        private readonly Querying.IndexSearcher _indexSearcher;
         private long _readTerms, _totalResults;
         private readonly long _maxNumberOfTerms;
         private long _current;
@@ -50,7 +60,7 @@ namespace Corax.Querying.Matches
         private MultiTermReader _termReader;
         private readonly ByteStringContext _context;
 
-        public bool IsBoosting => _isBoosting;
+        public bool IsBoosting => _scoringMode != ScoringMode.None;
         public long Count => _totalResults;
 
         public SkipSortingResult AttemptToSkipSorting()
@@ -61,13 +71,17 @@ namespace Corax.Querying.Matches
         public QueryCountConfidence Confidence => _confidence;
 
         public MultiTermMatch(Querying.IndexSearcher indexSearcher, in FieldMetadata field, ByteStringContext context, TTermProvider inner, bool streamingEnabled,
-            long maxNumberOfTerms = long.MaxValue, QueryCountConfidence confidence = QueryCountConfidence.Low, in CancellationToken token = default)
+            long maxNumberOfTerms = long.MaxValue, QueryCountConfidence confidence = QueryCountConfidence.Low, in CancellationToken token = default,
+            bool scoreAsConstant = false)
         {
             _inner = inner;
-            _isBoosting = field.HasBoost;
+            _scoringMode = field.HasBoost
+                ? (scoreAsConstant && inner.IsFillSupported ? ScoringMode.ConstantScore : ScoringMode.Bm25)
+                : ScoringMode.None;
+            _indexSearcher = indexSearcher;
             _token = token;
             _current = QueryMatch.Start;
-            if (_inner.IsFillSupported && _isBoosting == false)
+            if (_inner.IsFillSupported && _scoringMode != ScoringMode.Bm25)
                 _termReader = new MultiTermReader(indexSearcher);
             else
             {
@@ -86,7 +100,7 @@ namespace Corax.Querying.Matches
 
             _doNotSortResultsDueToStreaming = streamingEnabled;
 
-            if (_isBoosting)
+            if (_scoringMode == ScoringMode.Bm25)
             {
                 var pool = Bm25Relevance.RelevancePool ??= ArrayPool<Bm25Relevance>.Create();
                 _frequenciesHolder = pool.Rent(InitialFrequencyHolders);
@@ -96,7 +110,7 @@ namespace Corax.Querying.Matches
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Fill(Span<long> buffer)
         {
-            return _inner.IsFillSupported && _isBoosting == false
+            return _inner.IsFillSupported && _scoringMode != ScoringMode.Bm25
                 ? FillWithReader(buffer)
                 : FillWithTermMatches(buffer);
         }
@@ -358,7 +372,7 @@ namespace Corax.Querying.Matches
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int AndWith(Span<long> buffer, int matches)
         {
-            if (_inner.IsFillSupported && _isBoosting == false)
+            if (_inner.IsFillSupported && _scoringMode != ScoringMode.Bm25)
                 return AndWithFill(buffer, matches);
 
             return AndWithTermMatch(buffer, matches);
@@ -508,7 +522,7 @@ namespace Corax.Querying.Matches
 
         private void AddTermToBm25()
         {
-            if (_isBoosting && _currentTerm.Count != 0)
+            if (_scoringMode == ScoringMode.Bm25 && _currentTerm.Count != 0)
             {
                 if (_currentFreqIdx >= FrequenciesHolderSize)
                     UnlikelyGrowBufferOfTermMatches();
@@ -520,8 +534,14 @@ namespace Corax.Querying.Matches
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Score(Span<long> matches, Span<float> scores, float boostFactor)
         {
-            if (_isBoosting == false)
+            if (_scoringMode == ScoringMode.None)
                 return;
+
+            if (_scoringMode == ScoringMode.ConstantScore)
+            {
+                ScoreConstant(matches, scores, boostFactor);
+                return;
+            }
 
             //We've to gather all data from already seen TermMatches to get proper ranking :)
             for (int idX = 0; idX < _currentFreqIdx; ++idX)
@@ -535,6 +555,43 @@ namespace Corax.Querying.Matches
             Bm25Relevance.RelevancePool.Return(_frequenciesHolder);
             _frequenciesHolder = null;
             _currentFreqIdx = 0;
+        }
+
+        private void ScoreConstant(Span<long> matches, Span<float> scores, float boostFactor)
+        {
+            if (matches.Length == 0)
+                return;
+
+            _inner.Reset();
+            var reader = new MultiTermReader(_indexSearcher);
+
+            var contribution = Bm25Relevance.ConstantScoreValue * boostFactor;
+
+            using var bufferScope = _context.Allocate(ConstantScoreBufferSize * sizeof(long), out var bufferHolder);
+            var ids = bufferHolder.ToSpan<long>();
+            var alreadyScored = new GrowableBitArray(_context, matches.Length);
+
+            try
+            {
+                while (reader.Read(ref this, ids, long.MaxValue, out _) is var read and > 0)
+                {
+                    _token.ThrowIfCancellationRequested();
+                    for (int i = 0; i < read; i++)
+                    {
+                        var idx = matches.BinarySearch(ids[i]);
+                        if (idx < 0)
+                            continue;
+
+                        if (alreadyScored.Add(idx))
+                            scores[idx] += contribution;
+                    }
+                }
+            }
+            finally
+            {
+                alreadyScored.Dispose();
+                reader.Dispose();
+            }
         }
 
         public QueryInspectionNode Inspect()

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
@@ -62,9 +62,9 @@ public partial class IndexSearcher
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public MultiTermMatch ExistsQuery(in FieldMetadata field, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
     {
-        return forward 
-            ? MultiTermMatchBuilder<ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, default(Slice), streamingEnabled: streamingEnabled, token: token) 
-            : MultiTermMatchBuilder<ExistsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, default(Slice), streamingEnabled: streamingEnabled, token: token);
+        return forward
+            ? MultiTermMatchBuilder<ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator>>(field, default(Slice), streamingEnabled: streamingEnabled, token: token, scoreAsConstant: true)
+            : MultiTermMatchBuilder<ExistsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, default(Slice), streamingEnabled: streamingEnabled, token: token, scoreAsConstant: true);
     }
 
     

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
@@ -14,7 +14,7 @@ namespace Corax.Querying;
 
 public partial class IndexSearcher
 {
-    private MultiTermMatch MultiTermMatchBuilder<TTermProvider>(in FieldMetadata field, Slice term, bool streamingEnabled = false, bool validatePostfixLen = false, in CancellationToken token = default)
+    private MultiTermMatch MultiTermMatchBuilder<TTermProvider>(in FieldMetadata field, Slice term, bool streamingEnabled = false, bool validatePostfixLen = false, in CancellationToken token = default, bool scoreAsConstant = false)
         where TTermProvider : struct, ITermProvider
     {
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
@@ -42,7 +42,7 @@ public partial class IndexSearcher
         }
         
         return MultiTermMatch.Create(new MultiTermMatch<TTermProvider>(this, field, _transaction.Allocator, 
-            GetMultiTermMatchProvider<TTermProvider>(field, terms, termKey, seekKey, validatePostfixLen, token), streamingEnabled: streamingEnabled, token: token));
+            GetMultiTermMatchProvider<TTermProvider>(field, terms, termKey, seekKey, validatePostfixLen, token), streamingEnabled: streamingEnabled, token: token, scoreAsConstant: scoreAsConstant));
     }
 
     private MultiTermMatch MultiTermMatchBuilder<TTermProvider>(in FieldMetadata field, string term, bool streamingEnabled, CancellationToken token)

--- a/src/Corax/Utils/Bm25Relevance.cs
+++ b/src/Corax/Utils/Bm25Relevance.cs
@@ -23,8 +23,14 @@ public sealed unsafe class Bm25Relevance : IDisposable
     /// This is necessary in case we use 'order by score()' without a WHERE clause, where the document boost is the only factor in the equation.
     /// So in order not to multiply by 0 let set it to be very small. BM25F is using sum, so this has no impact on the result. 
     /// </summary>
-    public const float InitialScoreValue = 1 / 1_000_000f; 
-    
+    public const float InitialScoreValue = 1 / 1_000_000f;
+
+    /// <summary>
+    /// Score contribution of a document matched by a constant-scoring clause (e.g. exists()),
+    /// where existence carries no term-frequency signal.
+    /// </summary>
+    public const float ConstantScoreValue = 1f;
+
     private const int MaximumDocumentCapacity = MaxSizeOfStorage / (sizeof(long) + sizeof(short));
     private const int MaxSizeOfStorage = 1024 * 1024; //1MB;
     private const float BFactor = 0.25f;

--- a/test/FastTests/Corax/ExistsQueryScoring.cs
+++ b/test/FastTests/Corax/ExistsQueryScoring.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Corax;
+
+public class ExistsQueryScoring(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Querying)]
+    public void ExistsInsideBoostedOrGroupKeepsResultSetAndBoostOrdering()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item { Id = "items/searched", Title = "red apple", Content = "fruit" });
+            session.Store(new Item { Id = "items/equal", Title = "apple", Content = "fruit" });
+            session.Store(new Item { Id = "items/neither", Title = "banana", Content = "fruit" });
+            session.SaveChanges();
+
+            var viaExists = session.Advanced
+                .RawQuery<Item>("from Items where Content = 'fruit' and (boost(search(Title, 'red'), 5) or boost(Title = 'apple', 10) or exists(Title)) order by score()")
+                .WaitForNonStaleResults()
+                .ToList();
+
+            Assert.Equal(["items/equal", "items/searched", "items/neither"], viaExists.Select(i => i.Id));
+
+            var viaTrue = session.Advanced
+                .RawQuery<Item>("from Items where Content = 'fruit' and (boost(search(Title, 'red'), 5) or boost(Title = 'apple', 10) or true) order by score()")
+                .WaitForNonStaleResults()
+                .ToList();
+
+            Assert.Equal(viaTrue.Select(i => i.Id), viaExists.Select(i => i.Id));
+
+            var viaExistsMultiSort = session.Advanced
+                .RawQuery<Item>("from Items where Content = 'fruit' and (boost(search(Title, 'red'), 5) or boost(Title = 'apple', 10) or exists(Title)) order by score(), Title")
+                .WaitForNonStaleResults()
+                .ToList();
+
+            Assert.Equal(["items/equal", "items/searched", "items/neither"], viaExistsMultiSort.Select(i => i.Id));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void BoostedExistsContributesConstantScoreScaledByBoost()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax, includeScoresAndDistances: true));
+        StoreItem(store, "items/with", optional: "anything");
+        StoreItem(store, "items/withNull", optional: null, storeNullValue: true);
+        StoreItem(store, "items/without", optional: null);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced
+                .RawQuery<Item>("from Items where Content = 'fruit' and (boost(exists(Optional), 3) or true) order by score()")
+                .WaitForNonStaleResults()
+                .ToList();
+
+            Assert.Equal(3, results.Count);
+            Assert.Equal("items/without", results[^1].Id);
+
+            var scores = results.ToDictionary(i => i.Id,
+                i => (double)session.Advanced.GetMetadataFor(i)[Raven.Client.Constants.Documents.Metadata.IndexScore]);
+
+            Assert.Equal(scores["items/with"], scores["items/withNull"], 4);
+            Assert.Equal(3d, scores["items/with"] - scores["items/without"], 4);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void MultiValuedExistsContributesConstantOncePerDocument()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax, includeScoresAndDistances: true));
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item { Id = "items/many", Content = "fruit", Tags = ["a", "b", "c", "d", "e"] });
+            session.Store(new Item { Id = "items/one", Content = "fruit", Tags = ["z"] });
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced
+                .RawQuery<Item>("from Items where Content = 'fruit' and (boost(exists(Tags), 2) or true) order by score()")
+                .WaitForNonStaleResults()
+                .ToList();
+
+            Assert.Equal(2, results.Count);
+
+            var scores = results.ToDictionary(i => i.Id,
+                i => (double)session.Advanced.GetMetadataFor(i)[Raven.Client.Constants.Documents.Metadata.IndexScore]);
+
+            Assert.Equal(scores["items/one"], scores["items/many"], 4);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void ExistsUnderScoringKeepsResultSetOfUnscoredExists()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        StoreItem(store, "items/1", optional: "x");
+        StoreItem(store, "items/2", optional: "y");
+        StoreItem(store, "items/3", optional: null);
+
+        using (var session = store.OpenSession())
+        {
+            var unscored = session.Advanced
+                .RawQuery<Item>("from Items where exists(Optional)")
+                .WaitForNonStaleResults()
+                .ToList();
+
+            var scored = session.Advanced
+                .RawQuery<Item>("from Items where exists(Optional) order by score()")
+                .WaitForNonStaleResults()
+                .ToList();
+
+            Assert.Equal(new[] { "items/1", "items/2" }, unscored.Select(i => i.Id).OrderBy(i => i));
+            Assert.Equal(unscored.Select(i => i.Id).OrderBy(i => i), scored.Select(i => i.Id).OrderBy(i => i));
+        }
+    }
+
+    private static void StoreItem(IDocumentStore store, string id, string optional, bool storeNullValue = false)
+    {
+        var requestExecutor = store.GetRequestExecutor();
+        using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
+        {
+            var json = new DynamicJsonValue
+            {
+                ["@metadata"] = new DynamicJsonValue { ["@collection"] = "Items" },
+                ["Content"] = "fruit"
+            };
+            if (optional != null)
+                json["Optional"] = optional;
+            else if (storeNullValue)
+                json["Optional"] = null;
+
+            var reader = context.ReadObject(json, id);
+            requestExecutor.Execute(new PutDocumentCommand(requestExecutor.Conventions, id, null, reader), context);
+        }
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public string Optional { get; set; }
+        public string[] Tags { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27349

### Additional description

`exists(field)` under a scoring query took the per-term BM25 path: a `TermMatch` + `Bm25Relevance` allocation per unique term in the field, even though existence carries no
term-frequency signal. For fields with per-document unique values this means one tree seek and
one allocation per document in the index. Existence is binary, so `exists()` now scores as a constant `1f × boost` per matching document and keeps the bulk fill paths.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
