### PR TITLE
RavenDB-27380 Quill - Add AI chat window (review fixes)

### DIFF
--- a/src/Raven.Quill.Web/src/api/custom-services/assistant-service.test.ts
+++ b/src/Raven.Quill.Web/src/api/custom-services/assistant-service.test.ts
@@ -4,6 +4,7 @@ import {
     createAssistantService,
     describeAssistantError,
     isAssistantConsentRequired,
+    isQuillSessionExpired,
     type AssistantChatFrame,
     type AssistantStreamEvent,
 } from "@/api/custom-services/assistant-service";
@@ -109,6 +110,24 @@ describe("assistant stream", () => {
             message: "The AI assistant did not finish answering. Please try again.",
         });
     });
+
+    it("reports a stream cut off mid-frame as unfinished rather than malformed", async () => {
+        const client = createApiClient({
+            transport: () =>
+                Promise.resolve(
+                    new Response('data: {"type":"Ongoing","text":"Half"}\n\ndata: {"type":"Ongo', {
+                        headers: { "Content-Type": "text/event-stream" },
+                    }),
+                ),
+        });
+
+        const events = await streamEvents(client);
+
+        expect(events.at(-1)).toEqual({
+            type: "error",
+            message: "The AI assistant did not finish answering. Please try again.",
+        });
+    });
 });
 
 async function refusalOf(body: string, status: number, contentType: string) {
@@ -160,5 +179,21 @@ describe("isAssistantConsentRequired", () => {
         const error = await refusalOf("Unauthorized", 401, "text/plain");
 
         expect(isAssistantConsentRequired(error)).toBe(false);
+    });
+});
+
+describe("isQuillSessionExpired", () => {
+    it("recognizes Quill's bare 401 session challenge", async () => {
+        const error = await refusalOf("", 401, "text/plain");
+
+        expect(isQuillSessionExpired(error)).toBe(true);
+    });
+
+    it("does not read the AI service's relayed refusals as an expired session", async () => {
+        const consentError = await refusalOf('{"Status":"ConsentRequired"}', 401, "application/json");
+        const licenseError = await refusalOf("Unauthorized", 401, "text/plain");
+
+        expect(isQuillSessionExpired(consentError)).toBe(false);
+        expect(isQuillSessionExpired(licenseError)).toBe(false);
     });
 });

--- a/src/Raven.Quill.Web/src/api/custom-services/assistant-service.ts
+++ b/src/Raven.Quill.Web/src/api/custom-services/assistant-service.ts
@@ -112,9 +112,18 @@ export function isAssistantConsentRequired(error: unknown) {
     return isApiError(error) && readStatus(error.details) === "ConsentRequired";
 }
 
