### PR TITLE
RavenDB-27414: quill - start ravendb only once the setup package exists

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -65,7 +65,6 @@ docker/quill/s6-rc.d/** text eol=lf
 docker/quill/Dockerfile* text eol=lf
 docker/quill/scripts/** text eol=lf
 docker/quill/nginx.conf text eol=lf
-docker/quill/ravendb-settings.json text eol=lf
 
 * -crlf
 

--- a/docker/quill/Dockerfile
+++ b/docker/quill/Dockerfile
@@ -106,7 +106,6 @@ EOF
 
 COPY --from=ravendb   /usr/lib/ravendb/server /app/ravendb
 COPY --from=web-build /publish/web            /app/web
-COPY docker/quill/ravendb-settings.json /app/ravendb/settings.json
 COPY docker/quill/nginx.conf /etc/nginx/nginx.conf
 
 COPY docker/quill/s6-rc.d/ /etc/s6-overlay/s6-rc.d/

--- a/docker/quill/Dockerfile.source
+++ b/docker/quill/Dockerfile.source
@@ -151,7 +151,6 @@ EOF
 COPY --from=ravendb-server-build /publish/raven /app/ravendb
 COPY --from=ravendb-studio-build /src/src/Raven.Studio/wwwroot/dist/Raven.Studio.zip /app/ravendb/
 COPY --from=web-build            /publish/web   /app/web
-COPY docker/quill/ravendb-settings.json /app/ravendb/settings.json
 COPY docker/quill/nginx.conf /etc/nginx/nginx.conf
 
 COPY docker/quill/s6-rc.d/ /etc/s6-overlay/s6-rc.d/

--- a/docker/quill/ravendb-settings.json
+++ b/docker/quill/ravendb-settings.json
@@ -1,4 +1,0 @@
-{
-    "DataDir": "/var/lib/quill/ravendb",
-    "License.Eula.Accepted": true
-}

--- a/docker/quill/ravendb-settings.json
+++ b/docker/quill/ravendb-settings.json
@@ -1,7 +1,4 @@
 {
-    "Setup.Mode": "Unsecured",
-    "ServerUrl": "http://0.0.0.0:8080",
     "DataDir": "/var/lib/quill/ravendb",
-    "Security.UnsecuredAccessAllowed": "PublicNetwork",
     "License.Eula.Accepted": true
 }

--- a/docker/quill/s6-rc.d/01-ravendb/run
+++ b/docker/quill/s6-rc.d/01-ravendb/run
@@ -5,57 +5,50 @@ exec 2>&1
 
 mkdir -p /var/lib/quill/ravendb
 
-# When activation has produced a setup package, overlay its secure settings on
-# top of the baked-in unsecured config. Pre-activation the file is absent and
-# RavenDB starts unsecured on loopback (Setup.Mode=Unsecured from
-# docker/quill/ravendb-settings.json).
-#
+SETUP_DIR="${RAVEN_QUILL_SETUP_PACKAGE_PATH:-/var/lib/quill/setup}"
+SETUP_SETTINGS="$SETUP_DIR/A/settings.json"
+
+# wait for activation (02-web) to unpack the setup package
+if [ ! -f "$SETUP_SETTINGS" ]; then
+    echo "01-ravendb: waiting for the setup package at $SETUP_SETTINGS..."
+    while [ ! -f "$SETUP_SETTINGS" ]; do
+        sleep 2
+    done
+fi
+
 # The admin client cert's thumbprint is written by the .NET activation endpoint
 # next to the unpacked package as the file `admin-thumbprint`. Reading it here
 # rather than extracting from the PFX with openssl avoids PKCS#12 bag-ordering
 # quirks and one less binary dependency in the runtime image.
-SETUP_DIR="${RAVEN_QUILL_SETUP_PACKAGE_PATH:-/var/lib/quill/setup}"
-SETUP_SETTINGS="$SETUP_DIR/A/settings.json"
-if [ -f "$SETUP_SETTINGS" ]; then
-    cp "$SETUP_SETTINGS" /app/ravendb/settings.json
+cp "$SETUP_SETTINGS" /app/ravendb/settings.json
 
-    # Phase 1: nginx owns :443, so bind RavenDB's HTTPS to loopback:$RAVENDB_PORT instead. settings.json
-    # wins over env in RavenDB's config precedence, so rewrite the copied file (keep https — the
-    # scheme-match validator requires ServerUrl/PublicServerUrl schemes to agree). The appliance connects
-    # to RavenDB on this port (RavenStoreFactory.RavenInternalPort); nginx passes db.*/a.* through to it.
-    RAVENDB_PORT="${RAVEN_QUILL_RAVENDB_INTERNAL_PORT:-8443}"
-    sed -i -E "s#(\"ServerUrl\"[[:space:]]*:[[:space:]]*\")https://[^\"]*(\")#\1https://127.0.0.1:${RAVENDB_PORT}\2#" /app/ravendb/settings.json
+# Phase 1: nginx owns :443, so bind RavenDB's HTTPS to loopback:$RAVENDB_PORT instead. settings.json
+# wins over env in RavenDB's config precedence, so rewrite the copied file (keep https — the
+# scheme-match validator requires ServerUrl/PublicServerUrl schemes to agree). The appliance connects
+# to RavenDB on this port (RavenStoreFactory.RavenInternalPort); nginx passes db.*/a.* through to it.
+RAVENDB_PORT="${RAVEN_QUILL_RAVENDB_INTERNAL_PORT:-8443}"
+sed -i -E "s#(\"ServerUrl\"[[:space:]]*:[[:space:]]*\")https://[^\"]*(\")#\1https://127.0.0.1:${RAVENDB_PORT}\2#" /app/ravendb/settings.json
 
