### PR TITLE
Quill-271: pull the latest ravendb base on every image build

### DIFF
--- a/docker/quill/scripts/build.sh
+++ b/docker/quill/scripts/build.sh
@@ -84,7 +84,7 @@ fi
 
 cd "$(git rev-parse --show-toplevel)"
 
-cmd=(docker buildx build --platform "$PLATFORMS" -f "$DOCKERFILE")
+cmd=(docker buildx build --pull --platform "$PLATFORMS" -f "$DOCKERFILE")
 
 for tag in "${TAGS[@]}"; do
   cmd+=(-t "$tag")


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-271/pull-latest-ravendb-upon-building-Quill

### Additional description

Our build can bake a stale ravendb base. we run docker buildx build without `--pull` , and the Dockerfile pins the moving tag `ravendb/ravendb-nightly:7.2-latest` - so a build (local or CI) reuses a cached base, and a freshly built quill image can still contain an old ravendb-nightly.
I added the flag to address this.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
