### PR TITLE
RavenDB-27427 Disable HNSW vector node cache on encrypted databases

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -668,7 +668,8 @@ namespace Raven.Server.Config.Categories
 
         [Description("The maximum amount of memory for the HNSW vector search node cache per index. " +
                      "This cache pre-loads upper-level graph nodes to accelerate vector queries. " +
-                     "Changing this value does not require re-indexing.")]
+                     "Changing this value does not require re-indexing. " +
+                     "The cache is incompatible with encrypted databases; there it is ignored and vector search reads from disk.")]
         [DefaultValue(10)]
         [SizeUnit(SizeUnit.Megabytes)]
         [IndexUpdateType(IndexUpdateType.Refresh)]

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -47,6 +47,11 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     private int GetMaxNodesForVectorCache()
     {
+        // The cache is incompatible with encrypted databases: it reads through the committed
+        // write tx, whose pages are already encrypted by then. Encrypted databases read from disk.
+        if (_environment?.Options.Encryption.IsEnabled == true)
+            return 0;
+
         var cacheSizeBytes = _index.Configuration.CoraxVectorSearchCacheSize.GetValue(SizeUnit.Bytes);
         var bytesPerNode = HnswIndexCache.EstimateBytesPerNode(_index.Configuration.CoraxVectorDefaultNumberOfEdges);
         return (int)Math.Min(cacheSizeBytes / bytesPerNode, int.MaxValue);
@@ -208,11 +213,12 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     public override void Initialize(StorageEnvironment environment)
     {
+        _environment = environment;
+
         using (var roTx = environment.ReadTransaction())
             WarmInitialCaches(roTx);
         _currentCache = BuildSnapshotWrapper();
 
-        _environment = environment;
         _newTransactionCreatedHandler = tx => tx.ImmutableExternalState = Volatile.Read(ref _currentCache);
         environment.NewTransactionCreated += _newTransactionCreatedHandler;
     }

--- a/test/SlowTests/Corax/Vectors/VectorIndexOnEncryptedDatabase.cs
+++ b/test/SlowTests/Corax/Vectors/VectorIndexOnEncryptedDatabase.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Corax.Vectors;
+
+// The HNSW node cache is rebuilt from the post-commit hook, which reads through the committed
+// write tx; on encrypted storage those pages were already encrypted in place for the journal.
+// Encrypted databases therefore run vector indexes cache-less: indexing must complete without
+// errors and queries must resolve from disk.
+public class VectorIndexOnEncryptedDatabase(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenMultiplatformFact(RavenTestCategory.Corax | RavenTestCategory.Vector | RavenTestCategory.Encryption, RavenArchitecture.AllX64, LicenseRequired = true)]
+    public async Task VectorIndexOnEncryptedDatabaseIndexesAndQueries()
+    {
+        var databaseName = Encryption.SetupEncryptedDatabase(out var certificates, out _);
+
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        options.AdminCertificate = certificates.ServerCertificate.Value;
+        options.ClientCertificate = certificates.ServerCertificate.Value;
+        options.ModifyDatabaseName = _ => databaseName;
+        options.ModifyDatabaseRecord += r => r.Encrypted = true;
+
+        using var store = GetDocumentStore(options);
+
+        var random = new Random(42);
+        var first = new float[] { 1f, 0f, 0f, 0f, 0f, 0f, 0f, 0f };
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Document { Embeddings = first });
+            for (int i = 0; i < 200; i++)
+            {
+                var v = new float[8];
+                for (int j = 0; j < v.Length; j++)
+                    v[j] = (float)(random.NextDouble() * 2 - 1);
+                await session.StoreAsync(new Document { Embeddings = v });
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        await new NumericalVectorIndex().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
+        Assert.Null(Indexes.WaitForIndexingErrors(store, errorsShouldExists: false));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<Document, NumericalVectorIndex>()
+                .VectorSearch(x => x.WithField(f => f.Vector), f => f.ByEmbedding(first), 0.99f)
+                .ToListAsync();
+
+            Assert.NotEmpty(results);
+        }
+    }
+
+    private class NumericalVectorIndex : AbstractIndexCreationTask<Document>
+    {
+        public NumericalVectorIndex()
+        {
+            Map = docs => from doc in docs
+                select new { Vector = CreateVector(doc.Embeddings) };
+
+            VectorIndexes.Add(x => x.Vector, new VectorOptions { SourceEmbeddingType = VectorEmbeddingType.Single });
+        }
+    }
+
+    private class Document
+    {
+        public string Id { get; set; }
+        public float[] Embeddings { get; set; }
+        public object Vector { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27427

### Additional description

On encrypted databases every static Corax vector index errors on its first indexing batch in 7.2.5. CryptoPager re-encrypts a write transaction's page buffers in place at commit, and the HNSW node cache warm-up (RecreateSearcher, WarmFromScratch) runs after commit through that same transaction, so it reads ciphertext. All reported signatures (NRE in WarmFromScratch, "Bad variable size int", huge NativeList capacities, AOOR, journal-flush catastrophic failure) are that ciphertext flowing downstream. There is no on-disk damage; the failure is read-side only.

The fix disables the node cache when the storage environment is encrypted: GetMaxNodesForVectorCache returns 0, routing through the existing CacheSizeInMb=0 paths, so encrypted databases run vector search from disk exactly as 7.1 did. Initialize assigns the environment before the startup warm-up so the guard also covers that path. The config description now states the incompatibility.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

On encrypted databases Indexing.Corax.VectorSearch.CacheSizeInMb is ignored and vector search reads from disk (7.1 behavior). Unencrypted databases are unchanged.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
