### PR TITLE
Quill-268 Revert SendWithConsentRetryAsync

### DIFF
--- a/src/Raven.Quill/AiHelper/AiHelperInternalClient.cs
+++ b/src/Raven.Quill/AiHelper/AiHelperInternalClient.cs
@@ -30,7 +30,7 @@ public sealed class AiHelperInternalClient(
             Prompt = prompt,
         };
 
-        var (transport, content) = await SendAsync(AssistPath, "POST", request, ct);
+        var (transport, content) = await SendWithConsentRetryAsync(AssistPath, "POST", request, ct);
         if (transport != AiHelperStatus.Success)
             return new SuggestCdcInternalResult(transport, Configuration: null, [], 0, 0);
 
@@ -58,7 +58,7 @@ public sealed class AiHelperInternalClient(
             Prompt = prompt,
         };
 
-        var (transport, content) = await SendAsync(AssistPath, "POST", request, ct);
+        var (transport, content) = await SendWithConsentRetryAsync(AssistPath, "POST", request, ct);
         if (transport != AiHelperStatus.Success)
             return new SuggestAiAgentInternalResult(transport, [], [], 0, 0);
 
@@ -84,9 +84,77 @@ public sealed class AiHelperInternalClient(
             RavenVersion = ServerVersion.Build,
         };
 
+        var response = await PostChatAsync(request, ct);
+        if (await ShouldRetryWithConsentAsync(response, ct) == false)
+            return response;
+
+        response.Dispose();
+        return await PostChatAsync(request, ct);
+    }
+
+    // Owns the failure path of the response it inspects: reading the refusal or asking for consent can
+    // be cancelled, and nobody else is holding the 401 to close it.
+    private async Task<bool> ShouldRetryWithConsentAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            if (await IsConsentRequiredAsync(response, ct) == false)
+                return false;
+
+            // Consent is refused before the answer starts streaming, so asking again replays nothing.
+            // When it cannot be granted the original 401 already explains itself to the caller.
+            return await GiveConsentAsync(ct) == AiHelperStatus.Success;
+        }
+        catch
+        {
+            response.Dispose();
+            throw;
+        }
+    }
+
+    private async Task<HttpResponseMessage> PostChatAsync(ChatbotApiRequest request, CancellationToken ct)
+    {
         using var content = new StringContent(SerializeRequest(request), Encoding.UTF8, "application/json");
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, AssistPath) { Content = content };
         return await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, ct);
+    }
+
+    // Reading the body buffers it, so the response stays relayable after the check.
+    private async Task<bool> IsConsentRequiredAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        if (response.StatusCode != HttpStatusCode.Unauthorized)
+            return false;
+
+        var text = await response.Content.ReadAsStringAsync(ct);
+        var status = await ClassifyUnauthorizedAsync(text, ct);
+
+        logger.Log(
+            status == AiHelperStatus.ConsentRequired ? LogLevel.Information : LogLevel.Warning,
+            "AI Helper {Path} was refused: upstream 401, mapped {Status}. Body: {Body}",
+            AssistPath, status, TruncateForLog(text));
+
+        return status == AiHelperStatus.ConsentRequired;
+    }
+
+    private async Task<(AiHelperStatus Transport, string Content)> SendWithConsentRetryAsync(string path, string method, object request, CancellationToken ct)
+    {
+        var result = await SendAsync(path, method, request, ct);
+        if (result.Transport != AiHelperStatus.ConsentRequired)
+            return result;
+
+        var consent = await GiveConsentAsync(ct);
+        if (consent != AiHelperStatus.Success)
+            return (consent, string.Empty);
+
+        var retried = await SendAsync(path, method, request, ct);
+        if (retried.Transport == AiHelperStatus.ConsentRequired)
+        {
+            logger.LogWarning(
+                "AI Helper {Path}: assist still returns ConsentRequired after give-consent succeeded — propagation lag or cert-thumbprint mismatch.",
+                path);
+        }
+
+        return retried;
     }
 
     public async Task<(AiHelperStatus Transport, string Content)> SendAsync(string path, string method, object request, CancellationToken ct)

--- a/src/Raven.Quill/AiHelper/IAiHelperClient.cs
+++ b/src/Raven.Quill/AiHelper/IAiHelperClient.cs
@@ -11,15 +11,16 @@ public interface IAiHelperClient
         CdcSinkConfiguration cdcConfig, object? collectionsSample, string mode, string? prompt, CancellationToken ct);
 
     /// <summary>Starts one AI assistant (chatbot) turn and hands back the upstream response for the
