### PR TITLE
RavenDB-27399 Fix server-wide connection strings license handling

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/useConnectionStringsLicense.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/useConnectionStringsLicense.ts
@@ -74,6 +74,10 @@ export default function useConnectionStringsLicense(): ConnectionStringsLicense 
                 featureName: defaultFeatureAvailability.find((x) => x.featureIcon === "amazon-sqs-etl").featureName,
                 value: hasQueueEtl,
             },
+            {
+                featureName: defaultFeatureAvailability.find((x) => x.featureIcon === "azure-service-bus").featureName,
+                value: hasQueueEtl,
+            },
         ],
     });
 
@@ -160,6 +164,13 @@ const defaultFeatureAvailability: FeatureAvailabilityData[] = [
     {
         featureName: "Amazon SQS ETL",
         featureIcon: "amazon-sqs-etl",
+        community: { value: false },
+        professional: { value: false },
+        enterprise: { value: true },
+    },
+    {
+        featureName: "Azure Service Bus ETL",
+        featureIcon: "azure-service-bus",
         community: { value: false },
         professional: { value: false },
         enterprise: { value: true },

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideConnectionStrings/ServerWideConnectionStrings.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideConnectionStrings/ServerWideConnectionStrings.spec.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { composeStories } from "@storybook/react-webpack5";
+import * as stories from "./ServerWideConnectionStrings.stories";
+import { rtlRender, rtlRender_WithWaitForLoad } from "test/rtlTestUtils";
+import { mockServices } from "test/mocks/services/MockServices";
+
+const { ServerWideConnectionStringsStory } = composeStories(stories);
+
+describe("ServerWideConnectionStrings", () => {
+    beforeEach(() => {
+        (mockServices.tasksService.mock.getServerWideConnectionStrings as jest.Mock).mockClear();
+    });
+
+    it("fetches connection strings when license has server-wide connection strings", async () => {
+        const { screen } = await rtlRender_WithWaitForLoad(
+            <ServerWideConnectionStringsStory hasServerWideConnectionStrings />
+        );
+
+        expect(mockServices.tasksService.mock.getServerWideConnectionStrings).toHaveBeenCalled();
+        expect(screen.queryByTestId("loader")).not.toBeInTheDocument();
+    });
+
+    it("does not fetch connection strings and shows empty list without loading placeholder when license has no server-wide connection strings", () => {
+        const { screen } = rtlRender(<ServerWideConnectionStringsStory hasServerWideConnectionStrings={false} />);
+
+        expect(mockServices.tasksService.mock.getServerWideConnectionStrings).not.toHaveBeenCalled();
+        expect(screen.queryByTestId("loader")).not.toBeInTheDocument();
+        expect(screen.getByText(/no server-wide connection strings have been defined/i)).toBeInTheDocument();
+    });
+});

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideConnectionStrings/ServerWideConnectionStrings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideConnectionStrings/ServerWideConnectionStrings.tsx
@@ -116,13 +116,18 @@ export default function ServerWideConnectionStrings({
 
 function ServerWideConnectionStringsBody() {
     const hasOperatorAccess = useAppSelector(accessManagerSelectors.isOperatorOrAbove);
+    const hasServerWideConnectionStrings = useAppSelector(
+        licenseSelectors.statusValue("HasServerWideConnectionStrings")
+    );
     const loadStatus = useAppSelector(connectionStringSelectors.loadStatus);
     const connections = useAppSelector(connectionStringSelectors.connections);
     const isEmpty = useAppSelector(connectionStringSelectors.isEmpty);
 
+    const isLoading = hasServerWideConnectionStrings && (loadStatus === "idle" || loadStatus === "loading");
+
     return (
         <div className={hasOperatorAccess ? null : "item-disabled pe-none"}>
-            <LazyLoad active={loadStatus === "idle" || loadStatus === "loading"} className="mt-2">
+            <LazyLoad active={isLoading} className="mt-2">
                 {isEmpty ? (
                     <div className="w-100">
                         <EmptySet>No server-wide connection strings have been defined</EmptySet>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideConnectionStrings/ServerWideConnectionStringsInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideConnectionStrings/ServerWideConnectionStringsInfoHub.tsx
@@ -1,17 +1,37 @@
 import { AboutViewAnchored, AccordionItemWrapper } from "components/common/AboutView";
-import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import useConnectionStringsLicense from "components/pages/database/settings/connectionStrings/useConnectionStringsLicense";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "hooks/useRavenLink";
+import { licenseSelectors } from "components/common/shell/licenseSlice";
+import { useAppSelector } from "components/store";
+import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export default function ServerWideConnectionStringsInfoHub() {
     const { hasAll, featureAvailability } = useConnectionStringsLicense();
+    const hasServerWideConnectionStrings = useAppSelector(
+        licenseSelectors.statusValue("HasServerWideConnectionStrings")
+    );
+
+    const serverWideFeatureAvailability = useLimitedFeatureAvailability({
+        defaultFeatureAvailability,
+        overwrites: [
+            {
+                featureName: defaultFeatureAvailability[0].featureName,
+                value: hasServerWideConnectionStrings,
+            },
+        ],
+    });
+
+    const isLicenseUnlimited = hasAll && hasServerWideConnectionStrings;
 
     const connectionStringsOverviewDocsLink = useRavenLink({ hash: "P5XJOV" });
     const connectionStringsServerwideDocsLink = useRavenLink({ hash: "5AQ7XL" });
 
     return (
-        <AboutViewAnchored defaultOpen={hasAll ? null : "licensing"}>
+        <AboutViewAnchored defaultOpen={isLicenseUnlimited ? null : "licensing"}>
             <AccordionItemWrapper
                 targetId="about"
                 icon="about"
@@ -50,10 +70,20 @@ export default function ServerWideConnectionStringsInfoHub() {
                 </div>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper
-                data={featureAvailability}
-                isUnlimited={hasAll}
-                isOpenedByDefault={false}
+                data={[...serverWideFeatureAvailability, ...featureAvailability]}
+                isUnlimited={isLicenseUnlimited}
+                isOpenedByDefault={!hasServerWideConnectionStrings}
             />
         </AboutViewAnchored>
     );
 }
+
+const defaultFeatureAvailability: FeatureAvailabilityData[] = [
+    {
+        featureName: "Server-Wide Connection Strings",
+        featureIcon: "manage-connection-strings",
+        community: { value: false },
+        professional: { value: true },
+        enterprise: { value: true },
+    },
+];


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27399

### Additional description

- Skip loading placeholder when license has no server-wide connection strings (fetch is never dispatched, so status would stay idle forever)
- Include HasServerWideConnectionStrings in the info hub licensing summary and open it by default when the feature is not licensed
- Add missing Azure Service Bus row to connection strings feature availability (shared with the per-database view)
- Add spec covering fetch/no-fetch and placeholder behavior per license

without server-wide connection strings key in license.
<img width="2171" height="1136" alt="image" src="https://github.com/user-attachments/assets/3a548cc7-eda8-4a22-a5fe-ad32f8444c19" />

with server-wide connection strings key in license:
<img width="1865" height="1138" alt="image" src="https://github.com/user-attachments/assets/46820797-503e-4d0b-9a1a-01731a323615" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
