### PR TITLE
Disable HNSW vector node cache on encrypted databases

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -668,7 +668,8 @@ namespace Raven.Server.Config.Categories
 
         [Description("The maximum amount of memory for the HNSW vector search node cache per index. " +
                      "This cache pre-loads upper-level graph nodes to accelerate vector queries. " +
-                     "Changing this value does not require re-indexing.")]
+                     "Changing this value does not require re-indexing. " +
+                     "The cache is incompatible with encrypted databases; there it is ignored and vector search reads from disk.")]
         [DefaultValue(10)]
         [SizeUnit(SizeUnit.Megabytes)]
         [IndexUpdateType(IndexUpdateType.Refresh)]

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -47,6 +47,11 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     private int GetMaxNodesForVectorCache()
     {
+        // The cache is incompatible with encrypted databases: it reads through the committed
+        // write tx, whose pages are already encrypted by then. Encrypted databases read from disk.
+        if (_environment?.Options.Encryption.IsEnabled == true)
+            return 0;
+
         var cacheSizeBytes = _index.Configuration.CoraxVectorSearchCacheSize.GetValue(SizeUnit.Bytes);
         var bytesPerNode = HnswIndexCache.EstimateBytesPerNode(_index.Configuration.CoraxVectorDefaultNumberOfEdges);
         return (int)Math.Min(cacheSizeBytes / bytesPerNode, int.MaxValue);
@@ -208,11 +213,12 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     public override void Initialize(StorageEnvironment environment)
     {
+        _environment = environment;
+
         using (var roTx = environment.ReadTransaction())
             WarmInitialCaches(roTx);
         _currentCache = BuildSnapshotWrapper();
 
-        _environment = environment;
         _newTransactionCreatedHandler = tx => tx.ImmutableExternalState = Volatile.Read(ref _currentCache);
         environment.NewTransactionCreated += _newTransactionCreatedHandler;
     }

--- a/test/SlowTests/Corax/Vectors/VectorIndexOnEncryptedDatabase.cs
+++ b/test/SlowTests/Corax/Vectors/VectorIndexOnEncryptedDatabase.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Corax.Vectors;
+
+// The HNSW node cache is rebuilt from the post-commit hook, which reads through the committed
+// write tx; on encrypted storage those pages were already encrypted in place for the journal.
+// Encrypted databases therefore run vector indexes cache-less: indexing must complete without
+// errors and queries must resolve from disk.
+public class VectorIndexOnEncryptedDatabase(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenMultiplatformFact(RavenTestCategory.Corax | RavenTestCategory.Vector | RavenTestCategory.Encryption, RavenArchitecture.AllX64, LicenseRequired = true)]
+    public async Task VectorIndexOnEncryptedDatabaseIndexesAndQueries()
+    {
+        var databaseName = Encryption.SetupEncryptedDatabase(out var certificates, out _);
+
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        options.AdminCertificate = certificates.ServerCertificate.Value;
+        options.ClientCertificate = certificates.ServerCertificate.Value;
+        options.ModifyDatabaseName = _ => databaseName;
+        options.ModifyDatabaseRecord += r => r.Encrypted = true;
+
+        using var store = GetDocumentStore(options);
+
+        var random = new Random(42);
+        var first = new float[] { 1f, 0f, 0f, 0f, 0f, 0f, 0f, 0f };
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Document { Embeddings = first });
+            for (int i = 0; i < 200; i++)
+            {
+                var v = new float[8];
+                for (int j = 0; j < v.Length; j++)
+                    v[j] = (float)(random.NextDouble() * 2 - 1);
+                await session.StoreAsync(new Document { Embeddings = v });
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        await new NumericalVectorIndex().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
+        Assert.Null(Indexes.WaitForIndexingErrors(store, errorsShouldExists: false));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<Document, NumericalVectorIndex>()
+                .VectorSearch(x => x.WithField(f => f.Vector), f => f.ByEmbedding(first), 0.99f)
+                .ToListAsync();
+
+            Assert.NotEmpty(results);
+        }
+    }
+
+    private class NumericalVectorIndex : AbstractIndexCreationTask<Document>
+    {
+        public NumericalVectorIndex()
+        {
+            Map = docs => from doc in docs
+                select new { Vector = CreateVector(doc.Embeddings) };
+
+            VectorIndexes.Add(x => x.Vector, new VectorOptions { SourceEmbeddingType = VectorEmbeddingType.Single });
+        }
+    }
+
+    private class Document
+    {
+        public string Id { get; set; }
+        public float[] Embeddings { get; set; }
+        public object Vector { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes #23447.

On encrypted databases every static Corax vector index errors on its first indexing batch in 7.2.5. CryptoPager re-encrypts a write transaction's page buffers in place at commit, and the HNSW node cache warm-up (RecreateSearcher, WarmFromScratch) runs after commit through that same transaction, so it reads ciphertext. All the reported signatures (NRE in WarmFromScratch, "Bad variable size int", huge NativeList capacities, AOOR, journal-flush catastrophic failure) are that ciphertext flowing downstream.

The fix disables the node cache when the storage environment is encrypted: GetMaxNodesForVectorCache returns 0, which routes through the existing CacheSizeInMb=0 paths, so encrypted databases run vector search from disk exactly as 7.1 did. Initialize assigns the environment before the startup warm-up so the guard also covers that path. The config description now states the incompatibility.

Includes a regression test (VectorIndexOnEncryptedDatabaseIndexesAndQueries) using Encryption.SetupEncryptedDatabase with LicenseRequired = true. With the guard removed it fails with the production stack (NRE at HnswIndexCache.WarmFromScratch via RecreateSearcher in CommitStage3, index marked Critical); with the guard it passes; without a license it skips.

Not addressed here: the cache's append-only buffer exhausts under churn and the cache permanently decays to empty. Unencrypted-only, observed in a standalone harness, worth its own issue.
