### PR TITLE
RavenDB-27365 Quill license changes

### DIFF
--- a/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
+++ b/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
@@ -47,15 +47,38 @@ namespace Raven.Server.Commercial.WriteUsageMetering
         }
     }
 
+    public sealed class SystemCollectionsSnapshot
+    {
+        public SystemCollectionsSnapshot(string databaseId, Dictionary<string, SystemCollectionStats> systemCollections)
+        {
+            DatabaseId = databaseId;
+            SystemCollections = systemCollections;
+        }
+
+        public string DatabaseId { get; }
+
+        public Dictionary<string, SystemCollectionStats> SystemCollections { get; }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(DatabaseId)] = DatabaseId,
+                [nameof(SystemCollections)] = DynamicJsonValue.Convert(SystemCollections)
+            };
+        }
+    }
+
     public sealed class WriteUsageApplicationSnapshot
     {
-        public WriteUsageApplicationSnapshot(string applicationName, string topologyId, string changeVector, IReadOnlyList<LastEtagSnapshot> nodes, Dictionary<string, SystemCollectionStats> systemCollections)
+        public WriteUsageApplicationSnapshot(string applicationName, string topologyId, string changeVector, IReadOnlyList<LastEtagSnapshot> nodes,
+            IReadOnlyList<SystemCollectionsSnapshot> systemCollectionsList)
         {
             ApplicationName = applicationName;
             TopologyId = topologyId;
             ChangeVector = changeVector;
             Nodes = nodes;
-            SystemCollections = systemCollections;
+            SystemCollectionsList = systemCollectionsList;
         }
 
         public string ApplicationName { get; }
@@ -71,10 +94,11 @@ namespace Raven.Server.Commercial.WriteUsageMetering
         public IReadOnlyList<LastEtagSnapshot> Nodes { get; }
 
         /// <summary>
-        /// Last etag and document count per system ('@'-prefixed) collection, merged over the members
-        /// of the database group.
+        /// One entry per member of the database group, pairing the member's database id with the last etag
+        /// and document count of each of its system ('@'-prefixed) collections. Reported unmerged - the
+        /// backend receives every member's own values and aggregates them itself.
         /// </summary>
-        public Dictionary<string, SystemCollectionStats> SystemCollections { get; }
+        public IReadOnlyList<SystemCollectionsSnapshot> SystemCollectionsList { get; }
 
         public DynamicJsonValue ToJson()
         {
@@ -84,7 +108,7 @@ namespace Raven.Server.Commercial.WriteUsageMetering
                 [nameof(TopologyId)] = TopologyId,
                 [nameof(ChangeVector)] = ChangeVector,
                 [nameof(Nodes)] = new DynamicJsonArray(Nodes.Select(n => n.ToJson())),
-                [nameof(SystemCollections)] = DynamicJsonValue.Convert(SystemCollections)
+                [nameof(SystemCollectionsList)] = new DynamicJsonArray(SystemCollectionsList.Select(s => s.ToJson()))
             };
         }
     }

--- a/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
+++ b/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
@@ -32,14 +32,30 @@ namespace Raven.Server.Commercial.WriteUsageMetering
         }
     }
 
+    public sealed class SystemCollectionStats : IDynamicJson
+    {
+        public long Etag;
+        public long Count;
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Etag)] = Etag,
+                [nameof(Count)] = Count
+            };
+        }
+    }
+
     public sealed class WriteUsageApplicationSnapshot
     {
-        public WriteUsageApplicationSnapshot(string applicationName, string topologyId, string changeVector, IReadOnlyList<LastEtagSnapshot> nodes)
+        public WriteUsageApplicationSnapshot(string applicationName, string topologyId, string changeVector, IReadOnlyList<LastEtagSnapshot> nodes, Dictionary<string, SystemCollectionStats> systemCollections)
         {
             ApplicationName = applicationName;
             TopologyId = topologyId;
             ChangeVector = changeVector;
             Nodes = nodes;
+            SystemCollections = systemCollections;
         }
 
         public string ApplicationName { get; }
@@ -54,6 +70,12 @@ namespace Raven.Server.Commercial.WriteUsageMetering
         /// </summary>
         public IReadOnlyList<LastEtagSnapshot> Nodes { get; }
 
+        /// <summary>
+        /// Last etag and document count per system ('@'-prefixed) collection, merged over the members
+        /// of the database group.
+        /// </summary>
+        public Dictionary<string, SystemCollectionStats> SystemCollections { get; }
+
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
@@ -61,7 +83,8 @@ namespace Raven.Server.Commercial.WriteUsageMetering
                 [nameof(ApplicationName)] = ApplicationName,
                 [nameof(TopologyId)] = TopologyId,
                 [nameof(ChangeVector)] = ChangeVector,
-                [nameof(Nodes)] = new DynamicJsonArray(Nodes.Select(n => n.ToJson()))
+                [nameof(Nodes)] = new DynamicJsonArray(Nodes.Select(n => n.ToJson())),
+                [nameof(SystemCollections)] = DynamicJsonValue.Convert(SystemCollections)
             };
         }
     }

--- a/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
+++ b/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
@@ -23,9 +23,6 @@ namespace Raven.Server.Commercial.WriteUsageMetering
 
         public long LastEtag { get; }
 
-        /// <summary>
-        /// Document count per system ('@'-prefixed) collection of this member.
-        /// </summary>
         public Dictionary<string, long> SystemCollections { get; }
 
         public DynamicJsonValue ToJson()
@@ -55,13 +52,6 @@ namespace Raven.Server.Commercial.WriteUsageMetering
 
         public string ChangeVector { get; }
 
-        /// <summary>
-        /// One entry per member of the database group, pairing the member's database id with its last etag
-        /// and the document count of each of its system ('@'-prefixed) collections. Reported unmerged - the
-        /// backend receives every member's own values and aggregates them itself. Members that haven't
-        /// reported yet, or that report without a database id (unloaded, faulted, or a sharded orchestrator),
-        /// are not included.
-        /// </summary>
         public IReadOnlyList<WriteUsageNodeSnapshot> Nodes { get; }
 
         public DynamicJsonValue ToJson()

--- a/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
+++ b/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
@@ -10,13 +10,36 @@ namespace Raven.Server.Commercial.WriteUsageMetering
         public const string UsageEndpointPath = "/api/v1/quill/usage";
     }
 
+    public sealed class LastEtagSnapshot
+    {
+        public LastEtagSnapshot(string databaseId, long lastEtag)
+        {
+            DatabaseId = databaseId;
+            LastEtag = lastEtag;
+        }
+
+        public string DatabaseId { get; }
+
+        public long LastEtag { get; }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(DatabaseId)] = DatabaseId,
+                [nameof(LastEtag)] = LastEtag
+            };
+        }
+    }
+
     public sealed class WriteUsageApplicationSnapshot
     {
-        public WriteUsageApplicationSnapshot(string applicationName, string topologyId, string changeVector)
+        public WriteUsageApplicationSnapshot(string applicationName, string topologyId, string changeVector, IReadOnlyList<LastEtagSnapshot> nodes)
         {
             ApplicationName = applicationName;
             TopologyId = topologyId;
             ChangeVector = changeVector;
+            Nodes = nodes;
         }
 
         public string ApplicationName { get; }
@@ -25,13 +48,20 @@ namespace Raven.Server.Commercial.WriteUsageMetering
 
         public string ChangeVector { get; }
 
+        /// <summary>
+        /// One entry per member of the database group. Members that haven't reported yet, or that report
+        /// without a database id (unloaded, faulted, or a sharded orchestrator), are not included.
+        /// </summary>
+        public IReadOnlyList<LastEtagSnapshot> Nodes { get; }
+
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
                 [nameof(ApplicationName)] = ApplicationName,
                 [nameof(TopologyId)] = TopologyId,
-                [nameof(ChangeVector)] = ChangeVector
+                [nameof(ChangeVector)] = ChangeVector,
+                [nameof(Nodes)] = new DynamicJsonArray(Nodes.Select(n => n.ToJson()))
             };
         }
     }

--- a/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
+++ b/src/Raven.Server/Commercial/WriteUsageMetering/WriteUsageReport.cs
@@ -10,60 +10,30 @@ namespace Raven.Server.Commercial.WriteUsageMetering
         public const string UsageEndpointPath = "/api/v1/quill/usage";
     }
 
