### PR TITLE
RavenDB-27433 Honor exact() in Corax 2.0 vector search

### DIFF
--- a/src/Raven.Client/Http/HttpCache.cs
+++ b/src/Raven.Client/Http/HttpCache.cs
@@ -165,7 +165,7 @@ namespace Raven.Client.Http
             old?.ReleaseRefInternal();
         }
 
-        public void SetNotFound(string url, bool aggressivelyCached)
+        public unsafe void SetNotFound(string url, bool aggressivelyCached)
         {
             var flag = aggressivelyCached ? ItemFlags.AggressivelyCached : ItemFlags.None;
             var httpCacheItem = new HttpCacheItem

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Vector.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Vector.cs
@@ -101,6 +101,11 @@ internal static partial class QueryPlanBuilder
             ? vec.NumberOfCandidates
             : builderParameters.Index.Configuration.CoraxVectorDefaultNumberOfCandidatesForQuerying;
 
+        // exact(vector.search(...)) opts out of the HNSW approximation - brute-force the whole (or filtered) candidate
+        // set instead. ParseExact marks the clause template, and exact() is part of the structural plan key, so the
+        // exact and approximate forms of the same query never share a compiled plan.
+        bool isExact = exec.Clause.IsExact;
+
         var fieldName = exec.Clause.FieldName
                         ?? throw new InvalidOperationException("Vector clause has no pre-resolved field name.");
 
@@ -122,12 +127,12 @@ internal static partial class QueryPlanBuilder
             {
                 return (method, methodParameter) switch
                 {
-                    (method: VectorHelpers.MethodVectorValue.ForDocument, string docId) => CoraxVectorItem.BuildForDocVector(builderParameters, fieldMetadata, docId, numberOfCandidates, minimumMatch, false),
-                    (method: VectorHelpers.MethodVectorValue.ForDocument, StringSegment docIdSegment) => CoraxVectorItem.BuildForDocVector(builderParameters, fieldMetadata, docIdSegment.Value, numberOfCandidates, minimumMatch, false),
+                    (method: VectorHelpers.MethodVectorValue.ForDocument, string docId) => CoraxVectorItem.BuildForDocVector(builderParameters, fieldMetadata, docId, numberOfCandidates, minimumMatch, isExact),
+                    (method: VectorHelpers.MethodVectorValue.ForDocument, StringSegment docIdSegment) => CoraxVectorItem.BuildForDocVector(builderParameters, fieldMetadata, docIdSegment.Value, numberOfCandidates, minimumMatch, isExact),
                     (method: VectorHelpers.MethodVectorValue.ForRaw, string vectorAsBase64) => CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata,
-                        GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, vectorAsBase64), numberOfCandidates, minimumMatch, false),
+                        GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, vectorAsBase64), numberOfCandidates, minimumMatch, isExact),
                     (method: VectorHelpers.MethodVectorValue.ForRaw, StringSegment stringSegmentAsBase64) => CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata,
-                        GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, stringSegmentAsBase64.ToString()), numberOfCandidates, minimumMatch, false),
+                        GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, stringSegmentAsBase64.ToString()), numberOfCandidates, minimumMatch, isExact),
                     (_, BlittableJsonReaderArray { Length: 0 }) => throw new InvalidDataException("Cannot perform search on empty value."),
                     _ => throw new InvalidQueryException(
                         $"Unknown method in value ({vec.Method}. Parameter type: {methodParameter?.GetType().FullName}, Value: {methodParameter}")
@@ -151,9 +156,9 @@ internal static partial class QueryPlanBuilder
             var vector = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueTokenType, methodParameter, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
 
             if (vector.SingleVector != null)
-                return CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata, vector.SingleVector.Value, numberOfCandidates, minimumMatch, false);
+                return CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata, vector.SingleVector.Value, numberOfCandidates, minimumMatch, isExact);
 
-            return CoraxVectorItem.BuildMultiVector(builderParameters, fieldMetadata, vector.MultiVector, numberOfCandidates, minimumMatch, false);
+            return CoraxVectorItem.BuildMultiVector(builderParameters, fieldMetadata, vector.MultiVector, numberOfCandidates, minimumMatch, isExact);
         }
 
         // Direct value (not a method call) — use pre-resolved value
@@ -235,7 +240,7 @@ internal static partial class QueryPlanBuilder
 
             if (indexField != null)
                 AssertDimensions(singleVector);
-            return CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata, singleVector, numberOfCandidates, minimumMatch, false);
+            return CoraxVectorItem.BuildSingleVector(builderParameters, fieldMetadata, singleVector, numberOfCandidates, minimumMatch, isExact);
         }
 
         if (transformedEmbeddings.MultiVector != null)
@@ -248,7 +253,7 @@ internal static partial class QueryPlanBuilder
                     AssertDimensions(vector);
             }
 
-            return CoraxVectorItem.BuildMultiVector(builderParameters, fieldMetadata, multiVector, numberOfCandidates, minimumMatch, false);
+            return CoraxVectorItem.BuildMultiVector(builderParameters, fieldMetadata, multiVector, numberOfCandidates, minimumMatch, isExact);
         }
 
         throw new InvalidDataException("Expected to get single or multiple embeddings of VectorValue type but none was provided");

