### PR TITLE
RavenDB-27364:  Carry the client address through the SNI front with the PROXY protocol so rate limits partition per client

### DIFF
--- a/docker/quill/Dockerfile
+++ b/docker/quill/Dockerfile
@@ -133,6 +133,7 @@ ENV S6_VERBOSITY=0 \
     RAVEN_QUILL_SETUP_PACKAGE_PATH=/var/lib/quill/setup \
     RAVEN_QUILL_RAVENDB_S6_SERVICE=/run/service/01-ravendb \
     RAVEN_QUILL_RAVENDB_INTERNAL_PORT=8443 \
+    RAVEN_QUILL_RAVENDB_PROXY_PORT=8447 \
     RAVEN_DataDir=/var/lib/quill/ravendb \
     RAVEN_Logs_Path=/var/lib/quill/logs/ravendb-server \
     RAVEN_QUILL_STARTUP_GRACE_SECONDS=180

--- a/docker/quill/Dockerfile.source
+++ b/docker/quill/Dockerfile.source
@@ -176,6 +176,7 @@ ENV S6_VERBOSITY=0 \
     RAVEN_QUILL_SETUP_PACKAGE_PATH=/var/lib/quill/setup \
     RAVEN_QUILL_RAVENDB_S6_SERVICE=/run/service/01-ravendb \
     RAVEN_QUILL_RAVENDB_INTERNAL_PORT=8443 \
+    RAVEN_QUILL_RAVENDB_PROXY_PORT=8447 \
     RAVEN_DataDir=/var/lib/quill/ravendb \
     RAVEN_Logs_Path=/var/lib/quill/logs/ravendb-server \
     RAVEN_QUILL_STARTUP_GRACE_SECONDS=180

--- a/docker/quill/nginx.conf
+++ b/docker/quill/nginx.conf
@@ -1,58 +1,56 @@
-# Quill :443 SNI front. One published port; routed by SNI:
-#   db.*  / a.*    -> RavenDB, TLS pass-through (RavenDB terminates; admin-cert / mTLS preserved).
-#   public.*       -> terminate (wildcard cert) -> web app :5000, embed consume surface only (/apps/{slug}/embed/*).
-#   api.*          -> terminate -> web app :5000, programmatic API only (/api/* + /healthz).
-#   dashboard.*    -> terminate -> web app :5000, full app (SPA + API).
-# Subdomain matching is by prefix (regex), so this is independent of the instance's base domain.
-
 worker_processes auto;
 error_log /dev/stderr info;
 pid /run/nginx.pid;
 
