### PR TITLE
RavenDB-27389 Quill - Adjust heading sizes

### DIFF
--- a/src/Raven.Quill.Web/AGENTS.md
+++ b/src/Raven.Quill.Web/AGENTS.md
@@ -16,6 +16,7 @@ Frontend for Raven Quill. It is a Vite + React + TypeScript app and is finally b
 - Forms should use React Hook Form + Zod. If a reusable field is missing, add a generic form component instead of solving it only in one view.
 - Prefer shadcn components. Add missing shadcn components with `pnpm dlx shadcn@latest add <component>`. If shadcn does not cover the need, create a project component in the appropriate `src/components` area.
 - Use Tailwind for styling, but move hard-to-read style combinations into CSS/classes. Components must work in both light and dark themes; avoid one-theme hardcoded colors.
+- Typography goes through `<Heading>`/`<Text>` (`src/components/typography.tsx`), and `<SectionHeader>` for a section title with its description and action, instead of hand-written `text-*`/`font-*` classes. See the header comment in `typography.tsx` for the scale.
 - Keep components focused and reasonably small. If a component or hook grows awkward, step back and simplify the design before continuing.
 - Put reusable hooks/helpers in shared project utilities only when there is a realistic second use.
 - Boolean names must clearly read as booleans, e.g. `is`, `has`, `can`, `should`, `was`.

--- a/src/Raven.Quill.Web/CLAUDE.md
+++ b/src/Raven.Quill.Web/CLAUDE.md
@@ -16,6 +16,7 @@ Frontend for Raven Quill. It is a Vite + React + TypeScript app and is finally b
 - Forms should use React Hook Form + Zod. If a reusable field is missing, add a generic form component instead of solving it only in one view.
 - Prefer shadcn components. Add missing shadcn components with `pnpm dlx shadcn@latest add <component>`. If shadcn does not cover the need, create a project component in the appropriate `src/components` area.
 - Use Tailwind for styling, but move hard-to-read style combinations into CSS/classes. Components must work in both light and dark themes; avoid one-theme hardcoded colors.
+- Typography goes through `<Heading>`/`<Text>` (`src/components/typography.tsx`), and `<SectionHeader>` for a section title with its description and action, instead of hand-written `text-*`/`font-*` classes. See the header comment in `typography.tsx` for the scale.
 - Keep components focused and reasonably small. If a component or hook grows awkward, step back and simplify the design before continuing.
 - Put reusable hooks/helpers in shared project utilities only when there is a realistic second use.
 - Boolean names must clearly read as booleans, e.g. `is`, `has`, `can`, `should`, `was`.

