### PR TITLE
RavenDB-27321: put the intent prompt behind an explicit Add, and unify the selectable cards

### DIFF
--- a/src/Raven.Quill.Web/src/components/form/form-radio-cards.tsx
+++ b/src/Raven.Quill.Web/src/components/form/form-radio-cards.tsx
@@ -11,6 +11,13 @@ import { cn } from "@/lib/utils";
 export const SELECTED_CARD_CLASSES =
     "border-primary bg-linear-to-br from-primary/15 to-transparent ring-2 ring-ring/25";
 
+/**
+ * Type scale for a card's title and its supporting line. Exported for the same bespoke cards, which
+ * used to hardcode it and drifted from these every time the scale here changed.
+ */
+export const CARD_LABEL_CLASSES = "font-semibold";
+export const CARD_DESCRIPTION_CLASSES = "mt-1 block text-sm leading-5 text-muted-foreground";
+
 export type RadioCardOption<TValue extends string = string> = {
     value: TValue;
     label: ReactNode;
@@ -75,21 +82,23 @@ export function FormRadioCards<
                                 aria-checked={isSelected}
                                 disabled={isDisabled}
                                 onClick={select}
+                                // Keeps the padding on the header rather than the card so the whole
+                                // block stays part of the click target. Its bottom edge is the gap to
+                                // the content below, and stays under the card padding so the content
+                                // reads as belonging to the card instead of floating in it.
                                 className={cn(
-                                    "block w-full p-4 text-left",
-                                    option.content ? "rounded-t-lg" : "rounded-lg",
+                                    "block w-full text-left",
+                                    option.content ? "rounded-t-lg px-4 pt-4 pb-3" : "rounded-lg p-4",
                                     isDisabled && "cursor-not-allowed",
                                 )}
                             >
-                                {option.icon && <span className="mb-3 block">{option.icon}</span>}
-                                <span className="flex items-center gap-2 text-sm font-semibold">
+                                {option.icon && <span className="mb-2 block">{option.icon}</span>}
+                                <span className={cn("flex items-center gap-2", CARD_LABEL_CLASSES)}>
                                     {option.label}
                                     {option.badge}
                                 </span>
                                 {option.description && (
-                                    <span className="mt-2 block text-xs leading-5 text-muted-foreground">
-                                        {option.description}
-                                    </span>
+                                    <span className={CARD_DESCRIPTION_CLASSES}>{option.description}</span>
                                 )}
                             </button>
                             {option.content && (

--- a/src/Raven.Quill.Web/src/components/form/form-textarea.tsx
+++ b/src/Raven.Quill.Web/src/components/form/form-textarea.tsx
@@ -40,9 +40,13 @@ export function FormTextarea<TFieldValues extends FieldValues, TName extends Fie
 
     return (
         <Field className={className} data-invalid={invalid}>
-            <FieldLabel htmlFor={inputId} className={labelClassName}>
-                {label}
-            </FieldLabel>
+            {/* Field lays its children out with a gap, so an empty label would leave a stray one.
+                Callers that label the field from outside pass aria-labelledby instead. */}
+            {label && (
+                <FieldLabel htmlFor={inputId} className={labelClassName}>
+                    {label}
+                </FieldLabel>
+            )}
             <Textarea
                 id={inputId}
                 onBlur={onBlur}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
@@ -338,8 +338,89 @@ export const VerifySchemaCdcVerificationFailed: Story = {
     },
 };
 
+// Seeded with a prompt, so the field is already there and stepping back never hides it.
 export const MapSchema: Story = {
     render: () => <AppWizardAtStep initialStep="map" />,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        expect(canvas.getByRole("textbox", { name: /intent prompt/i })).toBeInTheDocument();
+    },
+};
+
+const withoutIntentPrompt = (seed: AppFormData): AppFormData => ({ ...seed, map: { ...seed.map, aiPrompt: "" } });
+
+// The real first-run state: AI mapping chosen, no prompt yet, so the step asks only the
+// AI-versus-manual question. Deliberately has no play - a story that clicks its own button is an
+// interaction test, and this one has to stay at rest to be worth looking at.
+export const MapSchemaWithoutIntentPrompt: Story = {
+    render: () => <AppWizardAtStep initialStep="map" seedOverride={withoutIntentPrompt} />,
+};
+
+/*
+   The three stories below drive the intent prompt's transitions. Each one ends up looking like a
+   state already on show above, so they are tagged "!dev" to keep them out of the sidebar - the
+   vitest addon selects on the "test" tag, so they still run.
+*/
+
+// Adding the field swaps the button for a focused textarea.
+export const MapSchemaAddIntentPrompt: Story = {
+    tags: ["!dev"],
+    render: () => <AppWizardAtStep initialStep="map" seedOverride={withoutIntentPrompt} />,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        expect(canvas.queryByRole("textbox", { name: /intent prompt/i })).not.toBeInTheDocument();
+
+        await userEvent.click(canvas.getByRole("button", { name: /add an intent prompt/i }));
+
+        const prompt = await waitFor(() => canvas.getByRole("textbox", { name: /intent prompt/i }));
+        expect(prompt).toHaveFocus();
+        expect(canvas.queryByRole("button", { name: /add an intent prompt/i })).not.toBeInTheDocument();
+    },
+};
+
+// Removing takes the text with it, so nothing keeps steering the suggestion from a hidden field.
+export const MapSchemaRemoveIntentPrompt: Story = {
+    tags: ["!dev"],
+    render: () => <AppWizardAtStep initialStep="map" />,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        expect(canvas.getByRole("textbox", { name: /intent prompt/i })).toHaveValue(
+            "Embed order line items and link customers by id.",
+        );
+
+        await userEvent.click(canvas.getByRole("button", { name: /remove/i }));
+
+        const addButton = await waitFor(() => canvas.getByRole("button", { name: /add an intent prompt/i }));
+        expect(addButton).toHaveFocus();
+
+        // Re-adding starts from empty rather than restoring the discarded prompt.
+        await userEvent.click(addButton);
+        await waitFor(() => expect(canvas.getByRole("textbox", { name: /intent prompt/i })).toHaveValue(""));
+    },
+};
+
+// Reaching for the prompt while "Manual" is selected asks for a mapping the prompt cannot steer,
+// so adding it moves the choice to AI Suggest.
+export const MapSchemaIntentPromptFromManual: Story = {
+    tags: ["!dev"],
+    render: () => (
+        <AppWizardAtStep
+            initialStep="map"
+            seedOverride={(seed) => ({ ...seed, map: { source: "manual", aiPrompt: "" } })}
+        />
+    ),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        expect(canvas.getByRole("radio", { name: /manual/i })).toBeChecked();
+
+        await userEvent.click(canvas.getByRole("button", { name: /add an intent prompt/i }));
+        await waitFor(() => expect(canvas.getByRole("radio", { name: /ai suggest/i })).toBeChecked());
+        expect(canvas.getByRole("textbox", { name: /intent prompt/i })).toBeInTheDocument();
+    },
 };
 
 export const MapTables: Story = {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
@@ -1,5 +1,5 @@
 import { useController, useFormContext, useFormState, useWatch } from "react-hook-form";
-import { SELECTED_CARD_CLASSES } from "@/components/form/form-radio-cards";
+import { CARD_LABEL_CLASSES, SELECTED_CARD_CLASSES } from "@/components/form/form-radio-cards";
 import { FormInput } from "@/components/form/form-input";
 import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
 import { Field, FieldDescription, FieldLabel } from "@/components/shadcn/ui/field";
@@ -130,7 +130,7 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
                                 )}
                             >
                                 {option.icon}
