### PR TITLE
RavenDB-23704: port PRs #20178 and #20266 to v8.0

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -66,7 +66,9 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 IsCloned = lowLevelTransaction.IsCloned,
                 NumberOfModifiedPages = lowLevelTransaction.NumberOfModifiedPages,
                 Committed = lowLevelTransaction.Committed,
+                TotalAllocatedSize = new Size(lowLevelTransaction.TotalAllocatedInBytes, SizeUnit.Bytes).ToString(),
                 DecompressedBufferSize = new Size(lowLevelTransaction.DecompressedBufferBytes, SizeUnit.Bytes).ToString(),
+                TotalEncryptionBufferSize = new Size(lowLevelTransaction.TotalEncryptionBufferInBytes, SizeUnit.Bytes).ToString(),
                 IsDisposed = lowLevelTransaction.IsDisposed,
             };
         }
@@ -107,7 +109,9 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(TxInfoResult.IsCloned)] = txInfo.IsCloned,
                 [nameof(TxInfoResult.NumberOfModifiedPages)] = txInfo.NumberOfModifiedPages,
                 [nameof(TxInfoResult.Committed)] = txInfo.Committed,
+                [nameof(TxInfoResult.TotalAllocatedSize)] = txInfo.TotalAllocatedSize,
                 [nameof(TxInfoResult.DecompressedBufferSize)] = txInfo.DecompressedBufferSize,
+                [nameof(TxInfoResult.TotalEncryptionBufferSize)] = txInfo.TotalEncryptionBufferSize,
                 [nameof(TxInfoResult.IsDisposed)] = txInfo.IsDisposed,
             };
         }
@@ -126,7 +130,9 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public bool IsCloned;
         public long NumberOfModifiedPages;
         public bool Committed;
+        public string TotalAllocatedSize;
         public string DecompressedBufferSize;
+        public string TotalEncryptionBufferSize;
         public bool IsDisposed;
     }
 }

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -118,13 +118,15 @@ namespace Voron.Impl
 
         public Size TransactionSize => new Size(NumberOfModifiedPages * Constants.Storage.PageSize, SizeUnit.Bytes) + AdditionalMemoryUsageSize;
 
+        public long TotalAllocatedInBytes => _allocator._totalAllocated;
+
+        public long TotalEncryptionBufferInBytes => PagerTransactionState.AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes);
+
         public Size AdditionalMemoryUsageSize
         {
             get
             {
-                var additionalMemoryUsageSize = PagerTransactionState.AdditionalMemoryUsageSize;
-                additionalMemoryUsageSize.Add(DecompressedBufferBytes, SizeUnit.Bytes);
-                return additionalMemoryUsageSize;
+                return new Size(DecompressedBufferBytes + TotalEncryptionBufferInBytes, SizeUnit.Bytes);
             }
         }
         public event Action<LowLevelTransaction> OnDispose;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23704/Unmanaged-memory-growing-up-to-OOM-during-backup

### Additional description

This PR ports previous PRs into `v8.0` branch.
PR 1) https://github.com/ravendb/ravendb/pull/20178
PR 2) https://github.com/ravendb/ravendb/pull/20266

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
