### PR TITLE
Quill-6 Remove 'Read' cert option

### DIFF
--- a/src/Raven.Quill.Web/src/mocks/settings-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/settings-mocks.ts
@@ -80,7 +80,7 @@ export const sampleCertificates: CertificateItem[] = [
         securityClearance: "ValidUser",
         notBefore: "2025-06-20T00:00:00Z",
         notAfter: "2026-06-20T00:00:00Z",
-        permissions: { "demo-shop": "Read" },
+        permissions: { "demo-shop": "ReadWrite" },
         disabled: false,
     },
     {

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-labels.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-labels.ts
@@ -1,6 +1,7 @@
 import type { CertificateItem, SecurityClearance } from "@/api/custom-services/certificates-service";
 import type { AppResponse, DatabaseAccess } from "@/api/generated/server-api";
 import type { FormSelectOption } from "@/components/form/form-select";
+import { GRANTABLE_DATABASE_ACCESS } from "@/pages/dashboard/certificates/certificate-permissions";
 
 export const DATABASE_ACCESS_LABELS: Record<DatabaseAccess, string> = {
     Admin: "Admin",
@@ -8,11 +9,9 @@ export const DATABASE_ACCESS_LABELS: Record<DatabaseAccess, string> = {
     Read: "Read",
 };
 
-export const DATABASE_ACCESS_OPTIONS: readonly FormSelectOption<DatabaseAccess>[] = [
-    { value: "Admin", label: DATABASE_ACCESS_LABELS.Admin },
-    { value: "ReadWrite", label: DATABASE_ACCESS_LABELS.ReadWrite },
-    { value: "Read", label: DATABASE_ACCESS_LABELS.Read },
-];
+export const DATABASE_ACCESS_OPTIONS: readonly FormSelectOption<DatabaseAccess>[] = GRANTABLE_DATABASE_ACCESS.map(
+    (access) => ({ value: access, label: DATABASE_ACCESS_LABELS[access] }),
+);
 
 export const SECURITY_CLEARANCE_LABELS: Record<SecurityClearance, string> = {
     UnauthenticatedClients: "Unauthenticated",

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-permissions.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-permissions.ts
@@ -1,12 +1,19 @@
 import { z } from "zod";
 import type { DatabaseAccess } from "@/api/generated/server-api";
 
+// The server contract also has Read, which Quill never grants.
+export const GRANTABLE_DATABASE_ACCESS = ["Admin", "ReadWrite"] as const satisfies readonly DatabaseAccess[];
+
 export const permissionRowSchema = z.object({
     database: z.string(),
-    access: z.enum(["Admin", "ReadWrite", "Read"]),
+    access: z.enum(["Admin", "ReadWrite", "Read"] as const satisfies readonly DatabaseAccess[]),
 });
 
 export type PermissionRow = z.infer<typeof permissionRowSchema>;
+
+function isGrantableAccess(access: DatabaseAccess): boolean {
+    return GRANTABLE_DATABASE_ACCESS.some((grantable) => grantable === access);
+}
 
 // Row validation lives here rather than at field level so dialogs can skip it
 // when the selected clearance hides the permission rows.
@@ -16,6 +23,14 @@ export function reportPermissionRowIssues(
     basePath: (string | number)[] = [],
 ) {
     rows.forEach((row, index) => {
+        if (!isGrantableAccess(row.access)) {
+            ctx.addIssue({
+                code: "custom",
+                path: [...basePath, index, "access"],
+                message: "Read-only access is no longer supported. Pick another level.",
+            });
+        }
+
         if (row.database === "") {
             ctx.addIssue({ code: "custom", path: [...basePath, index, "database"], message: "Required" });
             return;

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/edit-certificate-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/edit-certificate-dialog.tsx
@@ -177,7 +177,7 @@ function EditCertificateForm({
                         variant="outline"
                         size="sm"
                         className="w-fit"
-                        onClick={() => permissionRows.append({ database: "", access: "Read" })}
+                        onClick={() => permissionRows.append({ database: "", access: "ReadWrite" })}
                     >
                         <Plus className="size-3.5" aria-hidden="true" />
                         Add access

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/generate-certificate-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/generate-certificate-dialog.tsx
@@ -95,7 +95,7 @@ function GenerateCertificateForm({ apps, onGenerated }: { apps: AppResponse[]; o
             name: "",
             password: "",
             clearance: "ValidUser",
-            permissions: [{ database: "", access: "Read" }],
+            permissions: [{ database: "", access: "ReadWrite" }],
         },
     });
     const permissionRows = useFieldArray({ control: form.control, name: "permissions" });
@@ -174,7 +174,7 @@ function GenerateCertificateForm({ apps, onGenerated }: { apps: AppResponse[]; o
                         variant="outline"
                         size="sm"
                         className="w-fit"
-                        onClick={() => permissionRows.append({ database: "", access: "Read" })}
+                        onClick={() => permissionRows.append({ database: "", access: "ReadWrite" })}
                     >
                         <Plus className="size-3.5" aria-hidden="true" />
                         Add access


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/Quill-6/Quill-Remove-Read-cert-option

### Additional description

'Read' cert access isn't supported in Quill

<img width="533" height="198" alt="image" src="https://github.com/user-attachments/assets/fe73c470-cd95-4d3f-a680-50a226fc2bfe" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
