### PR TITLE
Quill-49 Remove the optional label from Public URL slug

### DIFF
--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-validation.tsx
@@ -7,17 +7,13 @@ import { MAX_SLUG_LENGTH, toSlug } from "@/pages/setup/add-app-wizard/slugify";
 const COLUMN_TYPES = ["Default", "Json", "Attachment"] as const satisfies readonly CdcColumnType[];
 const RELATION_TYPES = ["Array", "Map", "Value"] as const satisfies readonly CdcSinkRelationType[];
 
-// Optional override; when empty the server derives the slug from the app name. Mirrors the
-// server's normalization checks so obvious problems surface before provisioning (reserved
-// names are only known server-side and come back as a 400).
+// Mirrors the server's normalization checks so obvious problems surface before provisioning
+// (reserved names are only known server-side and come back as a 400).
 export const slugSchema = z
     .string()
     .trim()
+    .min(1, "Public URL slug is required")
     .superRefine((value, ctx) => {
-        if (value === "") {
-            return;
-        }
-
         const normalized = toSlug(value);
 
         if (normalized === "") {
@@ -276,15 +272,12 @@ export const createExternalConnectionSchema = (takenSlugs: string[] = []) => {
                 });
             }
 
-            const overrideSlug = values.slug.trim();
-            // With an empty override the server derives the slug from the app name, so the name is
-            // what has to be changed to free up the conflict.
-            const slug = toSlug(overrideSlug || values.appName);
+            const slug = toSlug(values.slug);
 
             if (slug !== "" && normalizedTakenSlugs.has(slug)) {
                 ctx.addIssue({
                     code: "custom",
-                    path: [overrideSlug === "" ? "appName" : "slug"],
+                    path: ["slug"],
                     message: `Slug "${slug}" is already used by another app`,
                 });
             }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard.tsx
@@ -87,7 +87,7 @@ export function AppWizard({ defaultValues, editedApp }: AppWizardProps) {
         mutationFn: async (formValues: AppFormData) => {
             return await api.services.setup.provision({
                 appName: formValues.externalConnection.appName,
-                slug: formValues.externalConnection.slug || null,
+                slug: formValues.externalConnection.slug,
             });
         },
         onSuccess: async (result, formValues) => {

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
@@ -45,7 +45,7 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
             <FormInput
                 control={control}
                 name="externalConnection.slug"
-                label={isEditingApp ? "Public URL slug" : "Public URL slug (optional)"}
+                label="Public URL slug"
                 placeholder="e.g. acme-shop"
                 disabled={isBusy || isEditingApp}
                 description={


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-49/Quill-Remove-the-optional-label-from-Public-URL-slug

### Additional description

The field was labelled "(optional)", but only /api/setup/provision derives the
slug from the app name; /connect, /discover, /verify-cdc, /map and /suggest/cdc
key their wizard state document by slug and reject an empty one. Clearing the
slug and pressing Next therefore failed with {"error":"slug is required"}.

The field is auto-filled from the app name and has a Regenerate button, so
requiring it costs nothing and stops the wizard from advertising a state its
own endpoints cannot handle. Validation now rejects an empty slug, the label
drops "(optional)", and the taken-slug conflict is reported on the slug field
instead of on the app name.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