-    public sealed class LastEtagSnapshot
+    public sealed class WriteUsageNodeSnapshot
     {
-        public LastEtagSnapshot(string databaseId, long lastEtag)
+        public WriteUsageNodeSnapshot(string databaseId, long lastEtag, Dictionary<string, long> systemCollections)
         {
             DatabaseId = databaseId;
             LastEtag = lastEtag;
+            SystemCollections = systemCollections;
         }
 
         public string DatabaseId { get; }
 
         public long LastEtag { get; }
 
-        public DynamicJsonValue ToJson()
-        {
-            return new DynamicJsonValue
-            {
-                [nameof(DatabaseId)] = DatabaseId,
-                [nameof(LastEtag)] = LastEtag
-            };
-        }
-    }
-
-    public sealed class SystemCollectionStats : IDynamicJson
-    {
-        public long Etag;
-        public long Count;
-
-        public DynamicJsonValue ToJson()
-        {
-            return new DynamicJsonValue
-            {
-                [nameof(Etag)] = Etag,
-                [nameof(Count)] = Count
-            };
-        }
-    }
-
-    public sealed class SystemCollectionsSnapshot
-    {
-        public SystemCollectionsSnapshot(string databaseId, Dictionary<string, SystemCollectionStats> systemCollections)
-        {
-            DatabaseId = databaseId;
-            SystemCollections = systemCollections;
-        }
-
-        public string DatabaseId { get; }
-
-        public Dictionary<string, SystemCollectionStats> SystemCollections { get; }
+        /// <summary>
+        /// Document count per system ('@'-prefixed) collection of this member.
+        /// </summary>
+        public Dictionary<string, long> SystemCollections { get; }
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
                 [nameof(DatabaseId)] = DatabaseId,
+                [nameof(LastEtag)] = LastEtag,
                 [nameof(SystemCollections)] = DynamicJsonValue.Convert(SystemCollections)
             };
         }
@@ -71,14 +41,12 @@ namespace Raven.Server.Commercial.WriteUsageMetering
 
     public sealed class WriteUsageApplicationSnapshot
     {
-        public WriteUsageApplicationSnapshot(string applicationName, string topologyId, string changeVector, IReadOnlyList<LastEtagSnapshot> nodes,
-            IReadOnlyList<SystemCollectionsSnapshot> systemCollectionsList)
+        public WriteUsageApplicationSnapshot(string applicationName, string topologyId, string changeVector, IReadOnlyList<WriteUsageNodeSnapshot> nodes)
         {
             ApplicationName = applicationName;
             TopologyId = topologyId;
             ChangeVector = changeVector;
             Nodes = nodes;
-            SystemCollectionsList = systemCollectionsList;
         }
 
         public string ApplicationName { get; }
@@ -88,17 +56,13 @@ namespace Raven.Server.Commercial.WriteUsageMetering
         public string ChangeVector { get; }
 
         /// <summary>
-        /// One entry per member of the database group. Members that haven't reported yet, or that report
-        /// without a database id (unloaded, faulted, or a sharded orchestrator), are not included.
+        /// One entry per member of the database group, pairing the member's database id with its last etag
+        /// and the document count of each of its system ('@'-prefixed) collections. Reported unmerged - the
+        /// backend receives every member's own values and aggregates them itself. Members that haven't
+        /// reported yet, or that report without a database id (unloaded, faulted, or a sharded orchestrator),
+        /// are not included.
         /// </summary>
-        public IReadOnlyList<LastEtagSnapshot> Nodes { get; }
-
-        /// <summary>
-        /// One entry per member of the database group, pairing the member's database id with the last etag
-        /// and document count of each of its system ('@'-prefixed) collections. Reported unmerged - the
-        /// backend receives every member's own values and aggregates them itself.
-        /// </summary>
-        public IReadOnlyList<SystemCollectionsSnapshot> SystemCollectionsList { get; }
+        public IReadOnlyList<WriteUsageNodeSnapshot> Nodes { get; }
 
         public DynamicJsonValue ToJson()
         {
@@ -107,8 +71,7 @@ namespace Raven.Server.Commercial.WriteUsageMetering
                 [nameof(ApplicationName)] = ApplicationName,
                 [nameof(TopologyId)] = TopologyId,
                 [nameof(ChangeVector)] = ChangeVector,
-                [nameof(Nodes)] = new DynamicJsonArray(Nodes.Select(n => n.ToJson())),
-                [nameof(SystemCollectionsList)] = new DynamicJsonArray(SystemCollectionsList.Select(s => s.ToJson()))
+                [nameof(Nodes)] = new DynamicJsonArray(Nodes.Select(n => n.ToJson()))
             };
         }
     }

--- a/src/Raven.Server/Documents/CollectionName.cs
+++ b/src/Raven.Server/Documents/CollectionName.cs
@@ -150,6 +150,11 @@ namespace Raven.Server.Documents
             return string.Equals(name, HiLoCollection, StringComparison.OrdinalIgnoreCase);
         }
 
+        public static bool IsEmptyCollection(string name)
+        {
+            return string.Equals(name, Constants.Documents.Collections.EmptyCollection, StringComparison.OrdinalIgnoreCase);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool IsHiLoCollection(LazyStringValue name)
         {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -257,6 +257,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         }
 
                         report.Status = DatabaseStatus.Loaded;
+                        report.DatabaseId = dbInstance.DbBase64Id;
                         var now = dbInstance.Time.GetUtcNow();
                         try
                         {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -412,7 +412,8 @@ namespace Raven.Server.ServerWide.Maintenance
             }
         }
 
-        // Last etag and document count for every system collection of this database.
+        // Last etag and document count for every '@'-prefixed collection of this database, except '@hilo'.
+        // Nothing else is filtered out beyond the prefix - '@empty' included - so the backend sees everything and decides.
         private static Dictionary<string, SystemCollectionStats> GetSystemCollectionsStats(DocumentsTransaction tx, DocumentsOperationContext context,
             DocumentsStorage documentsStorage)
         {
@@ -420,8 +421,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
             foreach (var collection in documentsStorage.GetCollectionsNames(context))
             {
-                if (collection.StartsWith('@') == false ||
-                    collection.Equals(Constants.Documents.Collections.EmptyCollection, StringComparison.OrdinalIgnoreCase))
+                if (collection.StartsWith('@') == false || CollectionName.IsHiLoCollection(collection))
                     continue;
 
                 stats[collection] = new SystemCollectionStats

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -411,15 +411,15 @@ namespace Raven.Server.ServerWide.Maintenance
             }
         }
 
-        // Document count for every '@'-prefixed collection of this database, except '@hilo'.
-        // Nothing else is filtered out beyond the prefix - '@empty' included - so the backend sees everything and decides.
         private static Dictionary<string, long> GetSystemCollectionsStats(DocumentsOperationContext context, DocumentsStorage documentsStorage)
         {
             var stats = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var collection in documentsStorage.GetCollectionsNames(context))
             {
-                if (collection.StartsWith('@') == false || CollectionName.IsHiLoCollection(collection))
+                if (collection.StartsWith('@') == false ||
+                    CollectionName.IsHiLoCollection(collection) ||
+                    CollectionName.IsEmptyCollection(collection))
                     continue;
 
                 stats[collection] = documentsStorage.GetNumberOfDocumentsFor(collection, context);

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -6,7 +6,6 @@ using Raven.Client;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
-using Raven.Server.Commercial.WriteUsageMetering;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Sharding;
@@ -407,28 +406,23 @@ namespace Raven.Server.ServerWide.Maintenance
                     report.NumberOfConflicts = documentsStorage.ConflictsStorage.ConflictsCount;
                     report.NumberOfDocuments = documentsStorage.GetNumberOfDocuments(context);
                     report.DatabaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
-                    report.SystemCollections = GetSystemCollectionsStats(tx, context, documentsStorage);
+                    report.SystemCollections = GetSystemCollectionsStats(context, documentsStorage);
                 }
             }
         }
 
-        // Last etag and document count for every '@'-prefixed collection of this database, except '@hilo'.
+        // Document count for every '@'-prefixed collection of this database, except '@hilo'.
         // Nothing else is filtered out beyond the prefix - '@empty' included - so the backend sees everything and decides.
-        private static Dictionary<string, SystemCollectionStats> GetSystemCollectionsStats(DocumentsTransaction tx, DocumentsOperationContext context,
-            DocumentsStorage documentsStorage)
+        private static Dictionary<string, long> GetSystemCollectionsStats(DocumentsOperationContext context, DocumentsStorage documentsStorage)
         {
-            var stats = new Dictionary<string, SystemCollectionStats>(StringComparer.OrdinalIgnoreCase);
+            var stats = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var collection in documentsStorage.GetCollectionsNames(context))
             {
                 if (collection.StartsWith('@') == false || CollectionName.IsHiLoCollection(collection))
                     continue;
 
-                stats[collection] = new SystemCollectionStats
-                {
-                    Etag = documentsStorage.GetLastDocumentEtag(tx.InnerTransaction, collection),
-                    Count = documentsStorage.GetNumberOfDocumentsFor(collection, context)
-                };
+                stats[collection] = documentsStorage.GetNumberOfDocumentsFor(collection, context);
             }
 
             return stats;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -6,6 +6,7 @@ using Raven.Client;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
