### PR TITLE
RavenDB-27181 : GPT-5.6 models unusable with AI agents - tools rejected on /v1/chat/completions

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/OpenAiSettings.cs
+++ b/src/Raven.Client/Documents/Operations/AI/OpenAiSettings.cs
@@ -10,7 +10,7 @@ public sealed class OpenAiSettings : OpenAiBaseSettings
 {
     public OpenAiSettings(string apiKey, string endpoint, string model, string organizationId = null, 
         string projectId = null, int? dimensions = null, double? temperature = null,
-        OpenAiReasoningEffort? reasoningEffort = null, int? seed = null) : base(apiKey, endpoint, model, dimensions, temperature)
+        string reasoningEffort = null, int? seed = null) : base(apiKey, endpoint, model, dimensions, temperature)
     {
         OrganizationId = organizationId;
         ProjectId = projectId;
@@ -55,22 +55,21 @@ public sealed class OpenAiSettings : OpenAiBaseSettings
     public string ProjectId { get; set; }
 
     /// <summary>
-    /// Controls the reasoning depth used by supported models (such as GPT-5 family).
-    /// Lower values reduce the amount of internal reasoning performed by the model,
+    /// The <c>reasoning_effort</c> to send to the provider, controlling the reasoning depth
+    /// of supported models (such as the GPT-5 family). Lower values reduce internal reasoning,
     /// which may improve latency and reduce variability in responses.
-    /// 
-    /// Supported values typically include:
-    /// <list type="bullet">
-    /// <item><description><c>minimal</c> - minimal reasoning, fastest responses.</description></item>
-    /// <item><description><c>low</c> - limited reasoning.</description></item>
-    /// <item><description><c>medium</c> - default reasoning level.</description></item>
-    /// <item><description><c>high</c> - deeper reasoning, potentially slower responses.</description></item>
-    /// </list>
-    /// 
-    /// Note that this setting reduces the likelihood of non-deterministic behavior,
-    /// but does not guarantee fully deterministic responses.
+    ///
+    /// Typical values are <c>none</c>, <c>minimal</c>, <c>low</c>, <c>medium</c>, <c>high</c>,
+    /// <c>xhigh</c> and <c>max</c>. Model families accept different subsets, for example
+    /// <c>minimal</c> is rejected by <c>gpt-5.1</c> and later, which take <c>none</c> instead.
+    /// When not set the field is omitted and the model applies its own default.
+    ///
+    /// Sent as supplied apart from trimming, and not validated by RavenDB, so new provider values
+    /// can be used without waiting for a RavenDB release. Providers match it exactly: OpenAI accepts
+    /// lowercase values only. Legacy <see cref="OpenAiReasoningEffort"/> member names persisted by
+    /// older clients (e.g. <c>High</c>) are normalized to the provider form by the server.
     /// </summary>
-    public OpenAiReasoningEffort? ReasoningEffort { get; set; }
+    public string ReasoningEffort { get; set; }
 
     /// <summary>
     /// Optional seed used to make the model's sampling more reproducible across requests.
@@ -106,7 +105,7 @@ public sealed class OpenAiSettings : OpenAiBaseSettings
         if (string.IsNullOrWhiteSpace(ProjectId) == false)
             json[nameof(ProjectId)] = ProjectId;
 
-        if (ReasoningEffort.HasValue)
+        if (string.IsNullOrWhiteSpace(ReasoningEffort) == false)
             json[nameof(ReasoningEffort)] = ReasoningEffort;
 
         if (Seed.HasValue)
@@ -118,13 +117,27 @@ public sealed class OpenAiSettings : OpenAiBaseSettings
 
 /// <summary>
 /// Specifies the reasoning effort level used by supported models.
-/// Controls how much internal reasoning the model performs,
-/// affecting latency and response variability.
+/// Kept for migration only; use the string-based <see cref="OpenAiSettings.ReasoningEffort"/> instead.
 /// </summary>
+[Obsolete("Use the string-based OpenAiSettings.ReasoningEffort instead, e.g. OpenAiReasoningEffort.High.ToReasoningEffort().")]
 public enum OpenAiReasoningEffort
 {
     Minimal,
     Low,
     Medium,
     High
+}
+
+public static class OpenAiReasoningEffortExtensions
+{
+#pragma warning disable CS0618 // the enum stays public for migration
+    /// <summary>
+    /// Converts a legacy <see cref="OpenAiReasoningEffort"/> value to the lowercase form
+    /// expected by the provider, e.g. <see cref="OpenAiReasoningEffort.High"/> to <c>high</c>.
+    /// </summary>
+    public static string ToReasoningEffort(this OpenAiReasoningEffort reasoningEffort)
+    {
+        return reasoningEffort.ToString().ToLowerInvariant();
+    }
+#pragma warning restore CS0618
 }

--- a/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
@@ -83,6 +83,9 @@ internal abstract class AbstractChatCompletionClientSettings
         {
             public const string Think = "think";
             public const string Temperature = "temperature";
+            public const string ReasoningEffort = "reasoning_effort";
+            public const string Seed = "seed";
+            public const string ReasoningEffortNoneValue = "none";
         }
 
         public static class Headers

--- a/src/Raven.Server/Documents/AI/Settings/OpenAiChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/OpenAiChatCompletionClientSettings.cs
@@ -11,10 +11,53 @@ namespace Raven.Server.Documents.AI.Settings;
 internal class OpenAiChatCompletionClientSettings : AbstractOpenAiChatCompletionClientSettings
 {
     private new readonly OpenAiSettings _settings;
-    public OpenAiChatCompletionClientSettings(OpenAiSettings settings) 
+    private readonly bool _disableReasoning;
+    private const string GptModelPrefix = "gpt-";
+    private static readonly Version MinVersionRequiringReasoningDisabled = new(5, 4);
+
+    public OpenAiChatCompletionClientSettings(OpenAiSettings settings)
         : base(settings)
     {
         _settings = settings;
+        _disableReasoning = ShouldDisableReasoningForChatCompletions(settings.Model);
+    }
+
+    // gpt-5.4 and later reject function tools combined with reasoning on /v1/chat/completions:
+    private static bool ShouldDisableReasoningForChatCompletions(string model)
+    {
+        if (string.IsNullOrWhiteSpace(model))
+            return false;
+
+        var modelName = model.AsSpan().Trim();
+
+        // e.g. openai/gpt-5.6-sol
+        var lastSlash = modelName.LastIndexOf('/');
+        if (lastSlash >= 0)
+            modelName = modelName[(lastSlash + 1)..];
+
+        if (modelName.StartsWith(GptModelPrefix, StringComparison.OrdinalIgnoreCase) == false)
+            return false;
+
+        var versionText = modelName[GptModelPrefix.Length..];
+
+        // e.g. "5.6-sol" -> "5.6"
+        var suffixIndex = versionText.IndexOf('-');
+        if (suffixIndex >= 0)
+            versionText = versionText[..suffixIndex];
+
+        // Version requires at least major.minor. A major-only name is accepted only as a single
+        // digit, so a future "gpt-6" follows the policy while "gpt-35-turbo" (Azure's alias for
+        // gpt-3.5-turbo, seen on OpenAI-compatible providers such as LiteLLM-fronted deployments)
+        // is not treated as version 35.
+        if (versionText.IndexOf('.') < 0)
+        {
+            return versionText.Length == 1 &&
+                   char.IsAsciiDigit(versionText[0]) &&
+                   versionText[0] > '5';
+        }
+
+        return Version.TryParse(versionText, out var version) &&
+               version >= MinVersionRequiringReasoningDisabled;
     }
 
     public override void AddHeaders(HttpRequestMessage request)
@@ -57,23 +100,52 @@ internal class OpenAiChatCompletionClientSettings : AbstractOpenAiChatCompletion
 
     public override void HandleCompletionRequestPayload(AsyncBlittableJsonTextWriter writer)
     {
-        if (_settings.ReasoningEffort.HasValue)
+        var reasoningEffort = GetEffectiveReasoningEffort();
+        if (reasoningEffort != null)
         {
             writer.WriteComma();
-            writer.WritePropertyName("reasoning_effort");
-            writer.WriteString(_settings.ReasoningEffort.Value.ToString().ToLower());
+            writer.WritePropertyName(Constants.RequestFields.ReasoningEffort);
+            writer.WriteString(reasoningEffort);
         }
         if (_settings.Seed.HasValue)
         {
             // Use a fixed seed to make sampling more reproducible across runs.
-            // This helps stabilize tests. Combined with reasoning_effort="minimal"
+            // This helps stabilize tests. Combined with a low reasoning_effort
             // it further reduces the probability of flaky responses.
             writer.WriteComma();
-            writer.WritePropertyName("seed");
+            writer.WritePropertyName(Constants.RequestFields.Seed);
             writer.WriteInteger(_settings.Seed.Value);
         }
         base.HandleCompletionRequestPayload(writer);
     }
+
+    // null means the field is omitted from the request
+    private string GetEffectiveReasoningEffort()
+    {
+        if (_disableReasoning)
+            return Constants.RequestFields.ReasoningEffortNoneValue;
+
+        var reasoningEffort = _settings.ReasoningEffort;
+        if (string.IsNullOrWhiteSpace(reasoningEffort))
+            return null;
+
+        return NormalizeReasoningEffort(reasoningEffort.Trim());
+    }
+
+#pragma warning disable CS0618 // configurations persisted by older clients hold the legacy enum shape
+    private static string NormalizeReasoningEffort(string value)
+    {
+        // ReasoningEffort is free-form, so "3" is a provider value - without this, Enum.TryParse
+        // below would read it as the number behind High
+        if (int.TryParse(value, out _))
+            return value;
+
+        if (Enum.TryParse(value, ignoreCase: false, out OpenAiReasoningEffort effort))
+            return effort.ToReasoningEffort();
+
+        return value;
+    }
+#pragma warning restore CS0618
 
     private class OpenAiErrorHolder
     {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
@@ -325,6 +325,7 @@ export function mapAiConnectionStringToDto(connection: AiConnection): AiConnecti
                       Model: connection.openAiSettings.model,
                       OrganizationId: connection.openAiSettings.organizationId,
                       ProjectId: connection.openAiSettings.projectId,
+                      ReasoningEffort: null,
                       Dimensions: mapDimensionsToDto(connection),
                       EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
                       EnablePromptCache: connection.openAiSettings.enablePromptCache,

--- a/test/SlowTests/Server/Documents/AI/RavenDB-27181.cs
+++ b/test/SlowTests/Server/Documents/AI/RavenDB-27181.cs
@@ -1,0 +1,322 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.AI;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Raven.Server.Json;
+using Raven.Server.ServerWide;
+using Raven.Client.Documents.Conventions;
+using Raven.Server.Logging;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Logging;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI;
+
+public class RavenDB_27181(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private const string ReasoningEffortField = "\"reasoning_effort\":";
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { "gpt-5.4" })]
+    public async Task AgentWithTools_OnAffectedModel_Answers(Options options, GenAiConfiguration config, string model)
+    {
+        using var store = GetDocumentStore(options);
+
+        config.Connection.OpenAiSettings.Model = model;
+        config.Connection.OpenAiSettings.ReasoningEffort = "high";
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("reasoning-effort-with-tools", config.ConnectionStringName, SystemPrompt) { SampleObject = SampleAnswer };
+        agent.Actions.Add(new AiAgentToolAction { Name = "GetUserAllergies", Description = "Get the allergies of the current user", ParametersSampleObject = "{}" });
+
+        var traces = await RunConversationAsync(store, agent);
+
+        Assert.All(traces, trace =>
+        {
+            Assert.Contains("\"tools\":", trace);
+            Assert.Contains($"{ReasoningEffortField}\"none\"", trace);
+        });
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { "gpt-5.4" })]
+    public async Task AgentWithoutTools_OnAffectedModel_AlsoRunsWithoutReasoning(Options options, GenAiConfiguration config, string model)
+    {
+        using var store = GetDocumentStore(options);
+
+        config.Connection.OpenAiSettings.Model = model;
+        config.Connection.OpenAiSettings.ReasoningEffort = "high";
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("reasoning-effort-no-tools", config.ConnectionStringName, SystemPrompt) { SampleObject = SampleAnswer };
+
+        var traces = await RunConversationAsync(store, agent);
+
+        Assert.All(traces, trace =>
+        {
+            Assert.DoesNotContain("\"tools\":", trace);
+            Assert.Contains($"{ReasoningEffortField}\"none\"", trace);
+        });
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { "gpt-5.2" })]
+    public async Task AgentWithTools_OnUnaffectedModel_KeepsConfiguredReasoning(Options options, GenAiConfiguration config, string model)
+    {
+        using var store = GetDocumentStore(options);
+
+        // the last family that accepts tools together with reasoning, so the policy must not reach it
+        config.Connection.OpenAiSettings.Model = model;
+        config.Connection.OpenAiSettings.ReasoningEffort = "high";
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("reasoning-effort-with-tools-unaffected", config.ConnectionStringName, SystemPrompt) { SampleObject = SampleAnswer };
+        agent.Actions.Add(new AiAgentToolAction { Name = "GetUserAllergies", Description = "Get the allergies of the current user", ParametersSampleObject = "{}" });
+
+        var traces = await RunConversationAsync(store, agent);
+
+        Assert.All(traces, trace =>
+        {
+            Assert.Contains("\"tools\":", trace);
+            Assert.Contains($"{ReasoningEffortField}\"high\"", trace);
+        });
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    // "High" is also the shape persisted by earlier enum-based versions, which must keep round-tripping
+    [InlineData("High")]
+    [InlineData("xhigh")]
+    [InlineData(null)]
+    public void ReasoningEffortSurvivesAConnectionStringRoundTrip(string effort)
+    {
+        using var store = GetDocumentStore();
+
+        var connectionString = new AiConnectionString
+        {
+            Name = "reasoning-effort-round-trip",
+            ModelType = AiModelType.Chat,
+            OpenAiSettings = new OpenAiSettings("api-key", Endpoint, "gpt-5-mini", reasoningEffort: effort)
+        };
+
+        store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(connectionString));
+
+        var connectionStrings = store.Maintenance.Send(new GetConnectionStringsOperation(connectionString.Name, ConnectionStringType.Ai)).AiConnectionStrings;
+        var settings = connectionStrings[connectionString.Name].OpenAiSettings;
+
+        Assert.Equal(effort, settings.ReasoningEffort);
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+#pragma warning disable CS0618 // reproduces what an enum-based client and server actually wrote
+    public void LegacyEnumWasSerializedAsItsMemberName()
+    {
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            // the connection string PUT path serializes the entity with DocumentConventions.Default,
+            // which registers a StringEnumConverter because SaveEnumsAsIntegers defaults to false
+            var onTheWire = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(
+                new LegacySettingsShape { ReasoningEffort = OpenAiReasoningEffort.High }, context);
+
+            Assert.True(onTheWire.TryGet(nameof(OpenAiSettings.ReasoningEffort), out string sentByOldClient));
+            Assert.Equal("High", sentByOldClient);
+
+            // the server persisted it through ToJson, where a boxed enum becomes its member name
+            var persisted = context.ReadObject(new DynamicJsonValue
+            {
+                [nameof(OpenAiSettings.ReasoningEffort)] = (OpenAiReasoningEffort?)OpenAiReasoningEffort.High
+            }, "old-persisted-settings");
+
+            Assert.True(persisted.TryGet(nameof(OpenAiSettings.ReasoningEffort), out string storedByOldServer));
+            Assert.Equal("High", storedByOldServer);
+        }
+    }
+#pragma warning restore CS0618
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public void NumericReasoningEffortDeserializesAsNotConfigured()
+    {
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            // no supported client wrote this shape (the PUT path hardcodes DocumentConventions.Default,
+            // where SaveEnumsAsIntegers is false), but a number must degrade rather than throw
+            var json = context.ReadObject(new DynamicJsonValue
+            {
+                [nameof(OpenAiSettings.Model)] = "gpt-5-mini",
+                [nameof(OpenAiSettings.ReasoningEffort)] = 3L
+            }, "numeric-settings");
+
+            var settings = JsonDeserializationServer.OpenAiSettings(json);
+
+            Assert.Null(settings.ReasoningEffort);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    // every value an enum-based client could have written, normalized to the provider form
+    [InlineData("gpt-5-mini", "Minimal", "minimal")]
+    [InlineData("gpt-5-mini", "Low", "low")]
+    [InlineData("gpt-5-mini", "Medium", "medium")]
+    [InlineData("gpt-5-mini", "High", "high")]
+    // values a client that never had the enum can write, passed through untouched
+    [InlineData("gpt-5.2", "xhigh", "xhigh")]
+    [InlineData("gpt-5.2", "max", "max")]
+    [InlineData("gpt-5-mini", "none", "none")]
+    [InlineData("gpt-5-mini", "future-effort", "future-effort")]
+    // the GPT-5.4+ workaround still wins over whatever was configured
+    [InlineData("gpt-5.4", "High", "none")]
+    public async Task LegacyConfigurationReachesTheProviderInTheExpectedForm(string model, string stored, string expected)
+    {
+        using var contextPool = new TransactionContextPool(RavenLogManager.Instance.CreateNullLogger(),
+            new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnlyForTests()));
+
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            // exactly what sits in the cluster for a connection string saved before this change
+            var legacyJson = context.ReadObject(new DynamicJsonValue
+            {
+                [nameof(AiConnectionString.Name)] = "legacy-connection",
+                [nameof(AiConnectionString.ModelType)] = AiModelType.Chat,
+                [nameof(AiConnectionString.OpenAiSettings)] = new DynamicJsonValue
+                {
+                    [nameof(OpenAiSettings.ApiKey)] = "api-key",
+                    [nameof(OpenAiSettings.Endpoint)] = Endpoint,
+                    [nameof(OpenAiSettings.Model)] = model,
+                    [nameof(OpenAiSettings.ReasoningEffort)] = stored
+                }
+            }, "legacy-connection-string");
+
+            // the real server-side PUT/load deserializer reads the legacy shape into the string property
+            var connectionString = JsonDeserializationCluster.AiConnectionString(legacyJson);
+            Assert.Equal(stored, connectionString.OpenAiSettings.ReasoningEffort);
+
+            using var client = ChatCompletionClient.CreateChatCompletionClient(contextPool, connectionString);
+
+            using (var stream = new MemoryStream())
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, stream))
+            {
+                client.WriteCompletionRequestPayload(writer, context, [], [], tools: null, useTools: true, streaming: false, ChatCompletionClient.EmptySchema);
+                await writer.FlushAsync();
+
+                Assert.Contains($"{ReasoningEffortField}\"{expected}\"", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+#pragma warning disable CS0618 // proves the migration path for the obsolete enum
+    [InlineData(OpenAiReasoningEffort.Minimal, "minimal")]
+    [InlineData(OpenAiReasoningEffort.High, "high")]
+    public void ToReasoningEffortLowercasesTheLegacyEnum(OpenAiReasoningEffort legacy, string expected)
+    {
+        Assert.Equal(expected, legacy.ToReasoningEffort());
+    }
+#pragma warning restore CS0618
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    // gpt-5.4 and later never get reasoning, and the minor version is compared as a number, not as text
+    [InlineData("gpt-5.4", "high", "none")]
+    [InlineData("gpt-5.6-sol", "xhigh", "none")]
+    [InlineData("gpt-5.10", "high", "none")]
+    // a future major without a minor version deliberately follows the same policy
+    [InlineData("gpt-6", "high", "none")]
+    // gateways expose the model with a provider prefix, but a name that merely contains it is a different model
+    [InlineData("openai/gpt-5.6-sol", "high", "none")]
+    [InlineData("my-gpt-5.4-clone", "high", "high")]
+    // earlier models keep the configured effort
+    [InlineData("gpt-5.2", "high", "high")]
+    [InlineData("gpt-5", "high", "high")]
+    // OpenAI-compatible providers expose Azure-style names such as gpt-35-turbo, which is not version 35
+    [InlineData("gpt-35-turbo", "high", "high")]
+    // legacy member names are normalized wherever they come from, including a hand-migrated string
+    [InlineData("gpt-5-mini", "High", "high")]
+    [InlineData("gpt-5-mini", "Medium", "medium")]
+    // numeric strings are provider values, not the numbers behind the legacy enum members
+    [InlineData("gpt-5-mini", "3", "3")]
+    [InlineData("gpt-5-mini", "42", "42")]
+    // new values pass through as supplied apart from trimming, and matching is exact beyond the legacy names
+    [InlineData("gpt-5.2", "xhigh", "xhigh")]
+    [InlineData("gpt-5.2", "max", "max")]
+    [InlineData("gpt-5-mini", " high ", "high")]
+    [InlineData("gpt-5-mini", "HIGH", "HIGH")]
+    [InlineData("gpt-5-mini", "   ", null)]
+    [InlineData("gpt-5-mini", null, null)]
+    public async Task EffectiveReasoningEffortIsWrittenToThePayload(string model, string effort, string expected)
+    {
+        var settings = new OpenAiSettings("api-key", Endpoint, model, reasoningEffort: effort);
+        var connectionString = new AiConnectionString { Name = "test-connection", ModelType = AiModelType.Chat, OpenAiSettings = settings };
+
+        using var contextPool = new TransactionContextPool(RavenLogManager.Instance.CreateNullLogger(),
+            new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnlyForTests()));
+        using var client = ChatCompletionClient.CreateChatCompletionClient(contextPool, connectionString);
+
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        using (var stream = new MemoryStream())
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, stream))
+        {
+            client.WriteCompletionRequestPayload(writer, context, [], [], tools: null, useTools: true, streaming: false, ChatCompletionClient.EmptySchema);
+            await writer.FlushAsync();
+
+            var payload = Encoding.UTF8.GetString(stream.ToArray());
+
+            if (expected == null)
+                Assert.DoesNotContain("reasoning_effort", payload);
+            else
+                Assert.Contains($"{ReasoningEffortField}\"{expected}\"", payload);
+        }
+    }
+
+    private const string SystemPrompt = "You are a helpful assistant. Answer concisely.";
+    private const string SampleAnswer = "{\"Answer\":\"answer here\"}";
+
+    private static async Task<List<string>> RunConversationAsync(IDocumentStore store, AiAgentConfiguration agent)
+    {
+        var createResult = await store.AI.CreateAgentAsync(agent, OutputSchema.Instance);
+
+        var chat = store.AI.Conversation(createResult.Identifier, "chats/", creationOptions: null, debug: true);
+        chat.SetUserPrompt("What is 2+2?");
+        var result = await chat.RunAsync<OutputSchema>(CancellationToken.None);
+
+        Assert.Equal(AiConversationResult.Done, result.Status);
+
+        using var session = store.OpenAsyncSession();
+        var traces = (await session.Advanced.LoadStartingWithAsync<DebugTraceDoc>($"{chat.Id}/{AiDebugTrace.TraceSegment}/")).ToList();
+
+        Assert.NotEmpty(traces);
+        return traces.Select(x => x.RequestBody).ToList();
+    }
+
+    private class OutputSchema
+    {
+        public static readonly OutputSchema Instance = new();
+        public string Answer = "Answer to the user question";
+    }
+
+    // the shape OpenAiSettings had before ReasoningEffort became a string
+    private sealed class LegacySettingsShape
+    {
+#pragma warning disable CS0618
+        public OpenAiReasoningEffort? ReasoningEffort { get; set; }
+#pragma warning restore CS0618
+    }
+
+    private class DebugTraceDoc
+    {
+        public string RequestBody { get; set; }
+    }
+
+    private const string Endpoint = "https://api.openai.com/";
+}

