### PR TITLE
RavenDB-27340 Use one status vocabulary and style everywhere

### DIFF
--- a/src/Raven.Quill.Web/src/components/data/status-indicator.tsx
+++ b/src/Raven.Quill.Web/src/components/data/status-indicator.tsx
@@ -1,14 +1,57 @@
-import { CircleCheckIcon } from "lucide-react";
+import type { ComponentProps } from "react";
+import { CircleAlert, Loader2Icon, TriangleAlert } from "lucide-react";
 
 import { Badge } from "@/components/shadcn/ui/badge";
 
-export function StatusIndicator({ tone, label }: { tone: "positive" | "muted"; label: string }) {
-    const isPositive = tone === "positive";
+export type StatusTone = "positive" | "muted" | "warning" | "info" | "danger" | "loading";
 
+const TONE_VARIANTS: Record<StatusTone, ComponentProps<typeof Badge>["variant"]> = {
+    positive: "success",
+    muted: "secondary",
+    info: "info",
+    loading: "secondary",
+    warning: "warning",
+    danger: "destructive",
+};
+
+// Only the tones that ask something of the operator carry an icon, so an icon always reads as
+// "this needs you" rather than decoration. The calm tones are label-only. The icons are hidden
+// from assistive tech because the badge label already names the state.
+function ToneIcon({ tone }: { tone: StatusTone }) {
+    switch (tone) {
+        case "warning":
+            return <TriangleAlert aria-hidden="true" />;
+        case "danger":
+            return <CircleAlert aria-hidden="true" />;
+        case "loading":
+            return <Loader2Icon className="animate-spin" aria-hidden="true" />;
+        default:
+            return null;
+    }
+}
+
+// The single status style for the whole app.
+export function StatusIndicator({
+    tone,
+    label,
+    title,
+    className,
+}: {
+    tone: StatusTone;
+    label: string;
+    title?: string;
+    className?: string;
+}) {
     return (
-        <Badge variant={isPositive ? "success" : "secondary"}>
-            {isPositive && <CircleCheckIcon aria-hidden="true" />}
+        <Badge variant={TONE_VARIANTS[tone]} className={className} title={title}>
+            <ToneIcon tone={tone} />
             {label}
         </Badge>
     );
+}
+
+// Channels and agents share one on/off state, so the wording lives here only — otherwise it
+// drifts between the channel cards, the tables, the detail header and the capability wizard.
+export function EnabledStatus({ isEnabled }: { isEnabled: boolean }) {
+    return <StatusIndicator tone={isEnabled ? "positive" : "muted"} label={isEnabled ? "Active" : "Disabled"} />;
 }

--- a/src/Raven.Quill.Web/src/pages/apps/agents-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/agents-section.tsx
@@ -3,7 +3,7 @@ import { Pencil, Plus, Trash2 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
-import { StatusIndicator } from "@/components/data/status-indicator";
+import { EnabledStatus } from "@/components/data/status-indicator";
 import { Button } from "@/components/shadcn/ui/button";
 import { TableCell, TableRow } from "@/components/shadcn/ui/table";
 import { appRoutes } from "@/lib/app-routes";
@@ -41,10 +41,7 @@ export function AgentsTable({ slug }: { slug: string }) {
                         <TableRow key={agent.agentId}>
                             <TableCell className="font-medium">{agent.name}</TableCell>
                             <TableCell>
-                                <StatusIndicator
-                                    tone={agent.disabled ? "muted" : "positive"}
-                                    label={agent.disabled ? "Disabled" : "Active"}
-                                />
+                                <EnabledStatus isEnabled={!agent.disabled} />
                             </TableCell>
                             <TableCell className="font-mono text-xs text-muted-foreground">
                                 {agent.model ?? "—"}

--- a/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.tsx
@@ -3,7 +3,7 @@ import { ArrowLeft, Palette } from "lucide-react";
 import { Link, useParams } from "react-router";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
-import { StatusIndicator } from "@/components/data/status-indicator";
+import { EnabledStatus } from "@/components/data/status-indicator";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Button } from "@/components/shadcn/ui/button";
 import { appRoutes } from "@/lib/app-routes";
@@ -56,10 +56,7 @@ export function AppChannelDetail() {
                                 <div className="grid gap-1">
                                     <div className="flex items-center gap-3">
                                         <h2 className="text-lg font-semibold">{channel.displayName}</h2>
-                                        <StatusIndicator
-                                            tone={channel.enabled ? "positive" : "muted"}
-                                            label={channel.enabled ? "Connected" : "Disabled"}
-                                        />
+                                        <EnabledStatus isEnabled={channel.enabled} />
                                     </div>
                                     <p className="text-sm text-muted-foreground">
                                         {channel.type ? CHANNEL_TYPE_LABELS[channel.type] : "—"}

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
@@ -1,7 +1,7 @@
-import { useId, useLayoutEffect, useRef, useState, type ComponentProps, type ReactNode, type UIEvent } from "react";
+import { useId, useLayoutEffect, useRef, useState, type ReactNode, type UIEvent } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ChevronRight, CircleAlert, CircleCheck, Loader2, type LucideIcon } from "lucide-react";
-import { Badge } from "@/components/shadcn/ui/badge";
+import { ChevronRight } from "lucide-react";
+import { StatusIndicator, type StatusTone } from "@/components/data/status-indicator";
 import { Label } from "@/components/shadcn/ui/label";
 import { Switch } from "@/components/shadcn/ui/switch";
 import { formatCompact } from "@/lib/format";
@@ -153,33 +153,20 @@ function CdcBatchList({ batches }: { batches: CdcLiveBatch[] }) {
     );
 }
 
-const BATCH_STATES: Record<
-    CdcLiveBatchState,
-    {
-        label: string;
-        badgeVariant: ComponentProps<typeof Badge>["variant"];
-        icon: LucideIcon;
-        iconClassName?: string;
-        accentClassName: string;
-    }
-> = {
+const BATCH_STATES: Record<CdcLiveBatchState, { label: string; tone: StatusTone; accentClassName: string }> = {
     success: {
         label: "Success",
-        badgeVariant: "success",
-        icon: CircleCheck,
+        tone: "positive",
         accentClassName: "border-l-success",
     },
     pending: {
         label: "Pending",
-        badgeVariant: "secondary",
-        icon: Loader2,
-        iconClassName: "animate-spin",
+        tone: "loading",
         accentClassName: "border-l-muted-foreground",
     },
     error: {
         label: "Error",
-        badgeVariant: "destructive",
-        icon: CircleAlert,
+        tone: "danger",
         accentClassName: "border-l-destructive",
     },
 };
@@ -196,7 +183,6 @@ function CdcBatchRow({
     onToggle: () => void;
 }) {
     const state = BATCH_STATES[batch.state];
-    const StateIcon = state.icon;
     const errorCount = batch.scriptErrors + batch.readErrors;
 
     return (
@@ -214,10 +200,7 @@ function CdcBatchRow({
                         isExpanded && "rotate-90",
                     )}
                 />
-                <Badge variant={state.badgeVariant} className="w-20 shrink-0 justify-start">
-                    <StateIcon aria-hidden={true} className={state.iconClassName} />
-                    {state.label}
-                </Badge>
+                <StatusIndicator tone={state.tone} label={state.label} className="shrink-0 justify-start" />
                 <span className="shrink-0 font-mono text-xs text-muted-foreground tabular-nums">
                     {formatBatchTime(batch.started)}
                 </span>

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-performance-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-performance-section.tsx
@@ -1,8 +1,7 @@
-import { type ComponentProps } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
-import { Badge } from "@/components/shadcn/ui/badge";
+import { StatusIndicator, type StatusTone } from "@/components/data/status-indicator";
 import { Button } from "@/components/shadcn/ui/button";
 import { CdcBatchLog } from "@/pages/apps/cdc-batch-log";
 import { DashboardStatCards, type DashboardStatCard } from "@/pages/dashboard/dashboard-stat-cards";
@@ -65,15 +64,15 @@ export function CdcPerformanceSection({
     );
 }
 
-const CDC_STATUS_BADGES: Record<CdcLiveStatus, { variant: ComponentProps<typeof Badge>["variant"]; label: string }> = {
-    active: { variant: "success", label: "Active" },
-    idle: { variant: "secondary", label: "Idle" },
-    error: { variant: "destructive", label: "Error" },
+const CDC_STATUS_BADGES: Record<CdcLiveStatus, { tone: StatusTone; label: string }> = {
+    active: { tone: "positive", label: "Active" },
+    idle: { tone: "muted", label: "Idle" },
+    error: { tone: "danger", label: "Error" },
 };
 
 function CdcStatusBadge({ status }: { status: CdcLiveStatus }) {
     const badge = CDC_STATUS_BADGES[status];
-    return <Badge variant={badge.variant}>{badge.label}</Badge>;
+    return <StatusIndicator tone={badge.tone} label={badge.label} />;
 }
 
 function CdcPerformanceContent({ performance }: { performance: CdcLivePerformance }) {

--- a/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router";
 import { api } from "@/api/api";
 import type { AgentSummaryResponse, ChannelSummaryResponse, ChannelType } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
+import { EnabledStatus } from "@/components/data/status-indicator";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
@@ -150,7 +151,7 @@ function ChannelCard({
                     </Link>
                 </CardTitle>
                 <CardAction>
-                    <ChannelStatusPill enabled={channel.enabled} />
+                    <EnabledStatus isEnabled={channel.enabled} />
                 </CardAction>
             </CardHeader>
 
@@ -234,18 +235,6 @@ function ChannelCard({
                 />
             </CardFooter>
         </Card>
-    );
-}
-
-function ChannelStatusPill({ enabled }: { enabled: boolean }) {
-    return (
-        <Badge variant={enabled ? "success" : "secondary"}>
-            <span
-                className={cn("size-1.5 rounded-full", enabled ? "bg-emerald-500" : "bg-muted-foreground/60")}
-                aria-hidden="true"
-            />
-            {enabled ? "Active" : "Paused"}
-        </Badge>
     );
 }
 

--- a/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
@@ -3,7 +3,7 @@ import { Eye, Link2, Pencil, Trash2 } from "lucide-react";
 import { Link } from "react-router";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
-import { StatusIndicator } from "@/components/data/status-indicator";
+import { EnabledStatus } from "@/components/data/status-indicator";
 import { Button } from "@/components/shadcn/ui/button";
 import { Skeleton } from "@/components/shadcn/ui/skeleton";
 import { TableCell, TableRow } from "@/components/shadcn/ui/table";
@@ -85,10 +85,7 @@ export function ChannelsSection({ slug, agent: fixedAgent }: { slug: string; age
                                     </TableCell>
                                     {!fixedAgent && <TableCell className="font-medium">{agent?.name}</TableCell>}
                                     <TableCell>
-                                        <StatusIndicator
-                                            tone={channel.enabled ? "positive" : "muted"}
-                                            label={channel.enabled ? "Connected" : "Disabled"}
-                                        />
+                                        <EnabledStatus isEnabled={channel.enabled} />
                                     </TableCell>
                                     <TableCell>{channel.type ? CHANNEL_TYPE_LABELS[channel.type] : "—"}</TableCell>
                                     <TableCell className="text-muted-foreground tabular-nums">

--- a/src/Raven.Quill.Web/src/pages/apps/channels/channel-active-links-columns.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/channel-active-links-columns.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable react-refresh/only-export-components */
 
-import type { ReactNode } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { CircleAlert, Copy, Eye, Trash2, TriangleAlert } from "lucide-react";
+import { Copy, Eye, Trash2 } from "lucide-react";
 import type { EmbedLinkSummaryResponse } from "@/api/generated/server-api";
 import { Parameters } from "@/components/data/parameters";
-import { Badge } from "@/components/shadcn/ui/badge";
+import { StatusIndicator } from "@/components/data/status-indicator";
 import { Button } from "@/components/shadcn/ui/button";
 import { copyToClipboard, formatDateTime } from "@/lib/utils";
 import { type EmbedLinkStatusTone, getExpiryStatus, getUsageStatus } from "@/pages/apps/channels/embed-link-status";
@@ -43,11 +42,7 @@ export function createActiveLinkColumns(slug: string): ColumnDef<EmbedLinkSummar
             header: "Expires",
             cell: ({ row }) => {
                 const status = getExpiryStatus(row.original.expiresAt);
-                return (
-                    <StatusValue tone={status.tone} title={status.title}>
-                        {status.label}
-                    </StatusValue>
-                );
+                return <StatusValue tone={status.tone} title={status.title} label={status.label} />;
             },
         },
         {
@@ -55,11 +50,7 @@ export function createActiveLinkColumns(slug: string): ColumnDef<EmbedLinkSummar
             header: "Usage",
             cell: ({ row }) => {
                 const status = getUsageStatus(row.original.invocationCount, row.original.maxInvocations);
-                return (
-                    <StatusValue tone={status.tone} title={status.title}>
-                        {status.label}
-                    </StatusValue>
-                );
+                return <StatusValue tone={status.tone} title={status.title} label={status.label} />;
             },
         },
         {
@@ -72,23 +63,24 @@ export function createActiveLinkColumns(slug: string): ColumnDef<EmbedLinkSummar
     ];
 }
 
-// Renders an expiry/usage value, escalating to a colored badge with an icon once the
+// Renders an expiry/usage value, escalating from plain text to a status badge once the
 // link needs attention so problem rows stand out at a glance.
-function StatusValue({ tone, title, children }: { tone: EmbedLinkStatusTone; title: string; children: ReactNode }) {
+function StatusValue({ tone, title, label }: { tone: EmbedLinkStatusTone; title: string; label: string }) {
     if (tone === "normal") {
         return (
             <span className="text-muted-foreground tabular-nums" title={title}>
-                {children}
+                {label}
             </span>
         );
     }
 
-    const Icon = tone === "critical" ? CircleAlert : TriangleAlert;
     return (
-        <Badge variant={tone === "critical" ? "destructive" : "warning"} className="tabular-nums" title={title}>
-            <Icon aria-hidden="true" />
-            {children}
-        </Badge>
+        <StatusIndicator
+            tone={tone === "critical" ? "danger" : "warning"}
+            label={label}
+            title={title}
+            className="tabular-nums"
+        />
     );
 }
 

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-card.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Copy } from "lucide-react";
 import type { CertificateItem } from "@/api/custom-services/certificates-service";
 import type { AppResponse } from "@/api/generated/server-api";
+import { StatusIndicator, type StatusTone } from "@/components/data/status-indicator";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { formatDate } from "@/lib/format";
@@ -20,13 +21,13 @@ import { EditCertificateDialog } from "@/pages/dashboard/certificates/edit-certi
 const STATE_STRIP_CLASSES: Record<CertificateState, string> = {
     valid: "bg-success",
     expired: "bg-destructive",
-    disabled: "bg-warning",
+    disabled: "bg-muted-foreground/60",
 };
 
-const STATE_BADGE_VARIANTS: Record<CertificateState, "success" | "destructive" | "warning"> = {
-    valid: "success",
-    expired: "destructive",
-    disabled: "warning",
+const STATE_TONES: Record<CertificateState, StatusTone> = {
+    valid: "positive",
+    expired: "danger",
+    disabled: "muted",
 };
 
 export function CertificateCard({ certificate, apps }: { certificate: CertificateItem; apps: AppResponse[] }) {
@@ -41,8 +42,8 @@ export function CertificateCard({ certificate, apps }: { certificate: Certificat
                     <div className="min-w-0 space-y-1">
                         <div className="flex flex-wrap items-center gap-2">
                             <h3 className="text-sm font-semibold">{certificate.name || "—"}</h3>
-                            <Badge variant={STATE_BADGE_VARIANTS[state]}>{CERTIFICATE_STATE_LABELS[state]}</Badge>
-                            {isAboutToExpire && <Badge variant="warning">About to expire</Badge>}
+                            <StatusIndicator tone={STATE_TONES[state]} label={CERTIFICATE_STATE_LABELS[state]} />
+                            {isAboutToExpire && <StatusIndicator tone="warning" label="About to expire" />}
                         </div>
                         <div className="flex items-center gap-1">
                             <span className="truncate font-mono text-xs text-muted-foreground">

--- a/src/Raven.Quill.Web/src/pages/dashboard/dashboard-apps-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/dashboard-apps-table.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 import { Database, Pencil, Plus, Trash2 } from "lucide-react";
 import type { ApplianceAppResponse, AppWrites } from "@/api/generated/server-api";
+import { StatusIndicator, type StatusTone } from "@/components/data/status-indicator";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/ui/table";
@@ -8,28 +9,27 @@ import { WruLabel } from "@/components/data/wru-label";
 import { appRoutes } from "@/lib/app-routes";
 import { datePeriodUnit, type DatePeriod } from "@/lib/date-period";
 import { formatCompact } from "@/lib/format";
-import { cn } from "@/lib/utils";
 import { DeleteAppDialog } from "@/pages/apps/delete-app-dialog";
 
-type StatusStyle = { dotClassName: string; label: string };
+type StatusStyle = { tone: StatusTone; label: string };
 
 // Maps the server's derived status codes (MetricsReadService.DeriveAppStatus emits
 // running/warning/setup) onto the dashboard's status vocabulary. loading/failed are
 // kept for forward-compatibility so a future provisioning/error state renders sensibly.
 const STATUS_STYLES: Record<string, StatusStyle> = {
-    running: { dotClassName: "bg-emerald-500", label: "Healthy" },
-    healthy: { dotClassName: "bg-emerald-500", label: "Healthy" },
-    warning: { dotClassName: "bg-amber-500", label: "Needs attention" },
-    setup: { dotClassName: "bg-sky-500", label: "Setup" },
-    loading: { dotClassName: "bg-muted-foreground/50", label: "Loading" },
-    failed: { dotClassName: "bg-red-500", label: "Failed" },
-    error: { dotClassName: "bg-red-500", label: "Failed" },
+    running: { tone: "positive", label: "Healthy" },
+    healthy: { tone: "positive", label: "Healthy" },
+    warning: { tone: "warning", label: "Needs attention" },
+    setup: { tone: "info", label: "Setup" },
+    loading: { tone: "loading", label: "Loading" },
+    failed: { tone: "danger", label: "Failed" },
+    error: { tone: "danger", label: "Failed" },
 };
 
 function resolveStatusStyle(status: string): StatusStyle {
     return (
         STATUS_STYLES[status.toLowerCase()] ?? {
-            dotClassName: "bg-muted-foreground/50",
+            tone: "muted",
             label: status ? status[0].toUpperCase() + status.slice(1) : "Unknown",
         }
     );
@@ -137,12 +137,9 @@ function AppStatusCell({ app }: { app: ApplianceAppResponse }) {
     const style = resolveStatusStyle(app.status);
 
     return (
-        <div className="flex items-start gap-2">
-            <span className={cn("mt-1.5 size-1.5 shrink-0 rounded-full", style.dotClassName)} aria-hidden="true" />
-            <div className="flex flex-col">
-                <span className="text-sm font-medium">{style.label}</span>
-                {app.statusSubtitle && <span className="text-xs text-muted-foreground">{app.statusSubtitle}</span>}
-            </div>
+        <div className="flex flex-col items-start gap-1">
+            <StatusIndicator tone={style.tone} label={style.label} />
+            {app.statusSubtitle && <span className="text-xs text-muted-foreground">{app.statusSubtitle}</span>}
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/dashboard/dashboard-stat-cards.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/dashboard-stat-cards.tsx
@@ -1,5 +1,4 @@
 import { useId, type ReactNode } from "react";
-import { TrendingDown, TrendingUp } from "lucide-react";
 import { Area, AreaChart, YAxis } from "recharts";
 import { ZERO_SAFE_Y_DOMAIN } from "@/lib/chart-domain";
 import { InfoHint } from "@/components/data/info-hint";
@@ -80,11 +79,9 @@ function StatCard({ card }: { card: DashboardStatCard }) {
 
 function DeltaBadge({ delta }: { delta: number }) {
     const isUp = delta >= 0;
-    const Icon = isUp ? TrendingUp : TrendingDown;
 
     return (
         <Badge variant={isUp ? "success" : "destructive"}>
-            <Icon aria-hidden="true" />
             {isUp ? "+" : ""}
             {delta.toFixed(1)}%
         </Badge>


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27340/Quill-Use-one-status-vocabulary-and-style-everywhere

### Additional description

The same channel state was worded three different ways and drawn two different ways. This consolidates both into a single component, `src/Raven.Quill.Web/src/components/data/status-indicator.tsx`.

**One vocabulary.** A new `EnabledStatus` owns the on/off wording for channels and agents, so the state now reads **Active / Disabled** on the Channels cards, the app overview table, the channel detail header, the capability wizard's final step, and the Agents table. Previously these were `Active / Paused`, `Connected / Disabled` and `Active / Disabled` depending on where you looked. "Disabled" matches the `agent.disabled` field, the "Enabled" switch that flips it, and the server's existing `All channels disabled` subtitle, so the wording lines up with the data model. The `Active channels` stat card and `ChannelStatsResponse.Active` already meant "enabled channels" and are unchanged — no server change in this PR.

**One badge style.** `StatusIndicator` now maps a semantic tone onto a badge variant, and every status in the app goes through it:

| Tone | Variant | Icon |
| --- | --- | --- |
| `positive` | success | — |
| `muted` | secondary | — |
| `info` | info | — |
| `loading` | secondary | spinning loader |
| `warning` | warning | triangle-alert |
| `danger` | destructive | circle-alert |

Icons appear only on tones that ask something of the operator, so an icon consistently means "this needs you" rather than decoration. The icons are `aria-hidden` because the badge label already names the state.

Call sites migrated onto it:

- Dashboard app status (`dashboard-apps-table.tsx`) — was a bare dot plus text, the only status in the app not rendered as a badge. It keeps its own Healthy / Needs attention / Setup / Failed vocabulary, which is a health axis derived server-side rather than an on/off state.
- Live CDC status and the CDC batch log rows. `pending` batches now actually show a spinner — the state carried a dead `iconClassName: "animate-spin"` that never rendered an icon.
- Embed link expiry/usage badges on the channel detail page.
- Certificate state badges, including dropping `disabled` from warning to muted so it matches a disabled channel or agent. The card's left accent strip went neutral with it.

The dashboard delta badge (`dashboard-stat-cards.tsx`) deliberately stays a plain `Badge` with no icon: it uses the destructive variant to mean "went down", not "needs attention", and the `+`/`-` sign already carries the direction. Its trend arrow was removed as decoration.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

UX consistency fix, closest to a bug fix — none of the four categories fit exactly.

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

Presentation-only. No API, data model or server changes; no behavioural logic touched.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

Verified each surface in Storybook (channel cards, app overview, channel detail, capability wizard channels step, dashboard home, certificates), asserting the rendered badge variant, label and icon per tone. `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test:unit` (131) and `pnpm test:storybook` (92) all pass, plus `dotnet build RavenDB.sln -c Release`.

No new tests were added — no test asserted the old strings, and these are presentation-only mappings. One gap worth flagging to reviewers: **no story exercises the CDC batch log**, so its `success` / `pending` / `error` rows are covered by typecheck and inspection rather than visual verification. Every tone they use is confirmed rendering correctly on other surfaces.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Visible label changes beyond the channel surfaces named in the issue, all in service of the single vocabulary and style:

- Certificates: the `Disabled` state badge moves from warning (amber, with icon) to muted (grey), and the card's accent strip follows.
- CDC batch log: `pending` rows gain the spinner they were always meant to have.
- Dashboard stat cards: the delta badge loses its trend arrow.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed

This PR is the UI work; it is scoped to Quill's web app and does not touch the Studio.