-    /// caller to relay. The response is the caller's to dispose.</summary>
+    /// caller to relay, granting consent and retrying first if the service asks for it. The response
+    /// is the caller's to dispose.</summary>
     Task<HttpResponseMessage> SendChatAsync(string message, string? conversationId, CancellationToken ct);
 
     /// <summary>Asks whether the license behind this appliance has already consented to sending data to
     /// the RavenDB AI service. Answers <see cref="AiHelperStatus.ConsentRequired"/> until it has.</summary>
     Task<AiHelperStatus> CheckConsentAsync(CancellationToken ct);
 
-    /// <summary>Records this appliance's consent to the AI service's terms. Only ever called for an
-    /// operator who accepted them: nothing in Quill grants consent on their behalf.</summary>
+    /// <summary>Records this appliance's consent to the AI service's terms, either because an operator
+    /// accepted them or because an AI call was refused for want of consent.</summary>
     Task<AiHelperStatus> GiveConsentAsync(CancellationToken ct);
 
     Task<(AiHelperStatus Transport, string Content)> SendAsync(string path, string method, object request, CancellationToken ct);

--- a/src/Raven.Quill/Endpoints/AssistantEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/AssistantEndpoints.cs
@@ -38,8 +38,6 @@ public static class AssistantEndpoints
     private static async Task<IResult> CheckConsentAsync(IAiHelperClient aiClient, CancellationToken ct) =>
         ToConsentResult(await aiClient.CheckConsentAsync(ct));
 
