### PR TITLE
RavenDB-27415: Adopting orphaned revisions must not re-create the deleted document

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -552,9 +552,9 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 }
 
                                 var nonPersistentFlags = GetNonPersistentDocumentFlags();
-                                if (doc.Flags.Contain(DocumentFlags.Revision))
+                                if (doc.Flags.Contain(DocumentFlags.DeleteRevision))
                                 {
-                                    database.DocumentsStorage.RevisionsStorage.Put(
+                                    database.DocumentsStorage.RevisionsStorage.Delete(
                                         context,
                                         doc.Id,
                                         document,
@@ -565,9 +565,9 @@ namespace Raven.Server.Documents.Replication.Incoming
                                     continue;
                                 }
 
-                                if (doc.Flags.Contain(DocumentFlags.DeleteRevision))
+                                if (doc.Flags.Contain(DocumentFlags.Revision))
                                 {
-                                    database.DocumentsStorage.RevisionsStorage.Delete(
+                                    database.DocumentsStorage.RevisionsStorage.Put(
                                         context,
                                         doc.Id,
                                         document,

--- a/test/SlowTests/Server/Replication/ReplicationAndRevisionsClusterTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationAndRevisionsClusterTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Session;
+using Raven.Server;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Replication
+{
+    public class ReplicationAndRevisionsClusterTests : ClusterTestBase
+    {
+        private const string DocId = "Docs/1";
+
+        private const string CollectionName = "Users";
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        public ReplicationAndRevisionsClusterTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication)]
+        public async Task AdoptOrphanedRevisions_MustNotRecreateTheDeletedDocument()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+
+            using var store = GetDocumentStore(new Options
+            {
+                Server = leader,
+                ReplicationFactor = 3
+            });
+
+            await RevisionsHelper.SetupRevisionsAsync(store, leader.ServerStore, configuration: new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 100
+                }
+            });
+
+            // 1. create two revisions for the document
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, DocId);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New" }, DocId);
+                await session.SaveChangesAsync();
+            }
+
+            Assert.True(await WaitForDocumentInClusterAsync<User>(nodes, store.Database, DocId, user => user.Name == "New", TimeSpan.FromSeconds(15)));
+
+            // 2. delete the document - this adds a delete revision, so the document is shown in the revisions bin
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete(DocId);
+                await session.SaveChangesAsync();
+            }
+
+            Assert.True(await WaitForDocumentDeletionInClusterAsync(nodes, store.Database, DocId, TimeSpan.FromSeconds(15)));
+
+            // 3. turn the revisions into *orphaned* revisions
+            foreach (var node in nodes)
+            {
+                var nodeDatabase = await Databases.GetDocumentDatabaseInstanceFor(node, store);
+
+                using (nodeDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    nodeDatabase.DocumentsStorage.RevisionsStorage.ForTestingPurposesOnly().DeleteLastRevisionFor(context, DocId, CollectionName);
+                    tx.Commit();
+                }
+            }
+
+            // Ensure no node has a delete revision for the document, so the revisions are orphaned and the document is not shown in the revisions bin.
+            foreach (var node in nodes)
+            {
+                using var nodeStore = GetDocumentStoreForNode(store, node);
+                using var session = nodeStore.OpenAsyncSession();
+
+                Assert.Null(await session.LoadAsync<User>(DocId));
+
+                var revisions = await session.Advanced.Revisions.GetMetadataForAsync(DocId);
+                Assert.Equal(2, revisions.Count);
+                Assert.DoesNotContain(revisions, revision => GetFlags(revision).Contain(DocumentFlags.DeleteRevision));
+            }
+
+            // 4. adopt the orphaned revisions
+            var adoptingNode = leader;
+            var adoptingNodeTag = adoptingNode.ServerStore.NodeTag;
+
+            using var adoptingNodeStore = GetDocumentStoreForNode(store, adoptingNode);
+
+            var operation = await adoptingNodeStore.Operations.SendAsync(new AdoptOrphanedRevisionsOperation(new AdoptOrphanedRevisionsOperation.Parameters()));
+            var adoptResult = (AdoptOrphanedRevisionsResult)await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+            Assert.Equal(1, adoptResult.AdoptedCount);
+
+            // 5. the adopted revision, on the node that ran the operation.
+            using (var session = adoptingNodeStore.OpenAsyncSession())
+            {
+                var revisions = await session.Advanced.Revisions.GetMetadataForAsync(DocId);
+                Assert.Equal(3, revisions.Count);
+
+                var adoptedRevisionFlags = GetFlags(revisions[0]);
+                var documentExists = await session.Advanced.ExistsAsync(DocId);
+
+                Output.WriteLine($"Node {adoptingNodeTag} ran the adoption: adopted revision flags '{adoptedRevisionFlags}', " +
+                                 $"'{DocId}' {(documentExists ? "EXISTS" : "doesn't exist")} on it right after the adoption");
+
+                Assert.True(adoptedRevisionFlags.Contain(DocumentFlags.DeleteRevision),
+                    $"The revision that node {adoptingNodeTag} adopted must be a delete revision, but its flags are '{adoptedRevisionFlags}'.");
+            }
+
+            // the revisions were really adopted - the document is shown in the revisions bin again
+            using (adoptingNode.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            {
+                var command = new GetRevisionsBinEntryCommand(0, int.MaxValue);
+                await adoptingNodeStore.GetRequestExecutor().ExecuteAsync(command, context);
+
+                Assert.Equal(1, command.Result.Results.Length);
+            }
+
+            // 6. wait for the adopted revision to replicate, then check the whole cluster
+            var documentRecreatedOn = new List<string>();
+
+            foreach (var node in nodes)
+            {
+                var nodeTag = node.ServerStore.NodeTag;
+
+                using var nodeStore = GetDocumentStoreForNode(store, node);
+
+                Assert.True(await WaitForValueAsync(async () =>
+                {
+                    using var session = nodeStore.OpenAsyncSession();
+                    var revisions = await session.Advanced.Revisions.GetMetadataForAsync(DocId);
+                    return revisions.Any(revision => GetFlags(revision).Contain(DocumentFlags.DeleteRevision));
+                }, true), $"The adopted delete revision never reached node {nodeTag}.");
+
+                using var nodeSession = nodeStore.OpenAsyncSession();
+
+                var deleteRevisionsFlags = (await nodeSession.Advanced.Revisions.GetMetadataForAsync(DocId))
+                    .Select(revision => GetFlags(revision))
+                    .Where(flags => flags.Contain(DocumentFlags.DeleteRevision))
+                    .ToList();
+
+                var document = await nodeSession.LoadAsync<User>(DocId);
+                var documentFlags = document == null ? null : GetFlags(nodeSession.Advanced.GetMetadataFor(document)).ToString();
+                var deleteRevisionsDescription = string.Join(", ", deleteRevisionsFlags.Select(flags => $"'{flags}'"));
+
+                Output.WriteLine($"Node {nodeTag}{(node == adoptingNode ? " (ran the adoption)" : "")}: " +
+                                 (document == null
+                                     ? $"'{DocId}' doesn't exist"
+                                     : $"'{DocId}' EXISTS with flags '{documentFlags}' and no properties (Name = {document.Name ?? "null"})") +
+                                 $", delete revisions: [{deleteRevisionsDescription}]");
+
+                if (document != null)
+                    documentRecreatedOn.Add($"{nodeTag} (document flags: '{documentFlags}')");
+            }
+
+            Assert.True(documentRecreatedOn.Count == 0,
+                $"'{DocId}' was deleted, but adopting its orphaned revisions re-created it as an empty (metadata only) document on: " +
+                $"{string.Join("; ", documentRecreatedOn)}. A node that receives the adopted revision through replication puts its metadata-only " +
+                $"payload back as a live document, and from there it replicates on as a regular document.");
+        }
+
+        private static DocumentFlags GetFlags(IMetadataDictionary metadata) =>
+            Enum.Parse<DocumentFlags>(metadata.GetString(Constants.Documents.Metadata.Flags));
+
+        private static IDocumentStore GetDocumentStoreForNode(DocumentStore store, RavenServer server)
+        {
+            return new DocumentStore
+            {
+                Database = store.Database,
+                Urls = new[] { server.WebUrl },
+                Conventions = new DocumentConventions { DisableTopologyUpdates = true }
+            }.Initialize();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27415/Adopting-orphaned-revisions-re-creates-the-deleted-document-as-an-empty-document-across-the-cluster

### Additional description

**Symptom.** Running *Adopt Orphaned Revisions* on a cluster re-created the deleted documents as
empty, metadata-only documents (`{"@metadata":{"@collection":"..."}}`) on every node **except** the
one that ran the operation, and from there they replicated on as ordinary live documents - indexed,
queryable, returned to clients and included in backups. In the reported incident 9,548 orphans were
adopted, so every one of them should have produced such a document; only the ones that broke an
index were noticed.

**Root cause.** `AdoptOrphanedFor` derived the new delete revision's flags from the last *revision*
instead of from the *document* (`RevisionsStorage.cs:2106` passed `lastRevision.Flags` through).
`ShouldAdoptRevision` only returns true when that revision is **not** a delete revision, so it is
always a normal revision - and a normal revision always carries `DocumentFlags.Revision`, which
`RevisionsStorage.Put` sets unconditionally. `CreateDeletedRevision` stripped only `HasAttachments`
and added `HasRevisions`, so the adopted row was stored as `DeleteRevision | Revision | HasRevisions`.
Adopt is the only path in the codebase that produced this combination.

That row is harmless on the node that wrote it, because adoption only writes to the revisions table.
It broke once it replicated, because incoming replication checked `Revision` **before**
`DeleteRevision`: the destination handled the row as a normal revision and went
`RevisionsStorage.Put` -> `PutFromRevisionIfChangeVectorIsGreater` (with a non-null document) ->
`DocumentsStorage.Put`, writing the delete revision's metadata-only body back as a live document.
A genuine delete revision, which doesn't carry `Revision`, takes the `DeleteRevision` branch instead
and *deletes* the document - that single flag was the whole difference.

For contrast, the legitimate delete path (the private `Delete`) performs byte-identical
strip/OR/`tvb` writes, but its flags come from the document or tombstone being deleted,
carries `Revision`.

**The change.**

1. `CreateDeletedRevision` - strip `Revision`. This is the fix. Placed in the method that ORs in
   `DocumentFlags.DeleteRevision`, next to the existing `HasAttachments` strip, so the w
   the row's well-formedness. It has exactly one caller, so this covers both entry points: the adopt
   operation and revert (which reaches the same path via `AdoptOrphanedFor`), sharded included.
2. Private `Delete` - strip `Revision` as well. A **no-op for every legitimate caller**
   across all of them - their flags come from a document, tombstone, conflict entry or a literal, and
   never contain `Revision`). Its purpose is that the only two callers that *can* pass `Revision` are
   the untrusted ones - incoming replication and the smuggler import stream - so a malfo
   normalized rather than stored as is.
3. `IncomingReplicationHandler` - check `DeleteRevision` before `Revision`. Needed because databases
   already hold mis-flagged rows on disk, and `ShouldSkip` lets revision items through *
   `AlreadyMerged` change-vector dedup, so those rows are re-sent on every fresh handshake (node
   added, replication reset, restore + re-sync). This is also the precedence the smuggler importer
   already uses (`DatabaseDestination`), so the two importers agreed on nothing here and the
   replication one had it backwards. Safe by construction: no legitimate item carries both bits, since
   documents never carry either (`PutFromRevisionIfChangeVectorIsGreater` strips both before writing a
   document) and revision rows never carry `DeleteRevision`.

**Why this reached production.** `RavenDB-21381` was the only test for the operation. It
single-node and asserted only `Assert.Contains(DocumentFlags.DeleteRevision.ToString(), ...)`, which
passes happily with `Revision` also set. There was no replication test for adopt orphaned revisions.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack usiag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes)ess modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