-                                <span className="text-sm font-semibold">{option.label}</span>
+                                <span className={CARD_LABEL_CLASSES}>{option.label}</span>
                             </button>
                         );
                     })}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map/map-schema-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map/map-schema-step.tsx
@@ -1,8 +1,11 @@
-import { Sparkles } from "lucide-react";
+import { useId, useState } from "react";
+import { Plus, Sparkles, Trash2Icon } from "lucide-react";
 import { useFormContext } from "react-hook-form";
 import { FormRadioCards } from "@/components/form/form-radio-cards";
 import { FormTextarea } from "@/components/form/form-textarea";
 import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
+import { Button } from "@/components/shadcn/ui/button";
+import { FieldLabel } from "@/components/shadcn/ui/field";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import { type AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { LockedConfigAlert } from "@/pages/setup/add-app-wizard/locked-config-alert";
@@ -27,22 +30,7 @@ export function MapSchemaStep({ isBusy }: WizardBodyComponentProps) {
                         label: AI_SUGGEST_OPTION.label,
                         description: AI_SUGGEST_OPTION.description,
                         icon: <Sparkles className="size-5" aria-hidden="true" />,
-                        content: ({ select }) => (
-                            <FormTextarea
-                                control={control}
-                                name="map.aiPrompt"
-                                label={
-                                    <>
-                                        Intent prompt
-                                        <span className="text-xs font-normal text-muted-foreground">(optional)</span>
-                                    </>
-                                }
-                                placeholder='e.g. "Embed line items in each order, link customers by id, flatten addresses."'
-                                rows={4}
-                                disabled={isDisabled}
-                                onFocus={select}
-                            />
-                        ),
+                        content: ({ select }) => <IntentPrompt isDisabled={isDisabled} select={select} />,
                     },
                     {
                         value: MANUAL_OPTION.value,
@@ -50,6 +38,75 @@ export function MapSchemaStep({ isBusy }: WizardBodyComponentProps) {
                         description: MANUAL_OPTION.description,
                     },
                 ]}