--- a/test/SlowTests.Issues/Issues/RavenDB_27433.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27433.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27433(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private sealed class VecDoc
+    {
+        public string Id { get; set; }
+        public float[] Embedding { get; set; }
+    }
+
+    private sealed class VecIndex : AbstractIndexCreationTask<VecDoc>
+    {
+        public VecIndex()
+        {
+            Map = docs => from d in docs
+                          select new
+                          {
+                              Embedding = CreateVector(d.Embedding)
+                          };
+        }
+    }
+
+    private const int DocCount = 32;
+
+    // Query vector points east. The seeded unit vectors fan out over the first quadrant, so cosine similarity to
+    // the query decreases monotonically with the doc number. No assertion here depends on the HNSW graph layout.
+    private static readonly float[] QueryVector = [1f, 0f];
+
+    private IDocumentStore SetupStore()
+    {
+        var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+
+        using (var session = store.OpenSession())
+        {
+            for (int i = 0; i < DocCount; i++)
+            {
+                double angle = i * (Math.PI / 2) / DocCount; // 0 .. <90 degrees
+                session.Store(new VecDoc { Id = $"docs/{i}", Embedding = [(float)Math.Cos(angle), (float)Math.Sin(angle)] });
+            }
+
+            session.SaveChanges();
+        }
+
+        new VecIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        return store;
+    }
+
+    // The vector match is the only plan node reporting IsExact, so this finds it for both the single-vector
+    // (VectorSearchMatch) and the multi-vector (MultiVectorSearchMatch) shapes.
+    private static QueryInspectionNode FindVectorNode(QueryInspectionNode node)
+    {
+        if (node is null)
+            return null;
+        if (node.Parameters is not null && node.Parameters.ContainsKey("IsExact"))
+            return node;
+        foreach (var child in node.Children ?? [])
+        {
+            var hit = FindVectorNode(child);
+            if (hit != null)
+                return hit;
+        }
+
+        return null;
+    }
+
+    private (List<string> Ids, QueryInspectionNode Plan) Query(IDocumentStore store, bool exact, object vector)
+    {
+        string predicate = "vector.search(Embedding, $vec, $minSim, $candidates)";
+        string rql = $@"from index 'VecIndex'
+                        where {(exact ? $"exact({predicate})" : predicate)}
+                        include timings()";
+
+        using var session = store.OpenSession();
+        var ids = session.Advanced
+            .RawQuery<VecDoc>(rql)
+            .AddParameter("vec", vector)
+            .AddParameter("minSim", 0.5f)
+            // More candidates than there are documents, so an exact scan returns every doc above minSim.
+            .AddParameter("candidates", DocCount * 4)
+            .Timings(out var timings)
+            .WaitForNonStaleResults()
+            .ToList()
+            .Select(d => d.Id)
+            .ToList();
+
+        var vectorNode = FindVectorNode(timings.QueryPlan as QueryInspectionNode);
+        Assert.NotNull(vectorNode);
+
+        return (ids, vectorNode);
+    }
+
+    private static long ScannedCandidates(QueryInspectionNode vectorNode) =>
+        long.Parse(vectorNode.Parameters["NumberOfCandidatesScanned"], NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ExactVectorSearchMustBruteForceAndNotFallBackToApproximateSearch(bool approximateFirst)
+    {
+        using var store = SetupStore();
+
+        // Both orders are exercised on purpose: exact() is part of the structural plan key, so whichever form runs
+        // first must not hand its compiled plan (and its search mode) to the other.
+        var approximate = approximateFirst ? AssertApproximate() : default;
+
+        var exact = Query(store, exact: true, QueryVector);
+        Assert.Equal("True", exact.Plan.Parameters["IsExact"]);
+        Assert.Equal("ExactAll", exact.Plan.Parameters["SearchMode"]);
+        // Brute force means every indexed vector is enumerated, not just the nodes an HNSW walk happens to reach.
+        Assert.Equal(DocCount, ScannedCandidates(exact.Plan));
+        Assert.NotEmpty(exact.Ids);
+
+        if (approximateFirst == false)
+            approximate = AssertApproximate();
+
+        // numberOfCandidates exceeds the document count, so the exact scan returns every match above minSim -
+        // the approximate result set can only ever be a subset of it.
+        Assert.Empty(approximate.Ids.Except(exact.Ids));
+
+        (List<string> Ids, QueryInspectionNode Plan) AssertApproximate()
+        {
+            var result = Query(store, exact: false, QueryVector);
+            Assert.Equal("False", result.Plan.Parameters["IsExact"]);
+            Assert.Equal("ApproximateAll", result.Plan.Parameters["SearchMode"]);
+            return result;
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void ExactMultiVectorSearchMustBruteForce()
+    {
+        using var store = SetupStore();
+
+        float[][] vectors = [[1f, 0f], [0f, 1f]];
+
+        Assert.Equal("False", Query(store, exact: false, vectors).Plan.Parameters["IsExact"]);
+        Assert.Equal("True", Query(store, exact: true, vectors).Plan.Parameters["IsExact"]);
+    }
+}


### PR DESCRIPTION
exact(vector.search(...)) was silently downgraded to the HNSW approximation: ParseExact marks the clause template (ClauseInfo.IsExact), but HandleVector passed a hardcoded `false` as isExact to every CoraxVectorItem.Build* call, so VectorSearchMatch / MultiVectorSearchMatch always ran in ApproximateAll mode and returned the same results as the non-exact form. Corax 1.0 threads the flag through (CoraxQueryBuilder.VectorSearch.HandleVector) - it was lost in the port.

Read the flag off the clause and pass it to all build sites. No plan-cache change is needed: exact() is a MethodExpression, so its name is already part of the structural plan key and the exact / approximate forms never share a compiled plan (covered by the test running both orders).

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27433

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