-    NODE_HOST="$(jq -r '.PublicServerUrl' "$SETUP_SETTINGS" | sed -E 's#^https?://##; s#[:/].*##')"
-    if [ -n "$NODE_HOST" ]; then
-        grep -q "[[:space:]]$NODE_HOST\$" /etc/hosts || echo "127.0.0.1 $NODE_HOST" >> /etc/hosts
-    fi
+NODE_HOST="$(jq -r '.PublicServerUrl' "$SETUP_SETTINGS" | sed -E 's#^https?://##; s#[:/].*##')"
+if [ -n "$NODE_HOST" ]; then
+    grep -q "[[:space:]]$NODE_HOST\$" /etc/hosts || echo "127.0.0.1 $NODE_HOST" >> /etc/hosts
+fi
 
-    CERT_DIR=/var/lib/quill/certs
-    mkdir -p "$CERT_DIR"
+CERT_DIR=/var/lib/quill/certs
+mkdir -p "$CERT_DIR"
 
-    PFX="$(basename "$(ls "$SETUP_DIR"/A/cluster.server.certificate.*.pfx | head -n1)")"
-    [ -f "$CERT_DIR/$PFX" ] || cp "$SETUP_DIR/A/$PFX" "$CERT_DIR/"
+PFX="$(basename "$(ls "$SETUP_DIR"/A/cluster.server.certificate.*.pfx | head -n1)")"
+[ -f "$CERT_DIR/$PFX" ] || cp "$SETUP_DIR/A/$PFX" "$CERT_DIR/"
 
-    sed -i "s#\"$PFX\"#\"$CERT_DIR/$PFX\"#" /app/ravendb/settings.json
+sed -i "s#\"$PFX\"#\"$CERT_DIR/$PFX\"#" /app/ravendb/settings.json
 
-    if [ -f "$SETUP_DIR/admin-thumbprint" ]; then
-        export RAVEN_Security_WellKnownCertificates_Admin="$(cat "$SETUP_DIR/admin-thumbprint")"
-    fi
+if [ -f "$SETUP_DIR/admin-thumbprint" ]; then
+    export RAVEN_Security_WellKnownCertificates_Admin="$(cat "$SETUP_DIR/admin-thumbprint")"
+fi
 
-    # Activate the license shipped in the setup package. The setup-wizard zip
-    # writes license.json at the package root (not into A/settings.json), and
-    # nothing else wires it up — without this RavenDB starts unlicensed
-    # (Community/AGPL) and rejects commercial features (AI Agent, etc.), even
-    # though a valid license sits on disk. RavenDB activates License.Path on
-    # first start when no license is stored yet, then persists it to cluster
-    # storage. License.Eula.Accepted is re-asserted because copying
-    # A/settings.json over the baked config drops the baked Eula flag, and a
-    # missing flag blocks activation.
-    if [ -f "$SETUP_DIR/license.json" ]; then
-        export RAVEN_License_Path="$SETUP_DIR/license.json"
-        export RAVEN_License_Eula_Accepted=true
-    fi
+if [ -f "$SETUP_DIR/license.json" ]; then
+    export RAVEN_License_Path="$SETUP_DIR/license.json"
+    export RAVEN_License_Eula_Accepted=true
 fi
 
 cd /app/ravendb