--- a/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
@@ -1,4 +1,4 @@
-using Raven.Client.Documents.Operations.AI;
+﻿using Raven.Client.Documents.Operations.AI;
 
 namespace Tests.Infrastructure.ConnectionString.AI;
 
@@ -33,12 +33,14 @@ internal static class OpenAiConnectorHelper
 {
     public const string Endpoint = "https://api.openai.com/";
 
+    private const string MinimalReasoningEffort = "minimal";
+
     public static AiConnectionString CreateAiConnectionString(string model, AiModelType modelType)
     {
         return new AiConnectionString
         {
             ModelType = modelType,
-            OpenAiSettings = new OpenAiSettings(RavenTestHelper.EnvironmentVariables.AiIntegrationOpenAiApiKey, Endpoint, model, reasoningEffort: OpenAiReasoningEffort.Minimal, seed: 48)
+            OpenAiSettings = new OpenAiSettings(RavenTestHelper.EnvironmentVariables.AiIntegrationOpenAiApiKey, Endpoint, model, reasoningEffort: MinimalReasoningEffort, seed: 48)
         };
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27181/GPT-5.6-models-unusable-with-AI-agents-tools-rejected-on-v1-chat-completions

### Additional description

This is a temporary workaround for OpenAI Chat Completions: GPT-5.4+ requests are sent with reasoning_effort: "none" to avoid the tools + reasoning incompatibility.

The long-term solution is to move to the newer OpenAI Responses API endpoint, where reasoning and tools can be used together.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant
The change is scoped to OpenAI Chat Completions, but intentionally changes the reasoning behavior for GPT-5.4+ models.

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant
The existing `ReasoningEffort` enum was left unchanged. `ReasoningEffortValue` was added as an optional string-based escape hatch, while existing serialized configurations continue to work unchanged.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 
The public OpenAI reasoning configuration now includes `ReasoningEffortValue`, and GPT-5.4+ Chat Completions use a temporary `reasoning_effort: "none"` workaround.

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No
For GPT-5.4+ models using OpenAI Chat Completions, RavenDB now sends `reasoning_effort: "none"` on all requests, including requests without tools. This is an intentional temporary workaround until support for the OpenAI Responses API is added.

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
