### PR TITLE
Quill-274 fix data source page

### DIFF
--- a/src/Raven.Quill.Web/src/pages/apps/app-data-source.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-data-source.tsx
@@ -29,7 +29,7 @@ export function AppDataSource() {
     return (
         <div className="flex h-full min-h-0 flex-col">
             <DetailHeader
-                title={appQuery.data?.name ?? slug}
+                title="Data source"
                 status={
                     <DataSourceStatus status={dashboardAppQuery.data?.status} isLoading={dashboardAppQuery.isPending} />
                 }

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-errors-alert.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-errors-alert.tsx
@@ -16,10 +16,9 @@ export function CdcErrorsAlert({ slug }: { slug: string }) {
     return (
         <Alert variant="destructive">
             <TriangleAlertIcon />
-            <AlertTitle>App errors detected</AlertTitle>
+            <AlertTitle>Sync errors detected</AlertTitle>
             <AlertDescription>
-                {errorCount === 1 ? "1 error was" : `${errorCount} errors were`} reported while syncing data changes for
-                this app.
+                {errorCount === 1 ? "1 error was" : `${errorCount} errors were`} reported while syncing data changes.
             </AlertDescription>
             <AlertAction>
                 <CdcErrorsSheet

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-errors-sheet.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-errors-sheet.tsx
@@ -31,8 +31,8 @@ export function CdcErrorsSheet({ slug, trigger }: { slug: string; trigger: React
             <SheetTrigger asChild>{trigger}</SheetTrigger>
             <SheetContent className="w-full sm:max-w-lg data-[side=right]:sm:max-w-lg">
                 <SheetHeader className="border-b">
-                    <SheetTitle>App errors</SheetTitle>
-                    <SheetDescription>Errors reported while syncing data changes for this app.</SheetDescription>
+                    <SheetTitle>Sync errors</SheetTitle>
+                    <SheetDescription>Errors reported while syncing data changes.</SheetDescription>
                 </SheetHeader>
                 <div className="min-h-0 flex-1 space-y-3 overflow-auto px-4 pb-4">
                     <ApiState
@@ -45,7 +45,7 @@ export function CdcErrorsSheet({ slug, trigger }: { slug: string; trigger: React
                     >
                         {errorsQuery.data &&
                             (errorsQuery.data.length === 0 ? (
-                                <Text variant="muted">No app errors.</Text>
+                                <Text variant="muted">No sync errors.</Text>
                             ) : (
                                 errorsQuery.data.map((error, index) => <CdcErrorCard key={index} error={error} />)
                             ))}

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-flow.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/app-wizard-flow.tsx
@@ -72,7 +72,7 @@ export const useAppSteps = (): WizardSteps<AppStepId, AppFormData> => {
             description:
                 "Choose the tables this app will work with. Only the selected tables are carried into the " +
                 "mapping and the task configuration - unselected tables, and relationships pointing to them, are " +
-                "ignored. Continuing runs a configuration validation dry run against the source database.",
+                "ignored. Clicking Next runs a configuration validation dry run against the source database.",
             bodyComponent: VerifySchemaStep,
             isFullHeight: true,
             validate: "verifySchema",


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/Quill-274/Quill-Align-the-Data-source-page-title-and-sync-error-terminology

### Additional description
Aligns the Data source page with the other app tabs and renames “App errors” to “Sync errors” for consistent UI terminology.

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
