### PR TITLE
RavenDB-27332 Quill - Compact source database type options and remove the default selection

### DIFF
--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.tsx
@@ -1,6 +1,5 @@
 import { AppWizard } from "@/pages/setup/add-app-wizard/app-wizard";
 import { type AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
-import { DEFAULT_PORT_BY_PROVIDER, DEFAULT_PROVIDER } from "@/pages/setup/add-app-wizard/connection-string";
 
 export function AddAppWizard() {
     return <AppWizard defaultValues={getDefaultValues()} />;
@@ -14,11 +13,11 @@ function getDefaultValues(): AppFormData {
         externalConnection: {
             appName: "",
             slug: "",
-            provider: DEFAULT_PROVIDER,
+            provider: "",
             mode: "fields",
             fields: {
                 host: "",
-                port: DEFAULT_PORT_BY_PROVIDER[DEFAULT_PROVIDER],
+                port: null,
                 database: "",
                 username: "",
                 password: "",

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
@@ -260,12 +260,22 @@ export const createExternalConnectionSchema = (takenSlugs: string[] = []) => {
         .object({
             appName: z.string().trim().min(1, "Application name is required"),
             slug: slugSchema,
-            provider: providerSchema,
+            // Empty until the operator picks a source database type; superRefine rejects it so the
+            // connect step can't advance without a choice.
+            provider: providerSchema.or(z.literal("")),
             mode: connectionModeSchema,
             fields: z.object(connectionFieldsShape),
             connectionString: z.string(),
         })
         .superRefine((values, ctx) => {
+            if (values.provider === "") {
+                ctx.addIssue({
+                    code: "custom",
+                    path: ["provider"],
+                    message: "Select a source database type",
+                });
+            }
+
             const overrideSlug = values.slug.trim();
             // With an empty override the server derives the slug from the app name, so the name is
             // what has to be changed to free up the conflict.

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/connection-string.ts
@@ -1,7 +1,8 @@
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 
 type ExternalConnection = AppFormData["externalConnection"];
-type Provider = ExternalConnection["provider"];
+/** The chosen source database. The form's provider field also allows "" while unselected. */
+export type Provider = Exclude<ExternalConnection["provider"], "">;
 
 export type SslMode = ExternalConnection["fields"]["ssl"];
 
@@ -50,7 +51,12 @@ const SSL_BY_PROVIDER: Record<Provider, { keyword: string; require: string; disa
     MySqlConnectorFactory: { keyword: "SslMode", require: "Required", disable: "None" },
 };
 
-export function buildConnectionString(provider: Provider, values: ConnectionValues): string {
+export function buildConnectionString(provider: Provider | "", values: ConnectionValues): string {
+    // No provider chosen yet - there is no dialect to build a string in.
+    if (provider === "") {
+        return "";
+    }
+
     const keywords = KEYWORDS_BY_PROVIDER[provider];
     const host = values.host.trim();
     const hostValue = provider === "SqlClient" && values.port != null ? `${host},${values.port}` : host;

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/edit-app-values.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/edit-app-values.ts
@@ -1,7 +1,11 @@
 import type { AppCdcConfigurationResponse, ApplianceAppResponse } from "@/api/generated/server-api";
 import { type AppFormData, tablesSchema } from "@/pages/setup/add-app-wizard/app-wizard-validation";
 import { collectConfigSchemas } from "@/pages/setup/add-app-wizard/config-io";
-import { DEFAULT_PORT_BY_PROVIDER, parseConnectionString } from "@/pages/setup/add-app-wizard/connection-string";
+import {
+    DEFAULT_PORT_BY_PROVIDER,
+    type Provider,
+    parseConnectionString,
+} from "@/pages/setup/add-app-wizard/connection-string";
 import { resolveProviderFromSourceType } from "@/pages/setup/add-app-wizard/steps/connect/connect-source-options";
 import { wrapDtoTablesToFormShape } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-dto";
 import { getSourceTableLabel } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-utils";
@@ -63,7 +67,6 @@ export function buildEditAppSeed(
     };
 }
 
-type Provider = AppFormData["externalConnection"]["provider"];
 type ConnectionSeed = Pick<AppFormData["externalConnection"], "mode" | "fields" | "connectionString">;
 
 /** Mirrors the config import: parsed fields when the stored string parses cleanly, the raw string

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-options.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-options.tsx
@@ -1,9 +1,6 @@
 import type { ReactNode } from "react";
-import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
-import { DEFAULT_PROVIDER } from "@/pages/setup/add-app-wizard/connection-string";
+import { DEFAULT_PROVIDER, type Provider } from "@/pages/setup/add-app-wizard/connection-string";
 import { MySqlIcon, PostgreSqlIcon, SqlServerIcon } from "@/pages/setup/add-app-wizard/steps/connect/provider-icons";
-
-type Provider = AppFormData["externalConnection"]["provider"];
 
 type ProviderOption = {
     value: Provider;
@@ -15,17 +12,17 @@ export const PROVIDER_OPTIONS: ProviderOption[] = [
     {
         value: "Npgsql",
         label: "PostgreSQL",
-        icon: <PostgreSqlIcon className="size-8" />,
+        icon: <PostgreSqlIcon className="size-5 shrink-0" />,
     },
     {
         value: "SqlClient",
         label: "SQL Server",
-        icon: <SqlServerIcon className="size-8" />,
+        icon: <SqlServerIcon className="size-5 shrink-0" />,
     },
     {
         value: "MySqlConnectorFactory",
         label: "MySQL",
-        icon: <MySqlIcon className="size-8" />,
+        icon: <MySqlIcon className="size-5 shrink-0" />,
     },
 ];
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
@@ -92,7 +92,7 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
                                 }
                                 disabled={isBusy}
                                 className={cn(
-                                    "flex min-h-28 flex-col items-center justify-center gap-3 rounded-lg border bg-background p-4 transition-colors",
+                                    "flex items-center gap-3 rounded-lg border bg-background px-4 py-3 transition-colors",
                                     isSelected && SELECTED_CARD_CLASSES,
                                     !isSelected && !isBusy && "hover:bg-accent hover:text-accent-foreground",
                                     isBusy && "cursor-not-allowed opacity-55",

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connection-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connection-editor.tsx
@@ -4,10 +4,8 @@ import { FormTextarea } from "@/components/form/form-textarea";
 import { FormToggleGroup, type FormToggleGroupOption } from "@/components/form/form-toggle-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/ui/tabs";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
-import { DEFAULT_PORT_BY_PROVIDER, type SslMode } from "@/pages/setup/add-app-wizard/connection-string";
+import { DEFAULT_PORT_BY_PROVIDER, type Provider, type SslMode } from "@/pages/setup/add-app-wizard/connection-string";
 import { useConnectionSync } from "@/pages/setup/add-app-wizard/steps/connect/use-connection-sync";
-
-type Provider = AppFormData["externalConnection"]["provider"];
 
 const CONNECTION_STRING_PLACEHOLDER_BY_PROVIDER: Record<Provider, string> = {
     Npgsql: "Host=localhost;Port=5432;Database=my_db;Username=admin;Password=pass",
@@ -71,7 +69,7 @@ function ConnectionFieldsEditor({ isDisabled }: { isDisabled: boolean }) {
                     name="externalConnection.fields.port"
                     label="Port"
                     type="number"
-                    placeholder={String(DEFAULT_PORT_BY_PROVIDER[provider])}
+                    placeholder={provider ? String(DEFAULT_PORT_BY_PROVIDER[provider]) : undefined}
                     disabled={isDisabled}
                 />
             </div>
@@ -104,7 +102,7 @@ function ConnectionFieldsEditor({ isDisabled }: { isDisabled: boolean }) {
                 label="SSL/TLS"
                 options={SSL_OPTIONS}
                 canDeselect={false}
-                description={SSL_DEFAULT_DESCRIPTION_BY_PROVIDER[provider]}
+                description={provider ? SSL_DEFAULT_DESCRIPTION_BY_PROVIDER[provider] : undefined}
                 disabled={isDisabled}
             />
         </>
@@ -121,7 +119,7 @@ function ConnectionStringEditor({ isDisabled }: { isDisabled: boolean }) {
             name="externalConnection.connectionString"
             label="Connection string"
             labelClassName="sr-only"
-            placeholder={CONNECTION_STRING_PLACEHOLDER_BY_PROVIDER[provider]}
+            placeholder={provider ? CONNECTION_STRING_PLACEHOLDER_BY_PROVIDER[provider] : undefined}
             textareaClassName="font-mono text-xs"
             description="Switching to the connection details reads them from this string and keeps only the settings they can show."
             disabled={isDisabled}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27332

### Additional description

- Changed the **Source database type** cards (PostgreSQL / SQL Server / MySQL) from a tall, centered icon-over-label layout to a compact horizontal one — smaller icon inline, left-aligned label — to match the Figma design.
- Removed the preselected provider: the add-app wizard now opens with no source database type selected and a blank port.
- Added validation requiring a provider choice ("Select a source database type") before the connect step can advance.
- Made the connection editor's port / SSL / connection-string placeholders render neutrally until a provider is chosen.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