--- a/docker/quill/s6-rc.d/01-ravendb/run
+++ b/docker/quill/s6-rc.d/01-ravendb/run
@@ -8,11 +8,17 @@ mkdir -p /var/lib/quill/ravendb
 SETUP_DIR="${RAVEN_QUILL_SETUP_PACKAGE_PATH:-/var/lib/quill/setup}"
 SETUP_SETTINGS="$SETUP_DIR/A/settings.json"
 
-# wait for activation (02-web) to unpack the setup package
+# Wait for activation (02-web) to unpack the setup package. Log a heartbeat every 60s: the wait is
+# unbounded (activation retries in 02-web until the package arrives)
 if [ ! -f "$SETUP_SETTINGS" ]; then
     echo "01-ravendb: waiting for the setup package at $SETUP_SETTINGS..."
+    waited=0
     while [ ! -f "$SETUP_SETTINGS" ]; do
         sleep 2
+        waited=$((waited + 2))
+        if [ $((waited % 60)) -eq 0 ]; then
+            echo "01-ravendb: still waiting for the setup package after ${waited}s (activation runs in 02-web; check its log)"
+        fi
     done
 fi
 

--- a/src/Raven.Quill/AiHelper/ILicenseClient.cs
+++ b/src/Raven.Quill/AiHelper/ILicenseClient.cs
@@ -6,3 +6,5 @@ public interface ILicenseClient
 }
 
 public sealed class LicenseRetrievalException(string message) : Exception(message);
+
+public sealed class LicenseKeyNotFoundException(string message) : Exception(message);

--- a/src/Raven.Quill/AiHelper/LicenseHttpClient.cs
+++ b/src/Raven.Quill/AiHelper/LicenseHttpClient.cs
@@ -28,6 +28,10 @@ public sealed class LicenseHttpClient : ILicenseClient
 
         using (response)
         {
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                throw new LicenseKeyNotFoundException(
+                    "license API has no setup package for this key; check QUILL_LICENSE_KEY.");
+
             if (response.IsSuccessStatusCode == false)
                 throw new LicenseRetrievalException(
                     $"license API returned {(int)response.StatusCode} {response.ReasonPhrase} retrieving the setup package.");
@@ -37,15 +41,34 @@ public sealed class LicenseHttpClient : ILicenseClient
         }
     }
 
+    private static readonly TimeSpan RetryAfterFallback = TimeSpan.FromSeconds(30);
+
+    private static TimeSpan RetryDelay(DelegateResult<HttpResponseMessage> outcome)
+    {
+        var retryAfter = outcome.Result?.Headers.RetryAfter;
+        if (retryAfter is null)
+            return RetryAfterFallback;
+
+        // Retry-After is either a delta (Retry-After: 30) or an HTTP date; Delta is null for the date form.
+        if (retryAfter.Delta is { } delta)
+            return delta;
+        if (retryAfter.Date is { } date)
+            return date - DateTimeOffset.UtcNow is { Ticks: > 0 } until ? until : RetryAfterFallback;
+
+        return RetryAfterFallback;
+    }
+
     private static readonly AsyncRetryPolicy<HttpResponseMessage> SetupPackageRetryPolicy = Policy
-        .HandleResult<HttpResponseMessage>(r => r.StatusCode is HttpStatusCode.ServiceUnavailable && r.Headers.RetryAfter != null)
+        .HandleResult<HttpResponseMessage>(r => r.StatusCode is HttpStatusCode.ServiceUnavailable or HttpStatusCode.TooManyRequests)
+        .OrResult(r => r.StatusCode is HttpStatusCode.BadGateway or HttpStatusCode.GatewayTimeout)
+        .Or<HttpRequestException>()
         .WaitAndRetryAsync(
-            retryCount: 5,
-            sleepDurationProvider: (_, result, _) => result.Result.Headers.RetryAfter.Delta.Value,
+            retryCount: 40,
+            sleepDurationProvider: (_, outcome, _) => RetryDelay(outcome),
             onRetryAsync: (outcome, _, _, _) =>
             {
                 // ResponseHeadersRead holds the connection until the message is disposed
-                using (outcome.Result)
-                    return Task.CompletedTask;
+                outcome.Result?.Dispose();
+                return Task.CompletedTask;
             });
 }

