### PR TITLE
RavenDB-27316 Quill: make the in-app form straight feedback, drop Contact vocabulary

### DIFF
--- a/src/Raven.Quill.Web/src/app.tsx
+++ b/src/Raven.Quill.Web/src/app.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils";
 import { QuillMark } from "@/components/brand/quill-logo.tsx";
 import { AssistantPanel } from "@/components/layout/assistant-panel";
 import { ASSISTANT_PANEL_TITLE_ID, useAssistantPinning, useAssistantStore } from "@/components/layout/assistant-store";
-import { ContactSheet } from "@/components/layout/contact-sheet";
+import { FeedbackSheet } from "@/components/layout/feedback-sheet";
 import { Button } from "@/components/shadcn/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
 
@@ -102,7 +102,7 @@ function App() {
                 <CommandPalette slug={slug} appName={activeAppLabel} />
 
                 <nav className="ml-4 flex shrink-0 items-center gap-4 text-sm" aria-label="Top navigation">
-                    <ContactSheet
+                    <FeedbackSheet
                         trigger={
                             <Button variant="outline" size="sm">
                                 <MessageCircle aria-hidden="true" />

--- a/src/Raven.Quill.Web/src/components/layout/feedback-sheet.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/feedback-sheet.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { ThumbsDown, ThumbsUp } from "lucide-react";
 import { z } from "zod";
 import { toast } from "sonner";
@@ -23,19 +23,20 @@ import { FormInput } from "@/components/form/form-input";
 import { FormTextarea } from "@/components/form/form-textarea";
 import { FormToggleGroup, type FormToggleGroupOption } from "@/components/form/form-toggle-group";
 import { withNestedSubmit } from "@/lib/form-utils";
+import { getSupportUrl } from "@/lib/help-links";
 
 const IMPRESSION_OPTIONS: FormToggleGroupOption[] = [
     { value: "positive", label: <ThumbsUp />, ariaLabel: "Positive" },
     { value: "negative", label: <ThumbsDown />, ariaLabel: "Negative" },
 ];
 
-type ContactSheetProps = {
+type FeedbackSheetProps = {
     trigger?: ReactNode;
     open?: boolean;
     onOpenChange?: (isOpen: boolean) => void;
 };
 
-export function ContactSheet({ trigger, open, onOpenChange }: ContactSheetProps) {
+export function FeedbackSheet({ trigger, open, onOpenChange }: FeedbackSheetProps) {
     const [internalIsOpen, setInternalIsOpen] = useState(false);
     const isOpen = open ?? internalIsOpen;
     const setIsOpen = onOpenChange ?? setInternalIsOpen;
@@ -45,33 +46,33 @@ export function ContactSheet({ trigger, open, onOpenChange }: ContactSheetProps)
             {trigger && <SheetTrigger asChild>{trigger}</SheetTrigger>}
             <SheetContent className="w-full gap-0 sm:max-w-md data-[side=right]:sm:max-w-md">
                 <SheetHeader className="border-b">
-                    <SheetTitle>Contact us</SheetTitle>
+                    <SheetTitle>Feedback</SheetTitle>
                     <SheetDescription>
-                        Share feedback about Quill. Product and version details are added automatically.
+                        Tell us how Quill is working for you. Product and version details are added automatically.
                     </SheetDescription>
                 </SheetHeader>
-                <ContactForm onSent={() => setIsOpen(false)} />
+                <FeedbackForm onSent={() => setIsOpen(false)} />
             </SheetContent>
         </GuardedSheet>
     );
 }
 
-const contactSchema = z.object({
+const feedbackSchema = z.object({
     name: z.string().trim().min(1, "Enter your name"),
     email: z.string().trim().pipe(z.email("Enter a valid email address")),
     impression: z.enum(["positive", "negative"]).nullable(),
     message: z.string().trim().min(1, "Type a message"),
 });
 
-type ContactFormData = z.infer<typeof contactSchema>;
+type FeedbackFormData = z.infer<typeof feedbackSchema>;
 
 // Don't include pathname because it can contain sensitive information
 const STUDIO_VIEW = "Quill";
 
-function ContactForm({ onSent }: { onSent: () => void }) {
-    const form = useForm<ContactFormData>({
+function FeedbackForm({ onSent }: { onSent: () => void }) {
+    const form = useForm<FeedbackFormData>({
         mode: "onChange",
-        resolver: zodResolver(contactSchema),
+        resolver: zodResolver(feedbackSchema),
         defaultValues: {
             name: "",
             email: "",
@@ -80,10 +81,15 @@ function ContactForm({ onSent }: { onSent: () => void }) {
         },
     });
 
+    // Shares the query key with the license and dashboard views, so this is
+    // usually a cache hit rather than an extra request.
+    const licenseQuery = useQuery(api.queries.settings.license());
+
     const unsavedChanges = useFormUnsavedChanges(form);
 
     const submitMutation = useMutation({
-        mutationFn: (values: ContactFormData) => api.services.settings.feedback({ ...values, studioView: STUDIO_VIEW }),
+        mutationFn: (values: FeedbackFormData) =>
+            api.services.settings.feedback({ ...values, studioView: STUDIO_VIEW }),
         onSuccess: () => {
             toast.success("Feedback sent. Thank you.");
             form.reset();
@@ -115,7 +121,7 @@ function ContactForm({ onSent }: { onSent: () => void }) {
                     name="impression"
                     label="Impression"
                     options={IMPRESSION_OPTIONS}
-                    description="Optional — how has Quill worked for you?"
+                    description="How has Quill worked for you?"
                 />
                 <FormTextarea
                     control={form.control}
@@ -124,6 +130,18 @@ function ContactForm({ onSent }: { onSent: () => void }) {
                     placeholder="Type your message here."
                     textareaClassName="min-h-40 resize-none"
                 />
+                <p className="text-muted-foreground">
+                    Blocked by something broken? Get faster help from{" "}
+                    <a
+                        href={getSupportUrl(licenseQuery.data?.response.id)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="underline underline-offset-2 hover:text-foreground"
+                    >
+                        Support
+                    </a>
+                    .
+                </p>
             </div>
 
             <SheetFooter className="border-t">

--- a/src/Raven.Quill.Web/src/components/layout/user-menu.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/user-menu.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router";
-import { KeyRound, LineChart, LogOut, MessageCircle, ShieldCheck, UserRound } from "lucide-react";
+import { KeyRound, LineChart, LogOut, ShieldCheck, UserRound } from "lucide-react";
 import { toast } from "sonner";
 import { useAuth } from "@/components/auth/auth-context";
 import { Button } from "@/components/shadcn/ui/button";
@@ -13,12 +13,10 @@ import {
     DropdownMenuTrigger,
 } from "@/components/shadcn/ui/dropdown-menu";
 import { Spinner } from "@/components/shadcn/ui/spinner";
-import { ContactSheet } from "@/components/layout/contact-sheet";
 
 export function UserMenu() {
     const { logout } = useAuth();
     const [isSigningOut, setIsSigningOut] = useState(false);
-    const [isContactOpen, setIsContactOpen] = useState(false);
 
     async function handleSignOut() {
         setIsSigningOut(true);
@@ -34,61 +32,52 @@ export function UserMenu() {
     }
 
     return (
-        <>
-            <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        aria-label="Account"
-                        className="text-muted-foreground hover:text-foreground"
-                    >
-                        <UserRound className="size-4" aria-hidden="true" />
-                    </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-48">
-                    <DropdownMenuLabel>Operator</DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem asChild>
-                        <Link to="/usage">
-                            <LineChart aria-hidden="true" />
-                            Usage
-                        </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                        <Link to="/license">
-                            <KeyRound aria-hidden="true" />
-                            License
-                        </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                        <Link to="/certificates">
-                            <ShieldCheck aria-hidden="true" />
-                            Certificates
-                        </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onSelect={() => setIsContactOpen(true)}>
-                        <MessageCircle aria-hidden="true" />
-                        Contact us
-                    </DropdownMenuItem>
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Account"
+                    className="text-muted-foreground hover:text-foreground"
+                >
+                    <UserRound className="size-4" aria-hidden="true" />
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuLabel>Operator</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                    <Link to="/usage">
+                        <LineChart aria-hidden="true" />
+                        Usage
+                    </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                    <Link to="/license">
+                        <KeyRound aria-hidden="true" />
+                        License
+                    </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                    <Link to="/certificates">
+                        <ShieldCheck aria-hidden="true" />
+                        Certificates
+                    </Link>
+                </DropdownMenuItem>
 
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                        variant="destructive"
-                        disabled={isSigningOut}
-                        onSelect={(event) => {
-                            event.preventDefault();
-                            void handleSignOut();
-                        }}
-                    >
-                        {isSigningOut ? <Spinner /> : <LogOut aria-hidden="true" />}
-                        Sign out
-                    </DropdownMenuItem>
-                </DropdownMenuContent>
-            </DropdownMenu>
-
-            {/* trigger-wrapper form can't work from inside a dropdown menu */}
-            <ContactSheet open={isContactOpen} onOpenChange={setIsContactOpen} />
-        </>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                    variant="destructive"
+                    disabled={isSigningOut}
+                    onSelect={(event) => {
+                        event.preventDefault();
+                        void handleSignOut();
+                    }}
+                >
+                    {isSigningOut ? <Spinner /> : <LogOut aria-hidden="true" />}
+                    Sign out
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
     );
 }

--- a/src/Raven.Quill.Web/src/lib/help-links.ts
+++ b/src/Raven.Quill.Web/src/lib/help-links.ts
@@ -13,7 +13,7 @@ export function getHelpLinks(licenseId: string | undefined): { label: string; hr
     ];
 }
 
-function getSupportUrl(licenseId: string | undefined) {
+export function getSupportUrl(licenseId: string | undefined) {
     if (!licenseId) {
         return SUPPORT_URL;
     }

--- a/src/Raven.Quill.Web/src/pages/dashboard/license.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/license.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Check, RefreshCw } from "lucide-react";
+import { Check, LifeBuoy, RefreshCw } from "lucide-react";
 import { api } from "@/api/api";
 import type { ConnectivityStatus, LicensePlan, ServerLicenseResponse } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
@@ -8,8 +8,8 @@ import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
 import { formatDate } from "@/lib/format";
+import { getSupportUrl } from "@/lib/help-links";
 import { cn } from "@/lib/utils";
-import { ContactSheet } from "@/components/layout/contact-sheet";
 
 // Subtle brand wash used to make the featured plan stand out.
 // Defined as a CSS class (see index.css) so it layers over the card's bg-color.
@@ -59,13 +59,12 @@ function LicenseSummaryCard({ license }: { license: ServerLicenseResponse }) {
                 <CardTitle>Current license</CardTitle>
                 {license.expired && <CardDescription>This license has expired.</CardDescription>}
                 <CardAction>
-                    <ContactSheet
-                        trigger={
-                            <Button variant="outline" size="sm">
-                                Contact us
-                            </Button>
-                        }
-                    />
+                    <Button variant="outline" size="sm" asChild>
+                        <a href={getSupportUrl(license.id)} target="_blank" rel="noreferrer">
+                            <LifeBuoy aria-hidden="true" />
+                            Support
+                        </a>
+                    </Button>
                 </CardAction>
             </CardHeader>
             <CardContent className="grid gap-6 sm:grid-cols-2">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27316

### Additional description

The Quill launcher was labelled **Feedback** while the panel heading inside said **Contact us** — two purposes in one form. The same `ContactSheet` also backed the user menu and the license card, and all three posted to `/settings/feedback`, so a licensing question arrived on the other side as a product-feedback record carrying a thumbs up/down.

Quill already exposes **Support** in the Help center (`help-links.ts`) for real problems, and `getSupportUrl` appends the license id so the request arrives already identified. That made "Contact us" redundant rather than a second form worth building, so the in-app form is feedback only now and "Contact" is gone from Quill's vocabulary.

| File | Change |
|---|---|
| `feedback-sheet.tsx` | renamed from `contact-sheet.tsx`; `ContactSheet`→`FeedbackSheet`, `ContactForm`→`FeedbackForm`, `contactSchema`→`feedbackSchema`, `ContactFormData`→`FeedbackFormData`; heading `Contact us` → `Feedback` |
| `app.tsx` | import rename only — the top-nav launcher already said "Feedback", so launcher and heading now agree |
| `user-menu.tsx` | "Contact us" item removed, along with the `isContactOpen` state, the separately-mounted sheet, and the "trigger-wrapper form can't work from inside a dropdown menu" workaround |
| `license.tsx` | "Contact us" button → **Support** link via `getSupportUrl(license.id)` |
| `help-links.ts` | `getSupportUrl` exported (was private) |

There is also a new hint under the message field pointing anyone actually blocked at Support, so the form doesn't quietly become a support channel nobody watches for urgency.

Frontend only — no API or contract change. The server side (`SendFeedbackRequest`, `FeedbackSender`, `/settings/feedback`) was already named feedback throughout and is untouched.

The remaining occurrences of "contact" in `Raven.Quill.Web` are intentional: Telegram's contact-share domain strings, and `assistant-consent.tsx`'s "Please contact support", which points the right way.

Validation: `tsc -b`, `eslint .` and `prettier --check` clean; 159 unit tests and 109 Storybook browser tests pass; `dotnet build RavenDB.sln -c Release` reports 0 errors.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

The Storybook browser suite renders both `UserMenu` and `DashboardLicense`, which are the two components changed structurally.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Two entry points change where they lead:

- **User menu** — the "Contact us" item is gone. Support in the Help center already covers it, and the Feedback button in the top nav is always visible.
- **License card** — its button now opens `ravendb.net/support` in a new tab (with the license id attached) instead of opening the in-app feedback sheet.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