+using Raven.Server.Commercial.WriteUsageMetering;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Sharding;
@@ -395,6 +396,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 report.NumberOfConflicts = prevDatabaseReport.NumberOfConflicts;
                 report.NumberOfDocuments = prevDatabaseReport.NumberOfDocuments;
                 report.DatabaseChangeVector = prevDatabaseReport.DatabaseChangeVector;
+                report.SystemCollections = prevDatabaseReport.SystemCollections;
             }
             else
             {
@@ -405,8 +407,31 @@ namespace Raven.Server.ServerWide.Maintenance
                     report.NumberOfConflicts = documentsStorage.ConflictsStorage.ConflictsCount;
                     report.NumberOfDocuments = documentsStorage.GetNumberOfDocuments(context);
                     report.DatabaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
+                    report.SystemCollections = GetSystemCollectionsStats(tx, context, documentsStorage);
                 }
             }
+        }
+
+        // Last etag and document count for every system collection of this database.
+        private static Dictionary<string, SystemCollectionStats> GetSystemCollectionsStats(DocumentsTransaction tx, DocumentsOperationContext context,
+            DocumentsStorage documentsStorage)
+        {
+            var stats = new Dictionary<string, SystemCollectionStats>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var collection in documentsStorage.GetCollectionsNames(context))
+            {
+                if (collection.StartsWith('@') == false ||
+                    collection.Equals(Constants.Documents.Collections.EmptyCollection, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                stats[collection] = new SystemCollectionStats
+                {
+                    Etag = documentsStorage.GetLastDocumentEtag(tx.InnerTransaction, collection),
+                    Count = documentsStorage.GetNumberOfDocumentsFor(collection, context)
+                };
+            }
+
+            return stats;
         }
 
         private static void FillReplicationInfo(DocumentDatabase dbInstance, DatabaseStatusReport report)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Commercial.WriteUsageMetering;
 using Raven.Server.ServerWide.Maintenance.Sharding;
 using Sparrow;
 using Sparrow.Json.Parsing;
@@ -68,6 +69,8 @@ namespace Raven.Server.ServerWide.Maintenance
         public Dictionary<string, ObservedIndexStatus> LastIndexStats = new();
         public Dictionary<string, long> LastSentEtag = new();
         public Dictionary<int, BucketReport> ReportPerBucket = new();
+
+        public Dictionary<string, SystemCollectionStats> SystemCollections = new();
         public Dictionary<long, PeriodicBackupStatusReport> BackupStatuses;
 
         public long LastCompareExchangeIndex { get; set; }
@@ -94,6 +97,7 @@ namespace Raven.Server.ServerWide.Maintenance
             LastIndexStats = other.LastIndexStats;
             LastSentEtag = other.LastSentEtag;
             ReportPerBucket = other.ReportPerBucket;
+            SystemCollections = other.SystemCollections;
             BackupStatuses = other.BackupStatuses;
 
             LastCompareExchangeIndex = other.LastCompareExchangeIndex;
@@ -169,6 +173,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 [nameof(LastCompletedClusterTransaction)] = LastCompletedClusterTransaction,
                 [nameof(LastSentEtag)] = DynamicJsonValue.Convert(LastSentEtag),
                 [nameof(ReportPerBucket)] = DynamicJsonValue.Convert(ReportPerBucket),
+                [nameof(SystemCollections)] = DynamicJsonValue.Convert(SystemCollections),
                 [nameof(Error)] = Error,
                 [nameof(UpTime)] = UpTime,
                 [nameof(LastCompareExchangeIndex)] = LastCompareExchangeIndex,

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Indexes;
-using Raven.Server.Commercial.WriteUsageMetering;
 using Raven.Server.ServerWide.Maintenance.Sharding;
 using Sparrow;
 using Sparrow.Json.Parsing;
@@ -70,7 +69,7 @@ namespace Raven.Server.ServerWide.Maintenance
         public Dictionary<string, long> LastSentEtag = new();
         public Dictionary<int, BucketReport> ReportPerBucket = new();
 
-        public Dictionary<string, SystemCollectionStats> SystemCollections = new();
+        public Dictionary<string, long> SystemCollections = new();
         public Dictionary<long, PeriodicBackupStatusReport> BackupStatuses;
 
         public long LastCompareExchangeIndex { get; set; }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -62,6 +62,7 @@ namespace Raven.Server.ServerWide.Maintenance
         public string Name;
         public string NodeName;
 
+        public string DatabaseId;
         public string DatabaseChangeVector;
 
         public Dictionary<string, ObservedIndexStatus> LastIndexStats = new();
@@ -86,6 +87,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
             Name = other.Name;
             NodeName = other.NodeName;
+            DatabaseId = other.DatabaseId;
             DatabaseChangeVector = other.DatabaseChangeVector;
 
             // shallow
@@ -157,6 +159,7 @@ namespace Raven.Server.ServerWide.Maintenance
             {
                 [nameof(Name)] = Name,
                 [nameof(NodeName)] = NodeName,
+                [nameof(DatabaseId)] = DatabaseId,
                 [nameof(Status)] = Status,
                 [nameof(LastEtag)] = LastEtag,
                 [nameof(LastTombstoneEtag)] = LastTombstoneEtag,

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -249,10 +249,12 @@ namespace Raven.Server.ServerWide.Maintenance
                             var state = new DatabaseObservationState(topology.Name, rawRecord, topology.Topology, clusterTopology, newStats, prevStats, etag, _iteration);
 
                             // Collect the current write-usage values for this topology (database or shard):
-                            // the MEMBER change vectors merged into a single cluster-wide change vector, plus
-                            // each member's own (database id, last etag) kept unmerged for per-node metering.
+                            // the MEMBER change vectors merged into a single cluster-wide change vector, each
+                            // member's own (database id, last etag) kept unmerged for per-node metering, and the
+                            // system collection stats merged over the members.
                             var memberChangeVectors = new List<string>();
                             var dbLastEtag = new List<LastEtagSnapshot>();
+                            var systemCollections = new Dictionary<string, SystemCollectionStats>(StringComparer.OrdinalIgnoreCase);
                             foreach (var member in state.DatabaseTopology.Members)
                             {
                                 var memberReport = state.GetCurrentDatabaseReport(member);
@@ -260,6 +262,18 @@ namespace Raven.Server.ServerWide.Maintenance
                                     continue;
 
                                 memberChangeVectors.Add(ChangeVector.StripMoveTag(memberReport.DatabaseChangeVector, context).AsString());
+
+                                if (memberReport.SystemCollections != null)
+                                {
+                                    foreach (var (collection, memberStats) in memberReport.SystemCollections)
+                                    {
+                                        if (systemCollections.TryGetValue(collection, out var merged) == false)
+                                            systemCollections[collection] = merged = new SystemCollectionStats();
+
+                                        merged.Etag = Math.Max(merged.Etag, memberStats.Etag);
+                                        merged.Count = Math.Max(merged.Count, memberStats.Count);
+                                    }
+                                }
 
                                 if (string.IsNullOrEmpty(memberReport.DatabaseId))
                                     continue;
@@ -269,7 +283,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                             var mergedChangeVector = ChangeVectorUtils.MergeVectors(memberChangeVectors);
                             writeUsageSnapshots.Add(new WriteUsageApplicationSnapshot(state.Name, state.DatabaseTopology.DatabaseTopologyIdBase64, mergedChangeVector,
-                                dbLastEtag));
+                                dbLastEtag, systemCollections));
 
                             try
                             {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -249,12 +249,12 @@ namespace Raven.Server.ServerWide.Maintenance
                             var state = new DatabaseObservationState(topology.Name, rawRecord, topology.Topology, clusterTopology, newStats, prevStats, etag, _iteration);
 
                             // Collect the current write-usage values for this topology (database or shard):
-                            // the MEMBER change vectors merged into a single cluster-wide change vector, each
-                            // member's own (database id, last etag) kept unmerged for per-node metering, and the
-                            // system collection stats merged over the members.
+                            // the MEMBER change vectors merged into a single cluster-wide change vector, and each
+                            // member's own (database id, last etag) and (database id, system collection stats)
+                            // kept unmerged - the backend gets every member's raw values and aggregates them.
                             var memberChangeVectors = new List<string>();
                             var dbLastEtag = new List<LastEtagSnapshot>();
-                            var systemCollections = new Dictionary<string, SystemCollectionStats>(StringComparer.OrdinalIgnoreCase);
+                            var systemCollectionsList = new List<SystemCollectionsSnapshot>();
                             foreach (var member in state.DatabaseTopology.Members)
                             {
                                 var memberReport = state.GetCurrentDatabaseReport(member);
@@ -263,27 +263,16 @@ namespace Raven.Server.ServerWide.Maintenance
 
                                 memberChangeVectors.Add(ChangeVector.StripMoveTag(memberReport.DatabaseChangeVector, context).AsString());
 
-                                if (memberReport.SystemCollections != null)
-                                {
-                                    foreach (var (collection, memberStats) in memberReport.SystemCollections)
-                                    {
-                                        if (systemCollections.TryGetValue(collection, out var merged) == false)
-                                            systemCollections[collection] = merged = new SystemCollectionStats();
-
-                                        merged.Etag = Math.Max(merged.Etag, memberStats.Etag);
-                                        merged.Count = Math.Max(merged.Count, memberStats.Count);
-                                    }
-                                }
-
                                 if (string.IsNullOrEmpty(memberReport.DatabaseId))
                                     continue;
 
                                 dbLastEtag.Add(new LastEtagSnapshot(memberReport.DatabaseId, memberReport.LastEtag));
+                                systemCollectionsList.Add(new SystemCollectionsSnapshot(memberReport.DatabaseId, memberReport.SystemCollections));
                             }
 
                             var mergedChangeVector = ChangeVectorUtils.MergeVectors(memberChangeVectors);
                             writeUsageSnapshots.Add(new WriteUsageApplicationSnapshot(state.Name, state.DatabaseTopology.DatabaseTopologyIdBase64, mergedChangeVector,
-                                dbLastEtag, systemCollections));
+                                dbLastEtag, systemCollectionsList));
 
                             try
                             {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -249,9 +249,10 @@ namespace Raven.Server.ServerWide.Maintenance
                             var state = new DatabaseObservationState(topology.Name, rawRecord, topology.Topology, clusterTopology, newStats, prevStats, etag, _iteration);
 
                             // Collect the current write-usage values for this topology (database or shard):
-                            // one entry per topology, carrying the MEMBER change vectors merged into a single
-                            // cluster-wide change vector.
+                            // the MEMBER change vectors merged into a single cluster-wide change vector, plus
+                            // each member's own (database id, last etag) kept unmerged for per-node metering.
                             var memberChangeVectors = new List<string>();
+                            var dbLastEtag = new List<LastEtagSnapshot>();
                             foreach (var member in state.DatabaseTopology.Members)
                             {
                                 var memberReport = state.GetCurrentDatabaseReport(member);
@@ -259,10 +260,16 @@ namespace Raven.Server.ServerWide.Maintenance
                                     continue;
 
                                 memberChangeVectors.Add(ChangeVector.StripMoveTag(memberReport.DatabaseChangeVector, context).AsString());
+
+                                if (string.IsNullOrEmpty(memberReport.DatabaseId))
+                                    continue;
+
+                                dbLastEtag.Add(new LastEtagSnapshot(memberReport.DatabaseId, memberReport.LastEtag));
                             }
 
                             var mergedChangeVector = ChangeVectorUtils.MergeVectors(memberChangeVectors);
-                            writeUsageSnapshots.Add(new WriteUsageApplicationSnapshot(state.Name, state.DatabaseTopology.DatabaseTopologyIdBase64, mergedChangeVector));
+                            writeUsageSnapshots.Add(new WriteUsageApplicationSnapshot(state.Name, state.DatabaseTopology.DatabaseTopologyIdBase64, mergedChangeVector,
+                                dbLastEtag));
 
                             try
                             {

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -250,11 +250,10 @@ namespace Raven.Server.ServerWide.Maintenance
 
                             // Collect the current write-usage values for this topology (database or shard):
                             // the MEMBER change vectors merged into a single cluster-wide change vector, and each
-                            // member's own (database id, last etag) and (database id, system collection stats)
-                            // kept unmerged - the backend gets every member's raw values and aggregates them.
+                            // member's own (database id, last etag, system collection document counts) kept
+                            // unmerged - the backend gets every member's raw values and aggregates them.
                             var memberChangeVectors = new List<string>();
-                            var dbLastEtag = new List<LastEtagSnapshot>();
-                            var systemCollectionsList = new List<SystemCollectionsSnapshot>();
+                            var nodeSnapshots = new List<WriteUsageNodeSnapshot>();
                             foreach (var member in state.DatabaseTopology.Members)
                             {
                                 var memberReport = state.GetCurrentDatabaseReport(member);
@@ -266,13 +265,12 @@ namespace Raven.Server.ServerWide.Maintenance
                                 if (string.IsNullOrEmpty(memberReport.DatabaseId))
                                     continue;
 
-                                dbLastEtag.Add(new LastEtagSnapshot(memberReport.DatabaseId, memberReport.LastEtag));
-                                systemCollectionsList.Add(new SystemCollectionsSnapshot(memberReport.DatabaseId, memberReport.SystemCollections));
+                                nodeSnapshots.Add(new WriteUsageNodeSnapshot(memberReport.DatabaseId, memberReport.LastEtag, memberReport.SystemCollections));
                             }
 
                             var mergedChangeVector = ChangeVectorUtils.MergeVectors(memberChangeVectors);
                             writeUsageSnapshots.Add(new WriteUsageApplicationSnapshot(state.Name, state.DatabaseTopology.DatabaseTopologyIdBase64, mergedChangeVector,
-                                dbLastEtag, systemCollectionsList));
+                                nodeSnapshots));
 
                             try
                             {

--- a/test/SlowTests.Issues/Issues/RavenDB-27365.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27365.cs
@@ -167,7 +167,7 @@ namespace SlowTests.Issues
                 // Wait for a tick that carries all three.
                 await WaitForValueAsync(() =>
                 {
-                    var reported = SnapshotEntryByDatabase(leader, store.Database)?.SystemCollectionsList?.SingleOrDefault()?.SystemCollections;
+                    var reported = SnapshotEntryByDatabase(leader, store.Database)?.Nodes?.SingleOrDefault()?.SystemCollections;
                     return reported != null && expected.All(reported.ContainsKey);
                 }, true, timeout: 30_000, interval: 100);
 
@@ -177,21 +177,17 @@ namespace SlowTests.Issues
                 var entry = SnapshotEntryByDatabase(leader, store.Database);
                 Assert.NotNull(entry);
 
-                // One entry per member, each carrying its own database id and its own stats.
-                var reportedByMember = entry.SystemCollectionsList.Single();
+                // One entry per member, each carrying its own database id and its own counts.
+                var reportedByMember = entry.Nodes.Single();
                 Assert.NotNull(reportedByMember.SystemCollections);
-
-                // Keyed by the same database id the last-etag tuple uses, so the two line up per member.
-                Assert.Equal(entry.Nodes.Single().DatabaseId, reportedByMember.DatabaseId);
 
                 var actual = string.Join(", ", reportedByMember.SystemCollections.Keys);
 
                 foreach (var collection in expected)
                 {
-                    Assert.True(reportedByMember.SystemCollections.TryGetValue(collection, out var stats),
+                    Assert.True(reportedByMember.SystemCollections.TryGetValue(collection, out var count),
                         $"Expected '{collection}' in the report, got: {actual}.");
-                    Assert.True(stats.Count > 0, $"Expected a document count for '{collection}', got {stats.Count}.");
-                    Assert.True(stats.Etag > 0, $"Expected a last etag for '{collection}', got {stats.Etag}.");
+                    Assert.True(count > 0, $"Expected a document count for '{collection}', got {count}.");
                 }
 
                 // Not reported: the user's own collection, which carries no '@' prefix. And '@all_docs',
@@ -221,33 +217,35 @@ namespace SlowTests.Issues
                 await WaitForDocumentInClusterAsync<object>(nodes, store.Database, "no-collection/1", x => x != null,
                     TimeSpan.FromSeconds(30));
 
-                // The '@empty' values each member should be reporting, read straight from its own storage.
+                // The values each member should be reporting, read straight from its own storage.
                 // Etags are node-local, so every member is checked against its own numbers - not the group's.
-                var expectedEtagByDatabaseId = new Dictionary<string, long>();
+                var expectedByDatabaseId = new Dictionary<string, (long LastEtag, long EmptyCount)>();
                 foreach (var node in nodes)
                 {
                     var database = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     using (var tx = context.OpenReadTransaction())
                     {
-                        expectedEtagByDatabaseId[database.DbBase64Id] = database.DocumentsStorage.GetLastDocumentEtag(
-                            tx.InnerTransaction, Constants.Documents.Collections.EmptyCollection);
+                        expectedByDatabaseId[database.DbBase64Id] = (
+                            database.DocumentsStorage.ReadLastEtag(tx.InnerTransaction),
+                            database.DocumentsStorage.GetNumberOfDocumentsFor(Constants.Documents.Collections.EmptyCollection, context));
                     }
                 }
 
-                Assert.Equal(2, expectedEtagByDatabaseId.Count);
+                Assert.Equal(2, expectedByDatabaseId.Count);
 
-                // Wait for a tick where both members have reported their own '@empty' stats.
+                // Wait for a tick where both members have reported their own values.
                 await WaitForValueAsync(() =>
                 {
-                    var reported = SnapshotEntryByDatabase(leader, store.Database)?.SystemCollectionsList;
-                    if (reported == null || reported.Count != expectedEtagByDatabaseId.Count)
+                    var reported = SnapshotEntryByDatabase(leader, store.Database)?.Nodes;
+                    if (reported == null || reported.Count != expectedByDatabaseId.Count)
                         return false;
 
-                    return reported.All(s => s.SystemCollections != null &&
-                                             expectedEtagByDatabaseId.TryGetValue(s.DatabaseId, out var expectedEtag) &&
-                                             s.SystemCollections.TryGetValue(Constants.Documents.Collections.EmptyCollection, out var stats) &&
-                                             stats.Etag == expectedEtag);
+                    return reported.All(n => n.SystemCollections != null &&
+                                             expectedByDatabaseId.TryGetValue(n.DatabaseId, out var expected) &&
+                                             n.LastEtag == expected.LastEtag &&
+                                             n.SystemCollections.TryGetValue(Constants.Documents.Collections.EmptyCollection, out var count) &&
+                                             count == expected.EmptyCount);
                 }, true, timeout: 30_000, interval: 100);
 
                 // Freeze ticks for a deterministic read of the published snapshot.
@@ -258,24 +256,23 @@ namespace SlowTests.Issues
 
                 // One entry per member, keyed by its database id and carrying that member's own values - the
                 // group is not collapsed into a single summary, so the backend aggregates it itself.
-                Assert.Equal(expectedEtagByDatabaseId.Count, entry.SystemCollectionsList.Count);
-                Assert.Equal(expectedEtagByDatabaseId.Keys.OrderBy(id => id),
-                    entry.SystemCollectionsList.Select(s => s.DatabaseId).OrderBy(id => id));
+                Assert.Equal(expectedByDatabaseId.Count, entry.Nodes.Count);
+                Assert.Equal(expectedByDatabaseId.Keys.OrderBy(id => id),
+                    entry.Nodes.Select(n => n.DatabaseId).OrderBy(id => id));
 
-                // The same database ids the last-etag tuples use, so the two lists line up per member.
-                Assert.Equal(entry.Nodes.Select(n => n.DatabaseId).OrderBy(id => id),
-                    entry.SystemCollectionsList.Select(s => s.DatabaseId).OrderBy(id => id));
-
-                foreach (var reported in entry.SystemCollectionsList)
+                foreach (var reported in entry.Nodes)
                 {
+                    var expected = expectedByDatabaseId[reported.DatabaseId];
+                    Assert.Equal(expected.LastEtag, reported.LastEtag);
+
                     Assert.NotNull(reported.SystemCollections);
-                    Assert.True(reported.SystemCollections.TryGetValue(Constants.Documents.Collections.EmptyCollection, out var stats),
+                    Assert.True(reported.SystemCollections.TryGetValue(Constants.Documents.Collections.EmptyCollection, out var count),
                         $"Expected '{Constants.Documents.Collections.EmptyCollection}' for database id '{reported.DatabaseId}', " +
                         $"got: {string.Join(", ", reported.SystemCollections.Keys)}.");
 
-                    Assert.Equal(expectedEtagByDatabaseId[reported.DatabaseId], stats.Etag);
-                    Assert.True(stats.Count > 0,
-                        $"Expected a document count for '{Constants.Documents.Collections.EmptyCollection}', got {stats.Count}.");
+                    Assert.Equal(expected.EmptyCount, count);
+                    Assert.True(count > 0,
+                        $"Expected a document count for '{Constants.Documents.Collections.EmptyCollection}', got {count}.");
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB-27365.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27365.cs
@@ -1,0 +1,195 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server;
+using Raven.Server.Commercial.WriteUsageMetering;
+using Raven.Server.Config;
+using Raven.Server.Documents;
+using Raven.Server.Documents.AI.Embeddings;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using ITestOutputHelper = Xunit.ITestOutputHelper;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27365 : ClusterTestBase
+    {
+        public RavenDB_27365(ITestOutputHelper output) : base(output)
+        {
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Cluster.SupervisorSamplePeriod)] = "50";
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Cluster.WorkerSamplePeriod)] = "25";
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Cluster.OnErrorDelayTime)] = "15";
+        }
+
+        private const string SourceCollection = "Dtos";
+
+        internal class Dto
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private static WriteUsageApplicationSnapshot SnapshotEntryByDatabase(RavenServer leader, string database)
+            => leader.ServerStore.Observer?.LatestWriteUsageSnapshot?.Applications.SingleOrDefault(d => d.ApplicationName == database);
+
+        /// <summary>
+        /// Registers a real embeddings generation task against the embedded model, so no external provider is
+        /// involved. Mirrors what EmbeddingsGenerationTestBase does, which we cannot inherit from here because
+        /// this fixture needs the cluster base for a leader that runs the observer.
+        /// </summary>
+        private static void AddEmbeddingsGenerationTask(IDocumentStore store, string collection)
+        {
+            var connectionString = new AiConnectionString
+            {
+                Name = "Local AI connection",
+                ModelType = AiModelType.TextEmbeddings,
+                EmbeddedSettings = new EmbeddedSettings()
+            };
+            connectionString.Identifier = connectionString.GenerateIdentifier();
+
+            var putResult = store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(connectionString));
+            Assert.NotNull(putResult.RaftCommandIndex);
+
+            var configuration = new EmbeddingsGenerationConfiguration
+            {
+                Name = "localAiTask",
+                ConnectionStringName = connectionString.Name,
+                Collection = collection,
+                EmbeddingsPathConfigurations =
+                [
+                    new EmbeddingPathConfiguration
+                    {
+                        Path = nameof(Dto.Name),
+                        ChunkingOptions = new ChunkingOptions { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 2048 }
+                    }
+                ],
+                Quantization = VectorEmbeddingType.Single,
+                ChunkingOptionsForQuerying = new ChunkingOptions { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 2048 }
+            };
+            configuration.Identifier = configuration.GenerateIdentifier();
+
+            store.Maintenance.Send(new AddEmbeddingsGenerationOperation(configuration));
+        }
+
+        [RavenFact(RavenTestCategory.Licensing | RavenTestCategory.Cluster)]
+        public async Task LastEtag_IsReportedPerDatabaseId()
+        {
+            var (nodes, leader) = await CreateRaftCluster(1, watcherCluster: true);
+
+            using (var store = GetDocumentStore(new Options { ReplicationFactor = 1, Server = leader }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    for (var i = 0; i < 10; i++)
+                        session.Store(new Dto { Name = $"name/{i}" });
+
+                    session.SaveChanges();
+                }
+
+                // The values the single member should be reporting, read straight from its storage.
+                var database = await nodes.Single().ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                string expectedDatabaseId;
+                long expectedLastEtag;
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenReadTransaction())
+                {
+                    expectedDatabaseId = database.DbBase64Id;
+                    expectedLastEtag = database.DocumentsStorage.ReadLastEtag(tx.InnerTransaction);
+                }
+
+                Assert.False(string.IsNullOrEmpty(expectedDatabaseId), "Expected the node to expose its database id.");
+                Assert.True(expectedLastEtag > 0, $"Expected the writes to advance the last etag, got {expectedLastEtag}.");
+
+                // The observer republishes the snapshot on every tick; wait for one carrying the write position.
+                await WaitForValueAsync(() => SnapshotEntryByDatabase(leader, store.Database)?.Nodes?.Count ?? 0, 1,
+                    timeout: 30_000, interval: 100);
+
+                // Freeze ticks for a deterministic read of the published snapshot.
+                leader.ServerStore.Observer.Suspended = true;
+
+                var entry = SnapshotEntryByDatabase(leader, store.Database);
+                Assert.NotNull(entry);
+
+                // One tuple per member, unmerged: the single member reports its own (database id, last etag).
+                Assert.Equal(1, entry.Nodes.Count);
+
+                var node = entry.Nodes.Single();
+                Assert.Equal(expectedDatabaseId, node.DatabaseId);
+                Assert.Equal(expectedLastEtag, node.LastEtag);
+
+                // The merged change vector is still reported alongside the per-node tuples.
+                Assert.Contains(expectedDatabaseId, entry.ChangeVector);
+            }
+        }
+
+        [RavenMultiplatformFact(RavenTestCategory.Licensing | RavenTestCategory.Cluster | RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        public async Task SystemCollections_AreReported_FromCollectionsTheProductCreates()
+        {
+            var (nodes, leader) = await CreateRaftCluster(1, watcherCluster: true);
+
+            using (var store = GetDocumentStore(new Options { ReplicationFactor = 1, Server = leader }))
+            {
+                // '@hilo' comes for free: storing an entity without an id makes the client ask the server for
+                // a HiLo range, and the server writes the range document into '@hilo'.
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Dto { Name = "a name to embed" });
+                    session.SaveChanges();
+                }
+
+                // Running the real embeddings generation task creates '@embeddings-cache' and
+                // '@embeddings/Dtos'. Nothing here writes a '@collection' by hand.
+                AddEmbeddingsGenerationTask(store, SourceCollection);
+
+                // '@empty' has no feature that owns it - it is where a write that omits '@collection' lands,
+                // and a session always stamps one from the entity type, so a raw command is how it arises.
+                using (var commands = store.Commands())
+                    commands.Put("no-collection/1", null, new { });
+
+                var embeddingsCollection = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(SourceCollection);
+                var expected = new[]
+                {
+                    CollectionName.HiLoCollection,
+                    Constants.Documents.Collections.EmbeddingsCacheCollection,
+                    embeddingsCollection
+                };
+
+                // Wait for a tick that carries all three.
+                await WaitForValueAsync(() =>
+                {
+                    var reported = SnapshotEntryByDatabase(leader, store.Database)?.SystemCollections;
+                    return reported != null && expected.All(reported.ContainsKey);
+                }, true, timeout: 30_000, interval: 100);
+
+                // Freeze ticks for a deterministic read of the published snapshot.
+                leader.ServerStore.Observer.Suspended = true;
+
+                var entry = SnapshotEntryByDatabase(leader, store.Database);
+                Assert.NotNull(entry);
+                Assert.NotNull(entry.SystemCollections);
+
+                var actual = string.Join(", ", entry.SystemCollections.Keys);
+
+                foreach (var collection in expected)
+                {
+                    Assert.True(entry.SystemCollections.TryGetValue(collection, out var stats),
+                        $"Expected '{collection}' in the report, got: {actual}.");
+                    Assert.True(stats.Count > 0, $"Expected a document count for '{collection}', got {stats.Count}.");
+                    Assert.True(stats.Etag > 0, $"Expected a last etag for '{collection}', got {stats.Etag}.");
+                }
+
+                // Not reported: the user's own collection, and '@empty' - which carries the '@' prefix but
+                // holds the user documents that were written without a collection.
+                Assert.DoesNotContain(Constants.Documents.Collections.EmptyCollection, entry.SystemCollections.Keys);
+                Assert.DoesNotContain(Constants.Documents.Collections.AllDocumentsCollection, entry.SystemCollections.Keys);
+                Assert.DoesNotContain(SourceCollection, entry.SystemCollections.Keys);
+            }
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB-27365.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27365.cs
@@ -40,11 +40,6 @@ namespace SlowTests.Issues
         private static WriteUsageApplicationSnapshot SnapshotEntryByDatabase(RavenServer leader, string database)
             => leader.ServerStore.Observer?.LatestWriteUsageSnapshot?.Applications.SingleOrDefault(d => d.ApplicationName == database);
 
-        /// <summary>
-        /// Registers a real embeddings generation task against the embedded model, so no external provider is
-        /// involved. Mirrors what EmbeddingsGenerationTestBase does, which we cannot inherit from here because
-        /// this fixture needs the cluster base for a leader that runs the observer.
-        /// </summary>
         private static void AddEmbeddingsGenerationTask(IDocumentStore store, string collection)
         {
             var connectionString = new AiConnectionString
@@ -94,7 +89,6 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                // The values the single member should be reporting, read straight from its storage.
                 var database = await nodes.Single().ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 string expectedDatabaseId;
                 long expectedLastEtag;
@@ -108,24 +102,20 @@ namespace SlowTests.Issues
                 Assert.False(string.IsNullOrEmpty(expectedDatabaseId), "Expected the node to expose its database id.");
                 Assert.True(expectedLastEtag > 0, $"Expected the writes to advance the last etag, got {expectedLastEtag}.");
 
-                // The observer republishes the snapshot on every tick; wait for one carrying the write position.
                 await WaitForValueAsync(() => SnapshotEntryByDatabase(leader, store.Database)?.Nodes?.Count ?? 0, 1,
                     timeout: 30_000, interval: 100);
 
-                // Freeze ticks for a deterministic read of the published snapshot.
                 leader.ServerStore.Observer.Suspended = true;
 
                 var entry = SnapshotEntryByDatabase(leader, store.Database);
                 Assert.NotNull(entry);
 
-                // One tuple per member, unmerged: the single member reports its own (database id, last etag).
                 Assert.Equal(1, entry.Nodes.Count);
 
                 var node = entry.Nodes.Single();
                 Assert.Equal(expectedDatabaseId, node.DatabaseId);
                 Assert.Equal(expectedLastEtag, node.LastEtag);
 
-                // The merged change vector is still reported alongside the per-node tuples.
                 Assert.Contains(expectedDatabaseId, entry.ChangeVector);
             }
         }
