### PR TITLE
RavenDB-27306 Quill: group the config database as a System row in Usage

### DIFF
--- a/src/Raven.Quill.Web/src/api/generated/server-api.ts
+++ b/src/Raven.Quill.Web/src/api/generated/server-api.ts
@@ -1582,6 +1582,8 @@ export interface components {
             to: string;
             /** Format: int64 */
             usage: number;
+            /** @default false */
+            isSystem: boolean;
         };
         QuillPeriodUsage: {
             /** Format: date-time */

--- a/src/Raven.Quill.Web/src/components/data/info-hint.tsx
+++ b/src/Raven.Quill.Web/src/components/data/info-hint.tsx
@@ -1,4 +1,4 @@
-import { InfoIcon } from "lucide-react";
+import { CircleQuestionMark } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
 
 export function InfoHint({ content }: { content: string }) {
@@ -6,8 +6,10 @@ export function InfoHint({ content }: { content: string }) {
         <TooltipProvider>
             <Tooltip>
                 <TooltipTrigger asChild>
-                    <span className="inline-flex text-muted-foreground">
-                        <InfoIcon className="size-3.5" aria-hidden="true" />
+                    {/* Faded rather than muted, so the hint reads as secondary to whatever colour
+                        the label beside it already has. */}
+                    <span className="inline-flex opacity-[0.66]">
+                        <CircleQuestionMark className="size-3.5" aria-hidden="true" />
                         <span className="sr-only">{content}</span>
                     </span>
                 </TooltipTrigger>

--- a/src/Raven.Quill.Web/src/components/table/virtual-data-table.tsx
+++ b/src/Raven.Quill.Web/src/components/table/virtual-data-table.tsx
@@ -25,10 +25,13 @@ interface VirtualDataTableProps<TData> {
     overscan?: number;
     rowHeightInPx?: number;
     getCellClassName?: (cellId: string) => string;
+    getHeadClassName?: (columnId: string) => string;
     getRowState?: (rowId: string) => string;
     getRowClassName?: (rowId: string) => string;
     /** Called with the row the pointer entered, or null when it left the rows. */
     onRowHoverChange?: (rowId: string | null) => void;
+    /** Called with the row that was clicked. Rows are only given a click target when set. */
+    onRowClick?: (rowId: string) => void;
     /** Floating content laid over the table region, e.g. a selection toolbar pinned to the bottom edge. */
     overlay?: ReactNode;
 }
@@ -46,9 +49,11 @@ export function VirtualDataTable<TData>({
     overscan = DEFAULT_OVERSCAN,
     rowHeightInPx = DEFAULT_ROW_HEIGHT_IN_PX,
     getCellClassName,
+    getHeadClassName,
     getRowState,
     getRowClassName,
     onRowHoverChange,
+    onRowClick,
     overlay,
 }: VirtualDataTableProps<TData>) {
     // Enable resizing for the whole table so the drag handles and content-based auto-sizing
@@ -75,7 +80,7 @@ export function VirtualDataTable<TData>({
         return (
             <div className={cn("min-w-0 overflow-hidden rounded-lg border", className)}>
                 <table className="w-full caption-bottom text-sm">
-                    <VirtualTableHeader table={table} canShrinkColumns />
+                    <VirtualTableHeader table={table} getHeadClassName={getHeadClassName} canShrinkColumns />
                     <TableBody>
                         <TableRow>
                             <TableCell colSpan={columnCount} className="h-24 text-center text-muted-foreground">
@@ -112,7 +117,7 @@ export function VirtualDataTable<TData>({
                 style={isFillHeight ? undefined : { maxHeight }}
             >
                 <table className="grid min-w-full caption-bottom text-sm" style={{ width: table.getTotalSize() }}>
-                    <VirtualTableHeader table={table} />
+                    <VirtualTableHeader table={table} getHeadClassName={getHeadClassName} />
                     <TableBody
                         className="relative grid"
                         style={{
@@ -134,6 +139,7 @@ export function VirtualDataTable<TData>({
                                     ref={(node) => rowVirtualizer.measureElement(node)}
                                     onPointerEnter={() => onRowHoverChange?.(row.id)}
                                     onPointerLeave={() => onRowHoverChange?.(null)}
+                                    onClick={onRowClick ? () => onRowClick(row.id) : undefined}
                                     className={cn("absolute flex w-full", getRowClassName?.(row.id))}
                                     // Positioned via top instead of translateY: Chromium never shrinks
                                     // scrollable overflow contributed by transformed children, so rows
@@ -171,9 +177,11 @@ export function VirtualDataTable<TData>({
 
 function VirtualTableHeader<TData>({
     table,
+    getHeadClassName,
     canShrinkColumns = false,
 }: {
     table: ReactTable<TData>;
+    getHeadClassName?: (columnId: string) => string;
     canShrinkColumns?: boolean;
 }) {
     return (
@@ -184,7 +192,10 @@ function VirtualTableHeader<TData>({
                         <TableHead
                             key={header.id}
                             data-column-id={header.column.id}
-                            className="group relative flex items-center overflow-hidden"
+                            className={cn(
+                                "group relative flex items-center overflow-hidden",
+                                getHeadClassName?.(header.column.id),
+                            )}
                             style={getColumnStyle(header.getSize(), canShrinkColumns && header.column.getCanResize())}
                         >
                             <span className="truncate">

--- a/src/Raven.Quill.Web/src/mocks/settings-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/settings-mocks.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import type { LicenseResponse, QuillUsageResponse } from "@/api/generated/server-api";
+import type { LicenseResponse, QuillApplicationUsage, QuillUsageResponse } from "@/api/generated/server-api";
 import type { CertificateItem } from "@/api/custom-services/certificates-service";
 import { apiHttp } from "./api-http";
 
@@ -104,6 +104,36 @@ export const sampleCertificates: CertificateItem[] = [
     },
 ];
 
+// The shape RavenDB reports: unpadded base64 of a 16-byte guid - 22 characters over A-Za-z0-9+/,
+// always ending in one of the four the final two bits allow. A couple carry a + or a /, because ids
+// that awkward to read are exactly why the table groups by name and only falls back to them.
+export const sampleTopologyIds = {
+    systemBusiest: "j9T7K/m7IZsA7MorB0UVmw",
+    system: "dFGqCGUYc8DUeweTsCxudA",
+    systemQuietest: "26jT6mFmbaClQn7J0vE1Yg",
+    huetopiaBusiest: "NA+WUHfUc3cvjURuPbGDFQ",
+    huetopia: "C3i3GQcS1dgeNvaAYmIHDQ",
+    supportCopilot: "Y44Uy3cyOPO0UdiBXNPCeg",
+    ordersSync: "5xTOTLh5XkChGKDVQRCK5Q",
+    bookshopHelper: "2ODd5OiMFOwoH1TF1cOhJQ",
+};
+
+function usageRow(
+    topologyId: string,
+    applicationName: string,
+    usage: number,
+    { isSystem = false }: { isSystem?: boolean } = {},
+): QuillApplicationUsage {
+    return {
+        topologyId,
+        applicationName,
+        from: "2026-06-01T00:00:00Z",
+        to: "2026-06-30T23:59:59Z",
+        usage,
+        isSystem,
+    };
+}
+
 // ~30 daily points with a gentle wave so the writes chart has shape.
 export const sampleQuillUsage: QuillUsageResponse = {
     byPeriod: Array.from({ length: 30 }, (_, index) => {
@@ -115,27 +145,17 @@ export const sampleQuillUsage: QuillUsageResponse = {
             usage: Math.round(280000 + wave * 130000),
         };
     }),
+    // Mirrors what a real licence covering several appliances reports: many system rows sharing the
+    // config database's name, a repeated app name, and unique apps - each distinguished only by
+    // topology id, and deliberately out of order so the grouping is doing the work.
     perApplication: [
-        {
-            topologyId: "topology-1",
-            applicationName: "support-copilot",
-            from: "2026-06-01T00:00:00Z",
-            to: "2026-06-30T23:59:59Z",
-            usage: 5200000,
-        },
-        {
-            topologyId: "topology-1",
-            applicationName: "orders-sync",
-            from: "2026-06-01T00:00:00Z",
-            to: "2026-06-30T23:59:59Z",
-            usage: 2400000,
-        },
-        {
-            topologyId: "topology-2",
-            applicationName: "docs-assistant",
-            from: "2026-06-01T00:00:00Z",
-            to: "2026-06-30T23:59:59Z",
-            usage: 1300000,
-        },
+        usageRow(sampleTopologyIds.system, "quill-config", 2600, { isSystem: true }),
+        usageRow(sampleTopologyIds.supportCopilot, "support-copilot", 5200000),
+        usageRow(sampleTopologyIds.huetopiaBusiest, "huetopia", 1300000),
+        usageRow(sampleTopologyIds.systemQuietest, "quill-config", 900, { isSystem: true }),
+        usageRow(sampleTopologyIds.ordersSync, "orders-sync", 2400000),
+        usageRow(sampleTopologyIds.systemBusiest, "quill-config", 4100, { isSystem: true }),
+        usageRow(sampleTopologyIds.huetopia, "huetopia", 640000),
+        usageRow(sampleTopologyIds.bookshopHelper, "bookshop-helper", 88000),
     ],
 };

--- a/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
@@ -4,7 +4,6 @@
 
 import { useMemo, useState } from "react";
 import {
-    flexRender,
     getCoreRowModel,
     getExpandedRowModel,
     useReactTable,
@@ -17,52 +16,57 @@ import type { QuillApplicationUsage } from "@/api/generated/server-api";
 import { InfoHint } from "@/components/data/info-hint";
 import { WruLabel } from "@/components/data/wru-label";
 import { Badge } from "@/components/shadcn/ui/badge";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/ui/table";
+import { VirtualDataTable } from "@/components/table/virtual-data-table";
 import { cn } from "@/lib/utils";
 import { rowKey, SYSTEM_GROUP_DESCRIPTION, toUsageGroups, type UsageGroup } from "@/pages/dashboard/usage-groups";
 
-// A group and the databases behind it share one table: the groups are the top-level rows, and their
-// databases the sub-rows react-table expands into.
+// Groups are the top-level rows; the databases behind them are the sub-rows.
 type UsageRow = UsageGroup | QuillApplicationUsage;
 
 function isGroup(row: UsageRow): row is UsageGroup {
     return "rows" in row;
 }
 
-// The name column reserves the chevron's width on every row, expandable or not, so all the names
-// line up in one column and the chevrons sit in a gutter of their own.
+// Reserved on every row, expandable or not, so the names line up in one column.
 const CHEVRON_GUTTER = "size-3.5 shrink-0";
 
-// Inter's font box sits high in a text-sm line box - more of the leading falls below the letters
-// than above - so an icon centred on that line box reads a hair low against them. `leading-none`
-// collapses the line box onto the font box, which centres the letters and the chevron on the same
-// axis, and the fixed height keeps every row as tall as it was.
+// `leading-none` is load-bearing: Inter's font box sits high in a text-sm line box, so an icon
+// centred on that line box reads low against the letters. Collapsing the line box centres both.
 const NAME_ROW = "flex h-5 items-center gap-1.5 leading-none";
 
-// Where the names land: pl-4 + the gutter + the gap. Members of an expanded group indent to it, so
-// they read as sitting under the name they belong to.
-const NAME_INDENT = "pl-9";
+const ROW_HEIGHT_IN_PX = 44;
 
-// Layout that belongs to the cell rather than to what it holds, so it stays on the <th>/<td> the
-// column renders into instead of on a wrapper inside it.
+// The usage column opts out of resizing, which is what keeps it at this width: auto-sizing hands
+// the leftover container width to the resizable columns, so the name column is the one that grows.
+const USAGE_COLUMN_WIDTH_IN_PX = 110;
+
 function headClassName(columnId: string) {
-    return cn("text-xs font-medium text-muted-foreground", columnId === "name" ? "w-full pl-4" : "pr-4 text-right");
+    return cn("text-xs font-medium text-muted-foreground", columnId === "usage" && "justify-end");
 }
 
 function cellClassName(columnId: string, depth: number) {
-    const isMember = depth > 0;
-
     if (columnId === "usage") {
-        return cn("pr-4 text-right text-muted-foreground tabular-nums", isMember ? "py-2" : "py-3");
+        return "justify-end text-muted-foreground tabular-nums";
     }
 
-    return isMember ? cn("py-2 font-mono text-xs text-muted-foreground", NAME_INDENT) : "py-3 pl-4 font-medium";
+    return depth > 0 ? "font-mono text-xs text-muted-foreground" : "font-medium";
 }
 
-// The group's own name cell: its shared name (or "System") and how many rows it stands for. The
-// whole row toggles it; the button carries the state and the keyboard, and lets its click bubble to
-// the row so one handler serves both. Groups standing for a single app have nothing to expand and
-// render as the plain name they always were.
+// A member indents by the same gutter its group spends on the chevron, so its id lines up under the
+// name above it. The indent sits inside the cell rather than in its padding: column auto-sizing
+// measures the content and assumes the default cell padding, so padding the cell instead would
+// leave the column short by the difference and clip the ids - which are the whole point of the row.
+function MemberName({ topologyId }: { topologyId: string }) {
+    return (
+        <span className={NAME_ROW}>
+            <span aria-hidden="true" className={CHEVRON_GUTTER} />
+            {topologyId}
+        </span>
+    );
+}
+
+// The whole row toggles the group; this button carries the state and the keyboard, and lets its
+// click bubble to the row so one handler serves both.
 function GroupName({
     group,
     isExpandable,
@@ -102,8 +106,9 @@ function GroupName({
                 {group.label}
             </button>
             {group.isSystem && (
-                // The hint explains the group; it doesn't toggle it.
-                <span onClick={(event) => event.stopPropagation()}>
+                // The hint explains the group; it doesn't toggle it. `flex` keeps the icon off the
+                // text baseline an inline wrapper would put it on, which rides a couple of px high.
+                <span className="flex" onClick={(event) => event.stopPropagation()}>
                     <InfoHint content={SYSTEM_GROUP_DESCRIPTION} />
                 </span>
             )}
@@ -122,9 +127,7 @@ const COLUMNS: ColumnDef<UsageRow>[] = [
             isGroup(row.original) ? (
                 <GroupName group={row.original} isExpandable={row.getCanExpand()} isExpanded={row.getIsExpanded()} />
             ) : (
-                // One row per database behind an expanded group, labelled by the topology id - the
-                // only thing that tells apart rows that share a name.
-                row.original.topologyId
+                <MemberName topologyId={row.original.topologyId} />
             ),
     },
     {
@@ -132,11 +135,13 @@ const COLUMNS: ColumnDef<UsageRow>[] = [
         header: () => <WruLabel />,
         accessorFn: (row) => row.usage,
         cell: ({ getValue }) => getValue<number>().toLocaleString(),
+        size: USAGE_COLUMN_WIDTH_IN_PX,
+        enableResizing: false,
     },
 ];
 
-// Only expandable groups hand react-table sub-rows, so `getCanExpand` answers for the chevron, the
-// cursor and the click handler alike, without a second notion of expandability alongside it.
+// Only expandable groups hand back sub-rows, so `getCanExpand` answers for the chevron, the cursor
+// and the click handler alike.
 function getSubRows(row: UsageRow) {
     return isGroup(row) && row.isExpandable ? row.rows : undefined;
 }
@@ -147,9 +152,8 @@ function getRowId(row: UsageRow, _index: number, parent?: Row<UsageRow>) {
 
 export function PerAppUsageTable({ apps }: { apps: QuillApplicationUsage[] }) {
     const [expanded, setExpanded] = useState<ExpandedState>({});
-    // react-table needs a stable data reference between renders; a fresh identity on every render
-    // makes it recompute row models and queue state resets. "use no memo" opts this file out of the
-    // React Compiler (incompatible with react-table), so the explicit useMemo matters.
+    // "use no memo" opts this file out of the React Compiler, so the memo has to be explicit:
+    // react-table resets its row models when `data` changes identity.
     const groups = useMemo<UsageRow[]>(() => toUsageGroups(apps), [apps]);
 
     const table = useReactTable({
@@ -163,47 +167,30 @@ export function PerAppUsageTable({ apps }: { apps: QuillApplicationUsage[] }) {
         state: { expanded },
     });
 
-    const rows = table.getRowModel().rows;
+    // The table addresses cells and rows by id alone, so resolve the styling and the toggles that
+    // depend on the row itself up front rather than picking the ids apart again downstream.
+    const cellClassNames = new Map<string, string>();
+    const toggles = new Map<string, () => void>();
+    for (const row of table.getRowModel().rows) {
+        if (row.getCanExpand()) {
+            toggles.set(row.id, row.getToggleExpandedHandler());
+        }
+        for (const cell of row.getVisibleCells()) {
+            cellClassNames.set(cell.id, cellClassName(cell.column.id, row.depth));
+        }
+    }
 
     return (
-        <Table>
-            <TableHeader>
-                {table.getHeaderGroups().map((headerGroup) => (
-                    <TableRow key={headerGroup.id} className="hover:bg-transparent">
-                        {headerGroup.headers.map((header) => (
-                            <TableHead key={header.id} className={headClassName(header.column.id)}>
-                                {flexRender(header.column.columnDef.header, header.getContext())}
-                            </TableHead>
-                        ))}
-                    </TableRow>
-                ))}
-            </TableHeader>
-            <TableBody>
-                {rows.length === 0 ? (
-                    <TableRow className="hover:bg-transparent">
-                        <TableCell colSpan={COLUMNS.length} className="h-20 text-center text-muted-foreground">
-                            No usage tracked yet.
-                        </TableCell>
-                    </TableRow>
-                ) : (
-                    rows.map((row) => (
-                        <TableRow
-                            key={row.id}
-                            onClick={row.getCanExpand() ? row.getToggleExpandedHandler() : undefined}
-                            className={cn(
-                                row.getCanExpand() && "cursor-pointer",
-                                row.depth > 0 && "hover:bg-transparent",
-                            )}
-                        >
-                            {row.getVisibleCells().map((cell) => (
-                                <TableCell key={cell.id} className={cellClassName(cell.column.id, row.depth)}>
-                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                </TableCell>
-                            ))}
-                        </TableRow>
-                    ))
-                )}
-            </TableBody>
-        </Table>
+        <VirtualDataTable
+            table={table}
+            columnCount={COLUMNS.length}
+            emptyMessage="No usage tracked yet."
+            className="bg-card"
+            rowHeightInPx={ROW_HEIGHT_IN_PX}
+            getHeadClassName={headClassName}
+            getCellClassName={(cellId) => cellClassNames.get(cellId) ?? ""}
+            getRowClassName={(rowId) => (toggles.has(rowId) ? "cursor-pointer" : "")}
+            onRowClick={(rowId) => toggles.get(rowId)?.()}
+        />
     );
 }

--- a/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
@@ -1,0 +1,209 @@
+/* eslint-disable react-hooks/incompatible-library */
+// https://github.com/TanStack/table/issues/5567
+"use no memo";
+
+import { useMemo, useState } from "react";
+import {
+    flexRender,
+    getCoreRowModel,
+    getExpandedRowModel,
+    useReactTable,
+    type ColumnDef,
+    type ExpandedState,
+    type Row,
+} from "@tanstack/react-table";
+import { ChevronRight } from "lucide-react";
+import type { QuillApplicationUsage } from "@/api/generated/server-api";
+import { InfoHint } from "@/components/data/info-hint";
+import { WruLabel } from "@/components/data/wru-label";
+import { Badge } from "@/components/shadcn/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/ui/table";
+import { cn } from "@/lib/utils";
+import { rowKey, SYSTEM_GROUP_DESCRIPTION, toUsageGroups, type UsageGroup } from "@/pages/dashboard/usage-groups";
+
+// A group and the databases behind it share one table: the groups are the top-level rows, and their
+// databases the sub-rows react-table expands into.
+type UsageRow = UsageGroup | QuillApplicationUsage;
+
+function isGroup(row: UsageRow): row is UsageGroup {
+    return "rows" in row;
+}
+
+// The name column reserves the chevron's width on every row, expandable or not, so all the names
+// line up in one column and the chevrons sit in a gutter of their own.
+const CHEVRON_GUTTER = "size-3.5 shrink-0";
+
+// Inter's font box sits high in a text-sm line box - more of the leading falls below the letters
+// than above - so an icon centred on that line box reads a hair low against them. `leading-none`
+// collapses the line box onto the font box, which centres the letters and the chevron on the same
+// axis, and the fixed height keeps every row as tall as it was.
+const NAME_ROW = "flex h-5 items-center gap-1.5 leading-none";
+
+// Where the names land: pl-4 + the gutter + the gap. Members of an expanded group indent to it, so
+// they read as sitting under the name they belong to.
+const NAME_INDENT = "pl-9";
+
+// Layout that belongs to the cell rather than to what it holds, so it stays on the <th>/<td> the
+// column renders into instead of on a wrapper inside it.
+function headClassName(columnId: string) {
+    return cn("text-xs font-medium text-muted-foreground", columnId === "name" ? "w-full pl-4" : "pr-4 text-right");
+}
+
+function cellClassName(columnId: string, depth: number) {
+    const isMember = depth > 0;
+
+    if (columnId === "usage") {
+        return cn("pr-4 text-right text-muted-foreground tabular-nums", isMember ? "py-2" : "py-3");
+    }
+
+    return isMember ? cn("py-2 font-mono text-xs text-muted-foreground", NAME_INDENT) : "py-3 pl-4 font-medium";
+}
+
+// The group's own name cell: its shared name (or "System") and how many rows it stands for. The
+// whole row toggles it; the button carries the state and the keyboard, and lets its click bubble to
+// the row so one handler serves both. Groups standing for a single app have nothing to expand and
+// render as the plain name they always were.
+function GroupName({
+    group,
+    isExpandable,
+    isExpanded,
+}: {
+    group: UsageGroup;
+    isExpandable: boolean;
+    isExpanded: boolean;
+}) {
+    if (!isExpandable) {
+        return (
+            <span className={NAME_ROW}>
+                <span aria-hidden="true" className={CHEVRON_GUTTER} />
+                {group.label}
+            </span>
+        );
+    }
+
+    return (
+        <span className={NAME_ROW}>
+            <button
+                type="button"
+                aria-expanded={isExpanded}
+                className={cn(
+                    "-mx-0.5 flex items-center gap-1.5 rounded-sm px-0.5",
+                    "focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none",
+                )}
+            >
+                <ChevronRight
+                    aria-hidden="true"
+                    className={cn(
+                        CHEVRON_GUTTER,
+                        "text-muted-foreground transition-transform",
+                        isExpanded && "rotate-90",
+                    )}
+                />
+                {group.label}
+            </button>
+            {group.isSystem && (
+                // The hint explains the group; it doesn't toggle it.
+                <span onClick={(event) => event.stopPropagation()}>
+                    <InfoHint content={SYSTEM_GROUP_DESCRIPTION} />
+                </span>
+            )}
+            <Badge variant="secondary" className="tabular-nums">
+                {group.rows.length}
+            </Badge>
+        </span>
+    );
+}
+
+const COLUMNS: ColumnDef<UsageRow>[] = [
+    {
+        id: "name",
+        header: "Name",
+        cell: ({ row }) =>
+            isGroup(row.original) ? (
+                <GroupName group={row.original} isExpandable={row.getCanExpand()} isExpanded={row.getIsExpanded()} />
+            ) : (
+                // One row per database behind an expanded group, labelled by the topology id - the
+                // only thing that tells apart rows that share a name.
+                row.original.topologyId
+            ),
+    },
+    {
+        id: "usage",
+        header: () => <WruLabel />,
+        accessorFn: (row) => row.usage,
+        cell: ({ getValue }) => getValue<number>().toLocaleString(),
+    },
+];
+
+// Only expandable groups hand react-table sub-rows, so `getCanExpand` answers for the chevron, the
+// cursor and the click handler alike, without a second notion of expandability alongside it.
+function getSubRows(row: UsageRow) {
+    return isGroup(row) && row.isExpandable ? row.rows : undefined;
+}
+
+function getRowId(row: UsageRow, _index: number, parent?: Row<UsageRow>) {
+    return isGroup(row) ? row.key : `${parent?.id}/${rowKey(row)}`;
+}
+
+export function PerAppUsageTable({ apps }: { apps: QuillApplicationUsage[] }) {
+    const [expanded, setExpanded] = useState<ExpandedState>({});
+    // react-table needs a stable data reference between renders; a fresh identity on every render
+    // makes it recompute row models and queue state resets. "use no memo" opts this file out of the
+    // React Compiler (incompatible with react-table), so the explicit useMemo matters.
+    const groups = useMemo<UsageRow[]>(() => toUsageGroups(apps), [apps]);
+
+    const table = useReactTable({
+        columns: COLUMNS,
+        data: groups,
+        getCoreRowModel: getCoreRowModel(),
+        getExpandedRowModel: getExpandedRowModel(),
+        getSubRows,
+        getRowId,
+        onExpandedChange: setExpanded,
+        state: { expanded },
+    });
+
+    const rows = table.getRowModel().rows;
+
+    return (
+        <Table>
+            <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id} className="hover:bg-transparent">
+                        {headerGroup.headers.map((header) => (
+                            <TableHead key={header.id} className={headClassName(header.column.id)}>
+                                {flexRender(header.column.columnDef.header, header.getContext())}
+                            </TableHead>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableHeader>
+            <TableBody>
+                {rows.length === 0 ? (
+                    <TableRow className="hover:bg-transparent">
+                        <TableCell colSpan={COLUMNS.length} className="h-20 text-center text-muted-foreground">
+                            No usage tracked yet.
+                        </TableCell>
+                    </TableRow>
+                ) : (
+                    rows.map((row) => (
+                        <TableRow
+                            key={row.id}
+                            onClick={row.getCanExpand() ? row.getToggleExpandedHandler() : undefined}
+                            className={cn(
+                                row.getCanExpand() && "cursor-pointer",
+                                row.depth > 0 && "hover:bg-transparent",
+                            )}
+                        >
+                            {row.getVisibleCells().map((cell) => (
+                                <TableCell key={cell.id} className={cellClassName(cell.column.id, row.depth)}>
+                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    ))
+                )}
+            </TableBody>
+        </Table>
+    );
+}

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.test.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { QuillApplicationUsage } from "@/api/generated/server-api";
+import { SYSTEM_GROUP_KEY, SYSTEM_GROUP_LABEL, toUsageGroups } from "@/pages/dashboard/usage-groups";
+
+function row(topologyId: string, applicationName: string, usage: number, isSystem = false): QuillApplicationUsage {
+    return {
+        topologyId,
+        applicationName,
+        from: "2026-06-01T00:00:00Z",
+        to: "2026-06-30T23:59:59Z",
+        usage,
+        isSystem,
+    };
+}
+
+describe("toUsageGroups", () => {
+    it("keeps a uniquely named app as a plain, unexpandable row", () => {
+        const [group] = toUsageGroups([row("t1", "support-copilot", 5200)]);
+
+        expect(group).toMatchObject({ label: "support-copilot", isExpandable: false, usage: 5200 });
+        expect(group!.rows).toHaveLength(1);
+    });
+
+    it("collapses same-named apps into one counted group", () => {
+        // Two appliances under one licence can both run an app called "huetopia"; as separate rows
+        // they read as duplicates, so they collapse into a group the count and ids explain.
+        const groups = toUsageGroups([row("t1", "huetopia", 300), row("t2", "huetopia", 700)]);
+
+        const group = groups.find((g) => g.label === "huetopia")!;
+        expect(group.isExpandable).toBe(true);
+        expect(group.usage).toBe(1000);
+        expect(group.rows.map((r) => r.topologyId)).toEqual(["t2", "t1"]); // heaviest first
+    });
+
+    it("collapses every system row into one group, whatever the config database is called", () => {
+        const groups = toUsageGroups([
+            row("t1", "quill-config", 40, true),
+            row("t2", "quill-config", 12, true),
+            row("t3", "acme-config", 900, true),
+        ]);
+
+        const group = groups.find((g) => g.key === SYSTEM_GROUP_KEY)!;
+        expect(group.label).toBe(SYSTEM_GROUP_LABEL);
+        expect(group.rows).toHaveLength(3);
+        expect(group.usage).toBe(952);
+    });
+
+    it("expands a lone system row, unlike a lone app", () => {
+        // The system label hides which database it is, so expanding has to stay the way back to that
+        // even for the single-appliance case.
+        const [group] = toUsageGroups([row("t1", "quill-config", 40, true)]);
+
+        expect(group!.isExpandable).toBe(true);
+    });
+
+    it("sorts the system group last and keeps apps in the order they arrived", () => {
+        const groups = toUsageGroups([
+            row("t9", "quill-config", 40, true),
+            row("t1", "zeta", 1),
+            row("t2", "alpha", 2),
+        ]);
+
+        expect(groups.map((g) => g.label)).toEqual(["zeta", "alpha", SYSTEM_GROUP_LABEL]);
+    });
+
+    it("never groups an app with a system row that shares its name", () => {
+        // "quill-config" is only the default; an app can legitimately be called that on an appliance
+        // configured with a different config database, and must not be folded into System.
+        const groups = toUsageGroups([row("t1", "quill-config", 500), row("t2", "quill-config", 40, true)]);
+
+        expect(groups).toHaveLength(2);
+        expect(groups.find((g) => g.key === SYSTEM_GROUP_KEY)!.usage).toBe(40);
+        expect(groups.find((g) => g.label === "quill-config" && !g.isSystem)!.usage).toBe(500);
+    });
+
+    it("has no groups at all when nothing is reported", () => {
+        expect(toUsageGroups([])).toEqual([]);
+    });
+});

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.ts
@@ -1,17 +1,14 @@
 import type { QuillApplicationUsage } from "@/api/generated/server-api";
 
-// The licence server reports one row per database, keyed by topology id - and the same name can
-// arrive many times over: one licence can cover several appliances, and re-provisioning one reports
-// under a fresh topology id. Stacking those as rows that read identically tells the user nothing,
-// so same-named rows collapse into a group that carries the shared name, a count and their combined
-// usage, and expanding it identifies each row by the topology id that actually distinguishes them.
+// One licence can cover several appliances, and re-provisioning one reports under a fresh topology
+// id, so the same name arrives many times over. Same-named rows collapse into a group; the topology
+// ids behind it are what tell them apart.
 export type UsageGroup = {
     key: string;
     label: string;
     isSystem: boolean;
-    // True when the group has rows worth naming individually. Every appliance has exactly one config
-    // database, so the system group is expandable even at a count of one: its label deliberately
-    // hides which database it is, and expanding is the only way back to that.
+    // The system group expands even at a count of one: its label hides which database it is, and
+    // expanding is the only way back to that.
     isExpandable: boolean;
     rows: QuillApplicationUsage[];
     usage: number;
@@ -19,7 +16,7 @@ export type UsageGroup = {
 
 export const SYSTEM_GROUP_KEY = "system";
 
-export const SYSTEM_GROUP_LABEL = "System";
+export const SYSTEM_GROUP_LABEL = "@system";
 
 export const SYSTEM_GROUP_DESCRIPTION =
     "Quill's own storage for your apps, channels and API keys. It is written to when you change " +
@@ -29,7 +26,7 @@ export function rowKey(row: QuillApplicationUsage) {
     return `${row.topologyId}/${row.applicationName}`;
 }
 
-// Descending usage, with the topology id breaking ties so equal rows can't shuffle between renders.
+// Topology id breaks ties so equal rows can't shuffle between renders.
 function byUsageDescending(a: QuillApplicationUsage, b: QuillApplicationUsage) {
     return b.usage - a.usage || a.topologyId.localeCompare(b.topologyId);
 }
@@ -40,13 +37,12 @@ function toGroup(key: string, label: string, isSystem: boolean, rows: QuillAppli
         label,
         isSystem,
         isExpandable: isSystem || rows.length > 1,
-        rows: [...rows].sort(byUsageDescending),
+        rows: rows.toSorted(byUsageDescending),
         usage: rows.reduce((total, row) => total + row.usage, 0),
     };
 }
 
-// Apps first, in the order the licence server listed them, then the single system group - the
-// appliance's own storage is not something the user made, so it doesn't compete for the top rows.
+// Apps first, in the order the licence server listed them, then the system group last.
 export function toUsageGroups(apps: QuillApplicationUsage[]): UsageGroup[] {
     const byName = new Map<string, QuillApplicationUsage[]>();
     const system: QuillApplicationUsage[] = [];
@@ -62,7 +58,7 @@ export function toUsageGroups(apps: QuillApplicationUsage[]): UsageGroup[] {
         else byName.set(app.applicationName, [app]);
     }
 
-    const groups = [...byName].map(([name, rows]) => toGroup(`app/${name}`, name, false, rows));
+    const groups = Array.from(byName, ([name, rows]) => toGroup(`app/${name}`, name, false, rows));
 
     if (system.length > 0) groups.push(toGroup(SYSTEM_GROUP_KEY, SYSTEM_GROUP_LABEL, true, system));
 

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.ts
@@ -1,0 +1,70 @@
+import type { QuillApplicationUsage } from "@/api/generated/server-api";
+
+// The licence server reports one row per database, keyed by topology id - and the same name can
+// arrive many times over: one licence can cover several appliances, and re-provisioning one reports
+// under a fresh topology id. Stacking those as rows that read identically tells the user nothing,
+// so same-named rows collapse into a group that carries the shared name, a count and their combined
+// usage, and expanding it identifies each row by the topology id that actually distinguishes them.
+export type UsageGroup = {
+    key: string;
+    label: string;
+    isSystem: boolean;
+    // True when the group has rows worth naming individually. Every appliance has exactly one config
+    // database, so the system group is expandable even at a count of one: its label deliberately
+    // hides which database it is, and expanding is the only way back to that.
+    isExpandable: boolean;
+    rows: QuillApplicationUsage[];
+    usage: number;
+};
+
+export const SYSTEM_GROUP_KEY = "system";
+
+export const SYSTEM_GROUP_LABEL = "System";
+
+export const SYSTEM_GROUP_DESCRIPTION =
+    "Quill's own storage for your apps, channels and API keys. It is written to when you change " +
+    "configuration, and those writes count toward your total.";
+
+export function rowKey(row: QuillApplicationUsage) {
+    return `${row.topologyId}/${row.applicationName}`;
+}
+
+// Descending usage, with the topology id breaking ties so equal rows can't shuffle between renders.
+function byUsageDescending(a: QuillApplicationUsage, b: QuillApplicationUsage) {
+    return b.usage - a.usage || a.topologyId.localeCompare(b.topologyId);
+}
+
+function toGroup(key: string, label: string, isSystem: boolean, rows: QuillApplicationUsage[]): UsageGroup {
+    return {
+        key,
+        label,
+        isSystem,
+        isExpandable: isSystem || rows.length > 1,
+        rows: [...rows].sort(byUsageDescending),
+        usage: rows.reduce((total, row) => total + row.usage, 0),
+    };
+}
+
+// Apps first, in the order the licence server listed them, then the single system group - the
+// appliance's own storage is not something the user made, so it doesn't compete for the top rows.
+export function toUsageGroups(apps: QuillApplicationUsage[]): UsageGroup[] {
+    const byName = new Map<string, QuillApplicationUsage[]>();
+    const system: QuillApplicationUsage[] = [];
+
+    for (const app of apps) {
+        if (app.isSystem) {
+            system.push(app);
+            continue;
+        }
+
+        const existing = byName.get(app.applicationName);
+        if (existing) existing.push(app);
+        else byName.set(app.applicationName, [app]);
+    }
+
+    const groups = [...byName].map(([name, rows]) => toGroup(`app/${name}`, name, false, rows));
+
+    if (system.length > 0) groups.push(toGroup(SYSTEM_GROUP_KEY, SYSTEM_GROUP_LABEL, true, system));
+
+    return groups;
+}

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { settingsMocks } from "@/mocks/settings-mocks";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { sampleTopologyIds, settingsMocks } from "@/mocks/settings-mocks";
 import { DashboardUsage } from "./usage";
 
 const meta = {
@@ -16,6 +17,20 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+// Assertions about a group's total belong to its whole row, not to the trigger inside it.
+function rowFor(trigger: HTMLElement) {
+    return trigger.closest("tr")!;
+}
+
+// Unpadded base64 of a 16-byte guid: 22 characters, the last carrying only two bits.
+const TOPOLOGY_ID = /^[A-Za-z0-9+/]{21}[AQgw]$/;
+
+// The usage column, whatever the row.
+function lastCell(row: HTMLElement) {
+    const cells = (row as HTMLTableRowElement).cells;
+    return cells[cells.length - 1]!;
+}
+
 export const Default: Story = {};
 
 export const Empty: Story = {
@@ -27,5 +42,102 @@ export const Empty: Story = {
                 settings: [settingsMocks.license(), settingsMocks.usage({ byPeriod: [], perApplication: [] })],
             },
         },
+    },
+};
+
+// The config database is reported once per appliance, so a licence covering several of them reports
+// many rows sharing its name. They collapse into one labelled, counted group at the bottom, and
+// expanding identifies each by topology id - the only thing that tells them apart.
+export const SystemRowsCollapseIntoOneCountedGroup: Story = {
+    tags: ["!dev"],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        const system = await waitFor(() => canvas.getByRole("button", { name: "System" }));
+
+        // Collapsed: the group carries the combined usage of its three rows and none of their ids.
+        expect(system).toHaveAttribute("aria-expanded", "false");
+        expect(rowFor(system)).toHaveTextContent("7,600");
+        expect(canvas.queryByText(TOPOLOGY_ID)).not.toBeInTheDocument();
+
+        // Sorted last, behind every app.
+        const names = canvas.getAllByRole("row").map((row) => row.textContent);
+        expect(names.at(-1)).toContain("System");
+
+        await userEvent.click(system);
+        expect(system).toHaveAttribute("aria-expanded", "true");
+
+        // Expanded: one row per database, heaviest first, each named by its id rather than by the
+        // name all three share.
+        const ids = canvas.getAllByText(TOPOLOGY_ID).map((cell) => cell.textContent);
+        expect(ids).toEqual([
+            sampleTopologyIds.systemBusiest,
+            sampleTopologyIds.system,
+            sampleTopologyIds.systemQuietest,
+        ]);
+        expect(canvas.queryByText("quill-config")).not.toBeInTheDocument();
+
+        await userEvent.click(system);
+        expect(canvas.queryByText(TOPOLOGY_ID)).not.toBeInTheDocument();
+    },
+};
+
+// Same treatment for apps: two appliances can both run an app called "huetopia", and as bare rows
+// they are indistinguishable.
+export const SameNamedAppsCollapseToo: Story = {
+    tags: ["!dev"],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        const huetopia = await waitFor(() => canvas.getByRole("button", { name: "huetopia" }));
+        expect(rowFor(huetopia)).toHaveTextContent("1,940,000");
+
+        await userEvent.click(huetopia);
+        expect(canvas.getByText(sampleTopologyIds.huetopiaBusiest)).toBeInTheDocument();
+        expect(canvas.getByText(sampleTopologyIds.huetopia)).toBeInTheDocument();
+    },
+};
+
+// A uniquely named app has nothing to expand, so it stays the plain row it always was.
+export const UniquelyNamedAppStaysAPlainRow: Story = {
+    tags: ["!dev"],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await waitFor(() => expect(canvas.getByText("support-copilot")).toBeInTheDocument());
+        expect(canvas.queryByRole("button", { name: /support-copilot/ })).not.toBeInTheDocument();
+    },
+};
+
+// The label is a small target in a wide row, so the whole row toggles - while the hint inside it
+// explains the group without collapsing it again.
+export const ClickingAnywhereInTheRowToggles: Story = {
+    tags: ["!dev"],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        const trigger = await waitFor(() => canvas.getByRole("button", { name: "System" }));
+        const row = rowFor(trigger);
+
+        await userEvent.click(lastCell(row)); // the usage figure, well away from the label
+        expect(trigger).toHaveAttribute("aria-expanded", "true");
+        expect(canvas.getByText(sampleTopologyIds.systemBusiest)).toBeInTheDocument();
+
+        await userEvent.click(within(row).getByText(/count toward your total/i));
+        expect(trigger).toHaveAttribute("aria-expanded", "true");
+    },
+};
+
+// Figures are compared down the column, so they end-align whatever their width - including the
+// indented rows of an expanded group.
+export const UsageFiguresAreEndAligned: Story = {
+    tags: ["!dev"],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await userEvent.click(await waitFor(() => canvas.getByRole("button", { name: "System" })));
+
+        const alignments = canvas.getAllByRole("row").map((row) => getComputedStyle(lastCell(row)).textAlign);
+        expect(new Set(alignments)).toEqual(new Set(["right"]));
     },
 };

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 import { sampleTopologyIds, settingsMocks } from "@/mocks/settings-mocks";
+import { SYSTEM_GROUP_LABEL } from "@/pages/dashboard/usage-groups";
 import { DashboardUsage } from "./usage";
 
 const meta = {
@@ -53,7 +54,7 @@ export const SystemRowsCollapseIntoOneCountedGroup: Story = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        const system = await waitFor(() => canvas.getByRole("button", { name: "System" }));
+        const system = await waitFor(() => canvas.getByRole("button", { name: SYSTEM_GROUP_LABEL }));
 
         // Collapsed: the group carries the combined usage of its three rows and none of their ids.
         expect(system).toHaveAttribute("aria-expanded", "false");
@@ -62,7 +63,7 @@ export const SystemRowsCollapseIntoOneCountedGroup: Story = {
 
         // Sorted last, behind every app.
         const names = canvas.getAllByRole("row").map((row) => row.textContent);
-        expect(names.at(-1)).toContain("System");
+        expect(names.at(-1)).toContain(SYSTEM_GROUP_LABEL);
 
         await userEvent.click(system);
         expect(system).toHaveAttribute("aria-expanded", "true");
@@ -116,7 +117,7 @@ export const ClickingAnywhereInTheRowToggles: Story = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        const trigger = await waitFor(() => canvas.getByRole("button", { name: "System" }));
+        const trigger = await waitFor(() => canvas.getByRole("button", { name: SYSTEM_GROUP_LABEL }));
         const row = rowFor(trigger);
 
         await userEvent.click(lastCell(row)); // the usage figure, well away from the label
@@ -128,16 +129,22 @@ export const ClickingAnywhereInTheRowToggles: Story = {
     },
 };
 
-// Figures are compared down the column, so they end-align whatever their width - including the
-// indented rows of an expanded group.
+// Figures are compared down the column, so their right edges line up whatever their width -
+// header included, and including the indented rows of an expanded group.
 export const UsageFiguresAreEndAligned: Story = {
     tags: ["!dev"],
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        await userEvent.click(await waitFor(() => canvas.getByRole("button", { name: "System" })));
+        await userEvent.click(await waitFor(() => canvas.getByRole("button", { name: SYSTEM_GROUP_LABEL })));
 
-        const alignments = canvas.getAllByRole("row").map((row) => getComputedStyle(lastCell(row)).textAlign);
-        expect(new Set(alignments)).toEqual(new Set(["right"]));
+        // Measured rather than asserted against a CSS property: the column has been laid out with
+        // text-align and with flex, and what the eye checks is where the digits end.
+        const edges = canvas
+            .getAllByRole("row")
+            .map((row) => Math.round(lastCell(row).firstElementChild!.getBoundingClientRect().right));
+
+        expect(edges.length).toBeGreaterThan(1);
+        expect(new Set(edges).size).toBe(1);
     },
 };

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
@@ -77,7 +77,7 @@ export function DashboardUsage() {
                     <CardTitle>Usage per app</CardTitle>
                     <CardDescription>Totals for {periodLabel}.</CardDescription>
                 </CardHeader>
-                <CardContent className={usageQuery.data ? "px-0" : undefined}>
+                <CardContent>
                     <ApiState
                         isLoading={usageQuery.isPending}
                         isError={usageQuery.isError}

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
@@ -1,17 +1,22 @@
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
+import { ChevronRight } from "lucide-react";
 import { api } from "@/api/api";
 import type { QuillApplicationUsage, QuillPeriodUsage } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
 import { WritesBarChart } from "@/components/data/charts";
 import { DatePeriodPicker } from "@/components/data/date-period-picker";
+import { InfoHint } from "@/components/data/info-hint";
 import { WruLabel } from "@/components/data/wru-label";
+import { Badge } from "@/components/shadcn/ui/badge";
 import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
 import { canDrillInto, drillInto, formatPeriodLabel, getDefaultDatePeriod, type DatePeriod } from "@/lib/date-period";
 import { useSetupStartDate } from "@/lib/use-start-date";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/ui/table";
 import { formatCompact } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { rowKey, SYSTEM_GROUP_DESCRIPTION, toUsageGroups, type UsageGroup } from "@/pages/dashboard/usage-groups";
 
 export function DashboardUsage() {
     const [period, setPeriod] = useState(getDefaultDatePeriod);
@@ -113,7 +118,108 @@ function toChartData(byPeriod: QuillPeriodUsage[], period: DatePeriod) {
         }));
 }
 
+// The name column reserves the chevron's width on every row, expandable or not, so all the names
+// line up in one column and the chevrons sit in a gutter of their own.
+const CHEVRON_GUTTER = "size-3.5 shrink-0";
+
+// Inter's font box sits high in a text-sm line box - more of the leading falls below the letters
+// than above - so an icon centred on that line box reads a hair low against them. `leading-none`
+// collapses the line box onto the font box, which centres the letters and the chevron on the same
+// axis, and the fixed height keeps every row as tall as it was.
+const NAME_ROW = "flex h-5 items-center gap-1.5 leading-none";
+
+// Where the names land: pl-4 + the gutter + the gap. Members of an expanded group indent to it, so
+// they read as sitting under the name they belong to.
+const NAME_INDENT = "pl-9";
+
+function UsageCell({ usage, className }: { usage: number; className?: string }) {
+    return (
+        <TableCell className={cn("py-3 pr-4 text-right text-muted-foreground tabular-nums", className)}>
+            {usage.toLocaleString()}
+        </TableCell>
+    );
+}
+
+// The group's own row: its shared name (or "System"), how many rows it stands for, and their
+// combined usage. The whole row toggles it; the button carries the state and the keyboard, and lets
+// its click bubble to the row so one handler serves both. Groups standing for a single app have
+// nothing to expand and render as the plain row they always were.
+function GroupRow({ group, isOpen, onToggle }: { group: UsageGroup; isOpen: boolean; onToggle: () => void }) {
+    return (
+        <TableRow
+            onClick={group.isExpandable ? onToggle : undefined}
+            className={cn(group.isExpandable && "cursor-pointer")}
+        >
+            <TableCell className="py-3 pl-4 font-medium">
+                <span className={NAME_ROW}>
+                    {group.isExpandable ? (
+                        <>
+                            <button
+                                type="button"
+                                aria-expanded={isOpen}
+                                className={cn(
+                                    "-mx-0.5 flex items-center gap-1.5 rounded-sm px-0.5",
+                                    "focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none",
+                                )}
+                            >
+                                <ChevronRight
+                                    aria-hidden="true"
+                                    className={cn(
+                                        CHEVRON_GUTTER,
+                                        "text-muted-foreground transition-transform",
+                                        isOpen && "rotate-90",
+                                    )}
+                                />
+                                {group.label}
+                            </button>
+                            {group.isSystem && (
+                                // The hint explains the group; it doesn't toggle it.
+                                <span onClick={(event) => event.stopPropagation()}>
+                                    <InfoHint content={SYSTEM_GROUP_DESCRIPTION} />
+                                </span>
+                            )}
+                            <Badge variant="secondary" className="tabular-nums">
+                                {group.rows.length}
+                            </Badge>
+                        </>
+                    ) : (
+                        <>
+                            <span aria-hidden="true" className={CHEVRON_GUTTER} />
+                            {group.label}
+                        </>
+                    )}
+                </span>
+            </TableCell>
+            <UsageCell usage={group.usage} />
+        </TableRow>
+    );
+}
+
+// One row per database behind an expanded group, labelled by the topology id - the only thing that
+// tells apart rows that share a name.
+function GroupMemberRow({ usage, topologyId }: { usage: number; topologyId: string }) {
+    return (
+        <TableRow className="hover:bg-transparent">
+            <TableCell className={cn("py-2 font-mono text-xs text-muted-foreground", NAME_INDENT)}>
+                {topologyId}
+            </TableCell>
+            <UsageCell usage={usage} className="py-2" />
+        </TableRow>
+    );
+}
+
 function PerAppUsageTable({ apps }: { apps: QuillApplicationUsage[] }) {
+    const [openGroups, setOpenGroups] = useState<ReadonlySet<string>>(new Set());
+    const groups = toUsageGroups(apps);
+
+    const toggle = (key: string) =>
+        setOpenGroups((open) => {
+            const next = new Set(open);
+            if (next.has(key)) next.delete(key);
+            else next.add(key);
+            return next;
+        });
+
     return (
         <Table>
             <TableHeader>
@@ -125,23 +231,29 @@ function PerAppUsageTable({ apps }: { apps: QuillApplicationUsage[] }) {
                 </TableRow>
             </TableHeader>
             <TableBody>
-                {apps.length === 0 ? (
+                {groups.length === 0 ? (
                     <TableRow className="hover:bg-transparent">
                         <TableCell colSpan={2} className="h-20 text-center text-muted-foreground">
                             No usage tracked yet.
                         </TableCell>
                     </TableRow>
                 ) : (
-                    apps.map((app) => (
-                        <TableRow key={`${app.topologyId}/${app.applicationName}`}>
-                            <TableCell className="py-3 pl-4 font-medium">{app.applicationName}</TableCell>
-                            <TableCell className="py-3 pr-4">
-                                <span className="w-16 text-right text-muted-foreground tabular-nums">
-                                    {app.usage.toLocaleString()}
-                                </span>
-                            </TableCell>
-                        </TableRow>
-                    ))
+                    groups.map((group) => {
+                        const isOpen = openGroups.has(group.key);
+                        return (
+                            <Fragment key={group.key}>
+                                <GroupRow group={group} isOpen={isOpen} onToggle={() => toggle(group.key)} />
+                                {isOpen &&
+                                    group.rows.map((row) => (
+                                        <GroupMemberRow
+                                            key={rowKey(row)}
+                                            usage={row.usage}
+                                            topologyId={row.topologyId}
+                                        />
+                                    ))}
+                            </Fragment>
+                        );
+                    })
                 )}
             </TableBody>
         </Table>

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
@@ -1,22 +1,17 @@
-import { Fragment, useState } from "react";
+import { useState } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { ChevronRight } from "lucide-react";
 import { api } from "@/api/api";
-import type { QuillApplicationUsage, QuillPeriodUsage } from "@/api/generated/server-api";
+import type { QuillPeriodUsage } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
 import { WritesBarChart } from "@/components/data/charts";
 import { DatePeriodPicker } from "@/components/data/date-period-picker";
-import { InfoHint } from "@/components/data/info-hint";
 import { WruLabel } from "@/components/data/wru-label";
-import { Badge } from "@/components/shadcn/ui/badge";
 import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
 import { canDrillInto, drillInto, formatPeriodLabel, getDefaultDatePeriod, type DatePeriod } from "@/lib/date-period";
 import { useSetupStartDate } from "@/lib/use-start-date";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/ui/table";
 import { formatCompact } from "@/lib/format";
-import { cn } from "@/lib/utils";
-import { rowKey, SYSTEM_GROUP_DESCRIPTION, toUsageGroups, type UsageGroup } from "@/pages/dashboard/usage-groups";
+import { PerAppUsageTable } from "@/pages/dashboard/per-app-usage-table";
 
 export function DashboardUsage() {
     const [period, setPeriod] = useState(getDefaultDatePeriod);
@@ -116,146 +111,4 @@ function toChartData(byPeriod: QuillPeriodUsage[], period: DatePeriod) {
             writes: bucket.usage,
             from: bucket.from,
         }));
-}
-
-// The name column reserves the chevron's width on every row, expandable or not, so all the names
-// line up in one column and the chevrons sit in a gutter of their own.
-const CHEVRON_GUTTER = "size-3.5 shrink-0";
-
-// Inter's font box sits high in a text-sm line box - more of the leading falls below the letters
-// than above - so an icon centred on that line box reads a hair low against them. `leading-none`
-// collapses the line box onto the font box, which centres the letters and the chevron on the same
-// axis, and the fixed height keeps every row as tall as it was.
-const NAME_ROW = "flex h-5 items-center gap-1.5 leading-none";
-
-// Where the names land: pl-4 + the gutter + the gap. Members of an expanded group indent to it, so
-// they read as sitting under the name they belong to.
-const NAME_INDENT = "pl-9";
-
-function UsageCell({ usage, className }: { usage: number; className?: string }) {
-    return (
-        <TableCell className={cn("py-3 pr-4 text-right text-muted-foreground tabular-nums", className)}>
-            {usage.toLocaleString()}
-        </TableCell>
-    );
-}
-
-// The group's own row: its shared name (or "System"), how many rows it stands for, and their
-// combined usage. The whole row toggles it; the button carries the state and the keyboard, and lets
-// its click bubble to the row so one handler serves both. Groups standing for a single app have
-// nothing to expand and render as the plain row they always were.
-function GroupRow({ group, isOpen, onToggle }: { group: UsageGroup; isOpen: boolean; onToggle: () => void }) {
-    return (
-        <TableRow
-            onClick={group.isExpandable ? onToggle : undefined}
-            className={cn(group.isExpandable && "cursor-pointer")}
-        >
-            <TableCell className="py-3 pl-4 font-medium">
-                <span className={NAME_ROW}>
-                    {group.isExpandable ? (
-                        <>
-                            <button
-                                type="button"
-                                aria-expanded={isOpen}
-                                className={cn(
-                                    "-mx-0.5 flex items-center gap-1.5 rounded-sm px-0.5",
-                                    "focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none",
-                                )}
-                            >
-                                <ChevronRight
-                                    aria-hidden="true"
-                                    className={cn(
-                                        CHEVRON_GUTTER,
-                                        "text-muted-foreground transition-transform",
-                                        isOpen && "rotate-90",
-                                    )}
-                                />
-                                {group.label}
-                            </button>
-                            {group.isSystem && (
-                                // The hint explains the group; it doesn't toggle it.
-                                <span onClick={(event) => event.stopPropagation()}>
-                                    <InfoHint content={SYSTEM_GROUP_DESCRIPTION} />
-                                </span>
-                            )}
-                            <Badge variant="secondary" className="tabular-nums">
-                                {group.rows.length}
-                            </Badge>
-                        </>
-                    ) : (
-                        <>
-                            <span aria-hidden="true" className={CHEVRON_GUTTER} />
-                            {group.label}
-                        </>
-                    )}
-                </span>
-            </TableCell>
-            <UsageCell usage={group.usage} />
-        </TableRow>
-    );
-}
-
-// One row per database behind an expanded group, labelled by the topology id - the only thing that
-// tells apart rows that share a name.
-function GroupMemberRow({ usage, topologyId }: { usage: number; topologyId: string }) {
-    return (
-        <TableRow className="hover:bg-transparent">
-            <TableCell className={cn("py-2 font-mono text-xs text-muted-foreground", NAME_INDENT)}>
-                {topologyId}
-            </TableCell>
-            <UsageCell usage={usage} className="py-2" />
-        </TableRow>
-    );
-}
-
-function PerAppUsageTable({ apps }: { apps: QuillApplicationUsage[] }) {
-    const [openGroups, setOpenGroups] = useState<ReadonlySet<string>>(new Set());
-    const groups = toUsageGroups(apps);
-
-    const toggle = (key: string) =>
-        setOpenGroups((open) => {
-            const next = new Set(open);
-            if (next.has(key)) next.delete(key);
-            else next.add(key);
-            return next;
-        });
-
-    return (
-        <Table>
-            <TableHeader>
-                <TableRow className="hover:bg-transparent">
-                    <TableHead className="w-full pl-4 text-xs font-medium text-muted-foreground">Name</TableHead>
-                    <TableHead className="pr-4 text-right text-xs font-medium text-muted-foreground">
-                        <WruLabel />
-                    </TableHead>
-                </TableRow>
-            </TableHeader>
-            <TableBody>
-                {groups.length === 0 ? (
-                    <TableRow className="hover:bg-transparent">
-                        <TableCell colSpan={2} className="h-20 text-center text-muted-foreground">
-                            No usage tracked yet.
-                        </TableCell>
-                    </TableRow>
-                ) : (
-                    groups.map((group) => {
-                        const isOpen = openGroups.has(group.key);
-                        return (
-                            <Fragment key={group.key}>
-                                <GroupRow group={group} isOpen={isOpen} onToggle={() => toggle(group.key)} />
-                                {isOpen &&
-                                    group.rows.map((row) => (
-                                        <GroupMemberRow
-                                            key={rowKey(row)}
-                                            usage={row.usage}
-                                            topologyId={row.topologyId}
-                                        />
-                                    ))}
-                            </Fragment>
-                        );
-                    })
-                )}
-            </TableBody>
-        </Table>
-    );
 }

--- a/src/Raven.Quill/Contracts/UsageResponse.cs
+++ b/src/Raven.Quill/Contracts/UsageResponse.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-
 namespace Raven.Quill.Contracts;
 
 public record QuillUsageResponse(
@@ -11,9 +9,14 @@ public record QuillPeriodUsage(
     DateTime To,
     long Usage);
 
+/// <param name="IsSystem">True for the appliance's own configuration database rather than a user-created
+/// app. The license server reports every database in the cluster, so this row is charged like any other and
+/// is kept in the list — the UI labels it instead of dropping it, so the per-app rows still sum to the total.
+/// Defaulted so a license-server payload that predates the flag still deserializes.</param>
 public record QuillApplicationUsage(
     string TopologyId,
     string ApplicationName,
     DateTime From,
     DateTime To,
-    long Usage);
+    long Usage,
+    bool IsSystem = false);

--- a/src/Raven.Quill/Licensing/LicenseStatsProvider.cs
+++ b/src/Raven.Quill/Licensing/LicenseStatsProvider.cs
@@ -1,7 +1,9 @@
 using System.Text.Json;
+using Microsoft.Extensions.Options;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Quill.AiHelper;
 using Raven.Quill.Contracts;
+using Raven.Quill.Hosting;
 using Raven.Quill.Metrics;
 
 namespace Raven.Quill.Licensing;
@@ -9,10 +11,14 @@ namespace Raven.Quill.Licensing;
 internal sealed class LicenseStatsProvider : ILicenseStatsProvider
 {
     private readonly IAiHelperClient _ravendb;
+    private readonly string _configDatabase;
 
-    public LicenseStatsProvider(IAiHelperClient ravendb)
+    public LicenseStatsProvider(IAiHelperClient ravendb, IOptions<ApplianceOptions> options)
     {
         _ravendb = ravendb;
+        // The config database name is configurable (RAVEN_QUILL_CONFIG_DB), so the appliance's own
+        // usage row can only be recognized by comparing against the configured value - never a literal.
+        _configDatabase = options.Value.ConfigDatabase;
     }
 
     private static readonly LicensePlan[] Plans =
@@ -50,7 +56,8 @@ internal sealed class LicenseStatsProvider : ILicenseStatsProvider
                 g.Key.ApplicationName,
                 g.Min(x => x.From),
                 g.Max(x => x.To),
-                g.Sum(x => x.Usage)))
+                g.Sum(x => x.Usage),
+                IsSystem: string.Equals(g.Key.ApplicationName, _configDatabase, StringComparison.OrdinalIgnoreCase)))
             .ToList();
 
         return new QuillUsageResponse(perApplicationUsages, usage.ByPeriod);

--- a/test/QuillTests/LicenseStatsProviderTests.cs
+++ b/test/QuillTests/LicenseStatsProviderTests.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using FastTests;
+using Microsoft.Extensions.Options;
+using Raven.Client.Documents.Operations.CdcSink;
+using Raven.Quill.AiHelper;
+using Raven.Quill.Contracts;
+using Raven.Quill.Hosting;
+using Raven.Quill.Licensing;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace QuillTests;
+
+public class LicenseStatsProviderTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Config_database_row_is_flagged_as_system_by_the_configured_name()
+    {
+        // The config database name is configurable, so the flag must follow ApplianceOptions - not the
+        // "quill-config" default. Here that default belongs to a *user* app and must stay unflagged.
+        var usage = await GetUsageAsync("acme-config",
+            Row("t1", "support-copilot", 5200),
+            Row("t2", "acme-config", 41),
+            Row("t3", "quill-config", 900));
+
+        Assert.False(Row(usage, "support-copilot").IsSystem);
+        Assert.True(Row(usage, "acme-config").IsSystem);
+        Assert.False(Row(usage, "quill-config").IsSystem);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task System_row_keeps_its_usage_and_stays_in_the_list()
+    {
+        // The license server charges the config database like any other, so dropping the row would leave
+        // the per-app rows short of the total shown beside them. It is labelled, never removed.
+        var usage = await GetUsageAsync("quill-config",
+            Row("t1", "support-copilot", 5200),
+            Row("t2", "quill-config", 41));
+
+        Assert.Equal(2, usage.PerApplication.Count);
+        Assert.Equal(41, Row(usage, "quill-config").Usage);
+        Assert.Equal(5241, usage.PerApplication.Sum(a => a.Usage));
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task System_row_is_matched_regardless_of_case()
+    {
+        // Database names are case-insensitive in RavenDB, so a differently-cased report still matches.
+        var usage = await GetUsageAsync("Quill-Config", Row("t1", "quill-config", 41));
+
+        Assert.True(Row(usage, "quill-config").IsSystem);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Every_appliance_reporting_under_one_license_is_flagged()
+    {
+        // One license can cover several appliances, and re-provisioning one reports under a fresh
+        // topology id - so the config database's name arrives many times over, and every one of them
+        // has to be flagged. Only the topology id tells them apart.
+        var usage = await GetUsageAsync("quill-config",
+            Row("t1", "quill-config", 40),
+            Row("t2", "quill-config", 12),
+            Row("t3", "support-copilot", 5200));
+
+        Assert.Equal(3, usage.PerApplication.Count);
+        Assert.Equal(
+            ["t1", "t2"],
+            usage.PerApplication.Where(a => a.IsSystem).Select(a => a.TopologyId).Order());
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Rows_for_one_database_are_merged_before_being_flagged()
+    {
+        // The license server reports one row per period; they collapse into a single row per database,
+        // and the merged row is still recognized as the config database.
+        var usage = await GetUsageAsync("quill-config",
+            Row("t2", "quill-config", 20),
+            Row("t2", "quill-config", 21));
+
+        var system = Assert.Single(usage.PerApplication);
+        Assert.True(system.IsSystem);
+        Assert.Equal(41, system.Usage);
+    }
+
+    private static async Task<QuillUsageResponse> GetUsageAsync(string configDatabase, params object[] perApplication)
+    {
+        var payload = JsonSerializer.Serialize(new { PerApplication = perApplication, ByPeriod = Array.Empty<object>() });
+        var provider = new LicenseStatsProvider(
+            new StubAiHelperClient(payload),
+            Options.Create(new ApplianceOptions { ConfigDatabase = configDatabase }));
+
+        return await provider.GetUsageAsync(2026, month: 6, day: null, CancellationToken.None);
+    }
+
+    private static object Row(string topologyId, string applicationName, long usage) => new
+    {
+        TopologyId = topologyId,
+        ApplicationName = applicationName,
+        From = "2026-06-01T00:00:00Z",
+        To = "2026-06-30T23:59:59Z",
+        Usage = usage,
+    };
+
+    private static QuillApplicationUsage Row(QuillUsageResponse usage, string applicationName) =>
+        Assert.Single(usage.PerApplication, a => a.ApplicationName == applicationName);
+
+    /// Answers every upstream call with one canned body, so the test drives only the projection.
+    private sealed class StubAiHelperClient(string content) : IAiHelperClient
+    {
+        public Task<(AiHelperStatus Transport, string Content)> SendAsync(string path, string method, object request, CancellationToken ct) =>
+            Task.FromResult((AiHelperStatus.Success, content));
+
+        public Task<T> DeserializeAsync<T>(string json, CancellationToken ct) where T : class =>
+            Task.FromResult(JsonSerializer.Deserialize<T>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!);
+
+        public Task<SuggestCdcInternalResult> SuggestCdcAsync(object? schema, object? samples, string prompt, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<SuggestAiAgentInternalResult> SuggestAiAgentAsync(CdcSinkConfiguration cdcConfig, object? collectionsSample, string mode, string? prompt, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<HttpResponseMessage> SendChatAsync(string message, string? conversationId, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<AiHelperStatus> CheckConsentAsync(CancellationToken ct) => throw new NotSupportedException();
+
+        public Task<AiHelperStatus> GiveConsentAsync(CancellationToken ct) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
### Issue link

http://issues.ravendb.net/issue/RavenDB-27306

### Additional description

**Problem.** The per-app breakdown on `/usage` listed `quill-config` by name, with nothing to say what it was or why an internal database counted against WRU. A licence covering several appliances reports it once per appliance, so it appeared repeatedly, indistinguishable from a real app — and app names can repeat too (`huetopia` twice in the issue's screenshot).

**Decision: label the row, don't hide it.** The licence server charges every database topology reported to it (`ClusterObserver` sends one snapshot per topology, unfiltered), so dropping the row from the table would leave the per-app rows short of the total shown directly above them — the UI would disagree with the invoice, which is worse than the original problem. Excluding the config database from metering altogether is the better fix *if* we decide it shouldn't be billed, but that means teaching `WriteUsageReporter` / `ClusterObserver` in `Raven.Server` about a database it has no concept of, plus coordination with api.ravendb.net. Left as a follow-up.

**Server.** `QuillApplicationUsage` gains `IsSystem`, set in `LicenseStatsProvider` by comparing the reported name against `ApplianceOptions.ConfigDatabase` — never against the `quill-config` literal, since the name is configurable via `RAVEN_QUILL_CONFIG_DB`. The flag is applied on projection *after* grouping, so it cannot merge distinct databases.

**Table.** Rows now group. All system rows collapse into one `System` group sorted last; non-system rows sharing a name collapse under that name. Expanding identifies each database by topology id — the only thing that tells same-named rows apart. Uniquely-named apps stay the plain rows they always were. The grouping is a pure function in `usage-groups.ts`, unit-testable away from the DOM.

Note that grouping keys off `isSystem`, not the name: an app legitimately called `quill-config`, on an appliance configured with a different config database, is never folded into System. There is a test for exactly that.

**Interaction and visuals.**
- The whole row toggles the group; the button keeps `aria-expanded` and keyboard access and lets its click bubble, so one handler serves both.
- Counts render in a `Badge`, matching the existing precedent in `channel-groups.tsx`.
- Every row reserves the chevron's width, so all names line up in one column instead of chevron rows sitting 20px right of plain ones.
- Usage figures are now genuinely end-aligned. The previous `w-16 text-right` sat on an inline `<span>`, where `w-16` is inert, and the cell itself never received `text-right` — so body figures were left-aligned under a right-aligned header.
- The hint icon is now `circle-question-mark` at 0.66 opacity.

**New user-facing copy** — the `System` label and its tooltip ("Quill's own storage for your apps, channels and API keys. It is written to when you change configuration, and those writes count toward your total."). Worth a second opinion on the wording.

**Verification.** Driven in Storybook and measured in the DOM at 841px and 375px: no horizontal overflow, usage column uniform across all rows, chevron/label alignment confirmed. Not yet exercised against a live appliance with real licence-server data, which is why "verified by manual testing" is left unchecked below.

**Follow-ups, deliberately out of scope:**
- `/usage` and the dashboard disagree on total WRU — `MetricsReadService` joins licence-server rows against the known app list and drops unmatched topologies from its total, so the dashboard excludes system writes while `/usage` includes them. Pre-existing.
- A sharded app would list as `slug$0`, `slug$1`, since `RawDatabaseRecord.Topologies` yields per-shard names. Theoretical today — Quill does not shard app databases.
- Whether api.ravendb.net actually bills the config database is still unanswered; it decides whether the metering-side fix is worth doing.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

`IsSystem` is additive and defaulted to `false`, so a licence-server payload that predates the field still deserializes.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

`LicenseStatsProviderTests` (new, 5 tests): the flag follows the configured name and not the `quill-config` literal; every appliance reporting under one licence is flagged; rows for one database merge before being flagged; the match is case-insensitive; the row keeps its usage and stays in the list.

`usage-groups.test.ts` (new, 7 tests): duplicate collapse, system rows across differing config-database names, lone-system-expandable, group ordering, the app-vs-system name collision, empty input.

`usage.stories.tsx` (5 new play tests): System collapses/expands/re-collapses with the right count, total and id order; same-named apps behave identically; a uniquely-named app stays a plain row; clicking the usage cell toggles the group while clicking the hint does not; every last-column cell is right-aligned with a group expanded.

Suites run: web unit 137 + 29, storybook 97 + 16, Quill usage/settings/dashboard .NET tests 41. Typecheck, eslint and prettier clean.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

`InfoHint` is shared by three call sites — the WRU labels, the dashboard stat cards, and this row — so the icon swap to `circle-question-mark` at 0.66 opacity affects all of them. In the WRU header the `<th>` is already `text-muted-foreground`, so the icon inherits muted *and* fades to 0.66, making those two hints noticeably fainter than before. I removed the hint's own `text-muted-foreground` so 0.66 is the only fade rather than two stacking; happy to pin the colour instead if the WRU hints should keep their previous weight.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed

https://github.com/user-attachments/assets/97f05425-78ed-47bc-b535-30b9e17ed4ce

