### PR TITLE
RavenDB-27413 Clarify duplicate buckets in the bucket report

### DIFF
--- a/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
@@ -75,7 +75,12 @@ namespace Raven.Server.Web.Studio.Processors
         public long NumberOfBuckets;
         public long RangeSize;
         public HashSet<int> ShardNumbers = new();
-        
+
+        // set only for a single-bucket range that resides on more than one shard (resharding in progress);
+        // points to the shard that owns the bucket according to the sharding configuration,
+        // the copies on the remaining shards are pending removal
+        public int? OwnerShardNumber;
+
         public string RangeSizeHumane => Size.Humane(RangeSize);
         public long DocumentsCount;
         public DateTime LastModified;
@@ -92,8 +97,9 @@ namespace Raven.Server.Web.Studio.Processors
                 [nameof(RangeSize)] = RangeSize,
                 [nameof(DocumentsCount)] = DocumentsCount,
                 [nameof(LastModified)] = LastModified,
+                [nameof(OwnerShardNumber)] = OwnerShardNumber,
             };
-            
+
             return json;
         }
     }

--- a/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBuckets.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Web.Studio.Processors
         public HashSet<int> ShardNumbers = new();
 
         // set only for a single-bucket range that resides on more than one shard (resharding in progress);
-        // points to the shard that owns the bucket according to the sharding configuration,
+        // points to the shard that will own the bucket once the migration completes (its destination),
         // the copies on the remaining shards are pending removal
         public int? OwnerShardNumber;
 

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
@@ -9,6 +9,7 @@ using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Server.Web.Studio.Processors;
 
 namespace Raven.Server.Web.Studio.Sharding.Processors
@@ -26,7 +27,19 @@ namespace Raven.Server.Web.Studio.Sharding.Processors
                 return await RequestHandler.ShardExecutor.ExecuteSingleShardAsync(new GetBucketsCommand(fromBucket, toBucket, range), shardNumber.Value, token);
 
             var shardedGetBucketsOperation = new ShardedGetBucketsOperation(RequestHandler.HttpContext.Request, fromBucket, toBucket, range);
-            return await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(shardedGetBucketsOperation, token);
+            var results = await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(shardedGetBucketsOperation, token);
+            MarkOwnerShards(results);
+            return results;
+        }
+
+        private void MarkOwnerShards(BucketsResults results)
+        {
+            var configuration = RequestHandler.DatabaseContext.DatabaseRecord.Sharding;
+            foreach (var bucketRange in results.BucketRanges.Values)
+            {
+                if (bucketRange.ShardNumbers.Count > 1 && bucketRange.FromBucket == bucketRange.ToBucket)
+                    bucketRange.OwnerShardNumber = ShardHelper.GetShardNumberFor(configuration, (int)bucketRange.FromBucket);
+            }
         }
     }
 

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedBucketsHandlerProcessorForGetBuckets.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
 using Raven.Client.Http;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Documents.Sharding.Operations;
@@ -38,8 +39,18 @@ namespace Raven.Server.Web.Studio.Sharding.Processors
             foreach (var bucketRange in results.BucketRanges.Values)
             {
                 if (bucketRange.ShardNumbers.Count > 1 && bucketRange.FromBucket == bucketRange.ToBucket)
-                    bucketRange.OwnerShardNumber = ShardHelper.GetShardNumberFor(configuration, (int)bucketRange.FromBucket);
+                    bucketRange.OwnerShardNumber = GetOwnerShard(configuration, (int)bucketRange.FromBucket);
             }
+        }
+
+        private static int GetOwnerShard(ShardingConfiguration configuration, int bucket)
+        {
+            if (configuration.BucketMigrations != null &&
+                configuration.BucketMigrations.TryGetValue(bucket, out var migration) &&
+                migration.Status != MigrationStatus.OwnershipTransferred)
+                return migration.DestinationShard;
+
+            return ShardHelper.GetShardNumberFor(configuration, bucket);
         }
     }
 