@@ -137,22 +127,14 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(new Options { ReplicationFactor = 1, Server = leader }))
             {
-                // Storing an entity without an id makes the client ask the server for a HiLo range, and the
-                // server writes the range document into '@hilo' - the one '@' collection we filter out, so
-                // this also gives the exclusion below something real to check against.
                 using (var session = store.OpenSession())
                 {
                     session.Store(new Dto { Name = "a name to embed" });
                     session.SaveChanges();
                 }
 
-                // Running the real embeddings generation task creates '@embeddings-cache' and
-                // '@embeddings/Dtos'. Nothing here writes a '@collection' by hand.
                 AddEmbeddingsGenerationTask(store, SourceCollection);
 
-                // '@empty' has no feature that owns it - it is where a write that omits '@collection' lands,
-                // and a session always stamps one from the entity type, so a raw command is how it arises.
-                // It carries the '@' prefix, so it is reported like any other.
                 using (var commands = store.Commands())
                     commands.Put("no-collection/1", null, new { });
 
@@ -160,24 +142,20 @@ namespace SlowTests.Issues
                 var expected = new[]
                 {
                     Constants.Documents.Collections.EmbeddingsCacheCollection,
-                    embeddingsCollection,
-                    Constants.Documents.Collections.EmptyCollection
+                    embeddingsCollection
                 };
 
-                // Wait for a tick that carries all three.
                 await WaitForValueAsync(() =>
                 {
                     var reported = SnapshotEntryByDatabase(leader, store.Database)?.Nodes?.SingleOrDefault()?.SystemCollections;
                     return reported != null && expected.All(reported.ContainsKey);
                 }, true, timeout: 30_000, interval: 100);
 
-                // Freeze ticks for a deterministic read of the published snapshot.
                 leader.ServerStore.Observer.Suspended = true;
 
                 var entry = SnapshotEntryByDatabase(leader, store.Database);
                 Assert.NotNull(entry);
 
-                // One entry per member, each carrying its own database id and its own counts.
                 var reportedByMember = entry.Nodes.Single();
                 Assert.NotNull(reportedByMember.SystemCollections);
 
@@ -190,15 +168,12 @@ namespace SlowTests.Issues
                     Assert.True(count > 0, $"Expected a document count for '{collection}', got {count}.");
                 }
 