+            />
+        </div>
+    );
+}
+
+/**
+ * The prompt steers the AI suggestion, but the step's actual question is AI versus manual, and the
+ * suggestion works unaided. Inline the field read as the thing to fill in, inviting experiments that
+ * derail the default mapping - so the two halves swap instead: a button that adds the field, and a
+ * Remove that takes it away again. Deliberately not a collapse, which would imply the text keeps
+ * steering the suggestion while hidden. Already-typed prompts open on the field.
+ */
+function IntentPrompt({ isDisabled, select }: { isDisabled: boolean; select: () => void }) {
+    const { control, getValues, setValue } = useFormContext<AppFormData>();
+    const promptId = useId();
+    const [isShown, setIsShown] = useState(() => getValues("map.aiPrompt").trim().length > 0);
+    // A prompt carried in from an earlier visit must not grab focus from the step; only swapping the
+    // two halves by click has earned it, in either direction.
+    const [shouldFocus, setShouldFocus] = useState(false);
+
+    if (!isShown) {
+        return (
+            <Button
+                variant="outline"
+                size="sm"
+                disabled={isDisabled}
+                autoFocus={shouldFocus}
+                // The prompt belongs to this card, so adding one also picks it.
+                onClick={() => {
+                    select();
+                    setIsShown(true);
+                    setShouldFocus(true);
+                }}
+            >
+                <Plus aria-hidden="true" />
+                Add an intent prompt
+            </Button>
+        );
+    }
+
+    return (
+        <div className="grid animate-in gap-2 duration-200 fade-in-0 slide-in-from-top-1">
+            <div className="flex items-center justify-between gap-2">
+                <FieldLabel htmlFor={promptId}>Intent prompt</FieldLabel>
+                <Button
+                    variant="destructive"
+                    size="xs"
+                    disabled={isDisabled}
+                    // Removing means going back to letting the AI decide, so the text goes too - it
+                    // would otherwise keep steering the suggestion from a field nobody can see.
+                    onClick={() => {
+                        setValue("map.aiPrompt", "");
+                        setIsShown(false);
+                        setShouldFocus(true);
+                    }}
+                >
+                    <Trash2Icon className="size-3" aria-hidden="true" />
+                    Remove
+                </Button>
+            </div>
+            <FormTextarea
+                id={promptId}
+                control={control}
+                name="map.aiPrompt"
+                placeholder='e.g. "Embed line items in each order, link customers by id, flatten addresses."'
+                rows={4}
+                disabled={isDisabled}
+                onFocus={select}
+                autoFocus={shouldFocus}
             />
         </div>
     );

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map/map-source-options.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map/map-source-options.ts
@@ -9,13 +9,15 @@ type MapSourceOption = {
 export const AI_SUGGEST_OPTION: MapSourceOption = {
     value: "ai-suggested",
     label: "AI Suggest",
-    description: "LLM proposes a draft configuration based on schema + your intent prompt.",
+    description:
+        "Reads your schema and works out the whole mapping on its own. Add an intent prompt only if " +
+        "you want to steer particular choices.",
 };
 
 export const MANUAL_OPTION: MapSourceOption = {
     value: "manual",
     label: "Manual",
-    description: "Empty form scaffolded from the discovered schema. You pick what to flat / embed / link.",
+    description: "Starts from an empty form scaffolded from your schema. You decide what to flatten, embed, or link.",
 };
 
 export const MAP_SOURCE_OPTIONS: MapSourceOption[] = [AI_SUGGEST_OPTION, MANUAL_OPTION];

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx
@@ -1,6 +1,10 @@
 import { useFormContext, useWatch } from "react-hook-form";
 import { cn } from "@/lib/utils";
-import { SELECTED_CARD_CLASSES } from "@/components/form/form-radio-cards";
+import {
+    CARD_DESCRIPTION_CLASSES,
+    CARD_LABEL_CLASSES,
+    SELECTED_CARD_CLASSES,
+} from "@/components/form/form-radio-cards";
 import { FormTextarea } from "@/components/form/form-textarea";
 import { Alert } from "@/components/shadcn/ui/alert";
 import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
@@ -84,8 +88,8 @@ export function CreateAgentStep({ isBusy }: WizardBodyComponentProps) {
                         mode === "manual" && SELECTED_CARD_CLASSES,
                     )}
                 >
-                    <span className="block text-sm font-semibold">Setup manually</span>
-                    <span className="mt-2 block text-xs leading-5 text-muted-foreground">
+                    <span className={cn("block", CARD_LABEL_CLASSES)}>Setup manually</span>
+                    <span className={CARD_DESCRIPTION_CLASSES}>
                         Skip the AI suggestions and build the agent configuration from scratch in the next step.
                     </span>
                 </button>

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/suggestion-picker.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/suggestion-picker.tsx
@@ -1,6 +1,10 @@
 import { useFormContext, useWatch } from "react-hook-form";
 import { cn } from "@/lib/utils";
-import { SELECTED_CARD_CLASSES } from "@/components/form/form-radio-cards";
+import {
+    CARD_DESCRIPTION_CLASSES,
+    CARD_LABEL_CLASSES,
+    SELECTED_CARD_CLASSES,
+} from "@/components/form/form-radio-cards";
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
 import { applySuggestionToForm } from "@/pages/setup/add-capability-wizard/agent-config-form";
 import { useCapabilityWizardStore } from "@/pages/setup/add-capability-wizard/capability-wizard-store";
@@ -36,10 +40,8 @@ export function SuggestionPicker() {
                             isSelected && SELECTED_CARD_CLASSES,
                         )}
                     >