--- a/src/Raven.Studio/typescript/models/database/status/bucketReportItem.ts
+++ b/src/Raven.Studio/typescript/models/database/status/bucketReportItem.ts
@@ -21,7 +21,11 @@ class bucketReportItem {
     lazyLoadChildren = false;
     
     shards: number[] = [];
-    
+
+    // shard which owns the bucket according to the sharding configuration - set only when the bucket
+    // temporarily resides on more than one shard (resharding in progress)
+    ownerShard: number = null;
+
     constructor(name: string, size: number, numberOfBuckets: number, documentsCount: number, shards: number[], internalChildren: bucketReportItem[] = null) {
         this.name = name;
         this.size = size;
@@ -29,6 +33,14 @@ class bucketReportItem {
         this.documentsCount = documentsCount;
         this.shards = shards;
         this.internalChildren = internalChildren;
+    }
+
+    isShardPendingRemoval(shard: number): boolean {
+        return this.ownerShard != null && this.shards.length > 1 && shard !== this.ownerShard;
+    }
+
+    pendingRemovalTooltip(): string {
+        return "This bucket is being moved to shard #" + this.ownerShard + ". The copy on this shard will be removed once resharding completes.";
     }
 
     formatSize() {

--- a/src/Raven.Studio/typescript/models/database/status/bucketReportItem.ts
+++ b/src/Raven.Studio/typescript/models/database/status/bucketReportItem.ts
@@ -22,8 +22,8 @@ class bucketReportItem {
     
     shards: number[] = [];
 
-    // shard which owns the bucket according to the sharding configuration - set only when the bucket
-    // temporarily resides on more than one shard (resharding in progress)
+    // shard which will own the bucket once resharding completes (the migration destination) - set only when
+    // the bucket temporarily resides on more than one shard (resharding in progress)
     ownerShard: number = null;
 
     constructor(name: string, size: number, numberOfBuckets: number, documentsCount: number, shards: number[], internalChildren: bucketReportItem[] = null) {

--- a/src/Raven.Studio/typescript/viewmodels/database/status/bucketsReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/bucketsReport.ts
@@ -148,11 +148,13 @@ class bucketsReport extends shardViewModelBase {
         const item = new bucketReportItem(name, dto.RangeSize, dto.NumberOfBuckets, dto.DocumentsCount, dto.ShardNumbers);
         item.fromRange = dto.FromBucket;
         item.toRange = dto.ToBucket;
+        item.ownerShard = dto.OwnerShardNumber ?? null;
         item.lazyLoadChildren = !leafBucket;
         if (leafBucket) {
             const leafItem = new bucketReportItem("Bucket: " + dto.FromBucket, dto.RangeSize, dto.NumberOfBuckets, dto.DocumentsCount, dto.ShardNumbers);
             leafItem.fromRange = dto.FromBucket;
             leafItem.toRange = dto.ToBucket;
+            leafItem.ownerShard = dto.OwnerShardNumber ?? null;
             item.internalChildren = [leafItem];
         }
         
@@ -471,7 +473,7 @@ class bucketsReport extends shardViewModelBase {
         let html = "<div class='tooltip-li'>Range: <div class='value'>" + d.name + "</div></div>";
         html += "<div class='tooltip-li'>Documents Count: <div class='value'>" + d.documentsCount + "</div></div>";
         html += "<div class='tooltip-li'>Buckets Count: <div class='value'>" + d.numberOfBuckets + "</div></div>";
-        html += "<div class='tooltip-li'>Shards: <div class='value'>" + d.shards.map(x => `<span># ${x}</span>`).join("") + "</div></div>";
+        html += "<div class='tooltip-li'>Shards: <div class='value'>" + d.shards.map(x => d.isShardPendingRemoval(x) ? `<span># ${x} (pending removal)</span>` : `<span># ${x}</span>`).join("") + "</div></div>";
         html += "<div class='tooltip-li'>Size: <div class='value'>" + generalUtils.formatBytesToSize(d.size) + "</div></div>";
 
         this.tooltip.html(html);

--- a/src/Raven.Studio/wwwroot/App/views/database/status/bucketsReport.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/bucketsReport.html
@@ -37,8 +37,15 @@
                     <td data-bind="text: documentsCount.toLocaleString()"></td>
                     <td>
                         <!-- ko foreach: shards -->
-                            <span class="label label-primary" data-bind="text: '#' + $data">
-                            </span>
+                            <!-- ko if: $parent.isShardPendingRemoval($data) -->
+                                <span class="label label-default shard-pending-removal" data-bind="attr: { title: $parent.pendingRemovalTooltip() }">
+                                    <i class="icon-trash"></i><span data-bind="text: '#' + $data"></span>
+                                </span>
+                            <!-- /ko -->
+                            <!-- ko ifnot: $parent.isShardPendingRemoval($data) -->
+                                <span class="label label-primary" data-bind="text: '#' + $data">
+                                </span>
+                            <!-- /ko -->
                         <!-- /ko -->
                     </td>
                     <td data-bind="html: formatSize(false)"></td>

--- a/src/Raven.Studio/wwwroot/App/views/database/status/bucketsReport.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/bucketsReport.html
@@ -39,7 +39,7 @@
                         <!-- ko foreach: shards -->
                             <!-- ko if: $parent.isShardPendingRemoval($data) -->
                                 <span class="label label-default shard-pending-removal" data-bind="attr: { title: $parent.pendingRemovalTooltip() }">
-                                    <i class="icon-trash"></i><span data-bind="text: '#' + $data"></span>
+                                    <i class="icon-waiting"></i><span data-bind="text: '#' + $data"></span><span class="pending-removal-text">pending removal</span>
                                 </span>
                             <!-- /ko -->
                             <!-- ko ifnot: $parent.isShardPendingRemoval($data) -->

--- a/src/Raven.Studio/wwwroot/Content/css/pages/storage-report.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/storage-report.less
@@ -583,4 +583,15 @@
         display: block;
         white-space: nowrap;
     }
+
+    .label.shard-pending-removal {
+        background-color: transparent;
+        border: 1px dashed @text-muted;
+        color: @text-muted;
+        cursor: help;
+
+        i {
+            margin-right: 3px;
+        }
+    }
 }

--- a/src/Raven.Studio/wwwroot/Content/css/pages/storage-report.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/storage-report.less
@@ -586,12 +586,17 @@
 
     .label.shard-pending-removal {
         background-color: transparent;
-        border: 1px dashed @text-muted;
-        color: @text-muted;
+        border: 1px dashed @brand-warning;
+        color: @brand-warning;
         cursor: help;
 
         i {
             margin-right: 3px;
+        }
+
+        .pending-removal-text {
+            margin-left: 4px;
+            font-weight: normal;
         }
     }
 }

--- a/test/SlowTests/Sharding/StudioBucketsTests.cs
+++ b/test/SlowTests/Sharding/StudioBucketsTests.cs
@@ -7,6 +7,10 @@ using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Client.Util;
+using Raven.Server.Utils;
 using Raven.Server.Web.Studio.Processors;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -120,6 +124,80 @@ namespace SlowTests.Sharding
             public int TotalSize;
             public int DocCount;
             public HashSet<int> Buckets;
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task GetBucketsView_OwnerShardIsTheDestinationDuringWholeMigration()
+        {
+            DoNotReuseServer();
+            using (var store = Sharding.GetDocumentStore())
+            {
+                // drive the migration by hand, so we can inspect the buckets report while it is held in each status
+                Server.ServerStore.Sharding.ManualMigration = true;
+
+                const string id = "foo/bar";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Original shard" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                var bucket = Sharding.GetBucket(record.Sharding, id);
+                var sourceShard = ShardHelper.GetShardNumberFor(record.Sharding, bucket);
+                var destinationShard = ShardingTestBase.GetNextSortedShardNumber(record.Sharding.Shards, sourceShard);
+
+                var result = await Server.ServerStore.Sharding.StartBucketMigration(store.Database, bucket, destinationShard, RaftIdGenerator.NewId());
+                var migrationIndex = result.Index;
+
+                var exists = WaitForDocument<User>(store, id, predicate: null, database: ShardHelper.ToShardName(store.Database, destinationShard));
+                Assert.True(exists, $"{id} wasn't found at shard {destinationShard}");
+
+                // Moving: the bucket already exists on both shards, but the sharding configuration still points at the source
+                await AssertOwnerShardAsync(store, bucket, MigrationStatus.Moving, sourceShard, destinationShard);
+
+                string lastSourceChangeVector;
+                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, sourceShard)))
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    lastSourceChangeVector = session.Advanced.GetChangeVectorFor(user);
+                }
+
+                result = await Server.ServerStore.Sharding.SourceMigrationCompleted(store.Database, bucket, migrationIndex, lastSourceChangeVector, RaftIdGenerator.NewId());
+                await Server.ServerStore.Cluster.WaitForIndexNotification(result.Index);
+
+                // Moved: the destination has everything, but the sharding configuration still points at the source
+                await AssertOwnerShardAsync(store, bucket, MigrationStatus.Moved, sourceShard, destinationShard);
+
+                result = await Server.ServerStore.Sharding.DestinationMigrationConfirm(store.Database, bucket, migrationIndex);
+                await Server.ServerStore.Cluster.WaitForIndexNotification(result.Index);
+
+                // OwnershipTransferred: the sharding configuration points at the destination, the source copy awaits cleanup
+                await AssertOwnerShardAsync(store, bucket, MigrationStatus.OwnershipTransferred, sourceShard, destinationShard);
+            }
+        }
+
+        private async Task AssertOwnerShardAsync(IDocumentStore store, int bucket, MigrationStatus expectedStatus, int sourceShard, int destinationShard)
+        {
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            Assert.True(record.Sharding.BucketMigrations.TryGetValue(bucket, out var migration), $"bucket {bucket} is not migrating");
+            Assert.Equal(expectedStatus, migration.Status);
+            Assert.Equal(sourceShard, migration.SourceShard);
+            Assert.Equal(destinationShard, migration.DestinationShard);
+
+            // the orchestrator picks up the record change asynchronously
+            var ownerShard = await WaitForValueAsync(async () =>
+            {
+                var results = await store.Operations.SendAsync(new GetBucketsOperation(range: 1));
+                return results.BucketRanges.TryGetValue(bucket, out var bucketRange) ? bucketRange.OwnerShardNumber : null;
+            }, (int?)destinationShard);
+
+            var results = await store.Operations.SendAsync(new GetBucketsOperation(range: 1));
+            Assert.True(results.BucketRanges.TryGetValue(bucket, out var bucketRange), $"bucket {bucket} is missing from the report");
+            Assert.Equal(2, bucketRange.ShardNumbers.Count);
+            Assert.Contains(sourceShard, bucketRange.ShardNumbers);
+            Assert.Contains(destinationShard, bucketRange.ShardNumbers);
+            Assert.Equal((int?)destinationShard, ownerShard);
         }
 
         [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27413

### Additional description

During resharding a bucket temporarily exists on two shards, and the buckets report showed both copies identically. This change makes the report distinguish them.

The sharded `GetBuckets` endpoint now resolves the owning shard (from the sharding configuration) for any single-bucket range that resides on more than one shard, and returns it as `OwnerShardNumber`.

In the Studio buckets report, the copy on the non-owning shard is rendered as a dimmed label with a dashed outline and a trash icon, with a tooltip explaining that this copy will be removed once resharding completes. The treemap tooltip also marks that shard with "(pending removal)". Aggregated (multi-bucket) range rows are unaffected, since multiple shards there are normal data distribution.

<img width="2502" height="1272" alt="Zrzut ekranu 2026-08-26 170052" src="https://github.com/user-attachments/assets/52d48bd2-ad47-4227-803e-c21d7e11faeb" />


There is also text in tooltip when the user hovers over the option to delete a shard:
`This bucket is being moved to shard #" + this.ownerShard + ". The copy on this shard will be removed once resharding completes.`

<img width="2442" height="1216" alt="image" src="https://github.com/user-attachments/assets/92869f02-93f2-4ea8-a392-c5e13c320076" />


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