-                // Not reported: the user's own collection, which carries no '@' prefix. And '@all_docs',
-                // which does carry the prefix but is a query-only pseudo-collection with no storage of
-                // its own, so it never reaches the report even though nothing filters it out.
                 Assert.DoesNotContain(SourceCollection, reportedByMember.SystemCollections.Keys);
 
-                // '@hilo' is the one '@' collection that is filtered out - the HiLo range documents are an
-                // internal bookkeeping detail of id generation, not something the backend should meter.
                 Assert.False(reportedByMember.SystemCollections.ContainsKey(CollectionName.HiLoCollection),
                     $"Did not expect '{CollectionName.HiLoCollection}' in the report, got: {actual}.");
+                Assert.False(reportedByMember.SystemCollections.ContainsKey(Constants.Documents.Collections.EmptyCollection),
+                    $"Did not expect '{Constants.Documents.Collections.EmptyCollection}' in the report, got: {actual}.");
             }
         }
 
@@ -209,17 +184,17 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(new Options { ReplicationFactor = 2, Server = leader }))
             {
-                // A write that omits '@collection' lands in '@empty', which then replicates. A session always
-                // stamps a collection from the entity type, so a raw command is how it arises.
+                const string reportedCollection = "@custom-collection";
                 using (var commands = store.Commands())
-                    await commands.PutAsync("no-collection/1", null, new { });
+                {
+                    await commands.PutAsync("custom/1", null, new { },
+                        new Dictionary<string, object> { [Constants.Documents.Metadata.Collection] = reportedCollection });
+                }
 
-                await WaitForDocumentInClusterAsync<object>(nodes, store.Database, "no-collection/1", x => x != null,
+                await WaitForDocumentInClusterAsync<object>(nodes, store.Database, "custom/1", x => x != null,
                     TimeSpan.FromSeconds(30));
 
-                // The values each member should be reporting, read straight from its own storage.
-                // Etags are node-local, so every member is checked against its own numbers - not the group's.
-                var expectedByDatabaseId = new Dictionary<string, (long LastEtag, long EmptyCount)>();
+                var expectedByDatabaseId = new Dictionary<string, (long LastEtag, long Count)>();
                 foreach (var node in nodes)
                 {
                     var database = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
@@ -228,13 +203,12 @@ namespace SlowTests.Issues
                     {
                         expectedByDatabaseId[database.DbBase64Id] = (
                             database.DocumentsStorage.ReadLastEtag(tx.InnerTransaction),
-                            database.DocumentsStorage.GetNumberOfDocumentsFor(Constants.Documents.Collections.EmptyCollection, context));
+                            database.DocumentsStorage.GetNumberOfDocumentsFor(reportedCollection, context));
                     }
                 }
 
                 Assert.Equal(2, expectedByDatabaseId.Count);
 
-                // Wait for a tick where both members have reported their own values.
                 await WaitForValueAsync(() =>
                 {
                     var reported = SnapshotEntryByDatabase(leader, store.Database)?.Nodes;
@@ -244,18 +218,15 @@ namespace SlowTests.Issues
                     return reported.All(n => n.SystemCollections != null &&
                                              expectedByDatabaseId.TryGetValue(n.DatabaseId, out var expected) &&
                                              n.LastEtag == expected.LastEtag &&
-                                             n.SystemCollections.TryGetValue(Constants.Documents.Collections.EmptyCollection, out var count) &&
-                                             count == expected.EmptyCount);
+                                             n.SystemCollections.TryGetValue(reportedCollection, out var count) &&
+                                             count == expected.Count);
                 }, true, timeout: 30_000, interval: 100);
 
