### PR TITLE
RavenDB-27368 Quill: render chart tooltips in place

### DIFF
--- a/src/Raven.Quill.Web/src/components/data/charts.stories.tsx
+++ b/src/Raven.Quill.Web/src/components/data/charts.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fireEvent, waitFor } from "storybook/test";
+import { WritesBarChart } from "./charts";
+
+const DATA = Array.from({ length: 12 }, (_, index) => ({
+    t: `2026-${String(index + 1).padStart(2, "0")}`,
+    writes: 100 + index * 25,
+}));
+
+// Tests, not catalogue entries: `!dev` keeps these out of the Storybook sidebar while
+// `pnpm test:storybook` still runs them. Play functions are the only way to exercise a
+// component here — the unit project runs in node with no DOM.
+const meta = {
+    title: "Data/Charts",
+    component: WritesBarChart,
+    tags: ["!dev"],
+    args: { data: DATA, xKey: "t" },
+} satisfies Meta<typeof WritesBarChart>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+function getChart(canvasElement: HTMLElement) {
+    const chart = canvasElement.querySelector<HTMLElement>(".recharts-wrapper");
+    if (!chart) throw new Error("chart did not render");
+    return chart;
+}
+
+function getTooltip(chart: HTMLElement) {
+    const tooltip = chart.querySelector<HTMLElement>(".recharts-tooltip-wrapper");
+    if (!tooltip) throw new Error("tooltip wrapper did not render");
+    return tooltip;
+}
+
+// Recharts positions the tooltip by transform, so the assertions below read the inline style
+// rather than a rendered offset. Step frames explicitly instead of using waitFor: the whole
+// point is what the tooltip looks like on the frame it appears, and waitFor's polling interval
+// is long enough to skip straight past it.
+async function pointAtAndWaitForTooltip(chart: HTMLElement, horizontalFraction: number) {
+    const tooltip = getTooltip(chart);
+    const box = chart.getBoundingClientRect();
+    const pointerOffset = box.width * horizontalFraction;
+
+    fireEvent.mouseMove(chart, { clientX: box.left + pointerOffset, clientY: box.top + box.height / 2 });
+
+    for (let frames = 0; frames < 10 && tooltip.style.visibility !== "visible"; frames++) {
+        await nextFrame();
+    }
+    expect(tooltip).toBeVisible();
+
+    return { tooltip, pointerOffset };
+}
+
+// React derives onMouseLeave from the native mouseout, so a dispatched mouseleave — which does
+// not bubble — never reaches recharts.
+function leave(chart: HTMLElement) {
+    fireEvent.mouseOut(chart, { relatedTarget: document.body });
+}
+
+function getTranslateX(tooltip: HTMLElement) {
+    const match = /translate\((-?[\d.]+)px/.exec(tooltip.style.transform);
+    if (!match?.[1]) throw new Error(`tooltip is not positioned by translate: "${tooltip.style.transform}"`);
+    return Number(match[1]);
+}
+
+export const TooltipAppearsAtThePointerWithoutSlidingIn: Story = {
+    play: async ({ canvasElement }) => {
+        const chart = await waitFor(() => getChart(canvasElement));
+        const { tooltip, pointerOffset } = await pointAtAndWaitForTooltip(chart, 0.3);
+
+        // No transition on the frame it appears, so it paints where it belongs instead of
+        // animating in from the chart origin. This is the regression the audit reported.
+        expect(tooltip.style.transition).toBe("");
+
+        // And where it belongs is next to the pointer. The coordinate snaps to the hovered
+        // bucket, hence the tolerance; the origin would be a whole pointerOffset away.
+        const appearedAt = getTranslateX(tooltip);
+        expect(Math.abs(appearedAt - pointerOffset)).toBeLessThan(80);
+
+        // Once it has appeared the transition comes back, so moving on glides rather than jumps.
+        await waitFor(() => expect(tooltip.style.transition).toContain("transform"));
+
+        // Settling must not shift it — the glide is for the next move, not for arriving.
+        expect(getTranslateX(tooltip)).toBe(appearedAt);
+    },
+};
+
+// Why the audit filed this globally: with several charts on a page you enter one after another,
+// and every entry replayed the slide-in.
+export const ReEnteringAChartDoesNotSlideIn: Story = {
+    play: async ({ canvasElement }) => {
+        const chart = await waitFor(() => getChart(canvasElement));
+
+        const first = await pointAtAndWaitForTooltip(chart, 0.3);
+        await waitFor(() => expect(first.tooltip.style.transition).toContain("transform"));
+
+        leave(chart);
+        await waitFor(() => expect(first.tooltip).not.toBeVisible());
+
+        const second = await pointAtAndWaitForTooltip(chart, 0.75);
+        expect(second.tooltip.style.transition).toBe("");
+        expect(Math.abs(getTranslateX(second.tooltip) - second.pointerOffset)).toBeLessThan(80);
+    },
+};

--- a/src/Raven.Quill.Web/src/components/shadcn/ui/chart.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/chart.tsx
@@ -229,7 +229,9 @@ function ChartTooltipContent({
                                         )}
                                         <div
                                             className={cn(
-                                                "flex flex-1 justify-between leading-none",
+                                                // gap-3 so a long series name keeps clear of the value
+                                                // instead of running into it under justify-between.
+                                                "flex flex-1 justify-between gap-3 leading-none",
                                                 nestLabel ? "items-end" : "items-center",
                                             )}
                                         >

--- a/src/Raven.Quill.Web/src/components/shadcn/ui/chart.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/chart.tsx
@@ -101,7 +101,28 @@ ${colorConfig
     );
 };
 
