### PR TITLE
RavenDB-25626 Patch button stuck in studio

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/query/queryCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/query/queryCommand.ts
@@ -122,9 +122,14 @@ var f = function() {
 }
 f();
 `;
-        const parameters = eval(parametersJs);
-        const rql = queryText.substring(match.index);
-        return [JSON.parse(parameters), rql];
+        try {
+            const parameters = eval(parametersJs);
+            const rql = queryText.substring(match.index);
+            return [JSON.parse(parameters), rql];
+        } catch (e) {
+            // the text before the query isn't a valid parameters section - send the raw text so the server reports the syntax error
+            return [undefined, queryText];
+        }
     }
 
     getPayload() {

--- a/src/Raven.Studio/typescript/viewmodels/database/patch/patch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/patch/patch.ts
@@ -317,10 +317,8 @@ class patch extends shardViewModelBase {
             this.spinners.countMatchingDocuments(true);
             
             this.getMatchingDocumentsNumber()
-                .done((matchingDocs: number) => {
-                    this.spinners.countMatchingDocuments(false);
-                    this.executePatch(matchingDocs);
-                });
+                .done((matchingDocs: number) => this.executePatch(matchingDocs))
+                .always(() => this.spinners.countMatchingDocuments(false));
         }
     }
 
@@ -413,7 +411,7 @@ class patch extends shardViewModelBase {
                 })
                 .execute()
                 .done((queryResults: pagedResultExtended<document>) => matchingDocs.resolve(queryResults.totalResultCount))
-                .fail(() => matchingDocs.resolve(-1))
+                .fail(() => matchingDocs.reject())
         } else {
             matchingDocs.resolve(-1);
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25626

### Additional description
Fix patch view stuck on counting matching documents when query prefix is not a valid parameters section

extractQueryParameters eval'd the text before the first from/match/with/declare clause as JS parameter declarations; invalid text (e.g. "run patch") threw a synchronous SyntaxError that escaped runPatch and left the spinner on forever. Fall back to sending the raw query so the server reports the syntax error, and skip the patch confirmation dialog when the count query fails.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