-                // Freeze ticks for a deterministic read of the published snapshot.
                 leader.ServerStore.Observer.Suspended = true;
 
                 var entry = SnapshotEntryByDatabase(leader, store.Database);
                 Assert.NotNull(entry);
 
-                // One entry per member, keyed by its database id and carrying that member's own values - the
-                // group is not collapsed into a single summary, so the backend aggregates it itself.
                 Assert.Equal(expectedByDatabaseId.Count, entry.Nodes.Count);
                 Assert.Equal(expectedByDatabaseId.Keys.OrderBy(id => id),
                     entry.Nodes.Select(n => n.DatabaseId).OrderBy(id => id));
@@ -266,13 +237,13 @@ namespace SlowTests.Issues
                     Assert.Equal(expected.LastEtag, reported.LastEtag);
 
                     Assert.NotNull(reported.SystemCollections);
-                    Assert.True(reported.SystemCollections.TryGetValue(Constants.Documents.Collections.EmptyCollection, out var count),
-                        $"Expected '{Constants.Documents.Collections.EmptyCollection}' for database id '{reported.DatabaseId}', " +
+                    Assert.True(reported.SystemCollections.TryGetValue(reportedCollection, out var count),
+                        $"Expected '{reportedCollection}' for database id '{reported.DatabaseId}', " +
                         $"got: {string.Join(", ", reported.SystemCollections.Keys)}.");
 
-                    Assert.Equal(expected.EmptyCount, count);
+                    Assert.Equal(expected.Count, count);
                     Assert.True(count > 0,
-                        $"Expected a document count for '{Constants.Documents.Collections.EmptyCollection}', got {count}.");
+                        $"Expected a document count for '{reportedCollection}', got {count}.");
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB-27365.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27365.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
@@ -163,7 +164,7 @@ namespace SlowTests.Issues
                 // Wait for a tick that carries all three.
                 await WaitForValueAsync(() =>
                 {
-                    var reported = SnapshotEntryByDatabase(leader, store.Database)?.SystemCollections;
+                    var reported = SnapshotEntryByDatabase(leader, store.Database)?.SystemCollectionsList?.SingleOrDefault()?.SystemCollections;
                     return reported != null && expected.All(reported.ContainsKey);
                 }, true, timeout: 30_000, interval: 100);
 