--- a/src/Raven.Quill.Web/eslint.config.js
+++ b/src/Raven.Quill.Web/eslint.config.js
@@ -32,13 +32,25 @@ export default defineConfig([
                     message:
                         "Use <Text> (variant muted/caption/label) from @/components/typography instead of raw text-sm/text-xs/text-muted-foreground/font-medium classes.",
                 },
+                {
+                    selector: "JSXOpeningElement[name.name=/^h[1-6]$/] > JSXAttribute[name.name='className']",
+                    message:
+                        "Style headings with <Heading variant=…> from @/components/typography, not classes on a raw <hN>.",
+                },
             ],
         },
     },
     {
-        // The primitive layer (shadcn/ui) and the typography components themselves legitimately author
-        // these classes; the rule that steers app callers toward <Text>/<Heading> must not fire here.
-        files: ["src/components/shadcn/ui/**/*.{ts,tsx}", "src/components/typography.tsx"],
+        // The rule that steers app callers toward <Text>/<Heading> must not fire where authoring raw
+        // classes is legitimate: the primitive layer (shadcn/ui) and the typography components
+        // themselves; the embeddable widget package, which ships its own token system (rq-*) and does
+        // not depend on @/components/typography; and Storybook infra chrome.
+        files: [
+            "src/components/shadcn/ui/**/*.{ts,tsx}",
+            "src/components/typography.tsx",
+            "packages/widget/**/*.{ts,tsx}",
+            ".storybook/**/*.{ts,tsx}",
+        ],
         rules: {
             "no-restricted-syntax": "off",
         },

--- a/src/Raven.Quill.Web/eslint.config.js
+++ b/src/Raven.Quill.Web/eslint.config.js
@@ -19,6 +19,29 @@ export default defineConfig([
         languageOptions: {
             globals: globals.browser,
         },
+        rules: {
+            // Keep typography going through <Heading>/<Text> (src/components/typography.tsx) instead of
+            // hand-written classes, so the scale stays the single source of truth. Scoped to plain
+            // <p>/<span>/<div> — the elements <Text> replaces — so shadcn primitives and icon color
+            // classes are untouched. The typography components themselves are exempt below.
+            "no-restricted-syntax": [
+                "error",
+                {
+                    selector:
+                        "JSXOpeningElement:matches([name.name='p'], [name.name='span'], [name.name='div']) > JSXAttribute[name.name='className'] > Literal[value=/\\btext-(sm|xs)\\b[^\"]*\\btext-muted-foreground\\b|\\btext-muted-foreground\\b[^\"]*\\btext-(sm|xs)\\b|\\btext-sm\\b[^\"]*\\bfont-medium\\b/]",
+                    message:
+                        "Use <Text> (variant muted/caption/label) from @/components/typography instead of raw text-sm/text-xs/text-muted-foreground/font-medium classes.",
+                },
+            ],
+        },
+    },
+    {
+        // The primitive layer (shadcn/ui) and the typography components themselves legitimately author
+        // these classes; the rule that steers app callers toward <Text>/<Heading> must not fire here.
+        files: ["src/components/shadcn/ui/**/*.{ts,tsx}", "src/components/typography.tsx"],
+        rules: {
+            "no-restricted-syntax": "off",
+        },
     },
     ...storybook.configs["flat/recommended"],
     {

--- a/src/Raven.Quill.Web/src/app.tsx
+++ b/src/Raven.Quill.Web/src/app.tsx
@@ -15,6 +15,7 @@ import QuillMark from "@/components/brand/quill-mark.svg?react";
 import { AssistantPanel } from "@/components/layout/assistant-panel";
 import { ASSISTANT_PANEL_TITLE_ID, useAssistantPinning, useAssistantStore } from "@/components/layout/assistant-store";
 import { FeedbackSheet } from "@/components/layout/feedback-sheet";
+import { Heading } from "@/components/typography";
 import { Button } from "@/components/shadcn/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
 
@@ -151,7 +152,9 @@ function App() {
                 )}
             >
                 {!isPageTitleHidden && (
-                    <h1 className="text-2xl font-semibold tracking-tight">{activeRoute?.title ?? "My apps"}</h1>
+                    <Heading as="h1" variant="page">
+                        {activeRoute?.title ?? "My apps"}
+                    </Heading>
                 )}
                 <div
                     className={cn(

--- a/src/Raven.Quill.Web/src/components/ace-editor/ace-editor-actions.tsx
+++ b/src/Raven.Quill.Web/src/components/ace-editor/ace-editor-actions.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/shadcn/ui/button";
 import { handleAutoResizeHeight, handleFormat } from "@/components/ace-editor/ace-editor-action-utils";
 import { useAceEditorContext } from "@/components/ace-editor/ace-editor-context";
 import { cn } from "@/lib/utils";
+import { Text } from "@/components/typography";
 
 type IconButtonProps = {
     children: ReactNode;
@@ -148,7 +149,9 @@ export function AceEditorHelpAction({
                             </Button>
                         </Dialog.Close>
                     </div>
-                    <div className="text-sm text-muted-foreground">{message}</div>
+                    <Text variant="muted" as="div">
+                        {message}
+                    </Text>
                 </Dialog.Content>
             </Dialog.Portal>
         </Dialog.Root>

--- a/src/Raven.Quill.Web/src/components/ai-connection-string/edit-ai-connection-string.tsx
+++ b/src/Raven.Quill.Web/src/components/ai-connection-string/edit-ai-connection-string.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { Text } from "@/components/typography";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import type { AiModelType } from "@/api/generated/server-api";
@@ -31,10 +32,12 @@ export function EditAiConnectionString({ name, modelType, trigger, onSaved }: Ed
                 </SheetHeader>
 
                 {detailQuery.isPending ? (
-                    <p className="p-4 text-sm text-muted-foreground">Loading connection string…</p>
+                    <Text variant="muted" className="p-4">
+                        Loading connection string…
+                    </Text>
                 ) : detailQuery.isError || !detailQuery.data ? (
                     <div className="space-y-3 p-4">
-                        <p className="text-sm text-muted-foreground">Could not load the connection string.</p>
+                        <Text variant="muted">Could not load the connection string.</Text>
                         <Button type="button" variant="outline" size="sm" onClick={() => void detailQuery.refetch()}>
                             Retry
                         </Button>

--- a/src/Raven.Quill.Web/src/components/auth/auth-routes.tsx
+++ b/src/Raven.Quill.Web/src/components/auth/auth-routes.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/components/auth/auth-context";
 import { AuthScreenLayout } from "@/components/auth/auth-screen-layout";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { appRoutes } from "@/lib/app-routes";
+import { Text } from "@/components/typography";
 
 export function RequireAuth({ children }: { children: ReactNode }) {
     const { isAuthenticated, isLoading } = useAuth();
@@ -52,10 +53,10 @@ function RedirectToLandingPage() {
 function AuthLoading() {
     return (
         <AuthScreenLayout>
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Text variant="muted" as="div" className="flex items-center gap-2">
                 <Spinner className="size-4" />
                 Checking authentication…
-            </div>
+            </Text>
         </AuthScreenLayout>
     );
 }

--- a/src/Raven.Quill.Web/src/components/data/ai-progress-status.tsx
+++ b/src/Raven.Quill.Web/src/components/data/ai-progress-status.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from "react";
+import { Text } from "@/components/typography";
 import { SparklesIcon } from "lucide-react";
 
 export type AiProgressStage = {
@@ -29,7 +30,7 @@ export function AiProgressStatus({
                     {formatElapsed(elapsedSeconds)}
                 </span>
             </div>
-            <p className="text-sm text-muted-foreground">{children}</p>
+            <Text variant="muted">{children}</Text>
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/components/data/ai-progress-status.tsx
+++ b/src/Raven.Quill.Web/src/components/data/ai-progress-status.tsx
@@ -23,12 +23,12 @@ export function AiProgressStatus({
         <div className="grid gap-2">
             <div className="flex items-center gap-2">
                 <SparklesIcon className="size-4 shrink-0 animate-pulse text-primary-strong" aria-hidden="true" />
-                <span className="animate-pulse text-sm font-medium" aria-live="polite">
+                <Text variant="label" as="span" className="animate-pulse" aria-live="polite">
                     {stage?.label}...
-                </span>
-                <span className="font-mono text-xs text-muted-foreground tabular-nums">
+                </Text>
+                <Text variant="caption" as="span" className="font-mono tabular-nums">
                     {formatElapsed(elapsedSeconds)}
-                </span>
+                </Text>
             </div>
             <Text variant="muted">{children}</Text>
         </div>

--- a/src/Raven.Quill.Web/src/components/data/api-state.tsx
+++ b/src/Raven.Quill.Web/src/components/data/api-state.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Button } from "@/components/shadcn/ui/button";
+import { Heading, Text } from "@/components/typography";
 
 type ApiStateProps = {
     errorTitle?: string;
@@ -25,9 +26,9 @@ export function ApiState({
         // itself is the message. Say it in words rather than promise a shape we cannot draw.
         if (!skeleton) {
             return (
-                <p role="status" className="text-sm text-muted-foreground">
+                <Text variant="muted" role="status">
                     {loadingLabel}
-                </p>
+                </Text>
             );
         }
 
@@ -44,8 +45,8 @@ export function ApiState({
     if (isError) {
         return (
             <div className="max-w-md space-y-3">
-                <h2 className="text-sm font-semibold">{errorTitle}</h2>
-                <p className="text-sm text-muted-foreground">Refresh the page or try again in a moment.</p>
+                <Heading variant="label">{errorTitle}</Heading>
+                <Text variant="muted">Refresh the page or try again in a moment.</Text>
                 {onRetry && (
                     <Button type="button" variant="outline" size="sm" onClick={onRetry}>
                         Retry

--- a/src/Raven.Quill.Web/src/components/data/code-block-tabs.tsx
+++ b/src/Raven.Quill.Web/src/components/data/code-block-tabs.tsx
@@ -3,6 +3,7 @@ import { highlightCode, type HighlightLanguage } from "@/components/ace-editor/s
 import { Button } from "@/components/shadcn/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/ui/tabs";
 import { cn, copyToClipboard } from "@/lib/utils";
+import { Text } from "@/components/typography";
 
 export type CodeTab = {
     value: string;
@@ -69,7 +70,9 @@ export function CodeBlockTabs({
                 ) : (
                     // A single snippet has no selector; its label stands in as the code block's title so the
                     // header still reads as a labelled bar rather than a lone copy button.
-                    <span className="pl-2 text-xs font-medium text-muted-foreground">{activeTab?.label}</span>
+                    <Text variant="caption" as="span" className="pl-2 font-medium">
+                        {activeTab?.label}
+                    </Text>
                 )}
                 <Button
                     type="button"

--- a/src/Raven.Quill.Web/src/components/data/connectivity-metric.tsx
+++ b/src/Raven.Quill.Web/src/components/data/connectivity-metric.tsx
@@ -11,8 +11,10 @@ export function ConnectivityMetric({ connectivity }: { connectivity: Connectivit
     return (
         <div className="space-y-2">
             <div className="space-y-1">
-                <div className="text-xs text-muted-foreground">Connectivity</div>
-                <div className="flex items-center gap-2 text-sm font-medium">
+                <Text variant="caption" as="div">
+                    Connectivity
+                </Text>
+                <Text variant="label" as="div" className="flex items-center gap-2">
                     <span
                         className={cn(
                             "size-2 rounded-full",
@@ -21,7 +23,7 @@ export function ConnectivityMetric({ connectivity }: { connectivity: Connectivit
                         aria-hidden="true"
                     />
                     {connectivity.statusCode}
-                </div>
+                </Text>
             </div>
             {connectivity.exception && (
                 <Text variant="muted" className="break-words">

--- a/src/Raven.Quill.Web/src/components/data/connectivity-metric.tsx
+++ b/src/Raven.Quill.Web/src/components/data/connectivity-metric.tsx
@@ -1,4 +1,5 @@
 import type { ConnectivityStatus } from "@/api/generated/server-api";
+import { Text } from "@/components/typography";
 import { cn } from "@/lib/utils";
 
 // Healthy means the licensing API answered OK with no transport error.
@@ -23,7 +24,9 @@ export function ConnectivityMetric({ connectivity }: { connectivity: Connectivit
                 </div>
             </div>
             {connectivity.exception && (
-                <p className="text-sm break-words text-muted-foreground">{connectivity.exception}</p>
+                <Text variant="muted" className="break-words">
+                    {connectivity.exception}
+                </Text>
             )}
         </div>
     );

--- a/src/Raven.Quill.Web/src/components/data/date-period-picker.tsx
+++ b/src/Raven.Quill.Web/src/components/data/date-period-picker.tsx
@@ -17,6 +17,7 @@ import {
     stepYear,
     type DatePeriod,
 } from "@/lib/date-period";
+import { Text } from "@/components/typography";
 
 type Granularity = "year" | "month" | "day";
 
@@ -61,7 +62,9 @@ function PickerNav({
             >
                 <ChevronLeft aria-hidden="true" />
             </Button>
-            <span className="text-sm font-medium">{label}</span>
+            <Text variant="label" as="span">
+                {label}
+            </Text>
             <Button variant="ghost" size="icon-sm" aria-label={`Next ${unit}`} disabled={!canGoNext} onClick={onNext}>
                 <ChevronRight aria-hidden="true" />
             </Button>

--- a/src/Raven.Quill.Web/src/components/data/detail-header.tsx
+++ b/src/Raven.Quill.Web/src/components/data/detail-header.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/shadcn/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/shadcn/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { Heading } from "@/components/typography";
 
 type BackTo = { to: string; label: string };
 
@@ -52,7 +53,9 @@ export function DetailHeader({
                         never indenting under the back arrow. */}
                     <div className="grid min-w-0 gap-1.5">
                         <div className="flex items-center gap-3">
-                            <h1 className="truncate text-2xl font-semibold tracking-tight">{title}</h1>
+                            <Heading as="h1" variant="page" className="truncate">
+                                {title}
+                            </Heading>
                             {status}
                         </div>
                         {meta && (

--- a/src/Raven.Quill.Web/src/components/data/detail-header.tsx
+++ b/src/Raven.Quill.Web/src/components/data/detail-header.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/shadcn/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/shadcn/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { Heading } from "@/components/typography";
+import { Heading, Text } from "@/components/typography";
 
 type BackTo = { to: string; label: string };
 
@@ -59,9 +59,9 @@ export function DetailHeader({
                             {status}
                         </div>
                         {meta && (
-                            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
+                            <Text variant="muted" as="div" className="flex flex-wrap items-center gap-x-4 gap-y-1">
                                 <TooltipProvider>{meta}</TooltipProvider>
-                            </div>
+                            </Text>
                         )}
                     </div>
                 </div>

--- a/src/Raven.Quill.Web/src/components/data/numbered-steps.tsx
+++ b/src/Raven.Quill.Web/src/components/data/numbered-steps.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Heading } from "@/components/typography";
+import { Heading, Text } from "@/components/typography";
 
 export type NumberedStep = {
     title: string;
@@ -17,9 +17,13 @@ export function NumberedSteps({ steps }: { steps: NumberedStep[] }) {
                 return (
                     <li key={step.title} className="grid grid-cols-[1.5rem_1fr] gap-x-3">
                         <div className="flex flex-col items-center">
-                            <span className="flex size-6 items-center justify-center rounded-full border border-border bg-muted text-xs font-medium text-muted-foreground">
+                            <Text
+                                variant="caption"
+                                as="span"
+                                className="flex size-6 items-center justify-center rounded-full border border-border bg-muted font-medium"
+                            >
                                 {index + 1}
-                            </span>
+                            </Text>
                             {!isLast && <span aria-hidden="true" className="mt-1 w-px flex-1 bg-border" />}
                         </div>
                         <div className={isLast ? "" : "pb-5"}>

--- a/src/Raven.Quill.Web/src/components/data/numbered-steps.tsx
+++ b/src/Raven.Quill.Web/src/components/data/numbered-steps.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Heading } from "@/components/typography";
 
 export type NumberedStep = {
     title: string;
@@ -22,7 +23,9 @@ export function NumberedSteps({ steps }: { steps: NumberedStep[] }) {
                             {!isLast && <span aria-hidden="true" className="mt-1 w-px flex-1 bg-border" />}
                         </div>
                         <div className={isLast ? "" : "pb-5"}>
-                            <h3 className="mb-1.5 text-base font-medium">{step.title}</h3>
+                            <Heading as="h3" variant="subsection" className="mb-1.5">
+                                {step.title}
+                            </Heading>
                             {step.content}
                         </div>
                     </li>

--- a/src/Raven.Quill.Web/src/components/data/page-error-state.tsx
+++ b/src/Raven.Quill.Web/src/components/data/page-error-state.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Heading } from "@/components/typography";
 
 type PageErrorStateProps = {
     code?: string;
@@ -12,7 +13,7 @@ export function PageErrorState({ code, title, description, children }: PageError
         <section className="flex min-h-full flex-col items-center justify-center gap-5 px-4 py-16 text-center">
             {code && <p className="text-6xl font-semibold tracking-tight text-muted-foreground/50">{code}</p>}
             <div className="max-w-md space-y-1.5">
-                <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+                <Heading variant="title">{title}</Heading>
                 <div className="text-sm text-muted-foreground">{description}</div>
             </div>
             {children && <div className="flex flex-wrap items-center justify-center gap-2">{children}</div>}

--- a/src/Raven.Quill.Web/src/components/data/page-error-state.tsx
+++ b/src/Raven.Quill.Web/src/components/data/page-error-state.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Heading } from "@/components/typography";
+import { Heading, Text } from "@/components/typography";
 
 type PageErrorStateProps = {
     code?: string;
@@ -13,8 +13,12 @@ export function PageErrorState({ code, title, description, children }: PageError
         <section className="flex min-h-full flex-col items-center justify-center gap-5 px-4 py-16 text-center">
             {code && <p className="text-6xl font-semibold tracking-tight text-muted-foreground/50">{code}</p>}
             <div className="max-w-md space-y-1.5">
-                <Heading variant="title">{title}</Heading>
-                <div className="text-sm text-muted-foreground">{description}</div>
+                <Heading as="h1" variant="title">
+                    {title}
+                </Heading>
+                <Text as="div" variant="muted">
+                    {description}
+                </Text>
             </div>
             {children && <div className="flex flex-wrap items-center justify-center gap-2">{children}</div>}
         </section>

--- a/src/Raven.Quill.Web/src/components/form/file-dropzone.tsx
+++ b/src/Raven.Quill.Web/src/components/form/file-dropzone.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState, type ReactNode } from "react";
 import { UploadIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Text } from "@/components/typography";
 
 type FileDropzoneProps = {
     /** Called with the first selected/dropped file. */
@@ -78,8 +79,14 @@ export function FileDropzone({
         >
             <span className="text-muted-foreground">{icon}</span>
             <div className="grid gap-0.5">
-                <span className="text-sm font-medium text-foreground">{title}</span>
-                {description && <span className="text-xs text-muted-foreground">{description}</span>}
+                <Text variant="label" as="span" className="text-foreground">
+                    {title}
+                </Text>
+                {description && (
+                    <Text variant="caption" as="span">
+                        {description}
+                    </Text>
+                )}
             </div>
             <input
                 ref={inputRef}

--- a/src/Raven.Quill.Web/src/components/form/form-radio-cards.tsx
+++ b/src/Raven.Quill.Web/src/components/form/form-radio-cards.tsx
@@ -15,7 +15,7 @@ export const SELECTED_CARD_CLASSES =
  * Type scale for a card's title and its supporting line. Exported for the same bespoke cards, which
  * used to hardcode it and drifted from these every time the scale here changed.
  */
-export const CARD_LABEL_CLASSES = "font-semibold";
+export const CARD_LABEL_CLASSES = "text-sm font-semibold";
 export const CARD_DESCRIPTION_CLASSES = "mt-1 block text-sm leading-5 text-muted-foreground";
 
 export type RadioCardOption<TValue extends string = string> = {

--- a/src/Raven.Quill.Web/src/components/form/form-string-list.tsx
+++ b/src/Raven.Quill.Web/src/components/form/form-string-list.tsx
@@ -17,6 +17,7 @@ import {
 import { FormInput } from "@/components/form/form-input";
 import { Button } from "@/components/shadcn/ui/button";
 import { Field, FieldDescription, FieldLabel } from "@/components/shadcn/ui/field";
+import { Text } from "@/components/typography";
 
 type FormStringListProps<TFieldValues extends FieldValues, TName extends ArrayPath<TFieldValues>> = UseFieldArrayProps<
     TFieldValues,
@@ -75,9 +76,9 @@ export function FormStringList<TFieldValues extends FieldValues, TName extends A
             </div>
 
             {fieldArray.fields.length === 0 ? (
-                <div className="rounded-md border bg-background px-3 py-4 text-center text-sm text-muted-foreground">
+                <Text variant="muted" as="div" className="rounded-md border bg-background px-3 py-4 text-center">
                     {emptyLabel}
-                </div>
+                </Text>
             ) : (
                 <div className="grid gap-2">
                     {fieldArray.fields.map((field, index) => (

--- a/src/Raven.Quill.Web/src/components/form/wizard/form-wizard.tsx
+++ b/src/Raven.Quill.Web/src/components/form/wizard/form-wizard.tsx
@@ -12,6 +12,7 @@ import { ArrowLeft, ArrowRight, Check } from "lucide-react";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { useUnsavedChanges } from "@/components/form/unsaved-changes/use-unsaved-changes";
+import { Heading, Text } from "@/components/typography";
 import { WizardErrorAlert } from "@/components/form/wizard/wizard-error-alert";
 import { toError, WizardHandledError } from "@/components/form/wizard/wizard-step-error";
 import { cn } from "@/lib/utils";
@@ -239,9 +240,13 @@ export function FormWizard<StepId extends string, Values extends FieldValues>({
                         >
                             <div className="flex flex-wrap items-start justify-between gap-3">
                                 <div>
-                                    <h2 className="text-2xl font-semibold tracking-normal">{currentStep.title}</h2>
+                                    <Heading as="h1" variant="page">
+                                        {currentStep.title}
+                                    </Heading>
                                     {currentStep.description && (
-                                        <p className="mt-3 text-sm text-muted-foreground">{currentStep.description}</p>
+                                        <Text variant="muted" className="mt-3">
+                                            {currentStep.description}
+                                        </Text>
                                     )}
                                 </div>
                                 {currentStep.headerAction && <currentStep.headerAction isBusy={isBusy} />}

--- a/src/Raven.Quill.Web/src/components/layout/app-breadcrumb-switcher.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/app-breadcrumb-switcher.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Text } from "@/components/typography";
 import { useLocation, useNavigate } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronsUpDown, Plus } from "lucide-react";
@@ -82,9 +83,9 @@ export function AppBreadcrumbSwitcher({ slug, appName }: AppBreadcrumbSwitcherPr
                         Loading apps…
                     </div>
                 ) : (
-                    <p className="px-1.5 py-2 text-sm text-muted-foreground">
+                    <Text variant="muted" className="px-1.5 py-2">
                         {appsQuery.isError ? "Couldn't load apps." : "No apps yet."}
-                    </p>
+                    </Text>
                 )}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onSelect={() => navigate(appRoutes.addApp())}>

--- a/src/Raven.Quill.Web/src/components/layout/app-breadcrumb-switcher.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/app-breadcrumb-switcher.tsx
@@ -78,10 +78,10 @@ export function AppBreadcrumbSwitcher({ slug, appName }: AppBreadcrumbSwitcherPr
                         ))}
                     </DropdownMenuRadioGroup>
                 ) : appsQuery.isLoading ? (
-                    <div className="flex items-center gap-2 px-1.5 py-2 text-sm text-muted-foreground">
+                    <Text variant="muted" as="div" className="flex items-center gap-2 px-1.5 py-2">
                         <Spinner />
                         Loading apps…
-                    </div>
+                    </Text>
                 ) : (
                     <Text variant="muted" className="px-1.5 py-2">
                         {appsQuery.isError ? "Couldn't load apps." : "No apps yet."}

--- a/src/Raven.Quill.Web/src/components/layout/assistant-composer.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-composer.tsx
@@ -5,6 +5,7 @@ import { useAssistantChatStore } from "@/components/layout/assistant-chat-store"
 import { useAssistantStore } from "@/components/layout/assistant-store";
 import { FormTextarea } from "@/components/form/form-textarea";
 import { Button } from "@/components/shadcn/ui/button";
+import { Text } from "@/components/typography";
 
 type PromptFormData = {
     prompt: string;
@@ -90,9 +91,9 @@ export function AssistantComposer() {
                     </Button>
                 )}
             </div>
-            <div className="pt-2 text-center text-xs text-muted-foreground">
+            <Text variant="caption" as="div" className="pt-2 text-center">
                 Responses are AI-generated and may require verification.
-            </div>
+            </Text>
         </form>
     );
 }

--- a/src/Raven.Quill.Web/src/components/layout/assistant-consent.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-consent.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { Text } from "@/components/typography";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Sparkles } from "lucide-react";
 import { api } from "@/api/api";
@@ -29,10 +30,10 @@ export function AssistantConsentGate() {
     if (consentQuery.isPending) {
         return (
             <AssistantConsentFrame>
-                <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Text variant="muted" className="flex items-center gap-2">
                     <Spinner />
                     Checking consent…
-                </p>
+                </Text>
             </AssistantConsentFrame>
         );
     }
@@ -55,10 +56,10 @@ export function AssistantConsentGate() {
     if (consentQuery.data.status === "ConsentRequired") {
         return (
             <AssistantConsentFrame>
-                <p className="text-sm text-muted-foreground">
+                <Text variant="muted">
                     The AI assistant sends your questions to the RavenDB AI service. It stays unavailable until you
                     review and accept the Terms of Use.
-                </p>
+                </Text>
                 <AssistantConsentDialog />
             </AssistantConsentFrame>
         );

--- a/src/Raven.Quill.Web/src/components/layout/assistant-messages.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-messages.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { Text } from "@/components/typography";
 import { ExternalLink, Sparkles } from "lucide-react";
 import { Streamdown } from "streamdown";
 import { useAssistantChatStore, type AssistantMessage } from "@/components/layout/assistant-chat-store";
@@ -53,7 +54,9 @@ function AssistantRelevantLinks({ links }: { links: AssistantMessage["relevantLi
 
     return (
         <div className="mt-2 border-t pt-2">
-            <p className="text-xs font-medium text-muted-foreground">Related documentation</p>
+            <Text variant="caption" className="font-medium">
+                Related documentation
+            </Text>
             <ul className="mt-1 flex flex-col gap-1">
                 {linkedSources.map((link) => (
                     <li key={link.Url}>
@@ -106,7 +109,7 @@ export function AssistantMessages() {
                     </div>
                     <div>
                         <p className="text-sm font-medium">How can I help?</p>
-                        <p className="text-sm text-muted-foreground">Ask about your apps, conversations, or setup.</p>
+                        <Text variant="muted">Ask about your apps, conversations, or setup.</Text>
                     </div>
                 </div>
             ) : (

--- a/src/Raven.Quill.Web/src/components/layout/assistant-messages.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-messages.tsx
@@ -108,7 +108,7 @@ export function AssistantMessages() {
                         <Sparkles className="size-5 text-primary" aria-hidden="true" />
                     </div>
                     <div>
-                        <p className="text-sm font-medium">How can I help?</p>
+                        <Text variant="label">How can I help?</Text>
                         <Text variant="muted">Ask about your apps, conversations, or setup.</Text>
                     </div>
                 </div>

--- a/src/Raven.Quill.Web/src/components/layout/assistant-panel.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-panel.tsx
@@ -17,6 +17,7 @@ import {
 import { useAssistantConsent } from "@/components/layout/use-assistant-consent";
 import { Button } from "@/components/shadcn/ui/button";
 import { cn } from "@/lib/utils";
+import { Heading } from "@/components/typography";
 
 const RESIZE_KEYBOARD_STEP_PX = 16;
 
@@ -123,9 +124,9 @@ export function AssistantPanel() {
             {!isPinned && <AssistantResizeHandle axis="height" />}
             <header className="flex items-center gap-2 border-b px-3 py-2">
                 <Sparkles className="size-4 text-primary" aria-hidden="true" />
-                <h2 id={ASSISTANT_PANEL_TITLE_ID} className="text-sm font-semibold">
+                <Heading id={ASSISTANT_PANEL_TITLE_ID} variant="label">
                     AI assistant
-                </h2>
+                </Heading>
                 <div className="ml-auto flex items-center gap-1">
                     <Button
                         variant="ghost"

--- a/src/Raven.Quill.Web/src/components/layout/command-palette.tsx
+++ b/src/Raven.Quill.Web/src/components/layout/command-palette.tsx
@@ -16,6 +16,7 @@ import {
 import { appNavigationSections, navigationItems } from "@/routes";
 import { appRoutes } from "@/lib/app-routes";
 import { THEME_OPTIONS } from "@/lib/theme-options";
+import { Text } from "@/components/typography";
 
 const IS_MAC = typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC");
 const DOCS_URL = "https://docs.ravendb.net/quill";
@@ -96,7 +97,9 @@ export function CommandPalette({ slug, appName }: CommandPaletteProps) {
                                     >
                                         <AppWindow aria-hidden="true" />
                                         <span>{app.name}</span>
-                                        <span className="text-xs text-muted-foreground">{app.slug}</span>
+                                        <Text variant="caption" as="span">
+                                            {app.slug}
+                                        </Text>
                                     </CommandItem>
                                 ))}
                             </CommandGroup>
@@ -132,11 +135,11 @@ export function CommandPalette({ slug, appName }: CommandPaletteProps) {
                             ))}
                         </CommandGroup>
                     </CommandList>
-                    <div className="-mx-1 -mb-1 flex items-center gap-3 border-t px-3 py-2 text-xs text-muted-foreground">
+                    <Text variant="caption" as="div" className="-mx-1 -mb-1 flex items-center gap-3 border-t px-3 py-2">
                         <FooterHint keys="↑↓" label="navigate" />
                         <FooterHint keys="↵" label="select" />
                         <FooterHint keys="esc" label="close" />
-                    </div>
+                    </Text>
                 </Command>
             </CommandDialog>
         </>

--- a/src/Raven.Quill.Web/src/components/section-header.tsx
+++ b/src/Raven.Quill.Web/src/components/section-header.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { Heading, Text } from "@/components/typography";
+
+// One decision per section header: pick `level` for the role, instead of choosing `as` and
+// `variant` independently from the Heading grid. Folds the title + description pairing so the two
+// can't drift apart between call sites (the same role always renders the same size).
+const LEVELS = {
+    page: { as: "h1", variant: "page" },
+    section: { as: "h2", variant: "section" },
+    subsection: { as: "h3", variant: "subsection" },
+    // Compact card-item / eyebrow header: semantically an h2, visually small.
+    item: { as: "h2", variant: "label" },
+} as const;
+
+type Level = keyof typeof LEVELS;
+
+export function SectionHeader({
+    level = "section",
+    title,
+    description,
+    action,
+    className,
+}: {
+    level?: Level;
+    title?: ReactNode;
+    description?: ReactNode;
+    action?: ReactNode;
+    className?: string;
+}) {
+    const { as, variant } = LEVELS[level];
+
+    return (
+        <div className={cn("flex items-start justify-between gap-3", className)}>
+            <div className="space-y-0.5">
+                {title && (
+                    <Heading as={as} variant={variant}>
+                        {title}
+                    </Heading>
+                )}
+                {description && <Text variant="muted">{description}</Text>}
+            </div>
+            {action}
+        </div>
+    );
+}

--- a/src/Raven.Quill.Web/src/components/section-header.tsx
+++ b/src/Raven.Quill.Web/src/components/section-header.tsx
@@ -6,11 +6,8 @@ import { Heading, Text } from "@/components/typography";
 // `variant` independently from the Heading grid. Folds the title + description pairing so the two
 // can't drift apart between call sites (the same role always renders the same size).
 const LEVELS = {
-    page: { as: "h1", variant: "page" },
     section: { as: "h2", variant: "section" },
     subsection: { as: "h3", variant: "subsection" },
-    // Compact card-item / eyebrow header: semantically an h2, visually small.
-    item: { as: "h2", variant: "label" },
 } as const;
 
 type Level = keyof typeof LEVELS;

--- a/src/Raven.Quill.Web/src/components/shadcn/ui/alert-dialog.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/alert-dialog.tsx
@@ -64,7 +64,7 @@ function AlertDialogTitle({ className, ...props }: React.ComponentProps<typeof A
     return (
         <AlertDialogPrimitive.Title
             data-slot="alert-dialog-title"
-            className={cn("text-base leading-none font-medium", className)}
+            className={cn("text-base leading-none font-semibold tracking-tight", className)}
             {...props}
         />
     );

--- a/src/Raven.Quill.Web/src/components/shadcn/ui/card.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/card.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Slot } from "radix-ui";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
@@ -30,22 +31,31 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     );
 }
 
+const cardTitleVariants = cva("leading-snug", {
+    variants: {
+        variant: {
+            default: "text-base font-semibold tracking-tight group-data-[size=sm]/card:text-sm",
+            // Lighter title for list-item / row cards where the name is data, not a section heading.
+            item: "text-base font-medium group-data-[size=sm]/card:text-sm",
+        },
+    },
+    defaultVariants: {
+        variant: "default",
+    },
+});
+
 // `asChild` lets a card that is a genuine page section render its title as a heading
 // (e.g. <CardTitle asChild><h2>…</h2></CardTitle>) so it joins the document outline,
 // while keeping the card-title styling. Non-section cards stay a plain div.
-function CardTitle({ className, asChild = false, ...props }: React.ComponentProps<"div"> & { asChild?: boolean }) {
+function CardTitle({
+    className,
+    variant = "default",
+    asChild = false,
+    ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof cardTitleVariants> & { asChild?: boolean }) {
     const Comp = asChild ? Slot.Root : "div";
 
-    return (
-        <Comp
-            data-slot="card-title"
-            className={cn(
-                "text-base leading-snug font-semibold tracking-tight group-data-[size=sm]/card:text-sm",
-                className,
-            )}
-            {...props}
-        />
-    );
+    return <Comp data-slot="card-title" className={cn(cardTitleVariants({ variant }), className)} {...props} />;
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {

--- a/src/Raven.Quill.Web/src/components/shadcn/ui/card.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/card.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Slot } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 
@@ -29,11 +30,19 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     );
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+// `asChild` lets a card that is a genuine page section render its title as a heading
+// (e.g. <CardTitle asChild><h2>…</h2></CardTitle>) so it joins the document outline,
+// while keeping the card-title styling. Non-section cards stay a plain div.
+function CardTitle({ className, asChild = false, ...props }: React.ComponentProps<"div"> & { asChild?: boolean }) {
+    const Comp = asChild ? Slot.Root : "div";
+
     return (
-        <div
+        <Comp
             data-slot="card-title"
-            className={cn("text-base leading-snug font-medium group-data-[size=sm]/card:text-sm", className)}
+            className={cn(
+                "text-base leading-snug font-semibold tracking-tight group-data-[size=sm]/card:text-sm",
+                className,
+            )}
             {...props}
         />
     );

--- a/src/Raven.Quill.Web/src/components/shadcn/ui/dialog.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/dialog.tsx
@@ -110,7 +110,7 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
     return (
         <DialogPrimitive.Title
             data-slot="dialog-title"
-            className={cn("text-base leading-none font-medium", className)}
+            className={cn("text-base leading-none font-semibold tracking-tight", className)}
             {...props}
         />
     );

--- a/src/Raven.Quill.Web/src/components/shadcn/ui/sheet.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/ui/sheet.tsx
@@ -90,7 +90,7 @@ function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPr
     return (
         <SheetPrimitive.Title
             data-slot="sheet-title"
-            className={cn("text-base font-medium text-foreground", className)}
+            className={cn("text-base font-semibold tracking-tight text-foreground", className)}
             {...props}
         />
     );

--- a/src/Raven.Quill.Web/src/components/table/table-pagination.tsx
+++ b/src/Raven.Quill.Web/src/components/table/table-pagination.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/shadcn/ui/button";
+import { Text } from "@/components/typography";
 
 interface TablePaginationProps {
     pageIndex: number;
@@ -15,13 +16,13 @@ export function TablePagination({ pageIndex, pageSize, totalCount, onPageIndexCh
 
     return (
         <div className="flex items-center justify-between gap-3">
-            <span className="text-sm text-muted-foreground tabular-nums">
+            <Text variant="muted" as="span" className="tabular-nums">
                 {rangeStart}&ndash;{rangeEnd} of {totalCount}
-            </span>
+            </Text>
             <div className="flex items-center gap-3">
-                <span className="text-sm text-muted-foreground tabular-nums">
+                <Text variant="muted" as="span" className="tabular-nums">
                     Page {pageIndex + 1} of {pageCount}
-                </span>
+                </Text>
                 <div className="flex items-center gap-1">
                     <Button
                         variant="outline"

--- a/src/Raven.Quill.Web/src/components/typography.stories.tsx
+++ b/src/Raven.Quill.Web/src/components/typography.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Heading, Text } from "./typography";
+
+const meta = {
+    title: "Foundations/Typography",
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Headings: Story = {
+    render: () => (
+        <div className="space-y-3">
+            <Heading as="h1" variant="page">
+                Page title (variant="page")
+            </Heading>
+            <Heading as="h2" variant="title">
+                Title (variant="title")
+            </Heading>
+            <Heading as="h2" variant="section">
+                Section (variant="section")
+            </Heading>
+            <Heading as="h3" variant="subsection">
+                Subsection (variant="subsection")
+            </Heading>
+            <Heading as="h4" variant="label">
+                Label (variant="label")
+            </Heading>
+        </div>
+    ),
+};
+
+export const Texts: Story = {
+    render: () => (
+        <div className="space-y-2">
+            <Text variant="body">Body — the default paragraph text.</Text>
+            <Text variant="muted">Muted — secondary supporting copy.</Text>
+            <Text variant="caption">Caption — small metadata and hints.</Text>
+            <Text variant="label">Label — emphasized inline label.</Text>
+        </div>
+    ),
+};

--- a/src/Raven.Quill.Web/src/components/typography.tsx
+++ b/src/Raven.Quill.Web/src/components/typography.tsx
@@ -1,0 +1,96 @@
+/* eslint-disable react-refresh/only-export-components */
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+// The app's single source of truth for heading and body-text styling. Prefer these over hand-written
+// `text-*`/`font-*` classes so the scale stays consistent.
+//
+// <Heading> — pick `as` for the document outline (the tag), `variant` for the look; they are independent
+// because the same visual level appears at different depths across the app. Keep one <h1> per page and
+// don't skip levels (h1 → h2 → h3).
+//   page       h1 page / wizard-step title
+//   title      xl standalone-screen title with no page shell (auth, error/empty states)
+//   section    h2 section header
+//   subsection h3 sub-section header
+//   label      compact chrome / card-item / eyebrow header (semantically an h2/h3, visually small)
+//
+// <Text> — supporting copy. `body` (plain), `muted` (secondary), `caption` (xs metadata), `label`
+// (emphasized inline). Renders <p> by default.
+//
+// Card/overlay titles are their own primitives kept visually aligned with this scale: CardTitle,
+// DialogTitle, SheetTitle, AlertDialogTitle all use text-base font-semibold tracking-tight. Use
+// `<CardTitle asChild><h2>…</h2></CardTitle>` when a card is a genuine page section.
+
+type HeadingElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+const headingVariants = cva("text-foreground", {
+    variants: {
+        variant: {
+            page: "text-2xl font-semibold tracking-tight",
+            title: "text-xl font-semibold tracking-tight",
+            section: "text-lg font-semibold tracking-tight",
+            subsection: "text-base font-semibold",
+            label: "text-sm font-semibold",
+        },
+    },
+    defaultVariants: {
+        variant: "section",
+    },
+});
+
+function Heading({
+    className,
+    variant = "section",
+    as = "h2",
+    ...props
+}: React.ComponentPropsWithoutRef<HeadingElement> &
+    VariantProps<typeof headingVariants> & {
+        as?: HeadingElement;
+    }) {
+    const Comp = as;
+
+    return (
+        <Comp
+            data-slot="heading"
+            data-variant={variant}
+            className={cn(headingVariants({ variant }), className)}
+            {...props}
+        />
+    );
+}
+
+const textVariants = cva("", {
+    variants: {
+        variant: {
+            body: "text-sm",
+            muted: "text-sm text-muted-foreground",
+            caption: "text-xs text-muted-foreground",
+            label: "text-sm font-medium",
+        },
+    },
+    defaultVariants: {
+        variant: "body",
+    },
+});
+
+type TextElement = "p" | "span" | "div";
+
+function Text({
+    className,
+    variant = "body",
+    as = "p",
+    ...props
+}: React.ComponentPropsWithoutRef<TextElement> &
+    VariantProps<typeof textVariants> & {
+        as?: TextElement;
+    }) {
+    const Comp = as;
+
+    return (
+        <Comp data-slot="text" data-variant={variant} className={cn(textVariants({ variant }), className)} {...props} />
+    );
+}
+
+export { Heading, headingVariants, Text, textVariants };

--- a/src/Raven.Quill.Web/src/components/typography.tsx
+++ b/src/Raven.Quill.Web/src/components/typography.tsx
@@ -7,6 +7,10 @@ import { cn } from "@/lib/utils";
 // The app's single source of truth for heading and body-text styling. Prefer these over hand-written
 // `text-*`/`font-*` classes so the scale stays consistent.
 //
+// For a section header (title, optional description, optional action) prefer <SectionHeader> from
+// @/components/section-header — it picks `as`+`variant` from one semantic `level` so the same role
+// can't render at two sizes across call sites. Reach for <Heading> directly only for standalone titles.
+//
 // <Heading> — pick `as` for the document outline (the tag), `variant` for the look; they are independent
 // because the same visual level appears at different depths across the app. Keep one <h1> per page and
 // don't skip levels (h1 → h2 → h3).

--- a/src/Raven.Quill.Web/src/pages/apps/agents/edit-agent-form.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/agents/edit-agent-form.tsx
@@ -22,6 +22,7 @@ import { FormErrorIcon } from "@/components/form/form-error-icon";
 import { FormInput } from "@/components/form/form-input";
 import { FormTextarea } from "@/components/form/form-textarea";
 import { useFormUnsavedChanges } from "@/components/form/unsaved-changes/use-unsaved-changes";
+import { Heading, Text } from "@/components/typography";
 import { appRoutes } from "@/lib/app-routes";
 import { invalidateAgentQueries } from "@/lib/query-invalidation";
 import {
@@ -252,11 +253,13 @@ function CollapsibleSection({
         <Collapsible open={isOpen} onOpenChange={onOpenChange} className="grid gap-3">
             <CollapsibleTrigger className="group flex w-full items-start justify-between gap-3 text-left">
                 <div>
-                    <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+                    <Heading as="h2" variant="section" className="flex items-center gap-1.5">
                         {title}
                         {errorIcon}
-                    </h3>
-                    <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+                    </Heading>
+                    <Text variant="caption" className="mt-1">
+                        {description}
+                    </Text>
                 </div>
                 <ChevronDown
                     className="mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"

--- a/src/Raven.Quill.Web/src/pages/apps/app-agents.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-agents.tsx
@@ -1,5 +1,6 @@
 import { useParams } from "react-router";
 import { AddAgentButton, AgentsTable } from "@/pages/apps/agents-section";
+import { Heading } from "@/components/typography";
 
 export function AppAgents() {
     const { slug = "" } = useParams();
@@ -7,7 +8,9 @@ export function AppAgents() {
     return (
         <div className="space-y-6">
             <div className="flex items-start justify-between gap-3">
-                <h1 className="text-2xl font-semibold tracking-tight">Agents</h1>
+                <Heading as="h1" variant="page">
+                    Agents
+                </Heading>
                 <AddAgentButton slug={slug} />
             </div>
             <AgentsTable slug={slug} />

--- a/src/Raven.Quill.Web/src/pages/apps/app-analytics.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-analytics.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Text } from "@/components/typography";
 import { useParams } from "react-router";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
@@ -126,7 +127,9 @@ function AnalyticsSeriesSection({
         <SectionCard title={title}>
             <div className="rounded-lg border p-4">
                 {series.keys.length === 0 ? (
-                    <p className="py-8 text-center text-sm text-muted-foreground">No data for this period.</p>
+                    <Text variant="muted" className="py-8 text-center">
+                        No data for this period.
+                    </Text>
                 ) : (
                     <SeriesBarChart data={series} onBarClick={onBarClick} />
                 )}

--- a/src/Raven.Quill.Web/src/pages/apps/app-channels.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-channels.tsx
@@ -4,6 +4,7 @@ import { api } from "@/api/api";
 import { DashboardStatCards, type DashboardStatCard } from "@/pages/dashboard/dashboard-stat-cards";
 import { AddChannelMenu } from "@/pages/apps/channels/add-channel-menu";
 import { ChannelGroups } from "@/pages/apps/channel-groups";
+import { Heading, Text } from "@/components/typography";
 
 export function AppChannels() {
     const { slug = "" } = useParams();
@@ -18,10 +19,12 @@ export function AppChannels() {
         <div className="space-y-6">
             <div className="flex items-start justify-between gap-3">
                 <div className="space-y-1">
-                    <h1 className="text-2xl font-semibold tracking-tight">Channels</h1>
-                    <p className="max-w-prose text-sm text-muted-foreground">
+                    <Heading as="h1" variant="page">
+                        Channels
+                    </Heading>
+                    <Text variant="muted" className="max-w-prose">
                         Channels are the surfaces end users reach your agents through.
-                    </p>
+                    </Text>
                 </div>
                 <AddChannelMenu slug={slug} label="New channel" variant="default" />
             </div>

--- a/src/Raven.Quill.Web/src/pages/apps/app-conversations.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-conversations.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router";
 import { getDefaultDatePeriod } from "@/lib/date-period";
 import { useAppStartDate } from "@/lib/use-start-date";
 import { ConversationStatsCards, ConversationsSection } from "@/pages/apps/conversations-section";
+import { Heading, Text } from "@/components/typography";
 
 export function AppConversations() {
     const { slug = "" } = useParams();
@@ -13,8 +14,10 @@ export function AppConversations() {
         <div className="space-y-8">
             <div className="space-y-6">
                 <div className="space-y-1">
-                    <h1 className="text-2xl font-semibold tracking-tight">Conversations</h1>
-                    <p className="text-sm text-muted-foreground">Live and historical chats across all channels.</p>
+                    <Heading as="h1" variant="page">
+                        Conversations
+                    </Heading>
+                    <Text variant="muted">Live and historical chats across all channels.</Text>
                 </div>
                 <ConversationStatsCards
                     slug={slug}

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
@@ -1,4 +1,5 @@
 import { useId, useLayoutEffect, useRef, useState, type ReactNode, type UIEvent } from "react";
+import { Text } from "@/components/typography";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronRight } from "lucide-react";
 import { StatusIndicator, type StatusTone } from "@/components/data/status-indicator";
@@ -21,7 +22,9 @@ export function CdcBatchLog({ batches }: { batches: CdcLiveBatch[] }) {
     if (batches.length === 0) {
         return (
             <div className="rounded-lg border">
-                <p className="py-12 text-center text-sm text-muted-foreground">No batches yet.</p>
+                <Text variant="muted" className="py-12 text-center">
+                    No batches yet.
+                </Text>
             </div>
         );
     }
@@ -103,7 +106,9 @@ function CdcBatchList({ batches }: { batches: CdcLiveBatch[] }) {
     return (
         <div className="overflow-hidden rounded-lg border">
             <div className="flex items-center justify-between gap-3 border-b bg-muted/40 px-3 py-2">
-                <p className="text-xs text-muted-foreground tabular-nums">{formatCompact(batches.length)} batches</p>
+                <Text variant="caption" className="tabular-nums">
+                    {formatCompact(batches.length)} batches
+                </Text>
                 <div className="flex items-center gap-2">
                     <Label htmlFor={followId} className="text-xs font-normal text-muted-foreground">
                         Follow latest

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
@@ -205,16 +205,16 @@ function CdcBatchRow({
                     )}
                 />
                 <StatusIndicator tone={state.tone} label={state.label} className="shrink-0 justify-start" />
-                <span className="shrink-0 font-mono text-xs text-muted-foreground tabular-nums">
+                <Text as="span" variant="caption" className="shrink-0 font-mono tabular-nums">
                     {formatBatchTime(batch.started)}
-                </span>
-                <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                </Text>
+                <Text as="span" variant="caption" className="min-w-0 flex-1 truncate">
                     {describeBatch(batch, errorCount)}
-                </span>
+                </Text>
                 {/* The narrow layout keeps state, time and summary; the duration stays in the details below. */}
-                <span className="hidden shrink-0 font-mono text-xs text-muted-foreground tabular-nums sm:inline">
+                <Text as="span" variant="caption" className="hidden shrink-0 font-mono tabular-nums sm:inline">
                     {formatBatchDuration(batch.durationInMs)}
-                </span>
+                </Text>
             </button>
             {isExpanded && (
                 <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1.5 px-3 pb-3 pl-10">

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-errors-sheet.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-errors-sheet.tsx
@@ -63,8 +63,12 @@ function CdcErrorCard({ error }: { error: CdcError }) {
     return (
         <div className="space-y-2 rounded-lg border p-3">
             <div className="flex items-center justify-between gap-2">
-                <span className="text-sm font-medium">{error.taskName}</span>
-                <span className="text-xs text-muted-foreground">{formatDateTime(error.createdAt)}</span>
+                <Text as="span" variant="label">
+                    {error.taskName}
+                </Text>
+                <Text as="span" variant="caption">
+                    {formatDateTime(error.createdAt)}
+                </Text>
             </div>
             <Badge variant="secondary">{error.step}</Badge>
             {shortMessage && <p className="text-sm break-words whitespace-pre-wrap text-destructive">{shortMessage}</p>}

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-errors-sheet.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-errors-sheet.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { Text } from "@/components/typography";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import type { CdcError } from "@/api/generated/server-api";
@@ -44,7 +45,7 @@ export function CdcErrorsSheet({ slug, trigger }: { slug: string; trigger: React
                     >
                         {errorsQuery.data &&
                             (errorsQuery.data.length === 0 ? (
-                                <p className="text-sm text-muted-foreground">No app errors.</p>
+                                <Text variant="muted">No app errors.</Text>
                             ) : (
                                 errorsQuery.data.map((error, index) => <CdcErrorCard key={index} error={error} />)
                             ))}
@@ -69,17 +70,17 @@ function CdcErrorCard({ error }: { error: CdcError }) {
             {shortMessage && <p className="text-sm break-words whitespace-pre-wrap text-destructive">{shortMessage}</p>}
             {error.error && <ErrorDetails details={error.error} />}
             {error.documentId && (
-                <p className="text-xs text-muted-foreground">
+                <Text variant="caption">
                     Document: <span className="font-mono text-foreground">{error.documentId}</span>
-                </p>
+                </Text>
             )}
             {error.affectedDocumentsCount !== null && (
-                <p className="text-xs text-muted-foreground">
+                <Text variant="caption">
                     Affected documents:{" "}
                     <span className="font-mono text-foreground tabular-nums">
                         {formatCompact(error.affectedDocumentsCount)}
                     </span>
-                </p>
+                </Text>
             )}
         </div>
     );

--- a/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
@@ -11,7 +11,7 @@ import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
 import { Skeleton } from "@/components/shadcn/ui/skeleton";
-import { Heading } from "@/components/typography";
+import { Heading, Text } from "@/components/typography";
 import { appRoutes } from "@/lib/app-routes";
 import { cn, formatDateTime, formatRelativeTime } from "@/lib/utils";
 import { SlackIcon } from "@/pages/apps/channels/channel-brand-icons";
@@ -80,9 +80,9 @@ export function ChannelGroups({ slug }: { slug: string }) {
         >
             {channelsQuery.data &&
                 (channels.length === 0 ? (
-                    <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
+                    <Text as="div" variant="muted" className="rounded-lg border border-dashed p-10 text-center">
                         No channels yet. Add one to start reaching users.
-                    </div>
+                    </Text>
                 ) : (
                     <div className="space-y-6">
                         {groups.map((group) => (
@@ -145,7 +145,7 @@ function ChannelCard({
             className="relative gap-3 transition-[background-color,box-shadow] hover:bg-muted/40 hover:ring-foreground/25 has-[a:focus-visible]:ring-2 has-[a:focus-visible]:ring-ring"
         >
             <CardHeader>
-                <CardTitle className="min-w-0 truncate font-medium tracking-normal">
+                <CardTitle variant="item" className="min-w-0 truncate">
                     <Link
                         to={appRoutes.app(slug, `channels/${channel.channelId}`)}
                         className="after:absolute after:inset-0 after:content-[''] hover:underline"
@@ -154,14 +154,14 @@ function ChannelCard({
                         {channel.displayName}
                     </Link>
                     {channel.telegram?.botUsername && (
-                        <div className="truncate text-xs font-normal text-muted-foreground">
+                        <Text as="div" variant="caption" className="truncate font-normal">
                             @{channel.telegram.botUsername}
-                        </div>
+                        </Text>
                     )}
                     {channel.slack?.teamName && (
-                        <div className="truncate text-xs font-normal text-muted-foreground">
+                        <Text as="div" variant="caption" className="truncate font-normal">
                             {channel.slack.teamName}
-                        </div>
+                        </Text>
                     )}
                 </CardTitle>
                 <CardAction>
@@ -173,7 +173,9 @@ function ChannelCard({
                 {agent ? (
                     <AgentChip name={agent.name} seed={agent.agentId} />
                 ) : (
-                    <span className="text-xs text-muted-foreground">Unassigned</span>
+                    <Text as="span" variant="caption">
+                        Unassigned
+                    </Text>
                 )}
 
                 <div className={cn("grid gap-2", isIFrame ? "grid-cols-2" : "grid-cols-1")}>
@@ -253,7 +255,9 @@ function StatBox({ label, value }: { label: string; value: ReactNode }) {
     return (
         <div className="rounded-md border bg-muted/30 px-2.5 py-1.5">
             <div className="text-[11px] text-muted-foreground">{label}</div>
-            <div className="text-sm font-medium tabular-nums">{value}</div>
+            <Text as="div" variant="label" className="tabular-nums">
+                {value}
+            </Text>
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
 import { Skeleton } from "@/components/shadcn/ui/skeleton";
+import { Heading } from "@/components/typography";
 import { appRoutes } from "@/lib/app-routes";
 import { cn, formatDateTime, formatRelativeTime } from "@/lib/utils";
 import { SlackIcon } from "@/pages/apps/channels/channel-brand-icons";
@@ -88,7 +89,7 @@ export function ChannelGroups({ slug }: { slug: string }) {
                             <section key={group.label} className="min-w-0">
                                 <div className="mb-3 flex items-center gap-2">
                                     <group.icon className="size-4 text-muted-foreground" aria-hidden="true" />
-                                    <h2 className="text-sm font-semibold">{group.label}</h2>
+                                    <Heading variant="label">{group.label}</Heading>
                                     <Badge variant="secondary" className="tabular-nums">
                                         {group.channels.length}
                                     </Badge>
@@ -144,7 +145,7 @@ function ChannelCard({
             className="relative gap-3 transition-[background-color,box-shadow] hover:bg-muted/40 hover:ring-foreground/25 has-[a:focus-visible]:ring-2 has-[a:focus-visible]:ring-ring"
         >
             <CardHeader>
-                <CardTitle className="min-w-0 truncate">
+                <CardTitle className="min-w-0 truncate font-medium tracking-normal">
                     <Link
                         to={appRoutes.app(slug, `channels/${channel.channelId}`)}
                         className="after:absolute after:inset-0 after:content-[''] hover:underline"

--- a/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
@@ -19,7 +19,17 @@ import { SectionCard } from "@/pages/apps/section-card";
 
 // When `agent` is set the section is scoped to that single agent: only its channels are listed,
 // the agent name column is dropped, and new channels are routed to it (e.g. the capability wizard).
-export function ChannelsSection({ slug, agent: fixedAgent }: { slug: string; agent?: FixedAgent }) {
+// `nested` renders the section under an existing heading (e.g. a wizard step title), so the
+// section title steps down to a sub-section instead of competing as a top-level section.
+export function ChannelsSection({
+    slug,
+    agent: fixedAgent,
+    nested = false,
+}: {
+    slug: string;
+    agent?: FixedAgent;
+    nested?: boolean;
+}) {
     const agentsQuery = useQuery(api.queries.agents.list(slug));
     const channelsQuery = useQuery(api.queries.channels.list(slug));
     // Active-link counts are supplementary — kept out of the ApiState gate so a
@@ -57,6 +67,8 @@ export function ChannelsSection({ slug, agent: fixedAgent }: { slug: string; age
     return (
         <SectionCard
             title={fixedAgent ? `Channels for “${fixedAgent.name}”` : "Channels"}
+            titleAs={nested ? "h3" : "h2"}
+            titleVariant={nested ? "subsection" : "section"}
             action={<AddChannelMenu slug={slug} agent={fixedAgent} />}
         >
             <ApiState

--- a/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
@@ -16,6 +16,7 @@ import type { FixedAgent } from "@/pages/apps/channels/web-widget-channel-form";
 import { GenerateEmbedLinkDialog } from "@/pages/apps/channels/generate-embed-link-dialog";
 import { DeleteChannelDialog } from "@/pages/apps/channels/delete-channel-dialog";
 import { SectionCard } from "@/pages/apps/section-card";
+import { Text } from "@/components/typography";
 
 // When `agent` is set the section is scoped to that single agent: only its channels are listed,
 // the agent name column is dropped, and new channels are routed to it (e.g. the capability wizard).
@@ -67,8 +68,7 @@ export function ChannelsSection({
     return (
         <SectionCard
             title={fixedAgent ? `Channels for “${fixedAgent.name}”` : "Channels"}
-            titleAs={nested ? "h3" : "h2"}
-            titleVariant={nested ? "subsection" : "section"}
+            level={nested ? "subsection" : "section"}
             action={<AddChannelMenu slug={slug} agent={fixedAgent} />}
         >
             <ApiState
@@ -94,14 +94,14 @@ export function ChannelsSection({
                                             {channel.displayName}
                                         </Link>
                                         {channel.telegram?.botUsername && (
-                                            <div className="text-xs font-normal text-muted-foreground">
+                                            <Text as="div" variant="caption" className="font-normal">
                                                 @{channel.telegram.botUsername}
-                                            </div>
+                                            </Text>
                                         )}
                                         {channel.slack?.teamName && (
-                                            <div className="text-xs font-normal text-muted-foreground">
+                                            <Text as="div" variant="caption" className="font-normal">
                                                 {channel.slack.teamName}
-                                            </div>
+                                            </Text>
                                         )}
                                     </TableCell>
                                     {!fixedAgent && <TableCell className="font-medium">{agent?.name}</TableCell>}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/add-channel-menu.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/add-channel-menu.tsx
@@ -14,6 +14,7 @@ import { SlackIcon } from "@/pages/apps/channels/channel-brand-icons";
 import { SlackChannelForm } from "@/pages/apps/channels/slack-channel-form";
 import { TelegramChannelForm } from "@/pages/apps/channels/telegram-channel-form";
 import { WebWidgetChannelForm, type FixedAgent } from "@/pages/apps/channels/web-widget-channel-form";
+import { Text } from "@/components/typography";
 
 type ChannelOptionId = "web-widget" | "telegram" | "slack";
 
@@ -102,7 +103,9 @@ export function AddChannelMenu({
                                         </Badge>
                                     )}
                                 </span>
-                                <span className="text-xs text-muted-foreground">{option.description}</span>
+                                <Text as="span" variant="caption">
+                                    {option.description}
+                                </Text>
                             </div>
                         </DropdownMenuItem>
                     ))}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/editable-tab-shell.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/editable-tab-shell.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Heading, Text } from "@/components/typography";
 
 // Layout for an editable channel-detail "fill" tab: a fixed header (title, description, and the
 // edit/save actions) that stays put while the body scrolls beneath it. Render inside a
@@ -18,8 +19,8 @@ export function EditableTabShell({
         <>
             <div className="flex items-start justify-between gap-3 pt-5 pb-4">
                 <div className="space-y-0.5">
-                    <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
-                    <p className="text-sm text-muted-foreground">{description}</p>
+                    <Heading variant="section">{title}</Heading>
+                    <Text variant="muted">{description}</Text>
                 </div>
                 {actions}
             </div>

--- a/src/Raven.Quill.Web/src/pages/apps/channels/editable-tab-shell.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/editable-tab-shell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Heading, Text } from "@/components/typography";
+import { SectionHeader } from "@/components/section-header";
 
 // Layout for an editable channel-detail "fill" tab: a fixed header (title, description, and the
 // edit/save actions) that stays put while the body scrolls beneath it. Render inside a
@@ -17,13 +17,13 @@ export function EditableTabShell({
 }) {
     return (
         <>
-            <div className="flex items-start justify-between gap-3 pt-5 pb-4">
-                <div className="space-y-0.5">
-                    <Heading variant="section">{title}</Heading>
-                    <Text variant="muted">{description}</Text>
-                </div>
-                {actions}
-            </div>
+            <SectionHeader
+                className="pt-5 pb-4"
+                level="section"
+                title={title}
+                description={description}
+                action={actions}
+            />
             {/* -mx-2/px-2 keeps card borders and focus rings off the scroller's clip edge. */}
             <div className="-mx-2 min-h-0 flex-1 overflow-y-auto px-2 pb-5">{children}</div>
         </>

--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-api-docs.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-api-docs.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Text } from "@/components/typography";
 import { ShieldAlertIcon } from "lucide-react";
 import { CodeBlockTabs } from "@/components/data/code-block-tabs";
 import { Alert, AlertDescription, AlertTitle } from "@/components/shadcn/ui/alert";
@@ -100,13 +101,13 @@ export function EmbedLinkApiDocs({ slug, channelId, parameters }: EmbedLinkApiDo
                             title: "Mint links from your backend",
                             content: (
                                 <>
-                                    <p className="max-w-prose text-sm text-muted-foreground">
+                                    <Text variant="muted" className="max-w-prose">
                                         Your server POSTs to the embed-links endpoint with your Dashboard API key in the{" "}
                                         <InlineCode>X-Api-Key</InlineCode> header, then hands the page nothing but the
                                         returned <InlineCode>url</InlineCode>. The app and channel are already filled in
                                         below - swap in your <InlineCode>QUILL_API_KEY</InlineCode>
                                         {hasParameters ? " and the parameter values" : ""}.
-                                    </p>
+                                    </Text>
 
                                     <div className="mt-3 grid gap-4 lg:grid-cols-2">
                                         <CodeBlockTabs
@@ -140,10 +141,10 @@ export function EmbedLinkApiDocs({ slug, channelId, parameters }: EmbedLinkApiDo
                             title: "Show the link in your page",
                             content: (
                                 <>
-                                    <p className="max-w-prose text-sm text-muted-foreground">
+                                    <Text variant="muted" className="max-w-prose">
                                         Then in the page, point an iframe at the <InlineCode>url</InlineCode> your
                                         endpoint returned:
-                                    </p>
+                                    </Text>
                                     <CodeBlockTabs
                                         value="html"
                                         copyLabel="Copy host page"

--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-preview.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-preview.tsx
@@ -1,4 +1,5 @@
 import { Copy, ExternalLink } from "lucide-react";
+import { Text } from "@/components/typography";
 import { CopyableCode } from "@/components/data/copyable-code";
 import { Field, FieldLabel } from "@/components/shadcn/ui/field";
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/shadcn/ui/input-group";
@@ -39,9 +40,9 @@ export function EmbedLinkPreview({ url, expiresAt, maxInvocations }: EmbedLinkPr
                 <FieldLabel>Embed snippet</FieldLabel>
                 <CopyableCode code={iframeSnippet} copyLabel="Copy embed snippet" />
             </Field>
-            <p className="text-xs text-muted-foreground">
+            <Text variant="caption">
                 Expires {formatDateTime(expiresAt)} · up to {maxInvocations.toLocaleString()} chats.
-            </p>
+            </Text>
             <iframe
                 src={url}
                 title="Embed preview"

--- a/src/Raven.Quill.Web/src/pages/apps/channels/parameter-binding-fields.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/parameter-binding-fields.tsx
@@ -5,6 +5,7 @@ import { FieldDescription } from "@/components/shadcn/ui/field";
 import { FormInput } from "@/components/form/form-input";
 import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
 import type { ParameterSource } from "@/pages/apps/channels/parameter-bindings";
+import { Heading, Text } from "@/components/typography";
 
 export function ParameterBindingRow<TFieldValues extends FieldValues>({
     control,
@@ -75,8 +76,10 @@ export function ParameterBindingFields<TFieldValues extends FieldValues>({
     return (
         <div className="flex flex-col gap-3">
             <div className="space-y-0.5">
-                <h3 className="text-sm font-medium">Parameters</h3>
-                <p className="text-xs text-muted-foreground">{description}</p>
+                <Heading as="h3" variant="label">
+                    Parameters
+                </Heading>
+                <Text variant="caption">{description}</Text>
             </div>
             {fields.map((field, index) => (
                 <ParameterBindingRow

--- a/src/Raven.Quill.Web/src/pages/apps/channels/slack-channel-form.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/slack-channel-form.tsx
@@ -10,6 +10,7 @@ import type { AgentSummaryResponse } from "@/api/generated/server-api";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Button } from "@/components/shadcn/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/shadcn/ui/collapsible";
+import { Heading, Text } from "@/components/typography";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { SheetClose, SheetFooter } from "@/components/shadcn/ui/sheet";
 import { ApiState } from "@/components/data/api-state";
@@ -183,11 +184,13 @@ function LoadedSlackChannelForm({
                         <Collapsible open={isManifestOpen} onOpenChange={setIsManifestOpen} className="grid gap-3">
                             <CollapsibleTrigger className="group flex w-full items-start justify-between gap-3 text-left">
                                 <div>
-                                    <h3 className="text-sm font-semibold">No Slack app yet?</h3>
-                                    <p className="mt-1 text-xs text-muted-foreground">
+                                    <Heading as="h3" variant="label">
+                                        No Slack app yet?
+                                    </Heading>
+                                    <Text variant="caption" className="mt-1">
                                         Create one from this manifest, install it to your workspace, then paste its
                                         credentials below.
-                                    </p>
+                                    </Text>
                                 </div>
                                 <ChevronDown
                                     className="mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
@@ -212,10 +215,10 @@ function LoadedSlackChannelForm({
                                     </li>
                                 </ol>
                                 <CopyableCode code={SLACK_APP_MANIFEST} copyLabel="Copy app manifest" />
-                                <p className="text-xs text-muted-foreground">
+                                <Text variant="caption">
                                     Then <span className="font-medium">Install to Workspace</span>. The bot token is on
                                     the OAuth &amp; Permissions page, the signing secret under Basic Information.
-                                </p>
+                                </Text>
                             </CollapsibleContent>
                         </Collapsible>
                         {!agent && (

--- a/src/Raven.Quill.Web/src/pages/apps/channels/slack-webhook-panel.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/slack-webhook-panel.tsx
@@ -4,6 +4,7 @@ import { ApiState } from "@/components/data/api-state";
 import { CopyableCode } from "@/components/data/copyable-code";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Badge } from "@/components/shadcn/ui/badge";
+import { Text } from "@/components/typography";
 import { formatDateTime, formatRelativeTime } from "@/lib/utils";
 
 export function SlackWebhookPanel({ slug, channelId }: { slug: string; channelId: string }) {
@@ -37,12 +38,12 @@ export function SlackWebhookPanel({ slug, channelId }: { slug: string; channelId
                         </li>
                         <li>Open a DM with the bot in Slack and send it a message.</li>
                     </ol>
-                    <p className="text-xs text-muted-foreground">
+                    <Text variant="caption">
                         The appliance must be reachable from the internet on this URL. Apps created from the current
                         Quill manifest already carry the im:history scope, so adding the event needs no reinstall. An
                         app created before users:read and users:read.email were added to the manifest must be
                         reinstalled to the workspace before a parameter can bind to the sender&apos;s email.
-                    </p>
+                    </Text>
                     <SlackHealthStrip slug={slug} channelId={channelId} />
                 </div>
             )}
@@ -67,11 +68,13 @@ export function SlackHealthStrip({ slug, channelId }: { slug: string; channelId:
             <div className="flex flex-wrap items-center gap-2 text-sm">
                 <SlackTokenBadge tokenValid={health.tokenValid} tokenError={health.tokenError} />
                 {health.lastInboundAt ? (
-                    <span className="text-xs text-muted-foreground" title={formatDateTime(health.lastInboundAt)}>
+                    <Text as="span" variant="caption" title={formatDateTime(health.lastInboundAt)}>
                         Last message {formatRelativeTime(health.lastInboundAt)}
-                    </span>
+                    </Text>
                 ) : (
-                    <span className="text-xs text-muted-foreground">Waiting for the first message...</span>
+                    <Text as="span" variant="caption">
+                        Waiting for the first message...
+                    </Text>
                 )}
             </div>
             {hasRecentSignatureFailure && (

--- a/src/Raven.Quill.Web/src/pages/apps/channels/telegram-connect-tab.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/telegram-connect-tab.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink, Send } from "lucide-react";
+import { Text } from "@/components/typography";
 import type { ChannelSummaryResponse } from "@/api/generated/server-api";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Button } from "@/components/shadcn/ui/button";
@@ -32,13 +33,15 @@ export function TelegramConnectTab({ channel }: { channel: ChannelSummaryRespons
                                 title: "Open the bot in Telegram",
                                 content: (
                                     <>
-                                        <p className="max-w-prose text-sm text-muted-foreground">
+                                        <Text variant="muted" className="max-w-prose">
                                             Open the bot in Telegram, or search for its username.
-                                        </p>
+                                        </Text>
                                         <div className="mt-3 flex max-w-prose items-center justify-between gap-3 rounded-md border bg-background p-3">
                                             <div className="min-w-0">
                                                 <p className="font-mono text-sm">@{botUsername}</p>
-                                                <p className="truncate text-xs text-muted-foreground">{botLink}</p>
+                                                <Text variant="caption" className="truncate">
+                                                    {botLink}
+                                                </Text>
                                             </div>
                                             <Button asChild size="sm" variant="outline" className="shrink-0">
                                                 <a href={botLink} target="_blank" rel="noreferrer">
@@ -54,19 +57,19 @@ export function TelegramConnectTab({ channel }: { channel: ChannelSummaryRespons
                             {
                                 title: "Start the conversation",
                                 content: (
-                                    <p className="max-w-prose text-sm text-muted-foreground">
+                                    <Text variant="muted" className="max-w-prose">
                                         Press <strong>Start</strong> (sends <InlineCode>/start</InlineCode>) to greet
                                         the bot and begin a conversation.
-                                    </p>
+                                    </Text>
                                 ),
                             },
                             {
                                 title: "Reset anytime",
                                 content: (
-                                    <p className="max-w-prose text-sm text-muted-foreground">
+                                    <Text variant="muted" className="max-w-prose">
                                         Send <InlineCode>/clear</InlineCode> anytime to wipe the current conversation
                                         and start fresh.
-                                    </p>
+                                    </Text>
                                 ),
                             },
                         ]}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/telegram-messages-tab.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/telegram-messages-tab.tsx
@@ -19,6 +19,7 @@ import {
     toMessagesDto,
     toMessagesFormValues,
 } from "@/pages/apps/channels/telegram-message-defaults";
+import { Heading, Text } from "@/components/typography";
 
 const messagesFormSchema = z.object({ messages: telegramMessagesSchema });
 type MessagesFormData = z.infer<typeof messagesFormSchema>;
@@ -84,8 +85,10 @@ export function TelegramMessagesTab({ slug, channel }: { slug: string; channel: 
                             className="grid gap-x-16 gap-y-4 rounded-md border bg-card p-4 md:grid-cols-[minmax(0,22rem)_1fr] md:p-5"
                         >
                             <div className="space-y-0.5">
-                                <h3 className="text-base font-medium">{group.title}</h3>
-                                <p className="text-sm text-muted-foreground">{group.description}</p>
+                                <Heading as="h3" variant="subsection">
+                                    {group.title}
+                                </Heading>
+                                <Text variant="muted">{group.description}</Text>
                             </div>
                             <div className="grid gap-4">
                                 {group.fields.map((field) =>

--- a/src/Raven.Quill.Web/src/pages/apps/channels/web-widget-appearance-tab.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/web-widget-appearance-tab.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { Text } from "@/components/typography";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
 import { FormFieldsSkeleton } from "@/components/data/loading-skeletons";
@@ -19,10 +20,10 @@ export function WebWidgetAppearanceTab({ slug, channelId }: { slug: string; chan
 
     return (
         <div className="grid gap-5">
-            <p className="text-sm text-muted-foreground">
+            <Text variant="muted">
                 Choose how this web widget looks and reads. Pick an accent color and the rest of the palette is derived
                 from it, so light and dark both stay coherent.
-            </p>
+            </Text>
 
             <ApiState
                 isLoading={themeQuery.isPending}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/web-widget-theme-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/web-widget-theme-editor.tsx
@@ -396,7 +396,9 @@ export function WebWidgetThemeEditor({
 
                 <div className="grid gap-3 xl:sticky xl:top-14">
                     <div className="flex flex-wrap items-center justify-between gap-2">
-                        <span className="text-sm font-medium">Live preview</span>
+                        <Text as="span" variant="label">
+                            Live preview
+                        </Text>
                         <div className="flex flex-wrap items-center gap-3">
                             <ToggleGroup
                                 type="single"

--- a/src/Raven.Quill.Web/src/pages/apps/channels/web-widget-theme-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/web-widget-theme-editor.tsx
@@ -12,6 +12,7 @@ import { FormSelect } from "@/components/form/form-select";
 import { FormStringList } from "@/components/form/form-string-list";
 import { FormSwitch } from "@/components/form/form-switch";
 import { FormToggleGroup } from "@/components/form/form-toggle-group";
+import { Heading, Text } from "@/components/typography";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Button } from "@/components/shadcn/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/shadcn/ui/collapsible";
@@ -90,7 +91,7 @@ function Section({
     return (
         <Collapsible open={isOpen} onOpenChange={setIsOpen} className="rounded-md border bg-card p-4" asChild>
             <section>
-                <h3 className="text-sm font-semibold">
+                <Heading as="h3" variant="subsection">
                     <CollapsibleTrigger className="group flex w-full items-center justify-between gap-3 rounded-sm text-left focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none">
                         <span className="flex items-center gap-1.5">
                             {title}
@@ -101,7 +102,7 @@ function Section({
                             aria-hidden="true"
                         />
                     </CollapsibleTrigger>
-                </h3>
+                </Heading>
                 <CollapsibleContent className="mt-4 grid gap-4">{children}</CollapsibleContent>
             </section>
         </Collapsible>
@@ -227,9 +228,9 @@ export function WebWidgetThemeEditor({
                     </div>
 
                     <Section title="Colors" control={form.control} paths={SECTION_FIELDS.colors} defaultOpen>
-                        <p className="text-sm text-muted-foreground">
+                        <Text variant="muted">
                             Each scheme keeps its own colors. Every other option applies to both.
-                        </p>
+                        </Text>
                         <Tabs
                             value={previewAppearance}
                             onValueChange={(next) => setPreviewAppearance(next as PreviewAppearance)}
@@ -298,10 +299,10 @@ export function WebWidgetThemeEditor({
                             disabled={isSaving}
                         />
                         {previewTheme.showHeader === false && (
-                            <p className="text-sm text-muted-foreground">
+                            <Text variant="muted">
                                 The header is hidden, so nothing below is shown to visitors. It is kept for when you
                                 turn the header back on.
-                            </p>
+                            </Text>
                         )}
                         <FormImagePicker
                             control={form.control}

--- a/src/Raven.Quill.Web/src/pages/apps/conversations/conversation-tool-call.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/conversations/conversation-tool-call.tsx
@@ -2,6 +2,7 @@ import { Wrench } from "lucide-react";
 import type { AiToolCallResult } from "@/api/generated/server-api";
 import { Parameters } from "@/components/data/parameters";
 import { CodeBlock, TranscriptDisclosure } from "@/pages/apps/conversations/transcript-disclosure";
+import { Text } from "@/components/typography";
 
 // A collapsed transcript entry for one tool the agent ran during a turn. Kept operator-friendly:
 // only the parameters the model filled in and the tool's response — no raw query internals.
@@ -63,7 +64,9 @@ function ToolCallResponse({ result }: { result: string | null | undefined }) {
 function ToolCallSection({ label, children }: { label: string; children: React.ReactNode }) {
     return (
         <div className="grid gap-1.5">
-            <span className="text-xs font-medium text-muted-foreground">{label}</span>
+            <Text as="span" variant="caption" className="font-medium">
+                {label}
+            </Text>
             {children}
         </div>
     );

--- a/src/Raven.Quill.Web/src/pages/apps/conversations/conversation-transcript-sheet.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/conversations/conversation-transcript-sheet.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { Text } from "@/components/typography";
 import { useQuery } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Streamdown } from "streamdown";
@@ -74,7 +75,7 @@ export function ConversationTranscriptSheet({
                     >
                         {conversationQuery.data &&
                             (turns.length === 0 ? (
-                                <p className="text-sm text-muted-foreground">No messages in this conversation.</p>
+                                <Text variant="muted">No messages in this conversation.</Text>
                             ) : (
                                 <TranscriptDisclosureState>
                                     <TranscriptRows scrollElement={scrollElement} rows={rows} />

--- a/src/Raven.Quill.Web/src/pages/apps/conversations/conversation-transcript-sheet.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/conversations/conversation-transcript-sheet.tsx
@@ -175,7 +175,11 @@ function TranscriptTurn({ turn, turnKey }: { turn: AiConversationMessage; turnKe
                         <Streamdown>{content}</Streamdown>
                     </div>
                 ))}
-            {turn.timestamp && <span className="text-xs text-muted-foreground">{formatDateTime(turn.timestamp)}</span>}
+            {turn.timestamp && (
+                <Text as="span" variant="caption">
+                    {formatDateTime(turn.timestamp)}
+                </Text>
+            )}
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/apps/section-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/section-card.tsx
@@ -1,5 +1,6 @@
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { Heading, Text } from "@/components/typography";
 
 export function SectionCard({
     title,
@@ -9,20 +10,30 @@ export function SectionCard({
     // a self-contained block of content rather than a heading over a bordered table or list.
     isRaised = false,
     children,
+    // Defaults suit a top-level section under a page title. Nested contexts (e.g. a
+    // wizard step that already has its own heading) can step the title down a level.
+    titleAs = "h2",
+    titleVariant = "section",
 }: {
     title?: ReactNode;
     description?: ReactNode;
     action?: ReactNode;
     isRaised?: boolean;
     children: ReactNode;
+    titleAs?: ComponentProps<typeof Heading>["as"];
+    titleVariant?: ComponentProps<typeof Heading>["variant"];
 }) {
     return (
         <section className={cn("min-w-0", isRaised && "rounded-md border bg-card p-4")}>
             {(title || action) && (
                 <div className="mb-2 flex items-center justify-between gap-3">
                     <div className="space-y-0.5">
-                        {title && <h2 className="text-lg font-semibold tracking-tight">{title}</h2>}
-                        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+                        {title && (
+                            <Heading as={titleAs} variant={titleVariant}>
+                                {title}
+                            </Heading>
+                        )}
+                        {description && <Text variant="muted">{description}</Text>}
                     </div>
                     {action}
                 </div>

--- a/src/Raven.Quill.Web/src/pages/apps/section-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/section-card.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { Heading, Text } from "@/components/typography";
+import { SectionHeader } from "@/components/section-header";
 
 export function SectionCard({
     title,
@@ -12,31 +12,19 @@ export function SectionCard({
     children,
     // Defaults suit a top-level section under a page title. Nested contexts (e.g. a
     // wizard step that already has its own heading) can step the title down a level.
-    titleAs = "h2",
-    titleVariant = "section",
+    level = "section",
 }: {
     title?: ReactNode;
     description?: ReactNode;
     action?: ReactNode;
     isRaised?: boolean;
     children: ReactNode;
-    titleAs?: ComponentProps<typeof Heading>["as"];
-    titleVariant?: ComponentProps<typeof Heading>["variant"];
+    level?: ComponentProps<typeof SectionHeader>["level"];
 }) {
     return (
         <section className={cn("min-w-0", isRaised && "rounded-md border bg-card p-4")}>
             {(title || action) && (
-                <div className="mb-2 flex items-center justify-between gap-3">
-                    <div className="space-y-0.5">
-                        {title && (
-                            <Heading as={titleAs} variant={titleVariant}>
-                                {title}
-                            </Heading>
-                        )}
-                        {description && <Text variant="muted">{description}</Text>}
-                    </div>
-                    {action}
-                </div>
+                <SectionHeader className="mb-2" level={level} title={title} description={description} action={action} />
             )}
             {children}
         </section>

--- a/src/Raven.Quill.Web/src/pages/apps/welcome-panel.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/welcome-panel.tsx
@@ -6,6 +6,7 @@ import { api } from "@/api/api";
 import { Button } from "@/components/shadcn/ui/button";
 import { appRoutes } from "@/lib/app-routes";
 import { cn } from "@/lib/utils";
+import { Heading, Text } from "@/components/typography";
 
 const DISMISSED_STORAGE_KEY_PREFIX = "quill-welcome-dismissed:";
 
@@ -60,10 +61,8 @@ export function WelcomePanel({ slug }: { slug: string }) {
         <section className="rounded-lg border bg-card p-4">
             <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
                 <div className="space-y-1">
-                    <h2 className="text-sm font-semibold">Welcome to Quill</h2>
-                    <p className="text-sm text-muted-foreground">
-                        Three steps to get your first agent answering questions in production.
-                    </p>
+                    <Heading variant="subsection">Welcome to Quill</Heading>
+                    <Text variant="muted">Three steps to get your first agent answering questions in production.</Text>
                 </div>
                 <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={dismiss}>
                     Dismiss

--- a/src/Raven.Quill.Web/src/pages/apps/welcome-panel.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/welcome-panel.tsx
@@ -93,7 +93,9 @@ function WelcomeStep({ position, label, isComplete, to }: WelcomeStepProps) {
         return (
             <span className="flex items-center gap-2">
                 <Indicator isComplete={isComplete} position={position} />
-                <span className="text-sm font-medium">{label}</span>
+                <Text as="span" variant="label">
+                    {label}
+                </Text>
             </span>
         );
     }
@@ -101,7 +103,9 @@ function WelcomeStep({ position, label, isComplete, to }: WelcomeStepProps) {
     return (
         <Link to={to} className="group flex items-center gap-2 transition-colors hover:text-primary-strong">
             <Indicator isComplete={isComplete} position={position} />
-            <span className="text-sm font-medium group-hover:underline">{label}</span>
+            <Text as="span" variant="label" className="group-hover:underline">
+                {label}
+            </Text>
         </Link>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/auth/boot-gate.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/auth/boot-gate.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { bootstrapMocks } from "@/mocks/bootstrap-mocks";
+import { Text } from "@/components/typography";
 import { BootGate } from "./boot-gate";
 
 const meta = {
@@ -7,7 +8,9 @@ const meta = {
     component: BootGate,
     args: {
         children: (
-            <div className="grid min-h-svh place-items-center text-sm text-muted-foreground">Operator dashboard</div>
+            <Text as="div" variant="muted" className="grid min-h-svh place-items-center">
+                Operator dashboard
+            </Text>
         ),
     },
 } satisfies Meta<typeof BootGate>;

--- a/src/Raven.Quill.Web/src/pages/auth/boot-gate.tsx
+++ b/src/Raven.Quill.Web/src/pages/auth/boot-gate.tsx
@@ -5,6 +5,7 @@ import { AuthScreenLayout } from "@/components/auth/auth-screen-layout";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { useActivationPolling } from "@/pages/auth/use-activation-polling";
+import { Heading, Text } from "@/components/typography";
 
 // Gates the whole app on appliance startup. While the appliance activates, admin
 // calls 503 and the auth status is unknowable, so we poll bootstrap status and show
@@ -30,8 +31,12 @@ function BootStarting({ phase }: { phase?: BootstrapPhase }) {
     return (
         <>
             <Spinner className="mx-auto size-7 text-primary-strong" />
-            <h1 className="mt-4 text-lg font-semibold tracking-tight">Starting Quill</h1>
-            <p className="mt-1.5 text-sm text-muted-foreground">{getStartingMessage(phase)}</p>
+            <Heading as="h1" variant="section" className="mt-4">
+                Starting Quill
+            </Heading>
+            <Text variant="muted" className="mt-1.5">
+                {getStartingMessage(phase)}
+            </Text>
         </>
     );
 }
@@ -42,10 +47,12 @@ function BootTimedOut({ onRetry }: { onRetry: () => void }) {
             <div className="mx-auto flex size-11 items-center justify-center rounded-full bg-destructive/10 text-destructive">
                 <TriangleAlert className="size-5" aria-hidden="true" />
             </div>
-            <h1 className="mt-4 text-lg font-semibold tracking-tight">Still starting…</h1>
-            <p className="mt-1.5 text-sm text-muted-foreground">
+            <Heading as="h1" variant="section" className="mt-4">
+                Still starting…
+            </Heading>
+            <Text variant="muted" className="mt-1.5">
                 Quill is taking longer than usual to come online. Keep waiting, or try again.
-            </p>
+            </Text>
             <Button className="mt-5 w-full" onClick={onRetry}>
                 Try again
             </Button>

--- a/src/Raven.Quill.Web/src/pages/auth/login.tsx
+++ b/src/Raven.Quill.Web/src/pages/auth/login.tsx
@@ -10,6 +10,7 @@ import { FormInput } from "@/components/form/form-input";
 import { Alert, AlertTitle } from "@/components/shadcn/ui/alert";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
+import { Heading, Text } from "@/components/typography";
 
 const INVALID_KEY_MESSAGE = "That API key wasn't accepted. Double-check it and try again.";
 const SIGN_IN_ERROR_MESSAGE = "We couldn't sign you in. Please try again in a moment.";
@@ -47,8 +48,10 @@ export function Login() {
         <AuthScreenLayout>
             <section className="w-full rounded-xl border bg-card p-6 shadow-sm">
                 <header className="space-y-1.5 text-center">
-                    <h1 className="text-xl font-semibold tracking-tight">Sign in</h1>
-                    <p className="text-sm text-muted-foreground">Enter the Dashboard API key to manage Quill.</p>
+                    <Heading as="h1" variant="title">
+                        Sign in
+                    </Heading>
+                    <Text variant="muted">Enter the Dashboard API key to manage Quill.</Text>
                 </header>
 
                 {formError && (
@@ -83,9 +86,9 @@ export function Login() {
                 </form>
             </section>
 
-            <p className="mt-6 max-w-sm text-center text-xs text-muted-foreground">
+            <Text variant="caption" className="mt-6 max-w-sm text-center">
                 The Dashboard API key was issued when Quill was provisioned.
-            </p>
+            </Text>
         </AuthScreenLayout>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates.tsx
@@ -17,6 +17,7 @@ import {
 import { CertificatesToolbar, type CertificateSort } from "@/pages/dashboard/certificates/certificates-toolbar";
 import { GenerateCertificateDialog } from "@/pages/dashboard/certificates/generate-certificate-dialog";
 import { originForSubdomain } from "@/lib/subdomain-origin";
+import { Heading } from "@/components/typography";
 
 interface CertificateFilters {
     search: string;
@@ -47,7 +48,9 @@ export function DashboardCertificates() {
         <div className="space-y-6">
             <div className="flex items-center justify-between gap-3">
                 <div>
-                    <h1 className="text-2xl font-semibold tracking-tight">Certificates</h1>
+                    <Heading as="h1" variant="page">
+                        Certificates
+                    </Heading>
                 </div>
                 <div className="flex items-center gap-2">
                     <Button variant="outline" size="sm" asChild>
@@ -129,7 +132,7 @@ function CertificateSection({
     return (
         <section className="space-y-3">
             <div className="flex items-center gap-2">
-                <h2 className="text-sm font-semibold">{title}</h2>
+                <Heading variant="label">{title}</Heading>
                 <Badge variant="secondary">{certificates.length}</Badge>
             </div>
             <div className="space-y-3">

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates.tsx
@@ -17,7 +17,7 @@ import {
 import { CertificatesToolbar, type CertificateSort } from "@/pages/dashboard/certificates/certificates-toolbar";
 import { GenerateCertificateDialog } from "@/pages/dashboard/certificates/generate-certificate-dialog";
 import { originForSubdomain } from "@/lib/subdomain-origin";
-import { Heading } from "@/components/typography";
+import { Heading, Text } from "@/components/typography";
 
 interface CertificateFilters {
     search: string;
@@ -100,11 +100,11 @@ export function DashboardCertificates() {
                 skeleton={<CardListSkeleton />}
             >
                 {visibleCertificates.length === 0 ? (
-                    <div className="rounded-lg border p-8 text-center text-sm text-muted-foreground">
+                    <Text as="div" variant="muted" className="rounded-lg border p-8 text-center">
                         {certificates.length === 0
                             ? "No certificates yet."
                             : "No certificates match the current filters."}
-                    </div>
+                    </Text>
                 ) : (
                     <div className="space-y-8">
                         {serverCertificates.length > 0 && (

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-card.tsx
@@ -5,7 +5,7 @@ import type { AppResponse } from "@/api/generated/server-api";
 import { StatusIndicator, type StatusTone } from "@/components/data/status-indicator";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
-import { Heading } from "@/components/typography";
+import { Heading, Text } from "@/components/typography";
 import { formatDate } from "@/lib/format";
 import { cn, copyToClipboard } from "@/lib/utils";
 import {
@@ -49,9 +49,9 @@ export function CertificateCard({ certificate, apps }: { certificate: Certificat
                             {isAboutToExpire && <StatusIndicator tone="warning" label="About to expire" />}
                         </div>
                         <div className="flex items-center gap-1">
-                            <span className="truncate font-mono text-xs text-muted-foreground">
+                            <Text as="span" variant="caption" className="truncate font-mono">
                                 {certificate.thumbprint}
-                            </span>
+                            </Text>
                             <Button
                                 type="button"
                                 variant="ghost"

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-card.tsx
@@ -5,6 +5,7 @@ import type { AppResponse } from "@/api/generated/server-api";
 import { StatusIndicator, type StatusTone } from "@/components/data/status-indicator";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
+import { Heading } from "@/components/typography";
 import { formatDate } from "@/lib/format";
 import { cn, copyToClipboard } from "@/lib/utils";
 import {
@@ -41,7 +42,9 @@ export function CertificateCard({ certificate, apps }: { certificate: Certificat
                 <div className="flex flex-wrap items-start justify-between gap-2">
                     <div className="min-w-0 space-y-1">
                         <div className="flex flex-wrap items-center gap-2">
-                            <h3 className="text-sm font-semibold">{certificate.name || "—"}</h3>
+                            <Heading as="h3" variant="label">
+                                {certificate.name || "—"}
+                            </Heading>
                             <StatusIndicator tone={STATE_TONES[state]} label={CERTIFICATE_STATE_LABELS[state]} />
                             {isAboutToExpire && <StatusIndicator tone="warning" label="About to expire" />}
                         </div>

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/edit-certificate-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/edit-certificate-dialog.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { Text } from "@/components/typography";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -142,9 +143,7 @@ function EditCertificateForm({
                 <div className="grid gap-3">
                     <div className="text-sm font-medium">App access</div>
                     {permissionRows.fields.length === 0 && (
-                        <p className="text-sm text-muted-foreground">
-                            No access granted — this certificate cannot reach any app.
-                        </p>
+                        <Text variant="muted">No access granted — this certificate cannot reach any app.</Text>
                     )}
                     {permissionRows.fields.map((row, index) => (
                         <div key={row.id} className="flex items-start gap-2">

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/edit-certificate-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/edit-certificate-dialog.tsx
@@ -141,7 +141,9 @@ function EditCertificateForm({
 
             {clearance === "ValidUser" && (
                 <div className="grid gap-3">
-                    <div className="text-sm font-medium">App access</div>
+                    <Text as="div" variant="label">
+                        App access
+                    </Text>
                     {permissionRows.fields.length === 0 && (
                         <Text variant="muted">No access granted — this certificate cannot reach any app.</Text>
                     )}

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/generate-certificate-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/generate-certificate-dialog.tsx
@@ -23,6 +23,7 @@ import {
 import { GuardedDialog } from "@/components/form/unsaved-changes/guarded-overlays";
 import { useFormUnsavedChanges } from "@/components/form/unsaved-changes/use-unsaved-changes";
 import { Spinner } from "@/components/shadcn/ui/spinner";
+import { Text } from "@/components/typography";
 import {
     CLEARANCE_OPTIONS,
     DATABASE_ACCESS_OPTIONS,
@@ -139,7 +140,9 @@ function GenerateCertificateForm({ apps, onGenerated }: { apps: AppResponse[]; o
 
             {clearance === "ValidUser" && (
                 <div className="grid gap-3">
-                    <div className="text-sm font-medium">App access</div>
+                    <Text as="div" variant="label">
+                        App access
+                    </Text>
                     {permissionRows.fields.map((row, index) => (
                         <div key={row.id} className="flex items-start gap-2">
                             <FormSelect

--- a/src/Raven.Quill.Web/src/pages/dashboard/connection-strings.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/connection-strings.tsx
@@ -11,6 +11,7 @@ import { AddAiConnectionString } from "@/components/ai-connection-string/add-ai-
 import { EditAiConnectionString } from "@/components/ai-connection-string/edit-ai-connection-string";
 import { DeleteAiConnectionStringDialog } from "@/components/ai-connection-string/delete-ai-connection-string-dialog";
 import { getProviderLabel, MODEL_TYPE_LABELS } from "@/components/ai-connection-string/ai-connection-string-utils";
+import { Heading, Text } from "@/components/typography";
 
 const CONNECTION_STRINGS_COLUMN_COUNT = 4;
 
@@ -24,10 +25,12 @@ export function DashboardConnectionStrings() {
         <div className="space-y-6">
             <div className="flex items-start justify-between gap-3">
                 <div className="space-y-1">
-                    <h1 className="text-2xl font-semibold tracking-tight">AI connection strings</h1>
-                    <p className="text-sm text-muted-foreground">
+                    <Heading as="h1" variant="page">
+                        AI connection strings
+                    </Heading>
+                    <Text variant="muted">
                         Provider credentials agents use to reach a model, shared by every app on this server.
-                    </p>
+                    </Text>
                 </div>
                 <AddAiConnectionString
                     modelType="Chat"

--- a/src/Raven.Quill.Web/src/pages/dashboard/dashboard-apps-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/dashboard-apps-table.tsx
@@ -15,6 +15,7 @@ import { datePeriodUnit, type DatePeriod } from "@/lib/date-period";
 import { formatCompact } from "@/lib/format";
 import { DeleteAppDialog } from "@/pages/apps/delete-app-dialog";
 import { EditAppConfirmDialog } from "@/pages/setup/add-app-wizard/edit-app-confirm-dialog";
+import { Heading, Text } from "@/components/typography";
 
 export function DashboardAppsTable({
     apps,
@@ -78,7 +79,7 @@ function AppsToolbar({ count, action }: { count: ReactNode; action: ReactNode })
     return (
         <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-2">
-                <h2 className="text-lg font-semibold tracking-tight">Apps</h2>
+                <Heading variant="section">Apps</Heading>
                 {count}
             </div>
             {action}
@@ -172,10 +173,12 @@ function EmptyAppsState() {
                 <div className="flex size-9 items-center justify-center rounded-md bg-accent text-accent-foreground">
                     <Database className="size-5" aria-hidden="true" />
                 </div>
-                <h2 className="mt-4 text-sm font-semibold">No apps added yet</h2>
-                <p className="mt-3 text-xs leading-5 text-muted-foreground">
+                <Heading variant="label" className="mt-4">
+                    No apps added yet
+                </Heading>
+                <Text variant="caption" className="mt-3 leading-5">
                     Create an app from a source database and a table mapping.
-                </p>
+                </Text>
                 <Button asChild size="sm" className="mt-5">
                     <Link to={appRoutes.addApp()}>
                         <Plus className="size-3.5" aria-hidden="true" />

--- a/src/Raven.Quill.Web/src/pages/dashboard/dashboard-apps-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/dashboard-apps-table.tsx
@@ -119,8 +119,12 @@ function AppRow({ app, writes }: { app: ApplianceAppResponse; writes: number | u
         <TableRow className="group">
             <TableCell className="py-3">
                 <Link to={appRoutes.app(app.slug)} className="flex flex-col gap-0.5">
-                    <span className="text-sm font-medium group-hover:underline">{app.name}</span>
-                    <span className="font-mono text-xs text-muted-foreground">{app.slug}</span>
+                    <Text as="span" variant="label" className="group-hover:underline">
+                        {app.name}
+                    </Text>
+                    <Text as="span" variant="caption" className="font-mono">
+                        {app.slug}
+                    </Text>
                 </Link>
             </TableCell>
             <TableCell className="text-sm">{app.source.type || "—"}</TableCell>
@@ -161,7 +165,11 @@ function AppStatusCell({ app }: { app: ApplianceAppResponse }) {
     return (
         <div className="flex flex-col items-start gap-1">
             <StatusIndicator tone={style.tone} label={style.label} />
-            {app.statusSubtitle && <span className="text-xs text-muted-foreground">{app.statusSubtitle}</span>}
+            {app.statusSubtitle && (
+                <Text as="span" variant="caption">
+                    {app.statusSubtitle}
+                </Text>
+            )}
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/dashboard/dashboard-home.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/dashboard-home.tsx
@@ -8,6 +8,7 @@ import { useSetupStartDate } from "@/lib/use-start-date";
 import { DashboardAppsTable, DashboardAppsTableSkeleton } from "@/pages/dashboard/dashboard-apps-table";
 import { StatCardsSection } from "@/pages/dashboard/dashboard-stat-cards";
 import { buildUsageStatCards } from "@/pages/dashboard/usage-stat-cards";
+import { Heading } from "@/components/typography";
 
 export function DashboardHome() {
     const [period, setPeriod] = useState(getDefaultDatePeriod);
@@ -21,7 +22,9 @@ export function DashboardHome() {
     return (
         <div className="space-y-6">
             <header className="flex items-center justify-between gap-3">
-                <h1 className="text-2xl font-semibold tracking-tight">My apps</h1>
+                <Heading as="h1" variant="page">
+                    My apps
+                </Heading>
             </header>
 
             {appsQuery.data && appsQuery.data.length > 0 && (

--- a/src/Raven.Quill.Web/src/pages/dashboard/dashboard-stat-cards.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/dashboard-stat-cards.tsx
@@ -8,6 +8,7 @@ import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } f
 import { Skeleton } from "@/components/shadcn/ui/skeleton";
 import { formatCompact } from "@/lib/format";
 import { SectionCard } from "@/pages/apps/section-card";
+import { Text } from "@/components/typography";
 
 export type DashboardStatCard = {
     label: string;
@@ -55,10 +56,10 @@ function StatCard({ card }: { card: DashboardStatCard }) {
         <Card className="gap-3">
             <CardContent className="space-y-1">
                 <div className="flex items-center justify-between gap-2">
-                    <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                    <Text as="span" variant="muted" className="flex items-center gap-1">
                         {card.label}
                         {card.labelInfo && <InfoHint content={card.labelInfo} />}
-                    </span>
+                    </Text>
                     {card.delta !== undefined && card.delta !== 0 && !card.isLoading && (
                         <DeltaBadge delta={card.delta} />
                     )}
@@ -68,7 +69,11 @@ function StatCard({ card }: { card: DashboardStatCard }) {
                 ) : (
                     <div className="text-3xl font-semibold tracking-tight tabular-nums">{valueLabel}</div>
                 )}
-                {card.caption && <div className="text-xs text-muted-foreground">{card.caption}</div>}
+                {card.caption && (
+                    <Text as="div" variant="caption">
+                        {card.caption}
+                    </Text>
+                )}
             </CardContent>
             {card.series && card.series.length > 1 && (
                 <Sparkline series={card.series} dates={card.seriesDates} label={card.label} />

--- a/src/Raven.Quill.Web/src/pages/dashboard/ip-configuration.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/ip-configuration.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Field, FieldError, FieldLabel } from "@/components/shadcn/ui/field";
 import { Input } from "@/components/shadcn/ui/input";
 import { containerNameForHost, isIpV4 } from "@/lib/subdomain-origin";
+import { Heading, Text } from "@/components/typography";
 
 const NEW_IP_PLACEHOLDER = "<new-ip>";
 const DNS_A_RECORD_TYPE = 1;
@@ -43,7 +44,9 @@ export function DashboardIpConfiguration({ hostname = window.location.hostname }
     return (
         <div className="space-y-6">
             <div className="flex items-center justify-between gap-3">
-                <h1 className="text-2xl font-semibold tracking-tight">IP configuration</h1>
+                <Heading as="h1" variant="page">
+                    IP configuration
+                </Heading>
                 <Button
                     variant="outline"
                     size="sm"
@@ -57,7 +60,9 @@ export function DashboardIpConfiguration({ hostname = window.location.hostname }
 
             <Card>
                 <CardHeader>
-                    <CardTitle>Current IP binding</CardTitle>
+                    <CardTitle asChild>
+                        <h2>Current IP binding</h2>
+                    </CardTitle>
                     <CardDescription>The IP address Quill&rsquo;s domain currently resolves to.</CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -86,9 +91,9 @@ export function DashboardIpConfiguration({ hostname = window.location.hostname }
                             </div>
                         </ApiState>
                     ) : (
-                        <p className="text-sm text-muted-foreground">
+                        <Text variant="muted">
                             This dashboard is opened directly by IP address, so there is no domain binding to show.
-                        </p>
+                        </Text>
                     )}
                 </CardContent>
             </Card>
@@ -108,7 +113,9 @@ function ChangeIpCard({ hostname }: { hostname: string }) {
     return (
         <Card>
             <CardHeader>
-                <CardTitle>Change the IP</CardTitle>
+                <CardTitle asChild>
+                    <h2>Change the IP</h2>
+                </CardTitle>
                 <CardDescription>
                     Run this command on the Docker host to point Quill&rsquo;s domains (dashboard, db, public, api) at a
                     new IP address.
@@ -129,10 +136,10 @@ function ChangeIpCard({ hostname }: { hostname: string }) {
                     {isInvalidIp && <FieldError>Enter a valid IPv4 address.</FieldError>}
                 </Field>
                 <CopyableCode code={command} language="sh" copyLabel="Copy update-dns command" />
-                <p className="text-xs text-muted-foreground">
+                <Text variant="caption">
                     DNS changes can take a few minutes to propagate. Refresh the current binding above to confirm the
                     update.
-                </p>
+                </Text>
             </CardContent>
         </Card>
     );

--- a/src/Raven.Quill.Web/src/pages/dashboard/ip-configuration.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/ip-configuration.tsx
@@ -77,16 +77,22 @@ export function DashboardIpConfiguration({ hostname = window.location.hostname }
                         >
                             <div className="grid gap-6 sm:grid-cols-2">
                                 <div className="space-y-1">
-                                    <div className="text-xs text-muted-foreground">Domain</div>
-                                    <div className="text-sm font-medium break-all">{hostname}</div>
+                                    <Text as="div" variant="caption">
+                                        Domain
+                                    </Text>
+                                    <Text as="div" variant="label" className="break-all">
+                                        {hostname}
+                                    </Text>
                                 </div>
                                 <div className="space-y-1">
-                                    <div className="text-xs text-muted-foreground">IP address</div>
-                                    <div className="text-sm font-medium tabular-nums">
+                                    <Text as="div" variant="caption">
+                                        IP address
+                                    </Text>
+                                    <Text as="div" variant="label" className="tabular-nums">
                                         {bindingQuery.data?.length
                                             ? bindingQuery.data.join(", ")
                                             : "No DNS record found"}
-                                    </div>
+                                    </Text>
                                 </div>
                             </div>
                         </ApiState>

--- a/src/Raven.Quill.Web/src/pages/dashboard/license.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/license.tsx
@@ -11,6 +11,7 @@ import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle }
 import { formatDate } from "@/lib/format";
 import { getSupportUrl } from "@/lib/help-links";
 import { cn } from "@/lib/utils";
+import { Heading, Text } from "@/components/typography";
 
 // Subtle brand wash used to make the featured plan stand out.
 // Defined as a CSS class (see index.css) so it layers over the card's bg-color.
@@ -22,7 +23,9 @@ export function DashboardLicense() {
     return (
         <div className="space-y-6">
             <div className="flex items-center justify-between gap-3">
-                <h1 className="text-2xl font-semibold tracking-tight">License</h1>
+                <Heading as="h1" variant="page">
+                    License
+                </Heading>
                 <Button
                     variant="outline"
                     size="sm"
@@ -88,10 +91,10 @@ function PlansSection({ plans }: { plans: LicensePlan[] }) {
         <section className="space-y-4">
             <div>
                 <div className="flex items-center gap-2">
-                    <h2 className="text-lg font-semibold">Available plans</h2>
+                    <Heading variant="section">Available plans</Heading>
                     <Badge variant="secondary">Coming soon</Badge>
                 </div>
-                <p className="text-sm text-muted-foreground">Talk to sales to install a license.</p>
+                <Text variant="muted">Talk to sales to install a license.</Text>
             </div>
             <div aria-disabled="true" className="pointer-events-none grid gap-4 opacity-60 grayscale md:grid-cols-3">
                 {plans.map((plan) => (
@@ -106,10 +109,8 @@ function HealthSection({ connectivity }: { connectivity: ConnectivityStatus }) {
     return (
         <section className="space-y-4">
             <div>
-                <h2 className="text-lg font-semibold">License health</h2>
-                <p className="text-sm text-muted-foreground">
-                    Check the status of your license, and connectivity with the API.
-                </p>
+                <Heading variant="section">License health</Heading>
+                <Text variant="muted">Check the status of your license, and connectivity with the API.</Text>
             </div>
             <Card>
                 <CardContent>

--- a/src/Raven.Quill.Web/src/pages/dashboard/license.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/license.tsx
@@ -74,12 +74,20 @@ function LicenseSummaryCard({ license }: { license: ServerLicenseResponse }) {
             </CardHeader>
             <CardContent className="grid gap-6 sm:grid-cols-2">
                 <div className="space-y-1">
-                    <div className="text-xs text-muted-foreground">Expiration date</div>
-                    <div className="text-sm font-medium">{formatDate(license.expiration)}</div>
+                    <Text as="div" variant="caption">
+                        Expiration date
+                    </Text>
+                    <Text as="div" variant="label">
+                        {formatDate(license.expiration)}
+                    </Text>
                 </div>
                 <div className="space-y-1">
-                    <div className="text-xs text-muted-foreground">License ID</div>
-                    <div className="text-sm font-medium tabular-nums">{license.id}</div>
+                    <Text as="div" variant="caption">
+                        License ID
+                    </Text>
+                    <Text as="div" variant="label" className="tabular-nums">
+                        {license.id}
+                    </Text>
                 </div>
             </CardContent>
         </Card>
@@ -136,7 +144,11 @@ function PlanCard({ plan }: { plan: LicensePlan }) {
             <CardContent className="space-y-4">
                 <div className="flex items-baseline gap-1">
                     <span className="text-2xl font-bold">{plan.priceLabel}</span>
-                    {plan.priceSuffix && <span className="text-sm text-muted-foreground">{plan.priceSuffix}</span>}
+                    {plan.priceSuffix && (
+                        <Text as="span" variant="muted">
+                            {plan.priceSuffix}
+                        </Text>
+                    )}
                 </div>
                 <ul className="space-y-2">
                     {plan.features.map((feature) => (

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
@@ -13,6 +13,7 @@ import { canDrillInto, drillInto, formatPeriodLabel, getDefaultDatePeriod, type 
 import { useSetupStartDate } from "@/lib/use-start-date";
 import { formatCompact } from "@/lib/format";
 import { PerAppUsageTable, PerAppUsageTableSkeleton } from "@/pages/dashboard/per-app-usage-table";
+import { Heading } from "@/components/typography";
 
 export function DashboardUsage() {
     const [period, setPeriod] = useState(getDefaultDatePeriod);
@@ -35,14 +36,18 @@ export function DashboardUsage() {
     return (
         <div className="space-y-5">
             <div className="flex items-center justify-between gap-3">
-                <h1 className="text-2xl font-semibold tracking-tight">Usage</h1>
+                <Heading as="h1" variant="page">
+                    Usage
+                </Heading>
                 <DatePeriodPicker value={period} earliest={setupStartDate} onChange={setPeriod} />
             </div>
 
             <Card>
                 <CardHeader>
-                    <CardTitle>
-                        <WruLabel />
+                    <CardTitle asChild>
+                        <h2>
+                            <WruLabel />
+                        </h2>
                     </CardTitle>
                     <CardDescription>{periodLabel}</CardDescription>
                     {totalUsage !== undefined && (
@@ -76,7 +81,9 @@ export function DashboardUsage() {
 
             <Card>
                 <CardHeader>
-                    <CardTitle>Usage per app</CardTitle>
+                    <CardTitle asChild>
+                        <h2>Usage per app</h2>
+                    </CardTitle>
                     <CardDescription>Totals for {periodLabel}.</CardDescription>
                 </CardHeader>
                 <CardContent>

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
@@ -13,7 +13,7 @@ import { canDrillInto, drillInto, formatPeriodLabel, getDefaultDatePeriod, type 
 import { useSetupStartDate } from "@/lib/use-start-date";
 import { formatCompact } from "@/lib/format";
 import { PerAppUsageTable, PerAppUsageTableSkeleton } from "@/pages/dashboard/per-app-usage-table";
-import { Heading } from "@/components/typography";
+import { Heading, Text } from "@/components/typography";
 
 export function DashboardUsage() {
     const [period, setPeriod] = useState(getDefaultDatePeriod);
@@ -54,7 +54,9 @@ export function DashboardUsage() {
                         <CardAction className="text-right">
                             <div className="text-2xl font-semibold">
                                 {formatCompact(totalUsage)}
-                                <span className="ml-1 text-sm font-normal text-muted-foreground">total</span>
+                                <Text as="span" variant="muted" className="ml-1 font-normal">
+                                    total
+                                </Text>
                             </div>
                         </CardAction>
                     )}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/import-config-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/import-config-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/shadcn/ui/dialog";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
+import { Text } from "@/components/typography";
 import { FileDropzone } from "@/components/form/file-dropzone";
 import { WizardErrorAlert } from "@/components/form/wizard/wizard-error-alert";
 import { useImportConfig } from "@/pages/setup/add-app-wizard/steps/connect/use-import-config";
@@ -74,9 +75,9 @@ export function ImportConfigDialog({ disabled }: ImportConfigDialogProps) {
                 {importMutation.isPending ? (
                     <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed px-6 py-8 text-center">
                         <Spinner className="size-6" />
-                        <p className="text-sm text-muted-foreground" aria-live="polite">
+                        <Text variant="muted" aria-live="polite">
                             {progressLabel}
-                        </p>
+                        </Text>
                     </div>
                 ) : (
                     <FileDropzone

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/explorer-rows.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/explorer-rows.tsx
@@ -4,6 +4,7 @@
 
 import { ArrowRight, ChevronDown, ChevronRight, CircleAlert, EllipsisVertical, Layers, Link2 } from "lucide-react";
 import { useFormContext, useFormState, type FieldPath } from "react-hook-form";
+import { Text } from "@/components/typography";
 import { Button } from "@/components/shadcn/ui/button";
 import {
     DropdownMenu,
@@ -41,9 +42,9 @@ export function ExplorerRowItem({ row }: { row: ExplorerRow }) {
 
 export function SchemaRow({ label }: { label: string }) {
     return (
-        <div className="rounded-sm bg-muted px-1.5 py-1 text-center font-mono text-xs text-muted-foreground">
+        <Text variant="caption" as="div" className="rounded-sm bg-muted px-1.5 py-1 text-center font-mono">
             {label}
-        </div>
+        </Text>
     );
 }
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/field-mapping-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/field-mapping-editor.tsx
@@ -6,6 +6,7 @@ import { ExpandableList } from "@/components/data/expandable-list";
 import { FormErrorIcon } from "@/components/form/form-error-icon";
 import { FormInput } from "@/components/form/form-input";
 import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
+import { Text } from "@/components/typography";
 import { Button } from "@/components/shadcn/ui/button";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import type { EmbeddedTablePath, RootTablePath } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-types";
@@ -44,19 +45,19 @@ export function FieldMappingEditor({ path }: FieldMappingEditorProps) {
     return (
         <div className="grid gap-2">
             <div className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-1.5 text-sm font-medium">
+                <Text variant="label" as="div" className="flex items-center gap-1.5">
                     Field mapping
                     <FormErrorIcon control={control} paths={[columnsPath as FieldPath<AppFormData>]} />
-                </div>
+                </Text>
                 <Button type="button" variant="ghost" size="sm" onClick={addFieldMapping}>
                     <Plus className="size-4" aria-hidden="true" />
                     Add field mapping
                 </Button>
             </div>
             {columnsFieldArray.fields.length === 0 ? (
-                <div className="rounded-md border border-dashed px-3 py-2 text-center text-sm text-muted-foreground">
+                <Text variant="muted" as="div" className="rounded-md border border-dashed px-3 py-2 text-center">
                     No field mappings defined.
-                </div>
+                </Text>
             ) : (
                 <div className="grid gap-2">
                     <div className={`${ROW_GRID_CLASS} text-xs text-muted-foreground`}>

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/table-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/table-editor.tsx
@@ -11,6 +11,7 @@ import {
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Label } from "@/components/shadcn/ui/label";
 import { Switch } from "@/components/shadcn/ui/switch";
+import { Text } from "@/components/typography";
 import { cn } from "@/lib/utils";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
@@ -103,8 +104,8 @@ function ActiveTableEditor({ activeTable }: { activeTable: MapActiveTable }) {
 
 function EmptyEditorMessage() {
     return (
-        <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+        <Text variant="muted" as="div" className="flex h-full items-center justify-center p-6">
             Select a table to view its configuration.
-        </div>
+        </Text>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/tables-explorer.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/tables-explorer.tsx
@@ -9,6 +9,7 @@ import { ChevronsDownUp, ChevronsUpDown, Plus } from "lucide-react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { Button } from "@/components/shadcn/ui/button";
 import { Input } from "@/components/shadcn/ui/input";
+import { Text } from "@/components/typography";
 import { useSetupWizardStore } from "@/pages/setup/add-app-wizard/app-wizard-store";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { buildExplorerRows } from "@/pages/setup/add-app-wizard/steps/map-tables/build-explorer-rows";
@@ -39,7 +40,9 @@ export function TablesExplorer() {
     return (
         <div className="flex h-full min-h-0 flex-col gap-2 p-2">
             <div className="flex items-center gap-0.5">
-                <div className="mr-auto px-1 text-sm font-medium">Tables</div>
+                <Text variant="label" as="div" className="mr-auto px-1">
+                    Tables
+                </Text>
                 <Button
                     variant="ghost"
                     size="icon"
@@ -164,5 +167,9 @@ function getActiveSchemaLabel(rows: ExplorerRow[], firstVisibleIndex: number): s
 }
 
 function EmptyExplorerMessage({ children }: { children: React.ReactNode }) {
-    return <div className="px-2 py-6 text-center text-sm text-muted-foreground">{children}</div>;
+    return (
+        <Text variant="muted" as="div" className="px-2 py-6 text-center">
+            {children}
+        </Text>
+    );
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-states.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-states.tsx
@@ -38,7 +38,7 @@ export function NoTablesFound({ schemas, onCustomizeSchemas }: { schemas: string
                 <CircleSlash2Icon className="size-5 text-muted-foreground" aria-hidden="true" />
             </div>
             <div className="text-center">
-                <p className="text-sm font-medium">We didn&apos;t find any tables in {scopeLabel}</p>
+                <Text variant="label">We didn&apos;t find any tables in {scopeLabel}</Text>
                 <Text variant="caption" className="mt-1">
                     Add other schemas to widen the table discovery scope.
                 </Text>

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-states.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/verify/verify-schema-states.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Text } from "@/components/typography";
 import { CircleSlash2Icon, PlusIcon, TriangleAlertIcon } from "lucide-react";
 import { Button } from "@/components/shadcn/ui/button";
 import { Skeleton } from "@/components/shadcn/ui/skeleton";
@@ -38,9 +39,9 @@ export function NoTablesFound({ schemas, onCustomizeSchemas }: { schemas: string
             </div>
             <div className="text-center">
                 <p className="text-sm font-medium">We didn&apos;t find any tables in {scopeLabel}</p>
-                <p className="mt-1 text-xs text-muted-foreground">
+                <Text variant="caption" className="mt-1">
                     Add other schemas to widen the table discovery scope.
-                </p>
+                </Text>
             </div>
             <Button type="button" variant="outline" size="sm" onClick={onCustomizeSchemas}>
                 <PlusIcon aria-hidden="true" />

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/channels/channels-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/channels/channels-step.tsx
@@ -15,5 +15,5 @@ export function ChannelsStep() {
         return <Alert>Create the agent first to add channels.</Alert>;
     }
 
-    return <ChannelsSection slug={slug} agent={createdAgent} />;
+    return <ChannelsSection slug={slug} agent={createdAgent} nested />;
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx
@@ -11,7 +11,8 @@ import { Alert } from "@/components/shadcn/ui/alert";
 import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
 import { AgentPromptProgress } from "@/pages/setup/add-capability-wizard/agent-prompt-progress";
-import { Heading, Text } from "@/components/typography";
+import { SectionHeader } from "@/components/section-header";
+import { Text } from "@/components/typography";
 import { emptyAgentConfiguration } from "@/pages/setup/add-capability-wizard/agent-config-form";
 import { useCapabilityWizardStore } from "@/pages/setup/add-capability-wizard/capability-wizard-store";
 import { SuggestedAgentsProgress } from "@/pages/setup/add-capability-wizard/steps/create/suggested-agents-progress";
@@ -47,9 +48,7 @@ export function CreateAgentStep({ isBusy }: WizardBodyComponentProps) {
     return (
         <div className="grid gap-6">
             <div className="grid gap-3">
-                <Heading as="h2" variant="label">
-                    AI-suggested agents based on your data
-                </Heading>
+                <SectionHeader level="section" title="AI-suggested agents based on your data" />
                 {isSuggesting ? (
                     <SuggestedAgentsProgress startedAt={suggestionStartedAt} />
                 ) : suggestions.length === 0 ? (

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/create/create-agent-step.tsx
@@ -11,6 +11,7 @@ import { Alert } from "@/components/shadcn/ui/alert";
 import type { WizardBodyComponentProps } from "@/components/form/wizard/form-wizard";
 import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capability-wizard-validation";
 import { AgentPromptProgress } from "@/pages/setup/add-capability-wizard/agent-prompt-progress";
+import { Heading, Text } from "@/components/typography";
 import { emptyAgentConfiguration } from "@/pages/setup/add-capability-wizard/agent-config-form";
 import { useCapabilityWizardStore } from "@/pages/setup/add-capability-wizard/capability-wizard-store";
 import { SuggestedAgentsProgress } from "@/pages/setup/add-capability-wizard/steps/create/suggested-agents-progress";
@@ -46,7 +47,9 @@ export function CreateAgentStep({ isBusy }: WizardBodyComponentProps) {
     return (
         <div className="grid gap-6">
             <div className="grid gap-3">
-                <h3 className="text-sm font-semibold">AI-suggested agents based on your data</h3>
+                <Heading as="h2" variant="label">
+                    AI-suggested agents based on your data
+                </Heading>
                 {isSuggesting ? (
                     <SuggestedAgentsProgress startedAt={suggestionStartedAt} />
                 ) : suggestions.length === 0 ? (
@@ -80,7 +83,9 @@ export function CreateAgentStep({ isBusy }: WizardBodyComponentProps) {
             </div>
 
             <div className="grid gap-3">
-                <p className="text-center text-xs text-muted-foreground">or</p>
+                <Text variant="caption" className="text-center">
+                    or
+                </Text>
                 <button
                     type="button"
                     aria-pressed={mode === "manual"}

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-actions-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-actions-section.tsx
@@ -26,7 +26,9 @@ export function AgentActionsSection({ className }: { className?: string }) {
             <div className="flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
                     <Webhook className="size-4 text-muted-foreground" />
-                    <span className="text-sm font-medium">Actions</span>
+                    <Text variant="label" as="span">
+                        Actions
+                    </Text>
                 </div>
                 <Button variant="outline" size="sm" onClick={() => fieldArray.append(emptyAgentAction())}>
                     <Plus />
@@ -61,7 +63,9 @@ function ActionItem({ index, remove }: { index: number; remove: () => void }) {
             editTitle="Configure action"
             summary={
                 <>
-                    <p className="truncate text-sm font-medium">{action.name || "(unnamed)"}</p>
+                    <Text variant="label" className="truncate">
+                        {action.name || "(unnamed)"}
+                    </Text>
                     {action.url && (
                         <Text variant="caption" className="mt-0.5 truncate">
                             {action.url}

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-actions-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-actions-section.tsx
@@ -1,4 +1,5 @@
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { Text } from "@/components/typography";
 import { Plus, Webhook } from "lucide-react";
 import { Button } from "@/components/shadcn/ui/button";
 import { FormInput } from "@/components/form/form-input";
@@ -61,7 +62,11 @@ function ActionItem({ index, remove }: { index: number; remove: () => void }) {
             summary={
                 <>
                     <p className="truncate text-sm font-medium">{action.name || "(unnamed)"}</p>
-                    {action.url && <p className="mt-0.5 truncate text-xs text-muted-foreground">{action.url}</p>}
+                    {action.url && (
+                        <Text variant="caption" className="mt-0.5 truncate">
+                            {action.url}
+                        </Text>
+                    )}
                 </>
             }
             onToggleExpanded={(isExpanded) => setValue(`review.actions.${index}.isExpanded`, isExpanded)}

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-configuration-tab.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-configuration-tab.tsx
@@ -6,6 +6,7 @@ import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capabili
 import { AgentActionsSection } from "@/pages/setup/add-capability-wizard/steps/review/agent-actions-section";
 import { AgentParametersSection } from "@/pages/setup/add-capability-wizard/steps/review/agent-parameters-section";
 import { AgentQueryToolsSection } from "@/pages/setup/add-capability-wizard/steps/review/agent-query-tools-section";
+import { Heading, Text } from "@/components/typography";
 
 export const SYSTEM_PROMPT_PLACEHOLDER =
     "Describe the agent's purpose and capabilities. " +
@@ -82,8 +83,12 @@ function ConfigurationSection({
     return (
         <section className="grid gap-3">
             <div>
-                <h3 className="text-sm font-semibold">{title}</h3>
-                <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+                <Heading as="h2" variant="section">
+                    {title}
+                </Heading>
+                <Text variant="caption" className="mt-1">
+                    {description}
+                </Text>
             </div>
             {children}
         </section>

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-configuration-tab.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-configuration-tab.tsx
@@ -6,7 +6,7 @@ import type { AgentFormData } from "@/pages/setup/add-capability-wizard/capabili
 import { AgentActionsSection } from "@/pages/setup/add-capability-wizard/steps/review/agent-actions-section";
 import { AgentParametersSection } from "@/pages/setup/add-capability-wizard/steps/review/agent-parameters-section";
 import { AgentQueryToolsSection } from "@/pages/setup/add-capability-wizard/steps/review/agent-query-tools-section";
-import { Heading, Text } from "@/components/typography";
+import { SectionHeader } from "@/components/section-header";
 
 export const SYSTEM_PROMPT_PLACEHOLDER =
     "Describe the agent's purpose and capabilities. " +
@@ -82,14 +82,7 @@ function ConfigurationSection({
 }) {
     return (
         <section className="grid gap-3">
-            <div>
-                <Heading as="h2" variant="section">
-                    {title}
-                </Heading>
-                <Text variant="caption" className="mt-1">
-                    {description}
-                </Text>
-            </div>
+            <SectionHeader level="section" title={title} description={description} />
             {children}
         </section>
     );

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-parameters-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-parameters-section.tsx
@@ -1,4 +1,5 @@
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { Text } from "@/components/typography";
 import { Plus, Settings2 } from "lucide-react";
 import { Button } from "@/components/shadcn/ui/button";
 import { FormInput } from "@/components/form/form-input";
@@ -81,7 +82,9 @@ function ParameterItem({ index, remove }: { index: number; remove: () => void })
                         </span>
                     </div>
                     {parameter.description && (
-                        <p className="mt-0.5 truncate text-xs text-muted-foreground">{parameter.description}</p>
+                        <Text variant="caption" className="mt-0.5 truncate">
+                            {parameter.description}
+                        </Text>
                     )}
                 </>
             }

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-parameters-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-parameters-section.tsx
@@ -39,7 +39,9 @@ export function AgentParametersSection({ className }: { className?: string }) {
             <div className="flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
                     <Settings2 className="size-4 text-muted-foreground" />
-                    <span className="text-sm font-medium">Agent parameters</span>
+                    <Text variant="label" as="span">
+                        Agent parameters
+                    </Text>
                 </div>
                 <Button variant="outline" size="sm" onClick={() => fieldArray.append(emptyAgentParameter())}>
                     <Plus />
@@ -75,11 +77,15 @@ function ParameterItem({ index, remove }: { index: number; remove: () => void })
             summary={
                 <>
                     <div className="flex min-w-0 items-center gap-2">
-                        <span className="truncate text-sm font-medium">{parameter.name || "(unnamed)"}</span>
-                        <span className="text-xs text-muted-foreground">|</span>
-                        <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                        <Text variant="label" as="span" className="truncate">
+                            {parameter.name || "(unnamed)"}
+                        </Text>
+                        <Text variant="caption" as="span">
+                            |
+                        </Text>
+                        <Text variant="caption" as="span" className="shrink-0 font-mono">
                             {getParameterTypeLabel(parameter.type)}
-                        </span>
+                        </Text>
                     </div>
                     {parameter.description && (
                         <Text variant="caption" className="mt-0.5 truncate">

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-query-tools-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-query-tools-section.tsx
@@ -1,4 +1,5 @@
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { Text } from "@/components/typography";
 import { Plus, SearchCode } from "lucide-react";
 import { Button } from "@/components/shadcn/ui/button";
 import { FormAceEditor } from "@/components/form/form-ace-editor";
@@ -73,7 +74,9 @@ function QueryToolItem({ index, remove }: { index: number; remove: () => void })
                 <>
                     <p className="truncate text-sm font-medium">{tool.name || "(unnamed)"}</p>
                     {tool.description && (
-                        <p className="mt-0.5 truncate text-xs text-muted-foreground">{tool.description}</p>
+                        <Text variant="caption" className="mt-0.5 truncate">
+                            {tool.description}
+                        </Text>
                     )}
                 </>
             }

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-query-tools-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-query-tools-section.tsx
@@ -37,7 +37,9 @@ export function AgentQueryToolsSection({ className }: { className?: string }) {
             <div className="flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
                     <SearchCode className="size-4 text-muted-foreground" />
-                    <span className="text-sm font-medium">Query tools</span>
+                    <Text variant="label" as="span">
+                        Query tools
+                    </Text>
                 </div>
                 <Button variant="outline" size="sm" onClick={() => fieldArray.append(emptyAgentQueryTool())}>
                     <Plus />
@@ -72,7 +74,9 @@ function QueryToolItem({ index, remove }: { index: number; remove: () => void })
             editTitle="Configure query tool"
             summary={
                 <>
-                    <p className="truncate text-sm font-medium">{tool.name || "(unnamed)"}</p>
+                    <Text variant="label" className="truncate">
+                        {tool.name || "(unnamed)"}
+                    </Text>
                     {tool.description && (
                         <Text variant="caption" className="mt-0.5 truncate">
                             {tool.description}

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-suggestion-tab.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/agent-suggestion-tab.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { Sparkles } from "lucide-react";
+import { Text } from "@/components/typography";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
@@ -29,10 +30,10 @@ export function AgentSuggestionTab() {
             {mode === "prompt" ? <PromptEditor /> : <SuggestionPicker />}
 
             <div className="grid gap-2">
-                <div className="flex items-center gap-2 text-sm font-medium">
+                <Text variant="label" as="div" className="flex items-center gap-2">
                     <Sparkles className="size-4" />
                     Agent summary
-                </div>
+                </Text>
                 <div className="flex flex-col divide-y rounded-lg border bg-background px-4">
                     <SummaryRow label="Agent name">{config.name || "—"}</SummaryRow>
                     <SummaryRow label="System prompt">
@@ -41,7 +42,9 @@ export function AgentSuggestionTab() {
                                 {systemPrompt}
                             </ExpandableText>
                         ) : (
-                            <span className="text-sm text-muted-foreground">—</span>
+                            <Text variant="muted" as="span">
+                                —
+                            </Text>
                         )}
                     </SummaryRow>
                     <SummaryRow label="Connection string">{connectionStringName || "—"}</SummaryRow>
@@ -102,7 +105,9 @@ function PromptEditor() {
 function SummaryRow({ label, children }: { label: string; children: ReactNode }) {
     return (
         <div className="flex min-h-12 items-center justify-between gap-12 py-3">
-            <span className="shrink-0 text-sm font-medium">{label}</span>
+            <Text variant="label" as="span" className="shrink-0">
+                {label}
+            </Text>
             <div className="flex min-w-0 justify-end text-sm">{children}</div>
         </div>
     );

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/config-item-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/config-item-card.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { ChevronDown, ChevronUp, Trash2 } from "lucide-react";
 import { Button } from "@/components/shadcn/ui/button";
 import { Separator } from "@/components/shadcn/ui/separator";
+import { Text } from "@/components/typography";
 
 type ConfigItemCardProps = {
     isExpanded: boolean;
@@ -63,8 +64,12 @@ export function ConfigItemCard({
 
 export function ConfigListEmpty({ label }: { label: string }) {
     return (
-        <div className="flex items-center justify-center rounded-md border border-dashed py-6 text-xs text-muted-foreground">
+        <Text
+            variant="caption"
+            as="div"
+            className="flex items-center justify-center rounded-md border border-dashed py-6"
+        >
             {label}
-        </div>
+        </Text>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
@@ -411,10 +411,10 @@ function TestParametersSection({
                 aria-expanded={!isCollapsed}
                 onClick={onToggleCollapsed}
             >
-                <span className="flex items-center gap-2 text-sm font-medium">
+                <Text variant="label" as="span" className="flex items-center gap-2">
                     <Settings2 className="size-4 text-muted-foreground" aria-hidden />
                     Parameters
-                </span>
+                </Text>
                 {isCollapsed ? (
                     <ChevronDown className="size-4 text-muted-foreground" aria-hidden />
                 ) : (
@@ -435,9 +435,9 @@ function TestParametersSection({
                         return (
                             <div key={field.id} className="grid gap-2 rounded-md border p-3">
                                 <div className="flex items-center justify-between gap-3">
-                                    <span className="truncate text-sm font-medium" title={field.name}>
+                                    <Text variant="label" as="span" className="truncate" title={field.name}>
                                         {field.name}
-                                    </span>
+                                    </Text>
                                     <FormSwitch
                                         control={control}
                                         name={`parameters.${index}.isSendToModel`}
@@ -508,10 +508,10 @@ function AgentAnswer({ message, isLoading }: { message: ChatMessage; isLoading: 
             <Bot className="mt-2 size-4 shrink-0 text-muted-foreground" aria-hidden />
             <div className="min-w-0 flex-1">
                 {isLoading && (
-                    <div className="mt-2 mb-1.5 flex items-center gap-2 text-xs text-muted-foreground">
+                    <Text variant="caption" as="div" className="mt-2 mb-1.5 flex items-center gap-2">
                         <Spinner className="size-3" />
                         <span>Generating response…</span>
-                    </div>
+                    </Text>
                 )}
                 {message.toolCalls && message.toolCalls.length > 0 && (
                     <div className="mb-2 grid gap-2">

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-sheet.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Text } from "@/components/typography";
 import { type Control, useFieldArray, useForm, useFormContext, useWatch } from "react-hook-form";
 import { useParams } from "react-router";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -421,7 +422,9 @@ function TestParametersSection({
                 )}
             </button>
             {isCollapsed ? (
-                <p className="truncate text-xs text-muted-foreground">{summary}</p>
+                <Text variant="caption" className="truncate">
+                    {summary}
+                </Text>
             ) : (
                 <div className="grid gap-2">
                     {fields.map((field, index) => {

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Text } from "@/components/typography";
 import { ChevronDown, ChevronUp, Database } from "lucide-react";
 import type { AgentToolCall } from "@/api/custom-services/agent-stream";
 import AceEditor from "@/components/ace-editor/ace-editor";
@@ -31,7 +32,7 @@ export function TestQueryToolCall({ toolCall }: { toolCall: AgentToolCall }) {
 
             {isExpanded && (
                 <div className="grid gap-3 border-t p-2">
-                    {toolCall.description && <p className="text-xs text-muted-foreground">{toolCall.description}</p>}
+                    {toolCall.description && <Text variant="caption">{toolCall.description}</Text>}
                     {toolCall.query && <CodeField label="Query" value={toolCall.query} mode="sql" height="80px" />}
                     <CodeField
                         label="Parameters filled by the model"

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call.tsx
@@ -72,7 +72,9 @@ function CodeField({
 }) {
     return (
         <div className="grid gap-1">
-            <span className="text-xs text-muted-foreground">{label}</span>
+            <Text variant="caption" as="span">
+                {label}
+            </Text>
             <div className="overflow-hidden rounded-md border">
                 <AceEditor mode={mode} value={value} readOnly height={height} maxHeight={300} />
             </div>

--- a/src/Raven.Quill.Web/src/pages/utility/ai-page.tsx
+++ b/src/Raven.Quill.Web/src/pages/utility/ai-page.tsx
@@ -2,6 +2,7 @@ import { Bot, Send } from "lucide-react";
 import { PagePanel } from "@/components/data/page-panel";
 import { Button } from "@/components/shadcn/ui/button";
 import { Textarea } from "@/components/shadcn/ui/textarea";
+import { Heading } from "@/components/typography";
 
 export function AiPage() {
     return (
@@ -9,7 +10,7 @@ export function AiPage() {
             <div className="mx-auto flex h-[36rem] max-h-[80vh] w-full max-w-3xl flex-col overflow-hidden rounded-lg border bg-card">
                 <header className="flex items-center gap-2 border-b px-4 py-3">
                     <Bot className="size-5 text-primary-strong" aria-hidden />
-                    <h2 className="text-sm font-semibold">AI Assistant</h2>
+                    <Heading variant="label">AI Assistant</Heading>
                 </header>
 
                 <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">

--- a/src/Raven.Quill.Web/src/pages/utility/ai-page.tsx
+++ b/src/Raven.Quill.Web/src/pages/utility/ai-page.tsx
@@ -2,7 +2,7 @@ import { Bot, Send } from "lucide-react";
 import { PagePanel } from "@/components/data/page-panel";
 import { Button } from "@/components/shadcn/ui/button";
 import { Textarea } from "@/components/shadcn/ui/textarea";
-import { Heading } from "@/components/typography";
+import { Heading, Text } from "@/components/typography";
 
 export function AiPage() {
     return (
@@ -18,7 +18,7 @@ export function AiPage() {
                         <Bot className="size-6 text-muted-foreground" aria-hidden />
                     </div>
                     <div className="max-w-sm space-y-1">
-                        <p className="text-sm font-medium">AI Assistant is coming soon</p>
+                        <Text variant="label">AI Assistant is coming soon</Text>
                     </div>
                 </div>
 

--- a/src/Raven.Quill.Web/src/pages/utility/simple-info-page.tsx
+++ b/src/Raven.Quill.Web/src/pages/utility/simple-info-page.tsx
@@ -1,4 +1,5 @@
 import { PagePanel } from "@/components/data/page-panel";
+import { Heading, Text } from "@/components/typography";
 
 type SimpleInfoPageProps = {
     title: string;
@@ -9,8 +10,8 @@ export function SimpleInfoPage({ description, title }: SimpleInfoPageProps) {
     return (
         <PagePanel>
             <div className="max-w-2xl space-y-2">
-                <h2 className="text-base font-semibold">{title}</h2>
-                <p className="text-sm text-muted-foreground">{description}</p>
+                <Heading variant="subsection">{title}</Heading>
+                <Text variant="muted">{description}</Text>
             </div>
         </PagePanel>
     );


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27389

### Additional description

- Added a small `cva`-based typography system (`typography.tsx`) as the single source of truth, following the existing button/badge convention. No new dependencies:
- `Heading` — as sets the tag, variant sets the size: `page` (2xl), `title` (xl), section (lg), `subsection` (base), `label` (sm).
- `Text` — supporting copy: `body`, `muted`, `caption`, `label`.
- Converted all ~45 headings to `<Heading>` and 57 supporting-copy paragraphs to `<Text>`.
- Aligned shadcn overlay/card titles (`CardTitle`, `DialogTitle`, `SheetTitle`, `AlertDialogTitle`) to the same look; `CardTitle` gained `asChild` for semantic section headings.
- A11y: one `<h1>` per page, no skipped levels; wizard step titles are `<h1>`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
 Visual only, no functional change. Because shared UI primitives were touched, the appearance updates everywhere they're used:

- Modal, sheet, and card titles (Dialog/Sheet/AlertDialog/Card) now render semibold + tracking-tight (were medium).
- Section/sub-section headings across all pages adopt the new size scale.
- Radio-card labels (e.g. the data-source picker) are pinned to a consistent size.
- No behavior, data, or API changes.
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