--- a/src/Raven.Quill/Hosting/ApplianceActivationService.cs
+++ b/src/Raven.Quill/Hosting/ApplianceActivationService.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.IO.Compression;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Options;
@@ -38,9 +37,12 @@ public sealed class ApplianceActivationService(
             try
             {
                 await using (var tempFile = File.Create(tempZipPath))
-                    await licenseClient.DownloadSetupPackageToAsync(opts.LicenseKey ?? string.Empty, tempFile, stoppingToken);
+                    await DownloadWithRetryAsync(opts.LicenseKey ?? string.Empty, tempFile, stoppingToken);
 
-                var staging = opts.SetupPackagePath + ".incoming";
+                var target = Path.TrimEndingDirectorySeparator(opts.SetupPackagePath);
+                var staging = target + ".incoming";
+                var previous = target + ".old";
+
                 if (Directory.Exists(staging))
                     Directory.Delete(staging, recursive: true);
 
@@ -50,10 +52,19 @@ public sealed class ApplianceActivationService(
 
                 WriteAdminThumbprint(staging);
 
-                if (Directory.Exists(opts.SetupPackagePath))
-                    Directory.Delete(opts.SetupPackagePath, recursive: true);
+                // Promote staging by renaming the current package aside first, so a complete package is on
+                // disk at every instant: a crash between the renames leaves either the old or the new one
+                // intact, never nothing. Renaming (not deleting then moving) also frees the target name
+                // synchronously, avoiding the Windows NTFS delete-pending race that can make the Move throw.
+                if (Directory.Exists(previous))
+                    Directory.Delete(previous, recursive: true);
+                if (Directory.Exists(target))
+                    Directory.Move(target, previous);
 
-                Directory.Move(staging, opts.SetupPackagePath);
+                Directory.Move(staging, target);
+
+                if (Directory.Exists(previous))
+                    Directory.Delete(previous, recursive: true);
             }
             finally
             {
@@ -68,7 +79,7 @@ public sealed class ApplianceActivationService(
 
             if (string.IsNullOrEmpty(opts.RavenDbS6Service) == false)
             {
-                RestartIntoSecureMode(opts);
+                RestartIntoSecureMode();
                 return;
             }
 
@@ -83,15 +94,44 @@ public sealed class ApplianceActivationService(
             logger.LogWarning(ex, "Activation: setup package was not a valid zip.");
             bootstrap.MarkFailed("activation failed: the setup package was invalid");
         }
-        catch (LicenseRetrievalException ex)
+        catch (LicenseKeyNotFoundException ex)
         {
-            logger.LogError(ex, "Activation: failed to retrieve the setup package.");
-            bootstrap.MarkFailed("activation failed: could not retrieve the setup package");
+            logger.LogError(ex, "Activation: the license key has no setup package.");
+            bootstrap.MarkFailed("activation failed: the license key was not recognized");
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Activation failed.");
             bootstrap.MarkFailed("activation failed; see server logs for details");
+        }
+    }
+
+    private static readonly TimeSpan DownloadRetryDelay = TimeSpan.FromSeconds(30);
+
+    private async Task DownloadWithRetryAsync(string licenseKey, Stream destination, CancellationToken ct)
+    {
+        var attempt = 0;
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                await licenseClient.DownloadSetupPackageToAsync(licenseKey, destination, ct);
+                return;
+            }
+            catch (LicenseRetrievalException ex)
+            {
+                attempt++;
+                logger.LogInformation(
+                    "Setup package not available yet (attempt {Attempt}: {Reason}); retrying in {Delay}s.",
+                    attempt, ex.Message, DownloadRetryDelay.TotalSeconds);
+
+                // A partial write from the failed attempt must not corrupt the next one.
+                destination.SetLength(0);
+                destination.Position = 0;
+
+                await Task.Delay(DownloadRetryDelay, ct);
+            }
         }
     }
 
@@ -115,22 +155,9 @@ public sealed class ApplianceActivationService(
         File.WriteAllText(Path.Combine(packagePath, "admin-thumbprint"), cert.Thumbprint);
     }
 
-    private void RestartIntoSecureMode(ApplianceOptions opts)
+    private void RestartIntoSecureMode()
     {
         bootstrap.TryMarkRestarting();
-
-        try
-        {
-            using var s6 = Process.Start(new ProcessStartInfo("s6-svc", "-r " + opts.RavenDbS6Service)
-            {
-                UseShellExecute = false,
-            });
-            s6?.WaitForExit(5000);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Could not signal s6 to restart RavenDB ({Service}); an s6 supervisor must restart the host.", opts.RavenDbS6Service);
-        }
 
         logger.LogInformation("Activation complete; restarting .NET host to bind the secure IDocumentStore.");
         lifetime.StopApplication();

--- a/src/Raven.Quill/Hosting/ApplianceActivationService.cs
+++ b/src/Raven.Quill/Hosting/ApplianceActivationService.cs
@@ -40,9 +40,20 @@ public sealed class ApplianceActivationService(
                 await using (var tempFile = File.Create(tempZipPath))
                     await licenseClient.DownloadSetupPackageToAsync(opts.LicenseKey ?? string.Empty, tempFile, stoppingToken);
 
-                Directory.CreateDirectory(opts.SetupPackagePath);
+                var staging = opts.SetupPackagePath + ".incoming";
+                if (Directory.Exists(staging))
+                    Directory.Delete(staging, recursive: true);
+
+                Directory.CreateDirectory(staging);
                 // zip-slip guard: ExtractToDirectory rejects ../ and absolute entries
-                ZipFile.ExtractToDirectory(tempZipPath, opts.SetupPackagePath, overwriteFiles: true);
+                ZipFile.ExtractToDirectory(tempZipPath, staging, overwriteFiles: true);
+
+                WriteAdminThumbprint(staging);
+
+                if (Directory.Exists(opts.SetupPackagePath))
+                    Directory.Delete(opts.SetupPackagePath, recursive: true);
+
+                Directory.Move(staging, opts.SetupPackagePath);
             }
             finally
             {
@@ -54,8 +65,6 @@ public sealed class ApplianceActivationService(
             }
 
             logger.LogInformation("Setup package activated and unpacked to {Path}.", opts.SetupPackagePath);
-
-            WriteAdminThumbprint(opts);
 
             if (string.IsNullOrEmpty(opts.RavenDbS6Service) == false)
             {
@@ -86,10 +95,10 @@ public sealed class ApplianceActivationService(
         }
     }
 
-    private void WriteAdminThumbprint(ApplianceOptions opts)
+    private void WriteAdminThumbprint(string packagePath)
     {
         var adminPfx = Directory
-            .GetFiles(opts.SetupPackagePath, "admin.client.certificate.*.pfx")
+            .GetFiles(packagePath, "admin.client.certificate.*.pfx")
             .OrderBy(p => p, StringComparer.Ordinal)
             .FirstOrDefault();
         if (adminPfx is null)
@@ -98,12 +107,12 @@ public sealed class ApplianceActivationService(
                 "No admin client certificate (admin.client.certificate.*.pfx) found under {Path}; " +
                 "skipping the admin-thumbprint marker — RavenDB will not trust the admin cert and the " +
                 "secure store may fail to authenticate (appliance can hang in Restarting).",
-                opts.SetupPackagePath);
+                packagePath);
             return;
         }
 
         using var cert = X509CertificateLoader.LoadPkcs12FromFile(adminPfx, password: "");
-        File.WriteAllText(Path.Combine(opts.SetupPackagePath, "admin-thumbprint"), cert.Thumbprint);
+        File.WriteAllText(Path.Combine(packagePath, "admin-thumbprint"), cert.Thumbprint);
     }
 
     private void RestartIntoSecureMode(ApplianceOptions opts)

--- a/src/Raven.Quill/Hosting/ApplianceOptions.cs
+++ b/src/Raven.Quill/Hosting/ApplianceOptions.cs
@@ -17,6 +17,8 @@ public sealed class ApplianceOptions
 
     public string SetupPackagePath { get; set; } = "/setup";
 
+    public string SetupNodeSettingsPath => Path.Combine(SetupPackagePath, "A", "settings.json");
+
     public string? LicenseKey { get; set; }
 
     public string? ApiKey { get; set; }

--- a/src/Raven.Quill/Hosting/BootstrapState.cs
+++ b/src/Raven.Quill/Hosting/BootstrapState.cs
@@ -49,8 +49,7 @@ public sealed class BootstrapStateFlag : IBootstrapState
 
     public BootstrapStateFlag(IOptions<ApplianceOptions> options)
     {
-        var setupSettings = Path.Combine(options.Value.SetupPackagePath, "A", "settings.json");
-        _startedWithSetupPackage = File.Exists(setupSettings);
+        _startedWithSetupPackage = File.Exists(options.Value.SetupNodeSettingsPath);
         _phase = _startedWithSetupPackage
             ? (int)BootstrapPhase.Restarting
             : (int)BootstrapPhase.NeedsActivation;

--- a/src/Raven.Quill/Hosting/RavenReadinessService.cs
+++ b/src/Raven.Quill/Hosting/RavenReadinessService.cs
@@ -44,8 +44,11 @@ public sealed class RavenReadinessService(
 
         try
         {
-            if (string.IsNullOrEmpty(opts.RavenDbS6Service) == false)
-                await WaitForSetupPackageAsync(opts, stoppingToken);
+            if (string.IsNullOrEmpty(opts.RavenDbS6Service) == false && bootstrap.StartedWithSetupPackage == false)
+            {
+                logger.LogInformation("Started without the setup package; waiting for activation to restart the host before probing RavenDB.");
+                await Task.Delay(Timeout.Infinite, stoppingToken);
+            }
 
             // grace period: RavenDB needs ~10-15s; earlier probes just spam errors
             if (opts.ReadinessInitialDelay > TimeSpan.Zero)
@@ -95,7 +98,7 @@ public sealed class RavenReadinessService(
                         opts.ReadinessOverallTimeout, opts.ReadinessInitialDelay);
                     ready.MarkFailed(ex.Message);
 
-                    if (File.Exists(GetSetupSettingsPath(opts)))
+                    if (File.Exists(opts.SetupNodeSettingsPath))
                         bootstrap.MarkRestarting("ravendb is not reachable: " + ex.Message);
                     else
                         bootstrap.MarkFailed("ravendb is not reachable: " + ex.Message);
@@ -118,18 +121,4 @@ public sealed class RavenReadinessService(
         await base.StopAsync(cancellationToken);
     }
 
-    private async Task WaitForSetupPackageAsync(ApplianceOptions opts, CancellationToken ct)
-    {
-        var settings = GetSetupSettingsPath(opts);
-        if (File.Exists(settings))
-            return;
-
-        logger.LogInformation("Waiting for the setup package at {Path} before probing RavenDB.", settings);
-
-        while (File.Exists(settings) == false)
-            await Task.Delay(TimeSpan.FromSeconds(2), ct);
-    }
-
-    private static string GetSetupSettingsPath(ApplianceOptions options) =>
-        Path.Combine(options.SetupPackagePath, "A", "settings.json");
 }

--- a/src/Raven.Quill/Hosting/RavenReadinessService.cs
+++ b/src/Raven.Quill/Hosting/RavenReadinessService.cs
@@ -44,6 +44,9 @@ public sealed class RavenReadinessService(
 
         try
         {
+            if (string.IsNullOrEmpty(opts.RavenDbS6Service) == false)
+                await WaitForSetupPackageAsync(opts, stoppingToken);
+
             // grace period: RavenDB needs ~10-15s; earlier probes just spam errors
             if (opts.ReadinessInitialDelay > TimeSpan.Zero)
             {
@@ -113,6 +116,18 @@ public sealed class RavenReadinessService(
 
         ready.MarkFailed("shutting down");
         await base.StopAsync(cancellationToken);
+    }
+
+    private async Task WaitForSetupPackageAsync(ApplianceOptions opts, CancellationToken ct)
+    {
+        var settings = GetSetupSettingsPath(opts);
+        if (File.Exists(settings))
+            return;
+
+        logger.LogInformation("Waiting for the setup package at {Path} before probing RavenDB.", settings);
+
+        while (File.Exists(settings) == false)
+            await Task.Delay(TimeSpan.FromSeconds(2), ct);
     }
 
     private static string GetSetupSettingsPath(ApplianceOptions options) =>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27414

### Additional description

the app  could come up permanently unlicensed while holding a valid license.json - reported as a 500 from /assistant/assist ("AI Assistant is available only for licensed instances"). 
ravendb activates a license file only at the cluster bootstrap, while its node is Passive; no later start re-reads License.Path. We started RavenDB unsecured before activation downloaded the setup package, and `RavenReadinessService` creates quill-config ~15s in, which bootstraps.
 so a slow download (or any first boot without `QUILL_LICENSE_KEY`) bootstrapped unlicensed, for the life of the volume. 

now `01-ravendb`  waits for the package: ravendb only start is the secure, licensed one. 
readiness waits for the same file (its probe would otherwise print a false FAILED), activation unpacks to `setup.incoming` and moves it into place so the file's presence means the package is complete, and the dead Unsecured settings are gone. 

volumes already bootstrapped unlicensed are deliberately not repaired - a single POST to /admin/license/activate fixes one in place

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

**see comment below !!**

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [s] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
