### PR TITLE
Quill-276: stamp the build version into RavenDB and Quill at image build

### DIFF
--- a/docker/quill/Dockerfile
+++ b/docker/quill/Dockerfile
@@ -6,11 +6,15 @@ ARG NODE_IMAGE=node:24-bookworm-slim
 ARG STUDIO_NODE_MAJOR=24
 ARG PNPM_VERSION=11.2.2
 ARG S6_OVERLAY_VERSION=3.2.1.0
+ARG VERSION=""
 
 FROM ${SDK_IMAGE} AS ravendb-server-build
 ARG TARGETARCH
+ARG VERSION
 WORKDIR /src
 COPY . .
+
+RUN sh docker/quill/scripts/stamp-version.sh "$VERSION"
 
 RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked \
     . docker/quill/scripts/dotnet-rid.sh \
@@ -30,6 +34,7 @@ RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked \
 
 FROM --platform=$BUILDPLATFORM ${SDK_IMAGE} AS ravendb-studio-build
 ARG STUDIO_NODE_MAJOR
+ARG VERSION
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
@@ -47,7 +52,7 @@ RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked \
 
 WORKDIR /src/src/Raven.Studio
 RUN VERSION_PREFIX=$(sed -n 's/.*AssemblyVersion("\([^"]*\)").*/\1/p' /src/src/CommonAssemblyInfo.cs) \
-    && printf '{ "Version": "%s-custom-72" }\n' "$VERSION_PREFIX" > wwwroot/version.txt \
+    && printf '{ "Version": "%s" }\n' "${VERSION:-$VERSION_PREFIX-custom-72}" > wwwroot/version.txt \
     && cat wwwroot/version.txt
 
 RUN --mount=type=cache,target=/root/.npm \
@@ -100,8 +105,11 @@ RUN pnpm build
 # Stage 4: publish the backend and overlay the Vite output into wwwroot.
 FROM ${SDK_IMAGE} AS web-build
 ARG TARGETARCH
+ARG VERSION
 WORKDIR /src
 COPY . .
+
+RUN sh docker/quill/scripts/stamp-version.sh "$VERSION"
 
 RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked \
     . docker/quill/scripts/dotnet-rid.sh \

--- a/docker/quill/scripts/build.sh
+++ b/docker/quill/scripts/build.sh
@@ -12,6 +12,9 @@ Options:
   --tag <name>          Image tag. Repeatable. (default: ravendb/quill:dev)
   --push                Push to registry instead of loading locally
   --platforms <list>    Comma-separated platforms (default: linux/amd64)
+  --version <ver>       Build version stamped into the image (e.g.
+                        7.2.6-quill-nightly-20260827-1044). Omit for local
+                        dev builds; the image then reports 7.2.6-custom-72.
   --no-cache            Force a full rebuild, ignoring layer cache
   --dry-run             Build locally without pushing (overrides --push)
   -h, --help            Show this help
@@ -29,6 +32,7 @@ PLATFORMS="linux/amd64"
 PUSH="false"
 NO_CACHE="false"
 DRY_RUN="false"
+VERSION=""
 
 DOCKERFILE="docker/quill/Dockerfile"
 
@@ -44,6 +48,7 @@ while [[ $# -gt 0 ]]; do
     --tag)       require_value --tag "$#";       TAGS+=("$2"); shift 2 ;;
     --push)      PUSH="true"; shift ;;
     --platforms) require_value --platforms "$#"; PLATFORMS="$2"; shift 2 ;;
+    --version)   require_value --version "$#";   VERSION="$2"; shift 2 ;;
     --no-cache)  NO_CACHE="true"; shift ;;
     --dry-run)   DRY_RUN="true"; shift ;;
     -h|--help)   show_help; exit 0 ;;
@@ -73,6 +78,10 @@ fi
 cd "$(git rev-parse --show-toplevel)"
 
 cmd=(docker buildx build --pull --platform "$PLATFORMS" -f "$DOCKERFILE")
+
+if [ -n "$VERSION" ]; then
+  cmd+=(--build-arg "VERSION=$VERSION")
+fi
 
 for tag in "${TAGS[@]}"; do
   cmd+=(-t "$tag")

--- a/docker/quill/scripts/stamp-version.sh
+++ b/docker/quill/scripts/stamp-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -e
+
+VERSION="$1"
+[ -z "$VERSION" ] && exit 0
+
+sed -i -E "s/AssemblyInformationalVersion\(\"[^\"]*\"\)/AssemblyInformationalVersion(\"$VERSION\")/" \
+    src/CommonAssemblyInfo.cs
+
+sed -i -E "s/(FullVersion = )\"[^\"]*\"/\1\"$VERSION\"/" \
+    src/Raven.Client/Properties/VersionInfo.cs
+
+echo "stamp-version: set version to $VERSION"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-276/stamp-the-build-version-into-the-image-so-RavenDB-and-Quill-report-it

### Additional description

stamp the build version into the image so RavenDB and Quill report it

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
