### PR TITLE
Quill-113 Setup wizard cdc errors not shown

### DIFF
--- a/src/Raven.Quill.Web/src/api/queries/apps-queries.ts
+++ b/src/Raven.Quill.Web/src/api/queries/apps-queries.ts
@@ -4,6 +4,8 @@ import { recordFetchStartedAt } from "@/lib/query-fetch-start";
 
 const baseKey = "apps";
 
+const CDC_ERRORS_POLL_INTERVAL_MS = 5_000;
+
 // Partial key covering every app's connection strings list, so mutations on the
 // (server-wide) connection strings can invalidate all of them at once.
 export const APP_AI_CONNECTION_STRINGS_KEY = [baseKey, "aiConnectionStringsList"] as const;
@@ -32,6 +34,9 @@ export function createAppsQueries(api: ServerApi["apps"]) {
                 // Errors must always reflect the current server state, so never serve them from cache.
                 staleTime: 0,
                 gcTime: 0,
+                // Data sync fails on its own schedule, often seconds after the view watching it
+                // opened, so a single fetch would leave the operator reading a stale zero.
+                refetchInterval: CDC_ERRORS_POLL_INTERVAL_MS,
             }),
         suggestAgentFromData: (slug: string) =>
             queryOptions({

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-performance-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-performance-section.tsx
@@ -2,10 +2,9 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
 import { StatusIndicator, type StatusTone } from "@/components/data/status-indicator";
-import { Button } from "@/components/shadcn/ui/button";
 import { CdcBatchLog } from "@/pages/apps/cdc-batch-log";
 import { DashboardStatCards, type DashboardStatCard } from "@/pages/dashboard/dashboard-stat-cards";
-import { CdcErrorsSheet } from "@/pages/apps/cdc-errors-sheet";
+import { CdcErrorsAlert } from "@/pages/apps/cdc-errors-alert";
 import { SectionCard } from "@/pages/apps/section-card";
 import {
     useCdcLivePerformance,
@@ -25,41 +24,34 @@ export function CdcPerformanceSection({
     errorTitle?: string;
 }) {
     const live = useCdcLivePerformance(slug);
-    // The button opens the stored error list, so it is gated on that list rather than on the
-    // live errorCount, which only covers the recently tracked batches and could disagree.
     const errorsQuery = useQuery(api.queries.apps.cdcErrors(slug));
-    const hasStoredErrors = (errorsQuery.data?.length ?? 0) > 0;
+    const storedErrorCount = errorsQuery.data?.length ?? 0;
+    const hasStoredErrors = storedErrorCount > 0;
+
+    // The live feed only counts errors inside the batches.
+    // Failure that never produced a batch (e.g. source table that doesn't exist) reaches the stored list alone.
+    // Reporting the larger of the two keeps the tile from claiming zero.
+    const errorCount = Math.max(live.performance?.errorCount ?? 0, storedErrorCount);
 
     return (
         <SectionCard
             title={title}
-            action={
-                (hasStoredErrors || live.performance) && (
-                    <div className="flex items-center gap-2">
-                        {hasStoredErrors && (
-                            <CdcErrorsSheet
-                                slug={slug}
-                                trigger={
-                                    <Button variant="destructive-outline" size="sm">
-                                        View errors
-                                    </Button>
-                                }
-                            />
-                        )}
-                        {live.performance && <CdcStatusBadge status={live.performance.status} />}
-                    </div>
-                )
-            }
+            action={live.performance && <CdcStatusBadge status={hasStoredErrors ? "error" : live.performance.status} />}
         >
-            <ApiState
-                isLoading={live.connection === "connecting"}
-                isError={live.connection === "error"}
-                errorTitle={errorTitle}
-                onRetry={live.retry}
-                loadingLabel={loadingLabel}
-            >
-                {live.performance && <CdcPerformanceContent performance={live.performance} />}
-            </ApiState>
+            <div className="space-y-4">
+                <CdcErrorsAlert slug={slug} />
+                <ApiState
+                    isLoading={live.connection === "connecting"}
+                    isError={live.connection === "error"}
+                    errorTitle={errorTitle}
+                    onRetry={live.retry}
+                    loadingLabel={loadingLabel}
+                >
+                    {live.performance && (
+                        <CdcPerformanceContent performance={live.performance} errorCount={errorCount} />
+                    )}
+                </ApiState>
+            </div>
         </SectionCard>
     );
 }
@@ -75,10 +67,10 @@ function CdcStatusBadge({ status }: { status: CdcLiveStatus }) {
     return <StatusIndicator tone={badge.tone} label={badge.label} />;
 }
 
-function CdcPerformanceContent({ performance }: { performance: CdcLivePerformance }) {
+function CdcPerformanceContent({ performance, errorCount }: { performance: CdcLivePerformance; errorCount: number }) {
     const cards: DashboardStatCard[] = [
         { label: "Recent writes", value: performance.recentWrites, isLoading: false },
-        { label: "Errors", value: performance.errorCount, isLoading: false },
+        { label: "Errors", value: errorCount, isLoading: false },
     ];
 
     return (


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/Quill-113/Quill-Setup-wizard-cdc-errors-not-shown

### Additional description

The "App created" dialog reported `Errors 0 / Idle` while the app view showed real sync failures.

- `cdcErrors` query now polls every 5s, so views watching it stop showing the zero they fetched right after provisioning
- Errors tile and status badge read the stored error list, not only the live batch feed, which never sees a failure that produced no batch
- `CdcErrorsAlert` moved inside the sync section, above the live feed, replacing the header-only "View errors" button so errors show even when the feed cannot connect

<img width="827" height="384" alt="image" src="https://github.com/user-attachments/assets/7ad5f284-8617-464c-a742-f4ff354c43e0" />


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