@@ -172,13 +173,19 @@ namespace SlowTests.Issues
 
                 var entry = SnapshotEntryByDatabase(leader, store.Database);
                 Assert.NotNull(entry);
-                Assert.NotNull(entry.SystemCollections);
 
-                var actual = string.Join(", ", entry.SystemCollections.Keys);
+                // One entry per member, each carrying its own database id and its own stats.
+                var reportedByMember = entry.SystemCollectionsList.Single();
+                Assert.NotNull(reportedByMember.SystemCollections);
+
+                // Keyed by the same database id the last-etag tuple uses, so the two line up per member.
+                Assert.Equal(entry.Nodes.Single().DatabaseId, reportedByMember.DatabaseId);
+
+                var actual = string.Join(", ", reportedByMember.SystemCollections.Keys);
 
                 foreach (var collection in expected)
                 {
-                    Assert.True(entry.SystemCollections.TryGetValue(collection, out var stats),
+                    Assert.True(reportedByMember.SystemCollections.TryGetValue(collection, out var stats),
                         $"Expected '{collection}' in the report, got: {actual}.");
                     Assert.True(stats.Count > 0, $"Expected a document count for '{collection}', got {stats.Count}.");
                     Assert.True(stats.Etag > 0, $"Expected a last etag for '{collection}', got {stats.Etag}.");
@@ -186,9 +193,83 @@ namespace SlowTests.Issues
 
                 // Not reported: the user's own collection, and '@empty' - which carries the '@' prefix but
                 // holds the user documents that were written without a collection.
-                Assert.DoesNotContain(Constants.Documents.Collections.EmptyCollection, entry.SystemCollections.Keys);
-                Assert.DoesNotContain(Constants.Documents.Collections.AllDocumentsCollection, entry.SystemCollections.Keys);
-                Assert.DoesNotContain(SourceCollection, entry.SystemCollections.Keys);
+                Assert.DoesNotContain(Constants.Documents.Collections.EmptyCollection, reportedByMember.SystemCollections.Keys);
+                Assert.DoesNotContain(Constants.Documents.Collections.AllDocumentsCollection, reportedByMember.SystemCollections.Keys);
+                Assert.DoesNotContain(SourceCollection, reportedByMember.SystemCollections.Keys);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Licensing | RavenTestCategory.Cluster, LicenseRequired = true)]
+        public async Task SystemCollections_AreReportedPerDatabaseId_Unmerged()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
+
+            using (var store = GetDocumentStore(new Options { ReplicationFactor = 2, Server = leader }))
+            {
+                // '@hilo' comes for free: storing an entity without an id makes the client ask the server for
+                // a HiLo range, and the server writes the range document into '@hilo', which then replicates.
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1);
+                    await session.StoreAsync(new Dto { Name = "a name" });
+                    await session.SaveChangesAsync();
+                }
+
+                // The '@hilo' values each member should be reporting, read straight from its own storage.
+                // Etags are node-local, so every member is checked against its own numbers - not the group's.
+                var expectedEtagByDatabaseId = new Dictionary<string, long>();
+                foreach (var node in nodes)
+                {
+                    var database = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                    using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    using (var tx = context.OpenReadTransaction())
+                    {
+                        expectedEtagByDatabaseId[database.DbBase64Id] =
+                            database.DocumentsStorage.GetLastDocumentEtag(tx.InnerTransaction, CollectionName.HiLoCollection);
+                    }
+                }
+
+                Assert.Equal(2, expectedEtagByDatabaseId.Count);
+
+                // Wait for a tick where both members have reported their own '@hilo' stats.
+                await WaitForValueAsync(() =>
+                {
+                    var reported = SnapshotEntryByDatabase(leader, store.Database)?.SystemCollectionsList;
+                    if (reported == null || reported.Count != expectedEtagByDatabaseId.Count)
+                        return false;
+
+                    return reported.All(s => s.SystemCollections != null &&
+                                             expectedEtagByDatabaseId.TryGetValue(s.DatabaseId, out var expectedEtag) &&
+                                             s.SystemCollections.TryGetValue(CollectionName.HiLoCollection, out var stats) &&
+                                             stats.Etag == expectedEtag);
+                }, true, timeout: 30_000, interval: 100);
+
+                // Freeze ticks for a deterministic read of the published snapshot.
+                leader.ServerStore.Observer.Suspended = true;
+
+                var entry = SnapshotEntryByDatabase(leader, store.Database);
+                Assert.NotNull(entry);
+
+                // One entry per member, keyed by its database id and carrying that member's own values - the
+                // group is not collapsed into a single summary, so the backend aggregates it itself.
+                Assert.Equal(expectedEtagByDatabaseId.Count, entry.SystemCollectionsList.Count);
+                Assert.Equal(expectedEtagByDatabaseId.Keys.OrderBy(id => id),
+                    entry.SystemCollectionsList.Select(s => s.DatabaseId).OrderBy(id => id));
+
+                // The same database ids the last-etag tuples use, so the two lists line up per member.
+                Assert.Equal(entry.Nodes.Select(n => n.DatabaseId).OrderBy(id => id),
+                    entry.SystemCollectionsList.Select(s => s.DatabaseId).OrderBy(id => id));
+
+                foreach (var reported in entry.SystemCollectionsList)
+                {
+                    Assert.NotNull(reported.SystemCollections);
+                    Assert.True(reported.SystemCollections.TryGetValue(CollectionName.HiLoCollection, out var stats),
+                        $"Expected '{CollectionName.HiLoCollection}' for database id '{reported.DatabaseId}', " +
+                        $"got: {string.Join(", ", reported.SystemCollections.Keys)}.");
+
+                    Assert.Equal(expectedEtagByDatabaseId[reported.DatabaseId], stats.Etag);
+                    Assert.True(stats.Count > 0, $"Expected a document count for '{CollectionName.HiLoCollection}', got {stats.Count}.");
+                }
             }
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB-27365.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27365.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -136,8 +137,9 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(new Options { ReplicationFactor = 1, Server = leader }))
             {
-                // '@hilo' comes for free: storing an entity without an id makes the client ask the server for
-                // a HiLo range, and the server writes the range document into '@hilo'.
+                // Storing an entity without an id makes the client ask the server for a HiLo range, and the
+                // server writes the range document into '@hilo' - the one '@' collection we filter out, so
+                // this also gives the exclusion below something real to check against.
                 using (var session = store.OpenSession())
                 {
                     session.Store(new Dto { Name = "a name to embed" });
@@ -150,15 +152,16 @@ namespace SlowTests.Issues
 
                 // '@empty' has no feature that owns it - it is where a write that omits '@collection' lands,
                 // and a session always stamps one from the entity type, so a raw command is how it arises.
+                // It carries the '@' prefix, so it is reported like any other.
                 using (var commands = store.Commands())
                     commands.Put("no-collection/1", null, new { });
 
                 var embeddingsCollection = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(SourceCollection);
                 var expected = new[]
                 {
-                    CollectionName.HiLoCollection,
                     Constants.Documents.Collections.EmbeddingsCacheCollection,
-                    embeddingsCollection
+                    embeddingsCollection,
+                    Constants.Documents.Collections.EmptyCollection
                 };
 
                 // Wait for a tick that carries all three.
@@ -191,11 +194,15 @@ namespace SlowTests.Issues
                     Assert.True(stats.Etag > 0, $"Expected a last etag for '{collection}', got {stats.Etag}.");
                 }
 
-                // Not reported: the user's own collection, and '@empty' - which carries the '@' prefix but
-                // holds the user documents that were written without a collection.
-                Assert.DoesNotContain(Constants.Documents.Collections.EmptyCollection, reportedByMember.SystemCollections.Keys);
-                Assert.DoesNotContain(Constants.Documents.Collections.AllDocumentsCollection, reportedByMember.SystemCollections.Keys);
+                // Not reported: the user's own collection, which carries no '@' prefix. And '@all_docs',
+                // which does carry the prefix but is a query-only pseudo-collection with no storage of
+                // its own, so it never reaches the report even though nothing filters it out.
                 Assert.DoesNotContain(SourceCollection, reportedByMember.SystemCollections.Keys);
+
+                // '@hilo' is the one '@' collection that is filtered out - the HiLo range documents are an
+                // internal bookkeeping detail of id generation, not something the backend should meter.
+                Assert.False(reportedByMember.SystemCollections.ContainsKey(CollectionName.HiLoCollection),
+                    $"Did not expect '{CollectionName.HiLoCollection}' in the report, got: {actual}.");
             }
         }
 