- **Revert revisions.** `RevertRevisions` reaches the same code through
  `AdoptOrphanedFor(context, document.Id, DocumentFlags.Reverted)`, so a delete revision it creates
  for a deleted document no longer carries `Revision`. Its exposure was narrower than ad
  revert path first runs the normal `DocumentsStorage.Delete`, which usually writes a proper delete
  revision, after which `ShouldAdoptRevision` returns false - so revert only hit this when that
  delete returned early. The existing exact-flag assertions in `RevertRevisionsTests` ar
  and still pass.
- **Incoming replication (internal, external/pull, shard migration).** The dispatch order changed.
  Only items carrying both `DeleteRevision` and `Revision` are affected; they now take the delete
  path. Single dispatch point - the pull and migration handlers inherit it.
- **Smuggler import.** A malformed delete revision in a dump is now normalized on import rather than
  stored with `Revision` intact.
- **Resharding edge case worth naming.** For a malformed row arriving over resharding with
  `PurgeOnDelete = true`, the delete path's purge branch becomes reachable (`fromResharding` satisfies
  it) and passes `NonPersistentDocumentFlags.None`, bypassing the `FromReplication` earl
  that document's revisions are purged instead of the row being written. Both the old and the new
  outcome are wrong for a malformed row; flagging it rather than treating it as a blocker.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed