### PR TITLE
RavenDB-27309 Rework Import and Export configuration placement

### DIFF
--- a/src/Raven.Quill.Web/src/components/form/wizard/form-wizard.tsx
+++ b/src/Raven.Quill.Web/src/components/form/wizard/form-wizard.tsx
@@ -42,6 +42,10 @@ export type WizardFooterComponentProps = {
     isBusy: boolean;
 };
 
+export type WizardHeaderComponentProps = {
+    isBusy: boolean;
+};
+
 export type WizardBadgeContext<Values extends FieldValues = FieldValues> = {
     values: Values;
     isComplete: boolean;
@@ -71,6 +75,8 @@ export type WizardStep<StepId extends string, Values extends FieldValues = Field
     canCancel?: boolean;
     canGoBack?: boolean;
     footerComponent?: (props: WizardFooterComponentProps) => ReactNode;
+    /** Rendered beside the step title, for actions that act on the whole configuration. */
+    headerAction?: (props: WizardHeaderComponentProps) => ReactNode;
 } & WizardStepBadge<Values>;
 
 export type WizardSteps<StepId extends string, Values extends FieldValues = FieldValues> = Record<
@@ -231,11 +237,14 @@ export function FormWizard<StepId extends string, Values extends FieldValues>({
                                 currentStep.isFullHeight ? "flex h-full flex-col gap-5" : "grid gap-5",
                             )}
                         >
-                            <div>
-                                <h2 className="text-2xl font-semibold tracking-normal">{currentStep.title}</h2>
-                                {currentStep.description && (
-                                    <p className="mt-3 text-sm text-muted-foreground">{currentStep.description}</p>
-                                )}
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                                <div>
+                                    <h2 className="text-2xl font-semibold tracking-normal">{currentStep.title}</h2>
+                                    {currentStep.description && (
+                                        <p className="mt-3 text-sm text-muted-foreground">{currentStep.description}</p>
+                                    )}
+                                </div>
+                                {currentStep.headerAction && <currentStep.headerAction isBusy={isBusy} />}
                             </div>
 
                             <currentStep.bodyComponent currentStepId={currentStepIdInFlow} isBusy={isBusy} />

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
@@ -221,6 +221,31 @@ export const ConnectSourceConnectionString: Story = {
     },
 };
 
