### PR TITLE
Quill-266: bind ravendb tcp listener to loopback inside the container

### DIFF
--- a/docker/quill/s6-rc.d/01-ravendb/run
+++ b/docker/quill/s6-rc.d/01-ravendb/run
@@ -34,6 +34,7 @@ cp "$SETUP_SETTINGS" /app/ravendb/settings.json
 # to RavenDB on this port (RavenStoreFactory.RavenInternalPort); nginx passes db.*/a.* through to it.
 RAVENDB_PORT="${RAVEN_QUILL_RAVENDB_INTERNAL_PORT:-8443}"
 sed -i -E "s#(\"ServerUrl\"[[:space:]]*:[[:space:]]*\")https://[^\"]*(\")#\1https://127.0.0.1:${RAVENDB_PORT}\2#" /app/ravendb/settings.json
+sed -i -E "s#(\"ServerUrl\.Tcp\"[[:space:]]*:[[:space:]]*\"tcp://)[^\"]*(:[0-9]+\")#\1127.0.0.1\2#" /app/ravendb/settings.json
 
 NODE_HOST="$(jq -r '.PublicServerUrl' "$SETUP_SETTINGS" | sed -E 's#^https?://##; s#[:/].*##')"
 if [ -n "$NODE_HOST" ]; then


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-266/RavenDB-fails-to-start-when-the-setup-package-binds-ServerUrl.Tcp-to-the-node-IP

### Additional description

the app crashes on start when the setup package's ServerUrl.Tcp is the operator's node IP (the normal case for a package generated with a NodeIp).
01-ravendb/run already rewrites to loopback (ServerUrl --> https://127.0.0.1:8443/) . ServerUrl.Tcp should also.
was never surfaced bc it's depended on whether the node IP happened to be bindable in the container.



### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [] Existing tests verify the correct behavior

**see comment below**

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