-                        <span className="block text-sm font-semibold">{config.name}</span>
-                        <span className="mt-2 line-clamp-4 block text-xs leading-5 text-muted-foreground">
-                            {config.systemPrompt}
-                        </span>
+                        <span className={cn("block", CARD_LABEL_CLASSES)}>{config.name}</span>
+                        <span className={cn(CARD_DESCRIPTION_CLASSES, "line-clamp-4")}>{config.systemPrompt}</span>
                     </button>
                 );
             })}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27321

Part of the Quill Beta UX audit, https://issues.hibernatingrhinos.com/issue/RavenDB-27256

### Additional description

The intent prompt sat inline on the Map schema step, where it read as the thing to fill in even though the AI suggestion works unaided. That invites experiments which derail the default mapping, on a step whose actual question is AI versus manual.

The ticket offered two directions. This is the cheap one. The larger one — moving the prompt into the mapping editor as a re-map action — is split out as RavenDB-27371, with the analysis of why it is a Medium rather than a Small.

**Intent prompt.** Now an explicit `Add an intent prompt` button that swaps itself for the field, with a `Remove` that swaps back. Deliberately not a collapse: the prompt feeds the suggestion query key and `computeMapKey`, so hiding the text while it still fed those would keep it steering the suggestion from a field nobody can see. `Remove` therefore clears the value too. Focus follows the click in both directions, but a prompt carried in from an earlier visit renders without stealing focus from the step.

