### PR TITLE
RavenDB-27355 Adjust dialog for smaller resolutions

### DIFF
--- a/src/Raven.Quill.Web/src/components/shadcn/ui/alert-dialog.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/alert-dialog.tsx
@@ -37,7 +37,7 @@ function AlertDialogContent({ className, ...props }: React.ComponentProps<typeof
             <AlertDialogPrimitive.Content
                 data-slot="alert-dialog-content"
                 className={cn(
-                    "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+                    "fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
                     className,
                 )}
                 {...props}

--- a/src/Raven.Quill.Web/src/components/shadcn/ui/dialog.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/dialog.tsx
@@ -54,7 +54,7 @@ function DialogContent({
                 ref={setContainer}
                 data-slot="dialog-content"
                 className={cn(
-                    "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+                    "fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
                     className,
                 )}
                 {...props}

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
@@ -11,7 +11,6 @@ import type { CdcLiveBatch, CdcLiveBatchState } from "@/pages/apps/use-cdc-live-
 // The h-10 header button plus the 1px row separator, so an unmeasured collapsed row already
 // estimates to its real height and the total size barely moves once measuring catches up.
 const COLLAPSED_ROW_HEIGHT_IN_PX = 41;
-const LIST_HEIGHT_IN_PX = 420;
 const OVERSCAN = 12;
 // Slack around the bottom edge so a resting scroll position still counts as "at the latest".
 const AT_LATEST_THRESHOLD_IN_PX = 24;
@@ -116,7 +115,7 @@ function CdcBatchList({ batches }: { batches: CdcLiveBatch[] }) {
                 ref={scrollRef}
                 onScroll={handleScroll}
                 className="overflow-y-auto overscroll-contain"
-                style={{ height: LIST_HEIGHT_IN_PX }}
+                style={{ height: "clamp(10rem, 40dvh, 26rem)" }}
             >
                 <div ref={contentRef} className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
                     {virtualizer.getVirtualItems().map((virtualRow) => {

--- a/src/Raven.Quill.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
@@ -160,7 +160,7 @@ export function GenerateEmbedLinkDialog({
             hasUnsavedChanges={unsavedChanges.hasUnsavedChanges}
         >
             <DialogTrigger asChild>{trigger}</DialogTrigger>
-            <DialogContent className={cn("sm:max-w-md", result && "max-h-[90vh] overflow-y-auto sm:max-w-lg")}>
+            <DialogContent className={cn("sm:max-w-md", result && "sm:max-w-lg")}>
                 <DialogHeader>
                     <DialogTitle>Generate embed link</DialogTitle>
                     <DialogDescription>

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/edit-certificate-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/edit-certificate-dialog.tsx
@@ -65,7 +65,7 @@ export function EditCertificateDialog({
     return (
         <GuardedDialog open={isOpen} onOpenChange={setIsOpen}>
             <DialogTrigger asChild>{trigger}</DialogTrigger>
-            <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+            <DialogContent className="sm:max-w-lg">
                 <DialogHeader>
                     <DialogTitle>Edit certificate</DialogTitle>
                     <DialogDescription>

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/generate-certificate-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/generate-certificate-dialog.tsx
@@ -70,7 +70,7 @@ export function GenerateCertificateDialog({ apps, trigger }: { apps: AppResponse
     return (
         <GuardedDialog open={isOpen} onOpenChange={setIsOpen}>
             <DialogTrigger asChild>{trigger}</DialogTrigger>
-            <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+            <DialogContent className="sm:max-w-lg">
                 <DialogHeader>
                     <DialogTitle>Generate client certificate</DialogTitle>
                     <DialogDescription>


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27355/Quill-Dialog-is-cut-off-on-720p

### Additional description

720p:
<img width="665" height="757" alt="image" src="https://github.com/user-attachments/assets/164f3dbc-b448-4c27-96db-bfba9e324bad" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
