### PR TITLE
RavenDB-27224: resolve the appliance's own hostname to loopback so Qu…

### DIFF
--- a/docker/quill/Dockerfile.source
+++ b/docker/quill/Dockerfile.source
@@ -7,8 +7,6 @@ ARG STUDIO_NODE_MAJOR=24
 ARG PNPM_VERSION=11.2.2
 ARG S6_OVERLAY_VERSION=3.2.1.0
 
-
-# Stage 0: build Raven.Server from source.
 FROM ${SDK_IMAGE} AS ravendb-server-build
 ARG TARGETARCH
 WORKDIR /src
@@ -17,6 +15,12 @@ COPY . .
 RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked \
     . docker/quill/scripts/dotnet-rid.sh \
     && dotnet publish src/Raven.Server/Raven.Server.csproj \
+        -c Release \
+        -r "$DOTNET_RID" \
+        --self-contained false \
+        -o /publish/raven \
+        --nologo \
+    && dotnet publish tools/rvn/rvn.csproj \
         -c Release \
         -r "$DOTNET_RID" \
         --self-contained false \

--- a/docker/quill/s6-rc.d/01-ravendb/run
+++ b/docker/quill/s6-rc.d/01-ravendb/run
@@ -10,12 +10,6 @@ mkdir -p /var/lib/quill/ravendb
 # RavenDB starts unsecured on loopback (Setup.Mode=Unsecured from
 # docker/quill/ravendb-settings.json).
 #
-# The hostname in PublicServerUrl (e.g. https://a.<slug>.myquill.ai, where
-# <slug> is the tenant slug assigned by the Quill sign-up flow and baked into
-# the setup package at activation) already resolves to 127.0.0.1 via public
-# DNS — *.<slug>.myquill.ai has wildcard A records pointing at loopback for
-# exactly this purpose — so no /etc/hosts hack is needed inside the container.
-#
 # The admin client cert's thumbprint is written by the .NET activation endpoint
 # next to the unpacked package as the file `admin-thumbprint`. Reading it here
 # rather than extracting from the PFX with openssl avoids PKCS#12 bag-ordering
@@ -31,6 +25,11 @@ if [ -f "$SETUP_SETTINGS" ]; then
     # to RavenDB on this port (RavenStoreFactory.RavenInternalPort); nginx passes db.*/a.* through to it.
     RAVENDB_PORT="${RAVEN_QUILL_RAVENDB_INTERNAL_PORT:-8443}"
     sed -i -E "s#(\"ServerUrl\"[[:space:]]*:[[:space:]]*\")https://[^\"]*(\")#\1https://127.0.0.1:${RAVENDB_PORT}\2#" /app/ravendb/settings.json
+
+    NODE_HOST="$(jq -r '.PublicServerUrl' "$SETUP_SETTINGS" | sed -E 's#^https?://##; s#[:/].*##')"
+    if [ -n "$NODE_HOST" ]; then
+        grep -q "[[:space:]]$NODE_HOST\$" /etc/hosts || echo "127.0.0.1 $NODE_HOST" >> /etc/hosts
+    fi
 
     CERT_DIR=/var/lib/quill/certs
     mkdir -p "$CERT_DIR"

--- a/docker/quill/scripts/update-dns.sh
+++ b/docker/quill/scripts/update-dns.sh
@@ -7,7 +7,8 @@ DOMAIN=$(openssl pkcs12 -in "$SETUP"/A/cluster.server.certificate.*.pfx -nokeys 
        | openssl x509 -noout -ext subjectAltName \
        | sed -nE 's|^ *DNS:\*\.||p')
 
-# TODO decide weather we should include 'a' in the $IP args or it should be fixed 127.0.0.1 so it will never leave the contianer. 
+# 'a' is included: every record points at the operator's IP, and the container resolves its own
+# hostname to loopback via /etc/hosts (01-ravendb/run) rather than relying on DNS to do it.
 exec /app/ravendb/rvn dns update -l "$SETUP/license.json" -d "$DOMAIN" \
-    -n "$IP=dashboard,db,public,api"
+    -n "$IP=a,dashboard,db,public,api"
 


### PR DESCRIPTION
…ill's calls to RavenDB stay inside the container

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27224

### Additional description

Quill web and RavenDB run in the same container and should talk over loopback. They didn't: `RavenStoreFactory` connects to `a.<domain>:8443`, and public DNS points that name at the operator's IP - so the call left the container, and once ravendb only listens on 127.0.0.1:8443 it failed outright.

`01-ravendb/run` now resolves the node's own hostname to `127.0.0.1` in the container's `/etc/hosts` before ravendb starts. public DNS keeps real IPs, so only the container short-circuits its own name.

`update-dns `now includes a in its list, answering the TODO that sat there: every record tracks the operator's IP, since the container no longer relies on DNS for itself. `Dockerfile.source `also publishes rvn, without which update-dns could never run.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

**see comment below**

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