-# Debian ships stream + ssl_preread (+ stream realip) as dynamic modules; load them (this config
-# replaces the distro default that would otherwise pull them in via modules-enabled).
 include /etc/nginx/modules-enabled/*.conf;
 
 events { worker_connections 1024; }
 
-# ---- Layer 4: SNI router on the public :443 (no decryption here) ----
 stream {
-    # __RAVENDB_PORT__ is rendered by 03-proxy/run from RAVEN_QUILL_RAVENDB_INTERNAL_PORT (the same env
-    # 01-ravendb/run binds RavenDB to), so the passthrough upstream tracks the configurable port.
     map $ssl_preread_server_name $upstream {
-        ~^db\.      127.0.0.1:__RAVENDB_PORT__;   # RavenDB (db.<base>) — raw passthrough
-        ~^a\.       127.0.0.1:__RAVENDB_PORT__;   # RavenDB's advertised PublicServerUrl host (a.<base>)
-        ~^public\.  127.0.0.1:8445;               # public embed surface — terminate, /apps/{slug}/embed/* only
-        ~^api\.     127.0.0.1:8446;               # programmatic API surface — terminate, /api/* + /healthz only
-        default     127.0.0.1:8444;               # dashboard.* — terminate, full app (SPA + API)
+        ~^db\.      127.0.0.1:__RAVENDB_PROXY_PORT__;  # RavenDB (db.<base>) — raw passthrough, via the strip hop
+        ~^a\.       127.0.0.1:__RAVENDB_PROXY_PORT__;  # RavenDB's advertised PublicServerUrl host (a.<base>)
+        ~^public\.  127.0.0.1:8445;                    # public embed surface — terminate, /apps/{slug}/embed/* only
+        ~^api\.     127.0.0.1:8446;                    # programmatic API surface — terminate, /api/* + /healthz only
+        default     127.0.0.1:8444;                    # dashboard.* — terminate, full app (SPA + API)
     }
 
     server {
         listen 443;
         ssl_preread on;            # read SNI without terminating TLS
         proxy_pass $upstream;
-        # No proxy_protocol: db.*/a.* are raw passthrough to RavenDB, which doesn't speak the PROXY
-        # protocol (a PROXY header would corrupt its TLS handshake). One SNI listener can't send it
-        # selectively, so the web terminator below sees the loopback IP -> the app rate-limits
-        # per-appliance rather than per-client. Acceptable for a single-operator appliance.
+        # This hop opens a new loopback connection, so the client address is lost unless we carry it.
+        # A header can't: the payload is encrypted and nothing here parses HTTP. The PROXY protocol
+        # prefixes it to the relayed bytes instead. It applies to every upstream, hence the strip hop
+        # below for RavenDB - a PROXY header would corrupt its TLS handshake.
+        proxy_protocol on;
         proxy_timeout 1h;          # long-lived WebSocket / streaming chat
+    }
+
+    # RavenDB can't read the PROXY header, so consume it here and relay the bytes untouched.
+    server {
+        listen 127.0.0.1:__RAVENDB_PROXY_PORT__ proxy_protocol;
+        proxy_pass 127.0.0.1:__RAVENDB_PORT__;
+        proxy_timeout 1h;
     }
 }
 