**Copy.** Both map source descriptions now say the AI works out the mapping on its own and the prompt is optional steering on top. Manual's "what to flat / embed / link" becomes "what to flatten, embed, or link".

**Card spacing.** The step's cards ran 16 / 12 / 8 / 16 — padding, icon to label, label to description, description to content. No ramp, and a description-to-content gap equal to the card padding, so the content read as floating rather than belonging to the card. Now 16 / 12 / 8 / 4. The header keeps its own padding rather than moving it to the card, so the whole block stays part of the click target.

**Card consistency.** `SuggestionPicker`, the "Setup manually" card and the provider tiles shared `SELECTED_CARD_CLASSES` but hardcoded the type scale, so they drifted from `FormRadioCards` every time it changed. The scale is now exported as `CARD_LABEL_CLASSES` / `CARD_DESCRIPTION_CLASSES` and consumed by all four sites, including `FormRadioCards` itself. All now measure label 16px/600 and description 14px/400 with a 4px gap.

**`FormTextarea`.** Renders its label only when given one. `Field` lays children out with a gap, so an empty label left a stray one.

Notes for reviewers:

* `form-radio-cards.tsx` is shared by four call sites. The map step is the only one using `content`, so the padding change is scoped to that card; the others get only the tighter label and icon gaps.
* `SuggestionPicker` still does not use `FormRadioCards`. It cannot as it stands: selection derives from two fields (`create.mode` + `create.selectedIndex`), picking writes several values through `applySuggestionToForm`, and it uses `aria-pressed` rather than `role="radio"`. Unifying the layout needs an externally-controlled mode on the shared component — a refactor, not a styling fix.
* Stories covering the transitions are tagged `!dev`: each ends up looking like a state already on show, so they stay out of the sidebar while the vitest addon, which selects on `test`, still runs them. First use of story tags in this project.
* Pre-existing and not introduced here: the `Add an intent prompt` button inherits `text-primary`, which measures 3.71:1 against the selected card in dark mode, below WCAG AA's 4.5:1. `--primary` is `brand-600` in both themes, so every `Button variant="link"` and `Badge variant="link"` shares it. Left alone rather than adding a one-off `dark:` override that would make this the only link in the app looking different. Worth its own ticket.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

The YouTrack type is Usability, which the template has no box for, so both are checked. The `Add`/`Remove` control is new behaviour; the card scale drift, the stray empty label and the "flat" wording are fixes.

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

Frontend only, no API or data path involved. The one thing to be aware of is that it edits a shared component — see the behaviour-change section below.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

`map.aiPrompt` is wizard-local: absent from `config-io.ts`, reset on import, and pinned empty by `edit-app-values.ts`. No persisted shape or endpoint changes.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

In-product copy on a beta surface, not documented behaviour.

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

Four new stories: the resting button state, plus interaction tests for add, remove and adding from Manual. 77 Storybook tests and 86 unit tests pass; typecheck, lint and prettier clean. Card spacing, type scale, focus behaviour, the reveal animation and the `!dev` tagging were each checked against a live render rather than inferred. The "internal classes" box is a backend convention with no frontend equivalent.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Two shared pieces changed, so surfaces beyond the Map schema step shift visually. No behavioural change to any of them.

* `FormRadioCards` — the tighter label and icon gaps also apply to the Choose data source step, the Choose capability step, and the web widget style editor. The padding change does not, since none of those pass `content`.
* Card type scale — `SuggestionPicker` and the "Setup manually" card in the capability wizard, and the provider tiles on the Connect source step, now follow `FormRadioCards` instead of their own hardcoded scale. This is the drift being corrected, so they change appearance where they previously disagreed.
* `FormTextarea` — the conditional label is subtractive only. All eleven other call sites pass a label and are unaffected.

The capability wizard files overlap RavenDB-27307 / RavenDB-27318; the changes there are styling-only.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed

Quill web, not the Studio. Follow-ups are tracked separately: RavenDB-27371 for moving the prompt into the mapping editor, plus the dark-mode `--primary` contrast and `SuggestionPicker` unification noted above.
