### PR TITLE
RavenDB-27423 - Fix failing Quill test

### DIFF
--- a/test/QuillTests/ChannelLifecycleEndpointsTests.cs
+++ b/test/QuillTests/ChannelLifecycleEndpointsTests.cs
@@ -31,7 +31,9 @@ public class ChannelLifecycleEndpointsTests(ITestOutputHelper output) : QuillTes
         Assert.Equal("IFrame", item.GetProperty("type").GetString());
         Assert.Equal("demo-agent", item.GetProperty("agentId").GetString());
         Assert.True(item.GetProperty("enabled").GetBoolean());
-        Assert.False(item.TryGetProperty("allowedOrigins", out _));
+        var origins = item.GetProperty("allowedOrigins");
+        Assert.Equal(1, origins.GetArrayLength());
+        Assert.Equal("http://localhost", origins[0].GetString());
         Assert.False(item.TryGetProperty("bindingId", out _));
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-11/Quill-Failing-test-Channelslistreturnsthecreatedchannel

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
