### PR TITLE
Quill-264: change docker logs banner color to orange

### DIFF
--- a/docker/quill/s6-rc.d/05-console/run
+++ b/docker/quill/s6-rc.d/05-console/run
@@ -58,7 +58,7 @@ print_urls() {
     say "Database:  https://db.$base"
 }
 
-printf '\033[35m'
+printf '\033[38;5;208m'
 cat <<'BANNER'
  _______  __   __  ___   ___      ___ 
 |       ||  | |  ||   | |   |    |   |


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-264/Quill-change-docker-logs-banner-color-to-orange

### Additional description

--

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

**see comment below**

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
