### PR TITLE
Quill-265 Slack channel UI adjustments

### DIFF
--- a/src/Raven.Quill.Web/src/components/ace-editor/static-highlight.ts
+++ b/src/Raven.Quill.Web/src/components/ace-editor/static-highlight.ts
@@ -6,6 +6,7 @@ import { Mode as JavaScriptMode } from "ace-builds/src-noconflict/mode-javascrip
 import { Mode as PowershellMode } from "ace-builds/src-noconflict/mode-powershell";
 import { Mode as PythonMode } from "ace-builds/src-noconflict/mode-python";
 import { Mode as ShMode } from "ace-builds/src-noconflict/mode-sh";
+import { Mode as YamlMode } from "ace-builds/src-noconflict/mode-yaml";
 import "@/components/ace-editor/ace-syntax-colors.css";
 
 const MODES = {
@@ -15,6 +16,7 @@ const MODES = {
     powershell: new PowershellMode(),
     python: new PythonMode(),
     sh: new ShMode(),
+    yaml: new YamlMode(),
 };
 
 export type HighlightLanguage = keyof typeof MODES;

--- a/src/Raven.Quill.Web/src/components/data/copyable-code.tsx
+++ b/src/Raven.Quill.Web/src/components/data/copyable-code.tsx
@@ -29,7 +29,7 @@ export function CopyableCode({ code, copyLabel, language, className }: CopyableC
                 type="button"
                 variant="ghost"
                 size="icon-sm"
-                className="absolute top-1.5 right-1.5"
+                className="absolute top-1/2 right-1.5 -translate-y-1/2"
                 aria-label={copyLabel}
                 onClick={() => copyToClipboard(code)}
             >

--- a/src/Raven.Quill.Web/src/components/data/numbered-steps.tsx
+++ b/src/Raven.Quill.Web/src/components/data/numbered-steps.tsx
@@ -1,33 +1,48 @@
 import type { ReactNode } from "react";
 import { Heading, Text } from "@/components/typography";
+import { cn } from "@/lib/utils";
 
 export type NumberedStep = {
     title: string;
     content: ReactNode;
 };
 
+// "sm" tightens the badge and title for dense contexts (e.g. a collapsible helper inside a form sheet);
+// "default" is the roomier walkthrough used on its own.
+type NumberedStepsSize = "default" | "sm";
+
+const SIZE_CLASSES: Record<NumberedStepsSize, { column: string; badge: string; title: "subsection" | "label" }> = {
+    default: { column: "grid-cols-[1.5rem_1fr]", badge: "size-6", title: "subsection" },
+    sm: { column: "grid-cols-[1.25rem_1fr]", badge: "size-5 text-[0.6875rem]", title: "label" },
+};
+
 // A numbered walkthrough: a badge and a connector rail in the left column, the step's title and content
 // in the right. The rail is drawn on every step but the last so the steps read as a single sequence.
-export function NumberedSteps({ steps }: { steps: NumberedStep[] }) {
+export function NumberedSteps({ steps, size = "default" }: { steps: NumberedStep[]; size?: NumberedStepsSize }) {
+    const sizeClasses = SIZE_CLASSES[size];
+
     return (
         <ol className="grid gap-0">
             {steps.map((step, index) => {
                 const isLast = index === steps.length - 1;
 
                 return (
-                    <li key={step.title} className="grid grid-cols-[1.5rem_1fr] gap-x-3">
+                    <li key={step.title} className={cn("grid gap-x-3", sizeClasses.column)}>
                         <div className="flex flex-col items-center">
                             <Text
                                 variant="caption"
                                 as="span"
-                                className="flex size-6 items-center justify-center rounded-full border border-border bg-muted font-medium"
+                                className={cn(
+                                    "flex items-center justify-center rounded-full border border-border bg-muted font-medium",
+                                    sizeClasses.badge,
+                                )}
                             >
                                 {index + 1}
                             </Text>
-                            {!isLast && <span aria-hidden="true" className="mt-1 w-px flex-1 bg-border" />}
+                            {!isLast && <span aria-hidden="true" className="w-px flex-1 bg-border" />}
                         </div>
                         <div className={isLast ? "" : "pb-5"}>
-                            <Heading as="h3" variant="subsection" className="mb-1.5">
+                            <Heading as="h3" variant={sizeClasses.title} className="mb-1">
                                 {step.title}
                             </Heading>
                             {step.content}

--- a/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.stories.tsx
@@ -82,6 +82,29 @@ export const SlackTokenRejected: Story = {
     },
 };
 
+export const SlackSendError: Story = {
+    parameters: {
+        router: {
+            initialPath: `/apps/demo/channels/${SAMPLE_SLACK_CHANNEL_ID}`,
+            path: "/apps/:slug/channels/:channelId",
+        },
+        msw: {
+            handlers: {
+                slack: [
+                    slackMocks.webhookInfo(),
+                    slackMocks.health([
+                        {
+                            ...sampleSlackHealth[0],
+                            lastSendErrorAt: new Date().toISOString(),
+                            lastSendError: "channel_not_found",
+                        },
+                    ]),
+                ],
+            },
+        },
+    },
+};
+
 export const Discord: Story = {
     parameters: {
         router: {

--- a/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.tsx
@@ -1,6 +1,18 @@
 import { useEffect, useLayoutEffect, useRef, useState, type ComponentType } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Bot, CodeXml, Fingerprint, Globe, MessageCircle, Pause, Pencil, Play, Send, Trash2 } from "lucide-react";
+import {
+    Bot,
+    Building2,
+    CodeXml,
+    Fingerprint,
+    Globe,
+    MessageCircle,
+    Pause,
+    Pencil,
+    Play,
+    Send,
+    Trash2,
+} from "lucide-react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { api } from "@/api/api";
@@ -219,6 +231,11 @@ function ChannelMeta({ channel, agent }: { channel: ChannelSummaryResponse; agen
             {agent?.name && (
                 <DetailHeaderMetaItem icon={Bot} tooltip="Agent">
                     {agent.name}
+                </DetailHeaderMetaItem>
+            )}
+            {channel.slack?.teamName && (
+                <DetailHeaderMetaItem icon={Building2} tooltip="Slack workspace">
+                    {channel.slack.teamName}
                 </DetailHeaderMetaItem>
             )}
             {allowedOrigins.length > 0 && (

--- a/src/Raven.Quill.Web/src/pages/apps/channels/slack-channel-form.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/slack-channel-form.tsx
@@ -13,8 +13,10 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { Heading, Text } from "@/components/typography";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { SheetClose, SheetFooter } from "@/components/shadcn/ui/sheet";
+import { Separator } from "@/components/shadcn/ui/separator";
 import { ApiState } from "@/components/data/api-state";
-import { CopyableCode } from "@/components/data/copyable-code";
+import { CodeBlockTabs } from "@/components/data/code-block-tabs";
+import { NumberedSteps } from "@/components/data/numbered-steps";
 import { FormInput } from "@/components/form/form-input";
 import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
 import { ParameterBindingFields } from "@/pages/apps/channels/parameter-binding-fields";
@@ -32,6 +34,7 @@ import {
     SLACK_SOURCE_VALUES,
     slackParameterSourceHint,
 } from "@/pages/apps/channels/slack-parameter-sources";
+import { SlackConnectionCard } from "@/pages/apps/channels/slack-connection-card";
 import { SlackWebhookPanel } from "@/pages/apps/channels/slack-webhook-panel";
 import type { FixedAgent } from "@/pages/apps/channels/web-widget-channel-form";
 
@@ -152,6 +155,13 @@ function LoadedSlackChannelForm({
         return (
             <div className="flex min-h-0 flex-1 flex-col">
                 <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
+                    <div className="space-y-1">
+                        <Heading as="h3" variant="subsection">
+                            Bot connected
+                        </Heading>
+                        <Text variant="muted">Now finish the event subscription so Slack delivers messages to it.</Text>
+                    </div>
+                    <SlackConnectionCard slug={slug} channelId={createdChannelId} />
                     <SlackWebhookPanel slug={slug} channelId={createdChannelId} />
                 </div>
                 <SheetFooter className="flex-row justify-end border-t">
@@ -197,30 +207,62 @@ function LoadedSlackChannelForm({
                                     aria-hidden="true"
                                 />
                             </CollapsibleTrigger>
-                            <CollapsibleContent className="grid gap-2">
-                                <ol className="list-decimal space-y-1.5 ps-5 text-xs text-muted-foreground">
-                                    <li>
-                                        At{" "}
-                                        <a
-                                            href="https://api.slack.com/apps"
-                                            target="_blank"
-                                            rel="noreferrer"
-                                            className="underline"
-                                        >
-                                            api.slack.com/apps
-                                        </a>
-                                        , choose{" "}
-                                        <span className="font-medium">Create New App &gt; From a manifest</span> and
-                                        paste:
-                                    </li>
-                                </ol>
-                                <CopyableCode code={SLACK_APP_MANIFEST} copyLabel="Copy app manifest" />
-                                <Text variant="caption">
-                                    Then <span className="font-medium">Install to Workspace</span>. The bot token is on
-                                    the OAuth &amp; Permissions page, the signing secret under Basic Information.
-                                </Text>
+                            <CollapsibleContent>
+                                <NumberedSteps
+                                    size="sm"
+                                    steps={[
+                                        {
+                                            title: "Create the app from this manifest",
+                                            content: (
+                                                <div className="space-y-2">
+                                                    <Text variant="caption">
+                                                        At{" "}
+                                                        <a
+                                                            href="https://api.slack.com/apps"
+                                                            target="_blank"
+                                                            rel="noreferrer"
+                                                            className="underline"
+                                                        >
+                                                            api.slack.com/apps
+                                                        </a>
+                                                        , choose{" "}
+                                                        <span className="font-medium">
+                                                            Create New App &gt; From a manifest
+                                                        </span>{" "}
+                                                        and paste:
+                                                    </Text>
+                                                    <CodeBlockTabs
+                                                        tabs={[
+                                                            {
+                                                                value: "manifest",
+                                                                label: "Manifest (YAML)",
+                                                                code: SLACK_APP_MANIFEST,
+                                                                language: "yaml",
+                                                            },
+                                                        ]}
+                                                        value="manifest"
+                                                        copyLabel="Copy app manifest"
+                                                    />
+                                                </div>
+                                            ),
+                                        },
+                                        {
+                                            title: "Install it and copy the credentials",
+                                            content: (
+                                                <Text variant="caption">
+                                                    <span className="font-medium">Install to Workspace</span>. The bot
+                                                    token is on the OAuth &amp; Permissions page, the signing secret
+                                                    under Basic Information.
+                                                </Text>
+                                            ),
+                                        },
+                                    ]}
+                                />
                             </CollapsibleContent>
                         </Collapsible>
+
+                        <Separator />
+
                         {!agent && (
                             <FormSelect
                                 control={form.control}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/slack-connect-tab.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/slack-connect-tab.tsx
@@ -1,10 +1,12 @@
 import type { ChannelSummaryResponse } from "@/api/generated/server-api";
 import { Alert } from "@/components/shadcn/ui/alert";
+import { SlackConnectionCard } from "@/pages/apps/channels/slack-connection-card";
 import { SlackWebhookPanel } from "@/pages/apps/channels/slack-webhook-panel";
 import { SectionCard } from "@/pages/apps/section-card";
 
-// "How Slack reaches this bot" — the Slack analogue of the Telegram Connect tab. The request URL is
-// fetched per channel; the token in it is a bearer secret, so it is shown here and nowhere else.
+// "How Slack reaches this bot" — the Slack analogue of the Telegram Connect tab. The connection card
+// confirms which workspace/bot is wired up and how it's doing; the event-subscription card is the admin
+// wiring.
 export function SlackConnectTab({ slug, channel }: { slug: string; channel: ChannelSummaryResponse }) {
     return (
         <div className="grid gap-5">
@@ -13,8 +15,18 @@ export function SlackConnectTab({ slug, channel }: { slug: string; channel: Chan
             )}
 
             <SectionCard
+                title="Connection"
+                description="The Slack workspace and bot this channel is wired to, and how the connection is doing."
+                isRaised
+            >
+                <div className="mt-4">
+                    <SlackConnectionCard slug={slug} channelId={channel.channelId} slack={channel.slack} />
+                </div>
+            </SectionCard>
+
+            <SectionCard
                 title="Slack event subscription"
-                description="Where Slack delivers this bot's direct messages, and how the connection is doing."
+                description="Where Slack delivers this bot's direct messages."
                 isRaised
             >
                 <div className="mt-4">

--- a/src/Raven.Quill.Web/src/pages/apps/channels/slack-connection-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/slack-connection-card.tsx
@@ -1,0 +1,100 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/api";
+import type { SlackSummaryResponse } from "@/api/generated/server-api";
+import { Alert } from "@/components/shadcn/ui/alert";
+import { Badge } from "@/components/shadcn/ui/badge";
+import { Text } from "@/components/typography";
+import { SlackIcon } from "@/pages/apps/channels/channel-brand-icons";
+import { formatDateTime, formatRelativeTime } from "@/lib/utils";
+
+// The connection identity + live health for a Slack channel: which workspace and bot it is wired to,
+// whether the token still works, when the last message arrived, and any recent delivery failure. Shown
+// on the Connect tab and again on the create sheet's success step so both confirm the same thing.
+export function SlackConnectionCard({
+    slug,
+    channelId,
+    slack,
+}: {
+    slug: string;
+    channelId: string;
+    slack?: SlackSummaryResponse | null;
+}) {
+    const healthQuery = useQuery(api.queries.slack.health(slug));
+    const health = healthQuery.data?.find((row) => row.channelId === channelId);
+
+    // The channel record carries workspace/bot identity synchronously; the health poll is the fallback
+    // right after creation, before the channel list has refetched.
+    const teamName = slack?.teamName ?? health?.teamName ?? null;
+    const botUserId = slack?.botUserId ?? health?.botUserId ?? null;
+
+    const hasRecentSignatureFailure =
+        health?.lastSignatureFailureAt != null &&
+        (health.lastInboundAt == null ||
+            new Date(health.lastSignatureFailureAt).getTime() > new Date(health.lastInboundAt).getTime());
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-background p-3">
+                <div className="flex min-w-0 items-center gap-3">
+                    <SlackIcon className="size-5 shrink-0 text-muted-foreground" aria-hidden={true} />
+                    <div className="min-w-0">
+                        <Text variant="label" className="truncate">
+                            {teamName ?? "Slack workspace"}
+                        </Text>
+                        <Text variant="caption" className="truncate font-mono">
+                            {botUserId ? `Bot ${botUserId}` : "Bot identity pending…"}
+                        </Text>
+                    </div>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-sm">
+                    <SlackTokenBadge tokenValid={health?.tokenValid} tokenError={health?.tokenError} />
+                    {health?.lastInboundAt ? (
+                        <Text as="span" variant="caption" title={formatDateTime(health.lastInboundAt)}>
+                            Last message {formatRelativeTime(health.lastInboundAt)}
+                        </Text>
+                    ) : (
+                        <Text as="span" variant="caption">
+                            Waiting for the first message...
+                        </Text>
+                    )}
+                </div>
+            </div>
+
+            {hasRecentSignatureFailure && health?.lastSignatureFailureAt && (
+                <Alert variant="destructive">
+                    A delivery failed signature verification {formatRelativeTime(health.lastSignatureFailureAt)} — the
+                    signing secret configured here likely differs from the Slack app&apos;s. Rotate the signing secret
+                    on this channel to match.
+                </Alert>
+            )}
+
+            {health?.lastSendError && (
+                <Alert variant="destructive">
+                    The bot couldn&apos;t deliver a reply
+                    {health.lastSendErrorAt ? ` ${formatRelativeTime(health.lastSendErrorAt)}` : ""}:{" "}
+                    {health.lastSendError}
+                </Alert>
+            )}
+        </div>
+    );
+}
+
+export function SlackTokenBadge({
+    tokenValid,
+    tokenError,
+}: {
+    tokenValid: boolean | null | undefined;
+    tokenError: string | null | undefined;
+}) {
+    if (tokenValid === true) {
+        return <Badge variant="success">Token valid</Badge>;
+    }
+    if (tokenValid === false) {
+        return (
+            <Badge variant="destructive" title={tokenError ?? undefined}>
+                Token rejected
+            </Badge>
+        );
+    }
+    return <Badge variant="secondary">Token status unknown</Badge>;
+}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/slack-webhook-panel.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/slack-webhook-panel.tsx
@@ -1,12 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
+import { ExternalLink } from "lucide-react";
 import { api } from "@/api/api";
 import { ApiState } from "@/components/data/api-state";
 import { CopyableCode } from "@/components/data/copyable-code";
-import { Alert } from "@/components/shadcn/ui/alert";
-import { Badge } from "@/components/shadcn/ui/badge";
+import { NumberedSteps } from "@/components/data/numbered-steps";
 import { Text } from "@/components/typography";
-import { formatDateTime, formatRelativeTime } from "@/lib/utils";
 
+// The admin-facing "wire Slack up to this bot" walkthrough: the per-channel request URL (a bearer
+// secret, so it is shown here and nowhere else) and the event-subscription steps. Connection identity
+// and live health live in SlackConnectionCard, shown alongside this.
 export function SlackWebhookPanel({ slug, channelId }: { slug: string; channelId: string }) {
     const infoQuery = useQuery(api.queries.slack.webhookInfo(slug, channelId));
 
@@ -20,89 +22,61 @@ export function SlackWebhookPanel({ slug, channelId }: { slug: string; channelId
         >
             {infoQuery.data && (
                 <div className="space-y-4">
-                    <ol className="list-decimal space-y-3 ps-5 text-sm">
-                        <li>
-                            In your{" "}
-                            <a href="https://api.slack.com/apps" target="_blank" rel="noreferrer" className="underline">
-                                Slack app settings
-                            </a>
-                            , open <span className="font-medium">Event Subscriptions</span> and turn events on.
-                        </li>
-                        <li>
-                            Paste the request URL — Slack verifies it immediately:
-                            <CopyableCode code={infoQuery.data.requestUrl} copyLabel="Copy request URL" />
-                        </li>
-                        <li>
-                            Under <span className="font-medium">Subscribe to bot events</span>, add{" "}
-                            <span className="font-medium">message.im</span>, then save.
-                        </li>
-                        <li>Open a DM with the bot in Slack and send it a message.</li>
-                    </ol>
+                    <NumberedSteps
+                        steps={[
+                            {
+                                title: "Open Event Subscriptions",
+                                content: (
+                                    <Text variant="muted">
+                                        In your{" "}
+                                        <a
+                                            href="https://api.slack.com/apps"
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            className="inline-flex items-center gap-0.5 underline underline-offset-2 hover:text-foreground"
+                                        >
+                                            Slack app settings
+                                            <ExternalLink className="size-3" aria-hidden="true" />
+                                        </a>
+                                        , open <span className="font-medium">Event Subscriptions</span> and turn events
+                                        on.
+                                    </Text>
+                                ),
+                            },
+                            {
+                                title: "Paste the request URL",
+                                content: (
+                                    <div className="space-y-2">
+                                        <Text variant="muted">Slack verifies it immediately.</Text>
+                                        <CopyableCode code={infoQuery.data.requestUrl} copyLabel="Copy request URL" />
+                                    </div>
+                                ),
+                            },
+                            {
+                                title: "Subscribe to bot events",
+                                content: (
+                                    <Text variant="muted">
+                                        Under <span className="font-medium">Subscribe to bot events</span>, add{" "}
+                                        <span className="font-medium">message.im</span>, then save.
+                                    </Text>
+                                ),
+                            },
+                            {
+                                title: "Test it",
+                                content: (
+                                    <Text variant="muted">Open a DM with the bot in Slack and send it a message.</Text>
+                                ),
+                            },
+                        ]}
+                    />
                     <Text variant="caption">
                         The appliance must be reachable from the internet on this URL. Apps created from the current
                         Quill manifest already carry the im:history scope, so adding the event needs no reinstall. An
                         app created before users:read and users:read.email were added to the manifest must be
                         reinstalled to the workspace before a parameter can bind to the sender&apos;s email.
                     </Text>
-                    <SlackHealthStrip slug={slug} channelId={channelId} />
                 </div>
             )}
         </ApiState>
     );
-}
-
-export function SlackHealthStrip({ slug, channelId }: { slug: string; channelId: string }) {
-    const healthQuery = useQuery(api.queries.slack.health(slug));
-    const health = healthQuery.data?.find((row) => row.channelId === channelId);
-    if (!health) {
-        return null;
-    }
-
-    const hasRecentSignatureFailure =
-        health.lastSignatureFailureAt != null &&
-        (health.lastInboundAt == null ||
-            new Date(health.lastSignatureFailureAt).getTime() > new Date(health.lastInboundAt).getTime());
-
-    return (
-        <div className="space-y-2">
-            <div className="flex flex-wrap items-center gap-2 text-sm">
-                <SlackTokenBadge tokenValid={health.tokenValid} tokenError={health.tokenError} />
-                {health.lastInboundAt ? (
-                    <Text as="span" variant="caption" title={formatDateTime(health.lastInboundAt)}>
-                        Last message {formatRelativeTime(health.lastInboundAt)}
-                    </Text>
-                ) : (
-                    <Text as="span" variant="caption">
-                        Waiting for the first message...
-                    </Text>
-                )}
-            </div>
-            {hasRecentSignatureFailure && (
-                <Alert variant="destructive">
-                    A recent delivery failed signature verification — the signing secret configured here likely differs
-                    from the Slack app's. Rotate the signing secret on this channel to match.
-                </Alert>
-            )}
-        </div>
-    );
-}
-
-export function SlackTokenBadge({
-    tokenValid,
-    tokenError,
-}: {
-    tokenValid: boolean | null | undefined;
-    tokenError: string | null | undefined;
-}) {
-    if (tokenValid === true) {
-        return <Badge variant="success">Token valid</Badge>;
-    }
-    if (tokenValid === false) {
-        return (
-            <Badge variant="destructive" title={tokenError ?? undefined}>
-                Token rejected
-            </Badge>
-        );
-    }
-    return <Badge variant="secondary">Token status unknown</Badge>;
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-265

### Additional description

Polishes the Slack channel detail and creation UX in Quill Studio (frontend only). Adds a Connection identity card to the Slack Connect tab (and the create-sheet success step) that surfaces the connected workspace, bot user, live token validity, last-message time, and — for the first time in the UI — outbound send failures and signature-verification failures, all from data already returned by the slack/health endpoint. The event-subscription instructions now use the shared NumberedSteps walkthrough, the app manifest renders as syntax-highlighted YAML via CodeBlockTabs, the create form is flattened to match the other channel types, and the Slack workspace is shown in the detail header. No backend/API changes.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