+// Import is a header action next to the step title, and it no longer waits for an application name:
+// the wizard endpoints get a draft slug until the operator provides a real one.
+export const ConnectSourceImport: Story = {
+    render: () => (
+        <AppWizardAtStep
+            initialStep="externalConnection"
+            seedOverride={(seed) => ({
+                ...seed,
+                externalConnection: { ...seed.externalConnection, appName: "", slug: "" },
+            })}
+        />
+    ),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const heading = canvas.getByRole("heading", { name: /connect to your source database/i });
+        const importButton = canvas.getByRole("button", { name: /import configuration/i });
+
+        expect(canvas.getByLabelText(/application name/i)).toHaveValue("");
+        expect(importButton).toBeEnabled();
+
+        // The heading sits in the title block, whose row also carries the header action.
+        expect(heading.parentElement?.parentElement).toContainElement(importButton);
+    },
+};
+
 const connectFailureHandlers = {
     setup: [
         setupMocks.connect({
@@ -571,6 +596,13 @@ export const MapTablesSuggesting: Story = {
 
 export const Preview: Story = {
     render: () => <AppWizardAtStep initialStep="preview" />,
+    // Export is a footer action, sharing the completion button's group.
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const exportButton = canvas.getByRole("button", { name: /export configuration/i });
+
+        expect(exportButton.parentElement).toContainElement(canvas.getByRole("button", { name: /create app/i }));
+    },
 };
 
 // The mapping ran but reported errors, so the preview shows the destructive banner instead of documents.

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-flow.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-flow.tsx
@@ -15,6 +15,8 @@ import { ConnectSourceStep } from "@/pages/setup/add-app-wizard/steps/connect/co
 import { MapSchemaStep } from "@/pages/setup/add-app-wizard/steps/map/map-schema-step";
 import { MapTablesStep } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-step";
 import { PreviewStep } from "@/pages/setup/add-app-wizard/steps/preview/preview-step";
+import { ExportConfigAction } from "@/pages/setup/add-app-wizard/steps/preview/export-config-action";
+import { ImportConfigHeaderAction } from "@/pages/setup/add-app-wizard/steps/connect/import-config-header-action";
 import { VerifySchemaStep } from "@/pages/setup/add-app-wizard/steps/verify/verify-schema-step";
 import { useConnectSourceStep } from "@/pages/setup/add-app-wizard/steps/connect/use-connect-source-step";
 import { useMapSchemaStep } from "@/pages/setup/add-app-wizard/steps/map/use-map-schema-step";
@@ -52,6 +54,7 @@ export const useAppSteps = (): WizardSteps<AppStepId, AppFormData> => {
         externalConnection: {
             title: "Connect to your source database",
             bodyComponent: ConnectSourceStep,
+            headerAction: ImportConfigHeaderAction,
             validate: "externalConnection",
             beforeNext: connectSourceBeforeNext,
             badgeFields: [],
@@ -110,6 +113,7 @@ export const useAppSteps = (): WizardSteps<AppStepId, AppFormData> => {
             description:
                 "Ingest chosen number of rows per root table into a throwaway namespace so you can check shape before the real load.",
             bodyComponent: PreviewStep,
+            footerComponent: ExportConfigAction,
             validate: "preview",
         },
     };

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/slugify.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/slugify.ts
@@ -7,3 +7,12 @@ export function toSlug(value: string) {
         .replace(/^-+|-+$/g, "")
         .toLowerCase();
 }
+
+/**
+ * A throwaway slug for work that must reach the server before the app is named - the wizard endpoints
+ * key their state by slug. Never shown to the operator and never kept, so it only has to be unlikely
+ * to collide with another draft; crypto.randomUUID is avoided because it needs a secure context.
+ */
+export function createDraftSlug() {
+    return `draft-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
@@ -1,4 +1,4 @@
-import { useController, useFormContext, useFormState, useWatch } from "react-hook-form";
+import { useController, useFormContext, useFormState } from "react-hook-form";
 import { CARD_LABEL_CLASSES, SELECTED_CARD_CLASSES } from "@/components/form/form-radio-cards";
 import { FormInput } from "@/components/form/form-input";
 import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
@@ -8,7 +8,6 @@ import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-sto
 import { type AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { PROVIDER_OPTIONS } from "@/pages/setup/add-app-wizard/steps/connect/connect-source-options";
 import { ConnectionEditor } from "@/pages/setup/add-app-wizard/steps/connect/connection-editor";
-import { ImportConfigDialog } from "@/pages/setup/add-app-wizard/steps/connect/import-config-dialog";
 import { TestConnectionButton } from "@/pages/setup/add-app-wizard/steps/connect/test-connection-button";
 import { toSlug } from "@/pages/setup/add-app-wizard/slugify";
 import { InputGroupAddon } from "@/components/shadcn/ui/input-group";
@@ -24,11 +23,6 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
     // where it is already the app's database name.
     const isSlugFollowingName = !touchedFields.externalConnection?.slug && !isEditingApp;
 
-    const appName = useWatch({ control, name: "externalConnection.appName" });
-    const slug = useWatch({ control, name: "externalConnection.slug" });
-    // The import runs through the wizard endpoints, which key their state by slug.
-    const isImportReady = slug.trim() !== "" || toSlug(appName) !== "";
-
     const {
         field: { value },
         fieldState: { error, invalid },
@@ -36,22 +30,6 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
 
     return (
         <div className="grid gap-5">
-            {!isEditingApp && (
-                <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border bg-muted/30 px-4 py-3">
-                    <div className="grid gap-0.5">
-                        <span className="text-sm font-medium">Have an exported configuration?</span>
-                        <span className="text-xs text-muted-foreground">
-                            Import it to reuse a saved connection and table mapping.
-                        </span>
-                    </div>
-                    <ImportConfigDialog
-                        disabled={isBusy || !isImportReady}
-                        disabledExplanation={
-                            isImportReady ? undefined : "Enter an application name first to import a configuration."
-                        }
-                    />
-                </div>
-            )}
             <FormInput
                 control={control}
                 name="externalConnection.appName"

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/import-config-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/import-config-dialog.tsx
@@ -17,11 +17,9 @@ import { useImportConfig } from "@/pages/setup/add-app-wizard/steps/connect/use-
 
 type ImportConfigDialogProps = {
     disabled?: boolean;
-    /** Tooltip on the disabled trigger, explaining why the import is unavailable. */
-    disabledExplanation?: string;
 };
 
-export function ImportConfigDialog({ disabled, disabledExplanation }: ImportConfigDialogProps) {
+export function ImportConfigDialog({ disabled }: ImportConfigDialogProps) {
     const [isOpen, setIsOpen] = useState(false);
     const { importMutation, progressLabel } = useImportConfig();
 
@@ -46,30 +44,24 @@ export function ImportConfigDialog({ disabled, disabledExplanation }: ImportConf
         });
     };
 
-    const trigger = (
-        <DialogTrigger asChild>
-            <Button type="button" variant="outline" disabled={disabled}>
-                <UploadIcon aria-hidden="true" />
-                Import configuration
-            </Button>
-        </DialogTrigger>
-    );
-
     return (
         <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-            {disabled && disabledExplanation ? (
-                // The disabled button swallows pointer events, so the span carries the tooltip.
-                <TooltipProvider>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <span>{trigger}</span>
-                        </TooltipTrigger>
-                        <TooltipContent>{disabledExplanation}</TooltipContent>
-                    </Tooltip>
-                </TooltipProvider>
-            ) : (
-                trigger
-            )}
+            <TooltipProvider>
+                <Tooltip>
+                    {/* A disabled button swallows pointer events, so the span carries the tooltip. */}
+                    <TooltipTrigger asChild>
+                        <span>
+                            <DialogTrigger asChild>
+                                <Button type="button" variant="outline" disabled={disabled}>
+                                    <UploadIcon aria-hidden="true" />
+                                    Import configuration
+                                </Button>
+                            </DialogTrigger>
+                        </span>
+                    </TooltipTrigger>
+                    <TooltipContent>Reuse a saved connection and table mapping.</TooltipContent>
+                </Tooltip>
+            </TooltipProvider>
             <DialogContent showCloseButton={!importMutation.isPending}>
                 <DialogHeader>
                     <DialogTitle>Import configuration</DialogTitle>

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/import-config-header-action.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/import-config-header-action.tsx
@@ -1,0 +1,14 @@
+import type { WizardHeaderComponentProps } from "@/components/form/wizard/form-wizard";
+import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
+import { ImportConfigDialog } from "@/pages/setup/add-app-wizard/steps/connect/import-config-dialog";
+
+/** Importing replaces the whole configuration, so it is offered only while a new app is being created. */
+export function ImportConfigHeaderAction({ isBusy }: WizardHeaderComponentProps) {
+    const isEditingApp = useSetupWizardStore((state) => state.editedAppSlug !== null);
+
+    if (isEditingApp) {
+        return null;
+    }
+
+    return <ImportConfigDialog disabled={isBusy} />;
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-import-config.ts
@@ -19,7 +19,7 @@ import {
     findDiscoveredTable,
     getSourceTableLabel,
 } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
-import { toSlug } from "@/pages/setup/add-app-wizard/slugify";
+import { createDraftSlug, toSlug } from "@/pages/setup/add-app-wizard/slugify";
 import { discoverTables } from "@/pages/setup/add-app-wizard/steps/verify/use-discover-tables";
 import {
     computeConnectKey,
@@ -38,10 +38,22 @@ const IMPORT_PHASES = {
 type ImportResult = {
     config: WizardConfig;
     slug: string;
+    isDraftSlug: boolean;
     formTables: AppFormData["mapTables"]["tables"];
     discoverResult: DiscoverResponse;
     schemas: string[];
 };
+
+/**
+ * The export carries no slug, and the import can run before the app is even named, so a draft slug
+ * stands in for the server calls. The form keeps its slug empty in that case: naming the app later
+ * changes the connect key, which is what makes the connect step re-run under the real slug.
+ */
+function resolveImportSlug(connection: AppFormData["externalConnection"]): { slug: string; isDraft: boolean } {
+    const slug = connection.slug.trim() || toSlug(connection.appName);
+
+    return slug ? { slug, isDraft: false } : { slug: createDraftSlug(), isDraft: true };
+}
 
 export function useImportConfig() {
     const { setValue, getValues } = useFormContext<AppFormData>();
@@ -58,11 +70,8 @@ export function useImportConfig() {
                 );
             }
 
-            // The export carries no slug, so the import runs under the operator's, derived from the
-            // app name when the override is empty. It cannot be blank: the wizard endpoints key
-            // their state by it, which is why the trigger stays disabled until one can be derived.
             const connectionValues = getValues("externalConnection");
-            const slug = connectionValues.slug.trim() || toSlug(connectionValues.appName);
+            const { slug, isDraft: isDraftSlug } = resolveImportSlug(connectionValues);
             const connection = {
                 ...connectionValues,
                 provider: config.provider,
@@ -108,14 +117,14 @@ export function useImportConfig() {
 
             try {
                 const formTables = tablesSchema.parse(wrapDtoTablesToFormShape(config.tables));
-                return { config, slug, formTables, discoverResult, schemas };
+                return { config, slug, isDraftSlug, formTables, discoverResult, schemas };
             } catch {
                 throw new Error(
                     "The configuration's table mapping is invalid or was exported from an incompatible version.",
                 );
             }
         },
-        onSuccess: ({ config, slug, formTables, discoverResult, schemas }) => {
+        onSuccess: ({ config, slug, isDraftSlug, formTables, discoverResult, schemas }) => {
             toast.success("Configuration imported");
 
             const verifySchemaTables = config.tables.map((table) => ({
@@ -129,8 +138,11 @@ export function useImportConfig() {
             setValue("externalConnection.mode", droppedKeywords.length === 0 ? "fields" : "raw");
             setValue("externalConnection.fields", fields);
             setValue("externalConnection.connectionString", config.connectionString);
-            // The form must carry the slug the import ran under: later steps key their work by it.
-            setValue("externalConnection.slug", slug, { shouldValidate: true });
+            // A real slug is the one later steps key their work by, so the form must carry it. A draft
+            // one is never shown: the operator still has to name the app, and the slug follows from that.
+            if (!isDraftSlug) {
+                setValue("externalConnection.slug", slug, { shouldValidate: true });
+            }
             setValue("verifySchema.tables", verifySchemaTables);
             setValue("map.source", "manual");
             setValue("map.aiPrompt", "");

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/preview/export-config-action.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/preview/export-config-action.tsx
@@ -1,0 +1,36 @@
+import { useFormContext, useWatch } from "react-hook-form";
+import { DownloadIcon } from "lucide-react";
+import { Button } from "@/components/shadcn/ui/button";
+import { ConfirmDialog } from "@/components/shadcn/ui/confirm-dialog";
+import type { WizardFooterComponentProps } from "@/components/form/wizard/form-wizard";
+import { buildConfigExport, downloadConfig } from "@/pages/setup/add-app-wizard/config-io";
+import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
+
+/** Sits beside the wizard's completion button: exporting is an alternative to creating the app now. */
+export function ExportConfigAction({ isBusy }: WizardFooterComponentProps) {
+    const { control, getValues } = useFormContext<AppFormData>();
+
+    const dataSource = useWatch({ control, name: "dataSource.source" });
+    const tables = useWatch({ control, name: "mapTables.tables" });
+
+    // Only an external source has a connection and a table mapping to export.
+    if (dataSource !== "external") {
+        return null;
+    }
+
+    return (
+        <ConfirmDialog
+            variant="warning"
+            trigger={
+                <Button type="button" variant="outline" size="lg" disabled={isBusy || tables.length === 0}>
+                    <DownloadIcon aria-hidden="true" />
+                    Export configuration
+                </Button>
+            }
+            title="Export configuration?"
+            description="The exported file contains the connection string in plain text, including any username and password it holds. Keep it somewhere safe and avoid sharing it."
+            confirmLabel="Export"
+            onConfirm={() => downloadConfig(buildConfigExport(getValues()))}
+        />
+    );
+}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/preview/preview-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/preview/preview-step.tsx
@@ -4,50 +4,25 @@ import { FormSelect } from "@/components/form/form-select";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import { FormInput } from "@/components/form/form-input";
-import { ConfirmDialog } from "@/components/shadcn/ui/confirm-dialog";
-import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/shadcn/ui/alert";
 import { WizardErrorList } from "@/components/form/wizard/wizard-error-list";
 import AceEditor from "@/components/ace-editor/ace-editor";
-import { CircleAlertIcon, DownloadIcon, MessageSquareWarningIcon } from "lucide-react";
-import { buildConfigExport, downloadConfig } from "@/pages/setup/add-app-wizard/config-io";
+import { CircleAlertIcon, MessageSquareWarningIcon } from "lucide-react";
 
 // Both failure paths report the same thing: the request itself failed, or it came back with errors.
 const MAPPING_TEST_ERROR_TITLE = "Testing the mapping failed";
 
 export function PreviewStep() {
-    const { control, getValues } = useFormContext<AppFormData>();
+    const { control } = useFormContext<AppFormData>();
 
     const tables = useWatch({
         control,
         name: "mapTables.tables",
     });
 
-    const dataSource = useWatch({
-        control,
-        name: "dataSource.source",
-    });
-
     return (
         <>
-            {dataSource === "external" && (
-                <div className="flex justify-end">
-                    <ConfirmDialog
-                        variant="warning"
-                        trigger={
-                            <Button type="button" variant="outline" disabled={tables.length === 0}>
-                                <DownloadIcon aria-hidden="true" />
-                                Export configuration
-                            </Button>
-                        }
-                        title="Export configuration?"
-                        description="The exported file contains the connection string in plain text, including any username and password it holds. Keep it somewhere safe and avoid sharing it."
-                        confirmLabel="Export"
-                        onConfirm={() => downloadConfig(buildConfigExport(getValues()))}
-                    />
-                </div>
-            )}
             <div className="grid grid-cols-2 gap-4">
                 <FormSelect
                     control={control}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27309

### Additional description

On `/app/add`, **Import** sat above the *Application name* input, mixed into the full configuration form. The ordering implied a name was required first — and it was: the import calls `/setup/connect` and discovery, and the server keys its `WizardState` document by slug, so the trigger stayed disabled until a slug could be derived. **Export** sat inside the Preview step body, which has no contextual relationship to it.

**Import → header action on the Connect step**

- Added a `headerAction` slot to `WizardStep`, mirroring the existing `footerComponent`. The step title block became a two-column flex row; steps without an action render exactly as before.
- The bordered "Have an exported configuration?" panel is gone. Its copy survives as the button's tooltip.
- Scoped to the Connect step only — importing replaces the whole configuration, so offering it from the Map or Preview step would silently discard the operator's mapping. `ImportConfigHeaderAction` also hides it once a configuration is locked (an import already applied, or the edit-app wizard).

**Import no longer waits for an application name**

- `resolveImportSlug` falls back to a draft slug (`draft-<random>`) so the wizard endpoints get the key they need, and the form's own slug is left empty in that case rather than showing the operator a throwaway value.
- When the operator names the app, `computeConnectKey` no longer matches the stored `connectKey`, so the Connect step's existing `beforeNext` re-runs connect + discovery under the real slug. `discoverSchemas` is preserved by the store, so tables in custom schemas survive the re-discover and the imported selection is kept.
- Cost: one extra connect+discover round trip, and one orphan `WizardState` document per draft import — the same leftover the wizard already creates for every app name an operator types and abandons.

**Export → footer, beside *Create app & continue***

- Moved out of the Preview body into that step's `footerComponent`, so it lands immediately left of the completion button it is an alternative to. Same confirm dialog and plain-text-connection-string warning, same `dataSource === "external"` and empty-mapping guards, `size="lg"` to match the other footer buttons.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Usability

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

Studio-only (Quill web UI). No server or client changes.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

The exported configuration file format is unchanged, so existing exported files still import.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

`crypto.randomUUID` was deliberately avoided for the draft slug because it requires a secure context, and Quill can be served over plain HTTP.

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

Two Storybook interaction tests: `ConnectSourceImport` asserts Import is enabled with an empty application name and sits in the step heading's row; `Preview` asserts Export shares the completion button's footer group.

Validation run: `typecheck`, `lint` and `format:check` clean; unit tests 102 + 29 pass; full Storybook suite 27 files / 76 tests pass; `dotnet build RavenDB.sln -c Release` succeeds. Verified in Storybook that the Connect step renders heading → Import → *Application name*, and the Preview footer reads Cancel, Back, Export configuration, Create app & continue with no Export left in the body.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Importing without an application name now runs its verification under a draft slug, which means the connect step re-runs connect + discovery once the app is named. The re-run path already existed for any slug change; this change makes it reachable one step earlier.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed

This PR *is* the UI work.