@@ -206,16 +213,15 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(new Options { ReplicationFactor = 2, Server = leader }))
             {
-                // '@hilo' comes for free: storing an entity without an id makes the client ask the server for
-                // a HiLo range, and the server writes the range document into '@hilo', which then replicates.
-                using (var session = store.OpenAsyncSession())
-                {
-                    session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1);
-                    await session.StoreAsync(new Dto { Name = "a name" });
-                    await session.SaveChangesAsync();
-                }
+                // A write that omits '@collection' lands in '@empty', which then replicates. A session always
+                // stamps a collection from the entity type, so a raw command is how it arises.
+                using (var commands = store.Commands())
+                    await commands.PutAsync("no-collection/1", null, new { });
 
-                // The '@hilo' values each member should be reporting, read straight from its own storage.
+                await WaitForDocumentInClusterAsync<object>(nodes, store.Database, "no-collection/1", x => x != null,
+                    TimeSpan.FromSeconds(30));
+
+                // The '@empty' values each member should be reporting, read straight from its own storage.
                 // Etags are node-local, so every member is checked against its own numbers - not the group's.
                 var expectedEtagByDatabaseId = new Dictionary<string, long>();
                 foreach (var node in nodes)
@@ -224,14 +230,14 @@ namespace SlowTests.Issues
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     using (var tx = context.OpenReadTransaction())
                     {
-                        expectedEtagByDatabaseId[database.DbBase64Id] =
-                            database.DocumentsStorage.GetLastDocumentEtag(tx.InnerTransaction, CollectionName.HiLoCollection);
+                        expectedEtagByDatabaseId[database.DbBase64Id] = database.DocumentsStorage.GetLastDocumentEtag(
+                            tx.InnerTransaction, Constants.Documents.Collections.EmptyCollection);
                     }
                 }
 
                 Assert.Equal(2, expectedEtagByDatabaseId.Count);
 
-                // Wait for a tick where both members have reported their own '@hilo' stats.
+                // Wait for a tick where both members have reported their own '@empty' stats.
                 await WaitForValueAsync(() =>
                 {
                     var reported = SnapshotEntryByDatabase(leader, store.Database)?.SystemCollectionsList;
@@ -240,7 +246,7 @@ namespace SlowTests.Issues
 
                     return reported.All(s => s.SystemCollections != null &&
                                              expectedEtagByDatabaseId.TryGetValue(s.DatabaseId, out var expectedEtag) &&
-                                             s.SystemCollections.TryGetValue(CollectionName.HiLoCollection, out var stats) &&
+                                             s.SystemCollections.TryGetValue(Constants.Documents.Collections.EmptyCollection, out var stats) &&
                                              stats.Etag == expectedEtag);
                 }, true, timeout: 30_000, interval: 100);
 
@@ -263,12 +269,13 @@ namespace SlowTests.Issues
                 foreach (var reported in entry.SystemCollectionsList)
                 {
                     Assert.NotNull(reported.SystemCollections);
-                    Assert.True(reported.SystemCollections.TryGetValue(CollectionName.HiLoCollection, out var stats),
-                        $"Expected '{CollectionName.HiLoCollection}' for database id '{reported.DatabaseId}', " +
+                    Assert.True(reported.SystemCollections.TryGetValue(Constants.Documents.Collections.EmptyCollection, out var stats),
+                        $"Expected '{Constants.Documents.Collections.EmptyCollection}' for database id '{reported.DatabaseId}', " +
                         $"got: {string.Join(", ", reported.SystemCollections.Keys)}.");
 
                     Assert.Equal(expectedEtagByDatabaseId[reported.DatabaseId], stats.Etag);
-                    Assert.True(stats.Count > 0, $"Expected a document count for '{CollectionName.HiLoCollection}', got {stats.Count}.");
+                    Assert.True(stats.Count > 0,
+                        $"Expected a document count for '{Constants.Documents.Collections.EmptyCollection}', got {stats.Count}.");
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27365

### Additional description

Send the last database etag along with the database ID (a list of tuples (Database ID, Last Etag).
Send all system documents summary - a dictionary of last etag and count. For example: {"@embedding": {"etag": 12312, "count": 123}, "@coversations": { 30, 5}}.
### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
