### PR TITLE
RavenDB-27418: quill - keep the client cert password out of the url, …

### DIFF
--- a/docker/quill/nginx.conf
+++ b/docker/quill/nginx.conf
@@ -52,6 +52,16 @@ stream {
 http {
     map $http_upgrade $connection_upgrade { default upgrade; "" close; }
 
+    # The map keeps the first 6 token chars and masks the rest, preserving any trailing sub-path:
+    #   /apps/acme/embed/1a2b3c4d...ff        ->  /apps/acme/embed/1a2b3c***
+    #   /apps/acme/embed/1a2b3c4d...ff/chat   ->  /apps/acme/embed/1a2b3c***/chat
+    map $uri $quill_log_uri {
+        "~^(/apps/[^/]+/embed/.{6})[^/]*(/.*)?$"  "$1***$2";
+        default                                    $uri;
+    }
+    log_format quill_access '$remote_addr $request_method $quill_log_uri $status $body_bytes_sent';
+    access_log /dev/stdout quill_access;
+
     # Take $remote_addr from the PROXY header the stream front sends, so it is the real client rather
     # than the loopback hop - this is what the X-Forwarded-For below then carries to the app. These
     # listeners are loopback-only and PROXY-only, so the stream front is the sole possible source.

--- a/src/Raven.Quill.Web/src/api/custom-services/certificates-service.ts
+++ b/src/Raven.Quill.Web/src/api/custom-services/certificates-service.ts
@@ -12,13 +12,14 @@ export function createCertificatesService(client: ApiClient) {
     return {
         list: (searchParams: { start: number; pageSize: number }) =>
             client.get<CertificateItem[], ApiErrorResponse>(API_ENDPOINTS.settings.certificates, { searchParams }),
-        generate: (
-            permissions: Record<string, DatabaseAccess>,
-            searchParams: { name: string; clearance: SecurityClearance; password?: string },
-        ) =>
-            client.post<Blob, ApiErrorResponse>(API_ENDPOINTS.settings.certificatesGenerate, permissions, {
+        generate: (body: {
+            name: string;
+            clearance: SecurityClearance;
+            password?: string;
+            permissions: Record<string, DatabaseAccess>;
+        }) =>
+            client.post<Blob, ApiErrorResponse>(API_ENDPOINTS.settings.certificatesGenerate, body, {
                 responseType: "blob",
-                searchParams,
             }),
     };
 }

--- a/src/Raven.Quill.Web/src/api/generated/server-api.ts
+++ b/src/Raven.Quill.Web/src/api/generated/server-api.ts
@@ -1431,6 +1431,14 @@ export interface components {
             /** Format: int32 */
             invocationCount: number;
         };
+        GenerateClientCertificateRequest: {
+            name: string;
+            clearance: components["schemas"]["SecurityClearance"];
+            password: null | string;
+            permissions: {
+                [key: string]: components["schemas"]["DatabaseAccess"];
+            };
+        };
         /** @enum {unknown} */
         GoogleAIVersion: "V1" | "V1_Beta" | null;
         GoogleSettings: {
@@ -3673,25 +3681,28 @@ export interface operations {
     };
     "settings.certificatesGenerate": {
         parameters: {
-            query: {
-                name: string;
-                clearance: components["schemas"]["SecurityClearance"];
-                password?: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: components["schemas"]["DatabaseAccess"];
-                };
+                "application/json": components["schemas"]["GenerateClientCertificateRequest"];
             };
         };
         responses: {
             /** @description Bad Request */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3723,6 +3734,15 @@ export interface operations {
         responses: {
             /** @description Bad Request */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4100,6 +4120,7 @@ export type DiscoverTableResponse = components["schemas"]["DiscoverTableResponse
 export type EditAgentRequest = components["schemas"]["EditAgentRequest"];
 export type EmbeddedSettings = components["schemas"]["EmbeddedSettings"];
 export type EmbedLinkSummaryResponse = components["schemas"]["EmbedLinkSummaryResponse"];
+export type GenerateClientCertificateRequest = components["schemas"]["GenerateClientCertificateRequest"];
 export type GoogleAIVersion = components["schemas"]["GoogleAIVersion"];
 export type GoogleSettings = components["schemas"]["GoogleSettings"];
 export type HuggingFaceSettings = components["schemas"]["HuggingFaceSettings"];
@@ -4329,7 +4350,7 @@ export function createServerApi(client: ApiClient) {
         settings: {
             certificates: (searchParams: { pageSize: string; start: string; }) => client.get<CertificateItem[], ApiErrorResponse>(API_ENDPOINTS.settings.certificates, { searchParams }),
             certificatesEdit: (request: Record<string, DatabaseAccess>, searchParams: { clearance: SecurityClearance; disable: boolean; name: string; thumbprint: string; }) => client.post<void, ApiErrorResponse>(API_ENDPOINTS.settings.certificatesEdit, request, { searchParams }),
-            certificatesGenerate: (request: Record<string, DatabaseAccess>, searchParams: { clearance: SecurityClearance; name: string; password?: string; }) => client.post<void, ApiErrorResponse>(API_ENDPOINTS.settings.certificatesGenerate, request, { searchParams }),
+            certificatesGenerate: (request: GenerateClientCertificateRequest) => client.post<void, ApiErrorResponse>(API_ENDPOINTS.settings.certificatesGenerate, request),
             feedback: (request: SendFeedbackRequest) => client.post<void, ApiErrorResponse>(API_ENDPOINTS.settings.feedback, request),
             license: () => client.get<LicenseResponse>(API_ENDPOINTS.settings.license),
             usage: (searchParams: { day?: string; month?: string; year: string; }) => client.get<QuillUsageResponse, ApiErrorResponse>(API_ENDPOINTS.settings.usage, { searchParams }),

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/generate-certificate-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/generate-certificate-dialog.tsx
@@ -104,14 +104,12 @@ function GenerateCertificateForm({ apps, onGenerated }: { apps: AppResponse[]; o
 
     const generateMutation = useMutation({
         mutationFn: (values: GenerateCertificateFormData) =>
-            api.services.certificates.generate(
-                values.clearance === "ValidUser" ? toPermissionsRecord(values.permissions) : {},
-                {
-                    name: values.name,
-                    clearance: values.clearance,
-                    password: values.password || undefined,
-                },
-            ),
+            api.services.certificates.generate({
+                name: values.name,
+                clearance: values.clearance,
+                password: values.password || undefined,
+                permissions: values.clearance === "ValidUser" ? toPermissionsRecord(values.permissions) : {},
+            }),
         onSuccess: async (zip, values) => {
             unsavedChanges.markSaved();
             // Same filename the server sets in its Content-Disposition header.

--- a/src/Raven.Quill/Contracts/GenerateClientCertificateRequest.cs
+++ b/src/Raven.Quill/Contracts/GenerateClientCertificateRequest.cs
@@ -1,0 +1,9 @@
+using Raven.Client.ServerWide.Operations.Certificates;
+
+namespace Raven.Quill.Contracts;
+
+public sealed record GenerateClientCertificateRequest(
+    string Name,
+    SecurityClearance Clearance,
+    string? Password,
+    Dictionary<string, DatabaseAccess> Permissions);

--- a/src/Raven.Quill/Endpoints/SettingsEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/SettingsEndpoints.cs
@@ -94,20 +94,21 @@ public static class SettingsEndpoints
         catch (LicenseLimitException ex)
         {
             logger.LogWarning(ex, "certificate operation rejected by license");
-            return Results.Json(new ApiErrorResponse(FirstSentence(ex.Message)), statusCode: StatusCodes.Status403Forbidden);
+            var error = ex.LimitType switch
+            {
+                LimitType.ReadOnlyCertificates =>
+                    "your license does not include read-only certificates; grant at least one app ReadWrite access, or upgrade the license",
+                LimitType.InvalidLicense =>
+                    "the RavenDB license is in an invalid state, so certificates cannot be issued",
+                _ => "the RavenDB license does not allow this certificate operation",
+            };
+            return Results.Json(new ApiErrorResponse(error), statusCode: StatusCodes.Status403Forbidden);
         }
         catch (RavenException ex)
         {
             logger.LogWarning(ex, "certificate operation rejected by RavenDB");
             return Results.BadRequest(new ApiErrorResponse("certificate request rejected; see server logs for details"));
         }
-    }
-
-    private static string FirstSentence(string message)
-    {
-        var line = message.Split('\n', 2)[0].TrimEnd('\r');
-        var separator = line.IndexOf(": ", StringComparison.Ordinal);
-        return separator >= 0 ? line[(separator + 2)..] : line;
     }
 
     public record CertificateItem(

--- a/src/Raven.Quill/Endpoints/SettingsEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/SettingsEndpoints.cs
@@ -1,6 +1,8 @@
 using System.Net.Mail;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Queries.MoreLikeThis;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Commercial;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Quill.Contracts;
 using Raven.Quill.Feedback;
@@ -37,45 +39,75 @@ public static class SettingsEndpoints
             .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest)
             .Produces<ApiErrorResponse>(StatusCodes.Status502BadGateway);
 
-        group.MapGet("/certificates/get", async (IDocumentStore store, int start, int pageSize, CancellationToken token) =>
-            {
-                var op = new GetCertificatesOperation(start, pageSize);
-                var result = await store.Maintenance.Server.SendAsync(op, token);
-                return Results.Ok(result.Select(CertificateItem.From).ToArray());
-            })
+        group.MapGet("/certificates/get", (IDocumentStore store, int start, int pageSize, ILogger<SettingsLogger> logger, CancellationToken token) =>
+                GuardCertificateErrorsAsync(logger, async () =>
+                {
+                    var op = new GetCertificatesOperation(start, pageSize);
+                    var result = await store.Maintenance.Server.SendAsync(op, token);
+                    return Results.Ok(result.Select(CertificateItem.From).ToArray());
+                }))
             .Produces<CertificateItem[]>()
             .WithName("settings.certificates")
             .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest);
 
-        group.MapPost("/certificates/generate", async (IDocumentStore store, string name, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance, string? password, CancellationToken token) =>
-            {
-                var op = new CreateClientCertificateOperation(name, permissions, clearance, password);
-                var fileBytes = await store.Maintenance.Server.SendAsync(op, token);
-                return Results.File(fileBytes.RawData, "application/octet-stream", $"{name}_certificates.zip");
-            })
-            .WithName("settings.certificatesGenerate")
-            .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest);
-
-        group.MapPost("/certificates/edit", async (IDocumentStore store, string thumbprint, string name, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance, bool disable, CancellationToken token) =>
-            {
-                var existing = await store.Maintenance.Server.SendAsync(new GetCertificateOperation(thumbprint), token);
-                if (existing is null)
-                    return Results.NotFound(new ApiErrorResponse($"no certificate with thumbprint '{thumbprint}'"));
-
-                var op = new EditClientCertificateOperation(new EditClientCertificateOperation.Parameters
+        group.MapPost("/certificates/generate", (IDocumentStore store, GenerateClientCertificateRequest body, ILogger<SettingsLogger> logger, CancellationToken token) =>
+                GuardCertificateErrorsAsync(logger, async () =>
                 {
-                    Thumbprint = thumbprint,
-                    Permissions = permissions,
-                    Disabled = disable,
-                    Name = name,
-                    Clearance = clearance
-                });
-                await store.Maintenance.Server.SendAsync(op, token);
-                return Results.Ok();
-            })
+                    var op = new CreateClientCertificateOperation(body.Name, body.Permissions, body.Clearance, body.Password);
+                    var fileBytes = await store.Maintenance.Server.SendAsync(op, token);
+                    return Results.File(fileBytes.RawData, "application/octet-stream", $"{body.Name}_certificates.zip");
+                }))
+            .WithName("settings.certificatesGenerate")
+            .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest)
+            .Produces<ApiErrorResponse>(StatusCodes.Status403Forbidden);
+
+        group.MapPost("/certificates/edit", (IDocumentStore store, string thumbprint, string name, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance, bool disable, ILogger<SettingsLogger> logger, CancellationToken token) =>
+                GuardCertificateErrorsAsync(logger, async () =>
+                {
+                    var existing = await store.Maintenance.Server.SendAsync(new GetCertificateOperation(thumbprint), token);
+                    if (existing is null)
+                        return Results.NotFound(new ApiErrorResponse($"no certificate with thumbprint '{thumbprint}'"));
+
+                    var op = new EditClientCertificateOperation(new EditClientCertificateOperation.Parameters
+                    {
+                        Thumbprint = thumbprint,
+                        Permissions = permissions,
+                        Disabled = disable,
+                        Name = name,
+                        Clearance = clearance
+                    });
+                    await store.Maintenance.Server.SendAsync(op, token);
+                    return Results.Ok();
+                }))
             .WithName("settings.certificatesEdit")
             .Produces<ApiErrorResponse>(StatusCodes.Status404NotFound)
-            .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest);
+            .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest)
+            .Produces<ApiErrorResponse>(StatusCodes.Status403Forbidden);
+    }
+
+    private static async Task<IResult> GuardCertificateErrorsAsync(ILogger logger, Func<Task<IResult>> action)
+    {
+        try
+        {
+            return await action();
+        }
+        catch (LicenseLimitException ex)
+        {
+            logger.LogWarning(ex, "certificate operation rejected by license");
+            return Results.Json(new ApiErrorResponse(FirstSentence(ex.Message)), statusCode: StatusCodes.Status403Forbidden);
+        }
+        catch (RavenException ex)
+        {
+            logger.LogWarning(ex, "certificate operation rejected by RavenDB");
+            return Results.BadRequest(new ApiErrorResponse("certificate request rejected; see server logs for details"));
+        }
+    }
+
+    private static string FirstSentence(string message)
+    {
+        var line = message.Split('\n', 2)[0].TrimEnd('\r');
+        var separator = line.IndexOf(": ", StringComparison.Ordinal);
+        return separator >= 0 ? line[(separator + 2)..] : line;
     }
 
     public record CertificateItem(
@@ -147,4 +179,6 @@ public static class SettingsEndpoints
         string? trimmed = value?.Trim();
         return string.IsNullOrEmpty(trimmed) ? null : trimmed;
     }
+
+    internal sealed class SettingsLogger;
 }


### PR DESCRIPTION
…return real errors, persist a scrubbed access log

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27418

### Additional description

Client-cert generation sent the password as a query parameter (nginx logged it), returned opaque 500s on licensing/validation failures, and let nginx fall back to an ephemeral access log. 
Now: `generate` binds the password in a request body (OpenAPI client regenerated). 
generate/edit/get map ravendb exceptions to structured errors (`LicenseLimitException` --> 403 with the message's first line, other `RavenException` --> 400, logged)
nginx access log goes through the 03-proxy-log pipeline (persisted + rotated), logging `$uri` (never the query string) with the embed token truncated to its first 6 chars


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

**see comment below**
### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