-    // Consent is the operator's to give: this runs only because they accepted the AI service's terms in
-    // the assistant panel, and nothing else in Quill grants it for them.
     private static async Task<IResult> GiveConsentAsync(
         IAiHelperClient aiClient,
         ILogger<AssistantLogger> logger,

--- a/test/QuillTests/AiHelperSuggestAgentEndpointTests.cs
+++ b/test/QuillTests/AiHelperSuggestAgentEndpointTests.cs
@@ -128,7 +128,7 @@ public class AiHelperSuggestAgentEndpointTests(ITestOutputHelper output, QuillAi
     }
 
     [RavenFact(RavenTestCategory.Quill)]
-    public async Task From_data_surfaces_consent_required_instead_of_granting_consent()
+    public async Task From_data_consent_required_then_signs_consent_and_retries_successfully()
     {
         // mock mirrors the real consent gate
         Mock.RequireConsentForAssist = true;
@@ -137,11 +137,10 @@ public class AiHelperSuggestAgentEndpointTests(ITestOutputHelper output, QuillAi
         await using var app = await NewAppAsync();
 
         var resp = await app.SuggestAgentAsync(new SuggestAgentRequest(null, "from-data"));
+        Assert.Equal("Success", resp.Status);
+        Assert.Single(resp.Configurations);
 
-        // Accepting the AI service's terms is the operator's call, made in the assistant panel.
-        Assert.Equal("ConsentRequired", resp.Status);
-        Assert.Empty(resp.Configurations);
-        Assert.Equal(0, Mock.GiveConsentCallCount);
+        Assert.Equal(1, Mock.GiveConsentCallCount);
     }
 
     [RavenFact(RavenTestCategory.Quill)]

--- a/test/QuillTests/AiHelperSuggestCdcEndpointTests.cs
+++ b/test/QuillTests/AiHelperSuggestCdcEndpointTests.cs
@@ -216,7 +216,7 @@ public class AiHelperSuggestCdcEndpointTests(ITestOutputHelper output, QuillAiHe
     }
 
     [RavenFact(RavenTestCategory.Quill)]
-    public async Task Consent_required_is_surfaced_instead_of_being_granted()
+    public async Task Consent_required_then_signs_consent_and_retries_successfully()
     {
         // mock mirrors the real consent gate
         Mock.RequireConsentForAssist = true;
@@ -224,12 +224,36 @@ public class AiHelperSuggestCdcEndpointTests(ITestOutputHelper output, QuillAiHe
         await SeedDiscoveredSchemaAsync(Host);
 
         var resp = await Host.SuggestCdcAsync(Request("shopping cart assistant", "orders"));
+        Assert.Equal("Success", resp.Status);
+        Assert.Equal("shop-cdc", resp.Configuration!.Name);
 
-        // Accepting the AI service's terms is the operator's call, made in the assistant panel — the
-        // wizard says what is missing rather than consenting for them.
+        Assert.Equal(1, Mock.GiveConsentCallCount);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Give_consent_rejection_surfaces_invalid_credentials()
+    {
+        Mock.RequireConsentForAssist = true;
+        Mock.GiveConsentResponse = (401, "{\"Status\":\"InvalidCredentials\"}");
+        await SeedDiscoveredSchemaAsync(Host);
+
+        var resp = await Host.SuggestCdcAsync(Request("x", "orders"));
+        Assert.Equal("InvalidCredentials", resp.Status);
+        Assert.Equal(1, Mock.GiveConsentCallCount);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Post_retry_consent_required_is_surfaced_verbatim()
+    {
+        Mock.RequireConsentForAssist = true;
+        // grant succeeds but gate stays closed: retry once, surface ConsentRequired, don't loop
+        Mock.ConsentGrantHasNoEffect = true;
+        await SeedDiscoveredSchemaAsync(Host);
+
+        var resp = await Host.SuggestCdcAsync(Request("x", "orders"));
         Assert.Equal("ConsentRequired", resp.Status);
         Assert.Null(resp.Configuration);
-        Assert.Equal(0, Mock.GiveConsentCallCount);
+        Assert.Equal(1, Mock.GiveConsentCallCount);
     }
 
     [RavenFact(RavenTestCategory.Quill)]

--- a/test/QuillTests/AssistantChatEndpointTests.cs
+++ b/test/QuillTests/AssistantChatEndpointTests.cs
@@ -61,18 +61,31 @@ public class AssistantChatEndpointTests(ITestOutputHelper output, QuillAiHelperF
     }
 
     [RavenFact(RavenTestCategory.Quill)]
-    public async Task Chat_relays_the_consent_refusal_instead_of_granting_consent()
+    public async Task Chat_gives_consent_once_and_retries_before_relaying_anything()
     {
         Mock.RequireConsentForAssist = true;
         Mock.ChatbotChunks = ["Answered after consent."];
 
+        var (response, frames) = await ChatAsync(new { message = "hi", conversationId = (string?)null });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, Mock.GiveConsentCallCount);
+        // Consent is settled before the relay starts, so the answer is streamed exactly once.
+        Assert.Equal(["Ongoing", "Done"], frames.Select(frame => frame.GetProperty("type").GetString()));
+        Assert.Equal("Answered after consent.", frames[0].GetProperty("text").GetString());
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Chat_relays_the_refusal_when_consent_cannot_be_granted()
+    {
+        Mock.RequireConsentForAssist = true;
+        Mock.GiveConsentResponse = (401, """{"Status":"InvalidCredentials"}""");
+
         var response = await Host.Client.PostAsJsonAsync(AssistantChatRoute, new { message = "hi" });
 
-        // Consent is the operator's to give through /api/assistant/consent. The client reads the
-        // upstream Status out of the body, the way the Studio does, and shows its consent gate.
+        // The client reads the upstream Status out of the body, the way the Studio does.
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         Assert.Equal("ConsentRequired", await ReadStatusAsync(response));
-        Assert.Equal(0, Mock.GiveConsentCallCount);
     }
 
     [RavenFact(RavenTestCategory.Quill)]

--- a/test/QuillTests/E2E/Fixtures/MockQuillServices.cs
+++ b/test/QuillTests/E2E/Fixtures/MockQuillServices.cs
@@ -88,6 +88,9 @@ public sealed class MockQuillServices : IAsyncDisposable
     /// When set, check-consent answers this instead of reporting whether the gate is open.
     public (int Status, string Body)? CheckConsentResponse { get; set; }
 
+    /// When true, a successful give-consent does NOT open the assist gate — simulates propagation lag.
+    public bool ConsentGrantHasNoEffect { get; set; }
+
     public int GiveConsentCallCount { get; private set; }
 
     // ---- /hook — a customer's action webhook ----
@@ -203,6 +206,7 @@ public sealed class MockQuillServices : IAsyncDisposable
         RequireConsentForAssist = false;
         GiveConsentResponse = (200, "{\"Status\":\"Success\"}");
         CheckConsentResponse = null;
+        ConsentGrantHasNoEffect = false;
         GiveConsentCallCount = 0;
         _consentGiven = false;
 
@@ -279,12 +283,12 @@ public sealed class MockQuillServices : IAsyncDisposable
                 : Results.Content("{\"Status\":\"Success\"}", "application/json");
         });
 
-        // the appliance posts here once an operator accepted the terms; a 200 opens the gate
+        // the appliance posts here after a ConsentRequired, then retries assist; a 200 opens the gate
         app.MapPost("/assistant/give-consent", () =>
         {
             GiveConsentCallCount++;
             var (status, body) = GiveConsentResponse;
-            if (status is >= 200 and < 300)
+            if (status is >= 200 and < 300 && ConsentGrantHasNoEffect == false)
                 _consentGiven = true;
             return Results.Content(body, "application/json", statusCode: status);
         });


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/Quill-268/ConsentRequired-error

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