-# ---- Layer 7: TLS terminate for the web subdomains, forward to the web app ----
 http {
     map $http_upgrade $connection_upgrade { default upgrade; "" close; }
 
+    # Take $remote_addr from the PROXY header the stream front sends, so it is the real client rather
+    # than the loopback hop - this is what the X-Forwarded-For below then carries to the app. Only the
+    # stream front can reach these listeners, and it always sends the header.
+    set_real_ip_from 127.0.0.1;
+    real_ip_header   proxy_protocol;
+
     server {
-        listen 127.0.0.1:8444 ssl;
+        listen 127.0.0.1:8444 ssl proxy_protocol;
         server_name _;
 
         ssl_certificate     /var/lib/quill/proxy/fullchain.pem;
         ssl_certificate_key /var/lib/quill/proxy/privkey.pem;
 
-        # Embed is the public.* consume surface only — minted links point at public.*, and the operator
-        # dashboard must not double as a public widget host. 404 the embed sub-shape here (the app's
-        # /apps/{slug}/embed route is anonymous; SPA routes under /apps/ keep flowing to `location /`).
         location ~* ^/apps/[^/]+/embed(/|$) { return 404; }
 
         location / {
@@ -80,7 +78,7 @@ http {
     # BEFORE location matching, so a crafted /apps/x/embed/%2e%2e/api falls out of the anchored regex
     # to `location / -> 404`. Re-review if merge_slashes is disabled or more locations are added.
     server {
-        listen 127.0.0.1:8445 ssl;
+        listen 127.0.0.1:8445 ssl proxy_protocol;
         server_name _;
 
         ssl_certificate     /var/lib/quill/proxy/fullchain.pem;
@@ -111,17 +109,13 @@ http {
         location / { return 404; }
     }
 
-    # api.* — programmatic API consume surface ONLY. No SPA, no /assets, no /embed, no /login.
-    # Only the JSON API (the X-Api-Key header credential) and the health probe are reachable; the
-    # dashboard SPA + static assets 404 here, so the operator console lives solely on dashboard.*.
-    #
     # Security-boundary note (RavenDB-26828): like public.* above, this relies on nginx normalizing
     # the request URI (decode %XX, resolve ../, merge_slashes on — all defaults) BEFORE location
     # matching. It is defense-in-depth: every admin /api/* group already enforces
     # .RequireAuthorization() at the app, independent of the subdomain it arrived on. Re-review if
     # merge_slashes is disabled or a regex location is added.
     server {
-        listen 127.0.0.1:8446 ssl;
+        listen 127.0.0.1:8446 ssl proxy_protocol;
         server_name _;
 
         ssl_certificate     /var/lib/quill/proxy/fullchain.pem;
@@ -141,7 +135,6 @@ http {
             proxy_buffering off;
         }
 
-        # Health / load-balancer probe (plain text, anonymous — outside /api/).
         location = /healthz {
             proxy_pass http://127.0.0.1:5000;
             proxy_set_header Host             $host;

--- a/docker/quill/nginx.conf
+++ b/docker/quill/nginx.conf
@@ -1,12 +1,25 @@
+# Quill :443 SNI front. One published port; routed by SNI:
+#   db.*  / a.*    -> RavenDB, TLS pass-through (RavenDB terminates; admin-cert / mTLS preserved),
+#                     via a hop that strips the PROXY header RavenDB can't read.
+#   public.*       -> terminate (wildcard cert) -> web app :5000, embed consume surface only (/apps/{slug}/embed/*).
+#   api.*          -> terminate -> web app :5000, programmatic API only (/api/* + /healthz).
+#   dashboard.*    -> terminate -> web app :5000, full app (SPA + API).
+# Subdomain matching is by prefix (regex), so this is independent of the instance's base domain.
+
 worker_processes auto;
 error_log /dev/stderr info;
 pid /run/nginx.pid;
 
+# Debian ships stream + ssl_preread (+ stream realip) as dynamic modules; load them (this config
+# replaces the distro default that would otherwise pull them in via modules-enabled).
 include /etc/nginx/modules-enabled/*.conf;
 
 events { worker_connections 1024; }
 
+# ---- Layer 4: SNI router on the public :443 (no decryption here) ----
 stream {
+    # 03-proxy/run renders the two port placeholders below from RAVEN_QUILL_RAVENDB_INTERNAL_PORT (the
+    # same env 01-ravendb/run binds RavenDB to) and RAVEN_QUILL_RAVENDB_PROXY_PORT, so neither drifts.
     map $ssl_preread_server_name $upstream {
         ~^db\.      127.0.0.1:__RAVENDB_PROXY_PORT__;  # RavenDB (db.<base>) — raw passthrough, via the strip hop
         ~^a\.       127.0.0.1:__RAVENDB_PROXY_PORT__;  # RavenDB's advertised PublicServerUrl host (a.<base>)
@@ -21,8 +34,8 @@ stream {
         proxy_pass $upstream;
         # This hop opens a new loopback connection, so the client address is lost unless we carry it.
         # A header can't: the payload is encrypted and nothing here parses HTTP. The PROXY protocol
-        # prefixes it to the relayed bytes instead. It applies to every upstream, hence the strip hop
-        # below for RavenDB - a PROXY header would corrupt its TLS handshake.
+        # prefixes it to the relayed bytes instead. One SNI listener can't send it selectively, hence
+        # the strip hop below - a PROXY header would corrupt RavenDB's TLS handshake.
         proxy_protocol on;
         proxy_timeout 1h;          # long-lived WebSocket / streaming chat
     }
@@ -35,12 +48,13 @@ stream {
     }
 }
 
+# ---- Layer 7: TLS terminate for the web subdomains, forward to the web app ----
 http {
     map $http_upgrade $connection_upgrade { default upgrade; "" close; }
 
     # Take $remote_addr from the PROXY header the stream front sends, so it is the real client rather
-    # than the loopback hop - this is what the X-Forwarded-For below then carries to the app. Only the
-    # stream front can reach these listeners, and it always sends the header.
+    # than the loopback hop - this is what the X-Forwarded-For below then carries to the app. These
+    # listeners are loopback-only and PROXY-only, so the stream front is the sole possible source.
     set_real_ip_from 127.0.0.1;
     real_ip_header   proxy_protocol;
 
@@ -51,6 +65,9 @@ http {
         ssl_certificate     /var/lib/quill/proxy/fullchain.pem;
         ssl_certificate_key /var/lib/quill/proxy/privkey.pem;
 
+        # Embed is the public.* consume surface only — minted links point at public.*, and the operator
+        # dashboard must not double as a public widget host. 404 the embed sub-shape here (the app's
+        # /apps/{slug}/embed route is anonymous; SPA routes under /apps/ keep flowing to `location /`).
         location ~* ^/apps/[^/]+/embed(/|$) { return 404; }
 
         location / {
@@ -109,6 +126,10 @@ http {
         location / { return 404; }
     }
 
+    # api.* — programmatic API consume surface ONLY. No SPA, no /assets, no /embed, no /login.
+    # Only the JSON API (the X-Api-Key header credential) and the health probe are reachable; the
+    # dashboard SPA + static assets 404 here, so the operator console lives solely on dashboard.*.
+    #
     # Security-boundary note (RavenDB-26828): like public.* above, this relies on nginx normalizing
     # the request URI (decode %XX, resolve ../, merge_slashes on — all defaults) BEFORE location
     # matching. It is defense-in-depth: every admin /api/* group already enforces
@@ -135,6 +156,7 @@ http {
             proxy_buffering off;
         }
 
+        # Health / load-balancer probe (plain text, anonymous — outside /api/).
         location = /healthz {
             proxy_pass http://127.0.0.1:5000;
             proxy_set_header Host             $host;

--- a/docker/quill/s6-rc.d/03-proxy/run
+++ b/docker/quill/s6-rc.d/03-proxy/run
@@ -11,6 +11,16 @@ CERT_DIR=/var/lib/quill/certs
 PROXY_DIR=/var/lib/quill/proxy
 mkdir -p "$PROXY_DIR"
 
+RAVENDB_PORT="${RAVEN_QUILL_RAVENDB_INTERNAL_PORT:-8443}"
+RAVENDB_PROXY_PORT="${RAVEN_QUILL_RAVENDB_PROXY_PORT:-8447}"
+
+for port in $RAVENDB_PORT 8444 8445 8446 5000; do
+    if [ "$RAVENDB_PROXY_PORT" = "$port" ]; then
+        echo "03-proxy: RAVEN_QUILL_RAVENDB_PROXY_PORT ($RAVENDB_PROXY_PORT) is already in use; pick another." >&2
+        exit 1
+    fi
+done
+
 i=0
 while [ -z "$(ls "$CERT_DIR"/cluster.server.certificate.*.pfx 2>/dev/null)" ]; do
     i=$((i + 1))
@@ -23,9 +33,8 @@ done
 
 proxy-certs
 
-# Render the RavenDB passthrough port into the config from RAVEN_QUILL_RAVENDB_INTERNAL_PORT — the same env
-# 01-ravendb/run binds RavenDB to — so the two never drift. Run the rendered copy.
-RAVENDB_PORT="${RAVEN_QUILL_RAVENDB_INTERNAL_PORT:-8443}"
-sed "s|__RAVENDB_PORT__|${RAVENDB_PORT}|g" /etc/nginx/nginx.conf > "$PROXY_DIR/nginx.conf"
+cp /etc/nginx/nginx.conf "$PROXY_DIR/nginx.conf"
+sed -i "s|__RAVENDB_PORT__|$RAVENDB_PORT|g"             "$PROXY_DIR/nginx.conf"
+sed -i "s|__RAVENDB_PROXY_PORT__|$RAVENDB_PROXY_PORT|g" "$PROXY_DIR/nginx.conf"
 
 exec nginx -c "$PROXY_DIR/nginx.conf" -g 'daemon off;'

--- a/test/QuillTests/HealthEndpointsTests.cs
+++ b/test/QuillTests/HealthEndpointsTests.cs
@@ -4,38 +4,39 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Raven.Client.Documents;
 using Raven.Quill.Hosting;
 using Tests.Infrastructure;
 using Xunit;
 
 namespace QuillTests;
 
-public class HealthEndpointsTests(ITestOutputHelper output, HealthEndpointsTests.Factory factory)
-    : RavenTestBase(output), IClassFixture<HealthEndpointsTests.Factory>
+public class HealthEndpointsTests(ITestOutputHelper output) : RavenTestBase(output)
 {
-    private readonly Factory _factory = factory;
-
     [RavenFact(RavenTestCategory.Quill | RavenTestCategory.Monitoring)]
     public async Task Returns_503_before_bootstrap_phase_is_ready()
     {
-        _factory.Bootstrap.MarkFailed("not yet");
-        var client = _factory.CreateClient();
-        var response = await client.GetAsync("/healthz");
+        using var factory = new Factory(GetDocumentStore());
+        factory.Bootstrap.MarkFailed("not yet");
+
+        var response = await factory.CreateClient().GetAsync("/healthz");
+
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
     }
 
     [RavenFact(RavenTestCategory.Quill | RavenTestCategory.Monitoring)]
     public async Task Returns_200_once_bootstrap_phase_is_ready()
     {
-        _factory.Bootstrap.MarkReady();
-        var client = _factory.CreateClient();
-        var response = await client.GetAsync("/healthz");
+        using var factory = new Factory(GetDocumentStore());
+        factory.Bootstrap.MarkReady();
+
+        var response = await factory.CreateClient().GetAsync("/healthz");
+
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    public sealed class Factory : WebApplicationFactory<Program>
+    public sealed class Factory(IDocumentStore store) : WebApplicationFactory<Program>
     {
-        // RavenHealthCheck reads IBootstrapState, not IServerReady — this flag flips /healthz 503↔200.
         public IBootstrapState Bootstrap { get; } = new BootstrapStateFlag(
             Microsoft.Extensions.Options.Options.Create(new ApplianceOptions
             {
@@ -50,7 +51,10 @@ public class HealthEndpointsTests(ITestOutputHelper output, HealthEndpointsTests
             builder.ConfigureServices(services =>
             {
                 services.RemoveAll<IBootstrapState>();
-                services.AddSingleton<IBootstrapState>(Bootstrap);
+                services.AddSingleton(Bootstrap);
+
+                services.RemoveAll<IDocumentStore>();
+                services.AddSingleton(store);
 
                 // Drop only RavenReadinessService — RemoveAll<IHostedService>() would also kill GenericWebHostService.
                 var toRemove = services


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27364

### Additional description

Every request reached the web app looking like it came from loopback, because the :443 SNI front routes without decrypting and opens a fresh connection to itself. The rate limit policies partition on the client address, so "60/min per client" was really 60/min for the whole appliance and one busy visitor could 429 every embed.

The front now sends the PROXY protocol, the three TLS terminators read the address from it, and the existing X-Forwarded-For plumbing carries it the rest of the way - no application changes.
` db.*/a.*` reach RavenDB through a new hop that consumes the PROXY header first, since RavenDB would read it as a corrupt TLS handshake. Its port comes from RAVEN_QUILL_RAVENDB_PROXY_PORT (default 8447), and 03-proxy refuses to start if that collides with another port.

Also fixes `HealthEndpointsTests`, which broke when RavenDB-27183 made the health check probe RavenDB: the test only substituted `IBootstrapState`, so the probe hit a server that isn't running and  `/healthz` returned 503 regardless of the phase.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

**see comments below**

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