+/** True for Quill's own authentication challenge: an expired operator session answers with a bare
+ * 401 and no body at all, while the AI service's relayed refusals carry a body. */
+export function isQuillSessionExpired(error: unknown) {
+    return isApiError(error) && error.status === 401 && error.details === undefined;
+}
+
+export const AI_LICENSE_UNAVAILABLE_MESSAGE =
+    "The AI assistant is not available for this appliance's license. Please contact support.";
+
 const ASSISTANT_STATUS_MESSAGES: Partial<Record<AssistantChatStatus, string>> = {
     ConsentRequired: AI_CONSENT_REQUIRED_MESSAGE,
-    InvalidCredentials: "The AI assistant is not available for this appliance's license.",
+    InvalidCredentials: AI_LICENSE_UNAVAILABLE_MESSAGE,
     InvalidData: "The AI assistant could not make sense of that request.",
     OutOfTokens: "The AI assistant has used up its quota for now. Please try again later.",
     RequestTooLarge: "That message is too large for the AI assistant. Please shorten it and try again.",

--- a/src/Raven.Quill.Web/src/api/custom-services/response-stream.test.ts
+++ b/src/Raven.Quill.Web/src/api/custom-services/response-stream.test.ts
@@ -47,8 +47,8 @@ describe("streamSseData", () => {
         await expect(collect(streamSseData(client, "/assistant/chat", {}))).resolves.toEqual(['{"a":1}']);
     });
 
-    it("yields a last frame that arrived without its trailing newline", async () => {
-        const client = clientStreaming('data: {"a":1}');
+    it("discards a trailing line the connection cut off before its newline", async () => {
+        const client = clientStreaming('data: {"a":1}\n\n', 'data: {"b":');
 
         await expect(collect(streamSseData(client, "/assistant/chat", {}))).resolves.toEqual(['{"a":1}']);
     });

--- a/src/Raven.Quill.Web/src/api/custom-services/response-stream.ts
+++ b/src/Raven.Quill.Web/src/api/custom-services/response-stream.ts
@@ -3,15 +3,16 @@ import type { ApiClient } from "@/api/http-client";
 const DATA_FIELD_PREFIX = "data:";
 
 /** POSTs `body` to `path` and yields the lines the server streams back, holding a partial trailing
- * line until the read that completes it. Non-2xx responses (e.g. a pre-stream 400/401) throw an
- * ApiError before the first line. Pass a `signal` to cancel the request (callers abort it when the
- * view unmounts mid-stream). */
+ * line until the read that completes it. A trailing line the stream ended without a newline is still
+ * yielded, flagged `isLineComplete: false`, so each framing can decide whether a cut-off tail counts.
+ * Non-2xx responses (e.g. a pre-stream 400/401) throw an ApiError before the first line. Pass a
+ * `signal` to cancel the request (callers abort it when the view unmounts mid-stream). */
 export async function* streamResponseLines(
     client: ApiClient,
     path: string,
     body: unknown,
     signal?: AbortSignal,
-): AsyncGenerator<string> {
+): AsyncGenerator<{ line: string; isLineComplete: boolean }> {
     const response = await client.post<Response>(path, body, { responseType: "response", signal });
 
     if (!response.body) {
@@ -33,12 +34,12 @@ export async function* streamResponseLines(
             buffer = lines.pop() ?? "";
 
             for (const line of lines) {
-                yield line;
+                yield { line, isLineComplete: true };
             }
         }
 
         if (buffer !== "") {
-            yield buffer;
+            yield { line: buffer, isLineComplete: false };
         }
     } finally {
         // Cancel the body so an aborted or abandoned generator stops the request streaming in the
@@ -48,14 +49,15 @@ export async function* streamResponseLines(
     }
 }
 
-/** The same stream framed as NDJSON: one JSON document per non-blank line. */
+/** The same stream framed as NDJSON: one JSON document per non-blank line. The last document keeps
+ * counting without its trailing newline, which NDJSON writers routinely omit. */
 export async function* streamNdjsonLines(
     client: ApiClient,
     path: string,
     body: unknown,
     signal?: AbortSignal,
 ): AsyncGenerator<string> {
-    for await (const line of streamResponseLines(client, path, body, signal)) {
+    for await (const { line } of streamResponseLines(client, path, body, signal)) {
         if (line.trim()) {
             yield line;
         }
@@ -63,14 +65,20 @@ export async function* streamNdjsonLines(
 }
 
 /** The same stream framed as Server-Sent Events: the payload of every `data:` field. Comments, other
- * field names and the blank lines between events are skipped. */
+ * field names and the blank lines between events are skipped. So is an unterminated trailing line —
+ * SSE frames always end in a newline, so that tail is a frame the connection cut off, and parsing it
+ * would misreport the truncation as a malformed response (the SSE spec discards it too). */
 export async function* streamSseData(
     client: ApiClient,
     path: string,
     body: unknown,
     signal?: AbortSignal,
 ): AsyncGenerator<string> {
-    for await (const line of streamResponseLines(client, path, body, signal)) {
+    for await (const { line, isLineComplete } of streamResponseLines(client, path, body, signal)) {
+        if (!isLineComplete) {
+            continue;
+        }
+
         const payload = readDataField(line);
         if (payload !== undefined) {
             yield payload;

--- a/src/Raven.Quill.Web/src/api/queries/apps-queries.ts
+++ b/src/Raven.Quill.Web/src/api/queries/apps-queries.ts
@@ -40,17 +40,22 @@ export function createAppsQueries(api: ServerApi["apps"]) {
                     recordFetchStartedAt(queryKey);
 
                     // Suggestions are an optional aid — the wizard works without them — so
-                    // failures degrade to an empty list instead of blocking navigation.
+                    // failures degrade to an empty list instead of blocking navigation. A missing
+                    // AI consent is reported alongside them so the step can name it instead of
+                    // blaming the operator's data.
                     const result = await api
                         .suggestAgent(slug, { mode: "from-data", intentPrompt: null })
                         .catch(() => null);
 
-                    return result?.status === "Success" ? result.configurations : [];
+                    return {
+                        configurations: result?.status === "Success" ? result.configurations : [],
+                        isConsentRequired: result?.status === "ConsentRequired",
+                    };
                 },
                 // A non-empty suggestion is an expensive AI call: never refetch it behind the
                 // wizard. An empty one (failure or no candidates) stays stale so the next
                 // fetch retries.
-                staleTime: (query) => ((query.state.data?.length ?? 0) > 0 ? Infinity : 0),
+                staleTime: (query) => (query.state.data?.configurations.length ? Infinity : 0),
             }),
         aiConnectionStringsList: (slug: string) =>
             queryOptions({

--- a/src/Raven.Quill.Web/src/components/layout/assistant-chat-store.ts
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-chat-store.ts
@@ -3,9 +3,10 @@ import { api } from "@/api/api";
 import {
     describeAssistantError,
     isAssistantConsentRequired,
+    isQuillSessionExpired,
     type AssistantRelevantLink,
 } from "@/api/custom-services/assistant-service";
-import { queryClient } from "@/lib/query-client";
+import { markSessionExpired, queryClient } from "@/lib/query-client";
 
 export type AssistantMessage = {
     id: string;
@@ -103,6 +104,15 @@ export const useAssistantChatStore = create<AssistantChatState>((set, get) => ({
             // an answer that never started would strand the "Thinking…" placeholder.
             if (abortController.signal.aborted) {
                 dropAnswerIfEmpty();
+                return;
+            }
+
+            if (isQuillSessionExpired(error)) {
+                updateAnswer({
+                    role: "error",
+                    text: "Your session expired before the assistant could answer. Please send the message again.",
+                });
+                markSessionExpired();
                 return;
             }
 

--- a/src/Raven.Quill.Web/src/components/layout/assistant-consent.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-consent.tsx
@@ -2,6 +2,8 @@ import { useState, type ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Sparkles } from "lucide-react";
 import { api } from "@/api/api";
+import { AI_LICENSE_UNAVAILABLE_MESSAGE } from "@/api/custom-services/assistant-service";
+import type { AiHelperStatus } from "@/api/generated/server-api";
 import { useAssistantConsent } from "@/components/layout/use-assistant-consent";
 import { Alert, AlertDescription } from "@/components/shadcn/ui/alert";
 import { Button } from "@/components/shadcn/ui/button";
@@ -64,9 +66,7 @@ export function AssistantConsentGate() {
     return (
         <AssistantConsentFrame>
             <Alert variant="destructive" className="text-left">
-                <AlertDescription>
-                    The AI assistant is not available for this license. Please contact support.
-                </AlertDescription>
+                <AlertDescription>{AI_LICENSE_UNAVAILABLE_MESSAGE}</AlertDescription>
             </Alert>
         </AssistantConsentFrame>
     );
@@ -100,12 +100,24 @@ function AssistantConsentDialog() {
     );
 }
 
+function describeConsentFailure(status: AiHelperStatus) {
+    return status === "ConsentRequired"
+        ? "The AI service has not registered the consent yet. Please try again in a moment."
+        : AI_LICENSE_UNAVAILABLE_MESSAGE;
+}
+
 function AssistantConsentDialogBody({ onGranted }: { onGranted: () => void }) {
     const [isAccepted, setIsAccepted] = useState(false);
     const queryClient = useQueryClient();
 
     const consentMutation = useMutation({
-        mutationFn: () => api.services.assistant.giveConsent(),
+        mutationFn: async () => {
+            const result = await api.services.assistant.giveConsent();
+            if (result.status !== "Success") {
+                throw new Error(describeConsentFailure(result.status));
+            }
+            return result;
+        },
         onSuccess: (result) => {
             queryClient.setQueryData(api.queries.assistant.consent().queryKey, result);
             onGranted();

--- a/src/Raven.Quill.Web/src/components/layout/assistant-consent.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-consent.tsx
@@ -4,6 +4,7 @@ import { Sparkles } from "lucide-react";
 import { api } from "@/api/api";
 import { AI_LICENSE_UNAVAILABLE_MESSAGE } from "@/api/custom-services/assistant-service";
 import type { AiHelperStatus } from "@/api/generated/server-api";
+import { invalidateConsentBlockedSuggestions } from "@/lib/query-invalidation";
 import { useAssistantConsent } from "@/components/layout/use-assistant-consent";
 import { Alert, AlertDescription } from "@/components/shadcn/ui/alert";
 import { Button } from "@/components/shadcn/ui/button";
@@ -120,6 +121,7 @@ function AssistantConsentDialogBody({ onGranted }: { onGranted: () => void }) {
         },
         onSuccess: (result) => {
             queryClient.setQueryData(api.queries.assistant.consent().queryKey, result);
+            void invalidateConsentBlockedSuggestions(queryClient);
             onGranted();
         },
     });

--- a/src/Raven.Quill.Web/src/components/layout/assistant-messages.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-messages.tsx
@@ -35,9 +35,17 @@ function AssistantMessageItem({ message }: { message: AssistantMessage }) {
     );
 }
 
+function isWebUrl(url: string | undefined) {
+    try {
+        const { protocol } = new URL(url ?? "");
+        return protocol === "http:" || protocol === "https:";
+    } catch {
+        return false;
+    }
+}
+
 function AssistantRelevantLinks({ links }: { links: AssistantMessage["relevantLinks"] }) {
-    // The links come straight from the AI service, so a blank url is possible and unlinkable.
-    const linkedSources = links?.filter((link) => link.Url?.trim());
+    const linkedSources = links?.filter((link) => isWebUrl(link.Url));
 
     if (!linkedSources || linkedSources.length === 0) {
         return null;

--- a/src/Raven.Quill.Web/src/components/layout/assistant-panel.stories.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-panel.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, waitFor, within } from "storybook/test";
+import { AI_LICENSE_UNAVAILABLE_MESSAGE } from "@/api/custom-services/assistant-service";
 import { assistantMocks } from "@/mocks/assistant-mocks";
 import { defaultApiMocks } from "@/mocks/default-mocks";
 import { AssistantPanel } from "./assistant-panel";
@@ -60,7 +61,7 @@ export const LicenseWithoutAssistant: Story = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        await waitFor(() => expect(canvas.getByRole("alert")).toHaveTextContent(/not available for this license/i));
+        await waitFor(() => expect(canvas.getByRole("alert")).toHaveTextContent(AI_LICENSE_UNAVAILABLE_MESSAGE));
     },
 };
 

--- a/src/Raven.Quill.Web/src/components/layout/assistant-store.ts
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-store.ts
@@ -26,6 +26,10 @@ export function clampAssistantSize(sizePx: number, minPx: number, maxPx: number)
     return Math.min(maxPx, Math.max(minPx, Math.round(sizePx)));
 }
 
+function persistSize(storageKey: string, sizePx: number) {
+    localStorage.setItem(storageKey, String(sizePx));
+}
+
 function readStoredSize(storageKey: string, defaultPx: number, minPx: number, maxPx = Number.POSITIVE_INFINITY) {
     const storedPx = Number(localStorage.getItem(storageKey));
     return Number.isFinite(storedPx) && storedPx > 0 ? clampAssistantSize(storedPx, minPx, maxPx) : defaultPx;
@@ -48,7 +52,7 @@ type AssistantState = {
     setHeight: (heightPx: number) => void;
 };
 
-export const useAssistantStore = create<AssistantState>((set) => ({
+export const useAssistantStore = create<AssistantState>((set, get) => ({
     isOpen: localStorage.getItem(ASSISTANT_OPEN_STORAGE_KEY) === "true",
     isPinned: localStorage.getItem(ASSISTANT_PINNED_STORAGE_KEY) !== "false",
     isResizing: false,
@@ -69,16 +73,29 @@ export const useAssistantStore = create<AssistantState>((set) => ({
         localStorage.setItem(ASSISTANT_PINNED_STORAGE_KEY, String(isPinned));
         set({ isPinned });
     },
-    setResizing: (isResizing) => set({ isResizing }),
+    setResizing: (isResizing) => {
+        set({ isResizing });
+        if (isResizing) {
+            return;
+        }
+
+        const { widthPx, heightPx } = get();
+        persistSize(ASSISTANT_WIDTH_STORAGE_KEY, widthPx);
+        persistSize(ASSISTANT_HEIGHT_STORAGE_KEY, heightPx);
+    },
     setWidth: (widthPx) => {
         const clampedPx = clampAssistantSize(widthPx, ASSISTANT_MIN_WIDTH_PX, ASSISTANT_MAX_WIDTH_PX);
-        localStorage.setItem(ASSISTANT_WIDTH_STORAGE_KEY, String(clampedPx));
         set({ widthPx: clampedPx });
+        if (!get().isResizing) {
+            persistSize(ASSISTANT_WIDTH_STORAGE_KEY, clampedPx);
+        }
     },
     setHeight: (heightPx) => {
         const clampedPx = clampAssistantSize(heightPx, ASSISTANT_MIN_HEIGHT_PX, assistantMaxHeightPx());
-        localStorage.setItem(ASSISTANT_HEIGHT_STORAGE_KEY, String(clampedPx));
         set({ heightPx: clampedPx });
+        if (!get().isResizing) {
+            persistSize(ASSISTANT_HEIGHT_STORAGE_KEY, clampedPx);
+        }
     },
 }));
 

--- a/src/Raven.Quill.Web/src/lib/query-client.ts
+++ b/src/Raven.Quill.Web/src/lib/query-client.ts
@@ -2,11 +2,14 @@ import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 import { isApiError } from "@/api/http-client";
 import { AUTH_STATUS_QUERY_KEY, UNAUTHENTICATED_STATUS } from "@/lib/auth-query";
 
-// Any operator API call that comes back 401 means the session is gone. Flip the
-// cached auth status to unauthenticated so RequireAuth redirects back to /login.
+export function markSessionExpired() {
+    queryClient.setQueryData(AUTH_STATUS_QUERY_KEY, UNAUTHENTICATED_STATUS);
+}
+
+// Any operator API call that comes back 401 means the session is gone.
 function handleUnauthorized(error: unknown) {
     if (isApiError(error) && error.status === 401) {
-        queryClient.setQueryData(AUTH_STATUS_QUERY_KEY, UNAUTHENTICATED_STATUS);
+        markSessionExpired();
     }
 }
 

--- a/src/Raven.Quill.Web/src/lib/query-invalidation.ts
+++ b/src/Raven.Quill.Web/src/lib/query-invalidation.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { api } from "@/api/api";
+import { AI_CONSENT_REQUIRED_MESSAGE } from "@/api/custom-services/assistant-service";
 import { APP_AI_CONNECTION_STRINGS_KEY } from "@/api/queries/apps-queries";
 
 // The dashboard "My apps" table (stats.dashboardApps) summarizes each app's agent and
@@ -41,4 +42,18 @@ export function invalidateChannelQueries(queryClient: QueryClient, slug: string)
         queryClient.invalidateQueries({ queryKey: api.queries.stats.channels(slug).queryKey }),
         queryClient.invalidateQueries({ queryKey: api.queries.stats.dashboardApps().queryKey }),
     ]);
+}
+
+export function invalidateConsentBlockedSuggestions(queryClient: QueryClient) {
+    return queryClient.invalidateQueries({
+        predicate: (query) => isConsentRequiredResult(query.state.data) || isConsentRequiredFailure(query.state.error),
+    });
+}
+
+function isConsentRequiredResult(data: unknown) {
+    return typeof data === "object" && data != null && "isConsentRequired" in data && data.isConsentRequired === true;
+}
+
+function isConsentRequiredFailure(error: unknown) {
+    return error instanceof Error && error.message === AI_CONSENT_REQUIRED_MESSAGE;
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx
@@ -1,4 +1,5 @@
 import { useFormContext, useWatch } from "react-hook-form";
+import { AI_CONSENT_REQUIRED_MESSAGE } from "@/api/custom-services/assistant-service";
 import { cn } from "@/lib/utils";
 import {
     CARD_DESCRIPTION_CLASSES,
@@ -20,7 +21,7 @@ export function CreateAgentStep({ isBusy }: WizardBodyComponentProps) {
     const { control, setValue } = useFormContext<AgentFormData>();
     const suggestions = useCapabilityWizardStore((state) => state.suggestions);
     const mode = useWatch({ control, name: "create.mode" });
-    const { isSuggesting, startedAt: suggestionStartedAt } = useSuggestedAgents();
+    const { isSuggesting, startedAt: suggestionStartedAt, isConsentRequired } = useSuggestedAgents();
 
     // "Next" in prompt mode is the generation call itself, so the wizard is only ever busy here
     // while the agent is being generated.
@@ -50,7 +51,9 @@ export function CreateAgentStep({ isBusy }: WizardBodyComponentProps) {
                     <SuggestedAgentsProgress startedAt={suggestionStartedAt} />
                 ) : suggestions.length === 0 ? (
                     <Alert>
-                        AI could not suggest agents from your data. Describe your own below, or set one up manually.
+                        {isConsentRequired
+                            ? AI_CONSENT_REQUIRED_MESSAGE
+                            : "AI could not suggest agents from your data. Describe your own below, or set one up manually."}
                     </Alert>
                 ) : (
                     <SuggestionPicker />

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/create/use-suggested-agents.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/create/use-suggested-agents.ts
@@ -13,7 +13,11 @@ import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capabili
  * same query, so this usually joins a call that is already in flight - and the caller renders
  * progress for however much of it is left.
  */
-export function useSuggestedAgents(): { isSuggesting: boolean; startedAt: number | undefined } {
+export function useSuggestedAgents(): {
+    isSuggesting: boolean;
+    startedAt: number | undefined;
+    isConsentRequired: boolean;
+} {
     const { slug = "" } = useParams();
     const { getValues, setValue } = useFormContext<AgentFormData>();
     const suggestions = useCapabilityWizardStore((state) => state.suggestions);
@@ -21,7 +25,7 @@ export function useSuggestedAgents(): { isSuggesting: boolean; startedAt: number
 
     const suggestQuery = api.queries.apps.suggestAgentFromData(slug);
     const query = useQuery(suggestQuery);
-    const suggestedAgents = query.data;
+    const suggestedAgents = query.data?.configurations;
 
     // The candidates arrive after this step is already on screen, so handing them to the store is a
     // genuine sync step. The store mirrors the cached array by reference, which applies each fetch
@@ -48,6 +52,7 @@ export function useSuggestedAgents(): { isSuggesting: boolean; startedAt: number
     return {
         isSuggesting: (query.isFetching || !suggestedAgents) && suggestions.length === 0,
         startedAt: getFetchStartedAt(suggestQuery.queryKey),
+        isConsentRequired: query.data?.isConsentRequired === true,
     };
 }
 


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27380

### Additional description

Review fixes for PR:
https://github.com/ravendb/ravendb/pull/23417

1. **Consent grant success** - Fixed. `mutationFn` in [assistant-consent.tsx:114](src/components/layout/assistant-consent.tsx:114) now throws on any non-`Success` status, so `onSuccess` (cache write + dialog close) only runs on a real grant. The dialog body renders the error inline; `ConsentRequired` gets a "not registered yet, try again in a moment" message and other statuses get the license message.

2. **Expired session vs license failure** - Fixed without backend changes. `isQuillSessionExpired` ([assistant-service.ts:117](src/api/custom-services/assistant-service.ts:117)) keys on 401 + `details === undefined`; I confirmed `readErrorDetails` in http-client returns `undefined` exactly for an empty body, so Quill's bare cookie challenge is distinguishable from the AI service's bodied 401s. The chat store writes a "session expired" bubble and calls the extracted `markSessionExpired()` so `RequireAuth` redirects. Tests cover both the bare-401 and the relayed-refusal cases.

3. **localStorage on pointermove** - Fixed. Drags only `set()` in-memory; persistence happens once in `setResizing(false)`, which fires on pointerup, pointercancel, and the unmount-mid-drag cleanup. Keyboard steps (outside a drag) still persist immediately, so no path loses the value.

4. **ConsentRequired in from-data suggestions** - Fixed. The query now returns `{configurations, isConsentRequired}` and [create-agent-step.tsx](src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx:53) shows `AI_CONSENT_REQUIRED_MESSAGE` pointing at the assistant panel instead of blaming the data. `staleTime` stays 0 for empty configurations, so it refetches after consent is granted.

5. **Unvalidated link href** - Fixed. `isWebUrl` allows only `http:`/`https:`; `javascript:`, `data:`, and relative URLs throw or fail the protocol check and are dropped. The fix omits non-web links entirely rather than rendering them as plain text (the finding's suggestion), which is consistent with how blank URLs were already handled - fine.

6. **Truncated final frame** - Fixed. `streamResponseLines` now yields `{line, isLineComplete}`; the SSE framing discards an incomplete tail (per spec) so a mid-frame cutoff falls through to the accurate "did not finish answering" message, while NDJSON keeps tolerating a missing trailing newline. Both behaviors have new tests.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