-const ChartTooltip = RechartsPrimitive.Tooltip;
+// Recharts positions the tooltip wrapper with a transform and transitions that transform while the
+// tooltip is active. On the frame the tooltip appears there is no position to move from, so the
+// transition animates it in from the chart origin instead of leaving it under the cursor. Suppress
+// the transition for that one frame, which keeps the glide as the pointer then moves along.
+function ChartTooltip({ isAnimationActive, ...props }: React.ComponentProps<typeof RechartsPrimitive.Tooltip>) {
+    const isActive = RechartsPrimitive.useIsTooltipActive();
+    const [hasAppeared, setHasAppeared] = React.useState(false);
+
+    React.useEffect(() => {
+        if (!isActive) {
+            return;
+        }
+
+        const frame = requestAnimationFrame(() => setHasAppeared(true));
+        return () => {
+            cancelAnimationFrame(frame);
+            setHasAppeared(false);
+        };
+    }, [isActive]);
+
+    return <RechartsPrimitive.Tooltip isAnimationActive={isAnimationActive ?? hasAppeared} {...props} />;
+}
 
 function ChartTooltipContent({
     active,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27368

### Additional description

Part of the Quill beta UX audit (RavenDB-27256).

**Tooltips flew in from the chart origin.** Recharts positions the tooltip wrapper purely by `transform: translate(x, y)` and, whenever the tooltip is active, applies `transition: transform 400ms ease` — `isAnimationActive` defaults to `"auto"` in recharts 3.9. The wrapper element already exists at `translate(0, 0)` while hidden, so on activation the new transform and the transition landed in the same frame and the browser animated the tooltip across the chart rather than drawing it under the pointer. Every chart replayed this on every entry, which is why it read so badly on pages with several charts.

`ChartTooltip` was a bare re-export of `RechartsPrimitive.Tooltip`, so there was no single place to correct this. It is now a thin wrapper that suppresses the transition for the one frame the tooltip appears and restores it immediately after — the tooltip paints at the pointer, and still glides as the pointer moves along. It keys off recharts' chart-local `useIsTooltipActive()` rather than tracking pointer state, so each chart resets independently, and callers can still pass `isAnimationActive` explicitly to override.

All four tooltip call sites (`components/data/charts.tsx`, `pages/dashboard/dashboard-stat-cards.tsx`) already route through `ChartTooltip`, and nothing uses recharts' `Tooltip` directly, so the single change covers every chart.

**Second commit:** the tooltip's name/value row was `justify-between` with no gap, so a series name long enough to fill the row ran straight into its value with no separation.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

Presentation only, scoped to the shared chart tooltip. No data, query or API surface is touched.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

`charts.stories.tsx` adds two play-function tests covering the appearance frame and re-entry into a chart. They step animation frames explicitly rather than using `waitFor`, whose polling interval is long enough to skip straight past the frame under test.

Frame by frame, the wrapper now reads:

```
frame +1: visible  transition=""                transform="translate(360px, 122px)"
frame +3: visible  transition="transform 400ms" transform="translate(360px, 122px)"
```

It appears at the pointer with no transition, then the glide returns without shifting it.

Both tests were confirmed to fail against the previous implementation with `expected 'transform 400ms' to be ''`, so they pin the actual regression rather than passing vacuously. Full suite green: 78 Storybook tests, 29 unit tests, plus typecheck, eslint and prettier.

Not verified by manual browser testing — the fix depends on `requestAnimationFrame`, which does not fire in a backgrounded preview, so it was verified in the Storybook Vitest project running real headless Chrome instead.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Every Quill chart tooltip is affected, by design — the Usage and per-app CDC writes charts, the App Usage breakdowns, and the dashboard stat card sparklines. In each case the tooltip now appears under the pointer instead of sliding in, and the movement animation is unchanged.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed

This is Quill's own web UI (`src/Raven.Quill.Web`), not the RavenDB Studio.
