### PR TITLE
RavenDB-26957 Return nothing for a contradictory range in Corax

### DIFF
--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
@@ -56,10 +56,28 @@ namespace Corax.Querying.Matches.TermProviders
                 _ => false
             };
 
+            // Without this, PrepareKeys puts the stop term behind the start term, iteration never reaches it
+            // and the range collapses into "everything from low onwards".
+            if (IsEmptyRange())
+            {
+                _isEmpty = true;
+                return;
+            }
+
             PrepareKeys();
             Reset();
         }
-        
+
+        private bool IsEmptyRange()
+        {
+            var cmp = _low.CompareTo(_high);
+            if (cmp > 0)
+                return true;
+
+            // <x, x> holds x; (x, x>, <x, x) and (x, x) are empty.
+            return cmp == 0 && (typeof(TLow) == typeof(Range.Exclusive) || typeof(THigh) == typeof(Range.Exclusive));
+        }
+
         private void PrepareKeys()
         {
             // We want to rewrite the range, so it starts and ends with elements that are presented in our data source

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
@@ -53,8 +53,33 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider, I
         _skipRangeCheck = _isForward
             ? _high.Options is SliceOptions.AfterAllKeys
             : _low.Options is SliceOptions.BeforeAllKeys;
+
+        // Same collapse as in TermNumericRangeProvider - PrepareKeys would put the stop term behind the start one.
+        if (IsEmptyRange())
+        {
+            _isEmpty = true;
+            return;
+        }
+
         PrepareKeys();
         Reset();
+    }
+
+    private bool IsEmptyRange()
+    {
+        // BeforeAllKeys sorts below every term, AfterAllKeys above it - and the mirrored forms are contradictory.
+        if (_low.Options is SliceOptions.BeforeAllKeys || _high.Options is SliceOptions.AfterAllKeys)
+            return false;
+
+        if (_low.Options is SliceOptions.AfterAllKeys || _high.Options is SliceOptions.BeforeAllKeys)
+            return true;
+
+        var cmp = _low.AsSpan().SequenceCompareTo(_high.AsSpan());
+        if (cmp > 0)
+            return true;
+
+        // <x, x> holds x; (x, x>, <x, x) and (x, x) are empty.
+        return cmp == 0 && (typeof(TLow) == typeof(Range.Exclusive) || typeof(THigh) == typeof(Range.Exclusive));
     }
 
 

--- a/test/SlowTests.Issues/Issues/RavenDB_26957.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26957.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26957(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class Movie
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public long Runtime { get; set; }
+        public double Rating { get; set; }
+    }
+
+    private class Movies_Showcase : AbstractIndexCreationTask<Movie>
+    {
+        public Movies_Showcase()
+        {
+            Map = movies => from m in movies
+                            select new
+                            {
+                                m.Title,
+                                m.Runtime,
+                                m.Rating
+                            };
+        }
+    }
+
+    private IDocumentStore SetupStore(Options options)
+    {
+        var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Movie { Id = "movies/1", Title = "aaa", Runtime = 25, Rating = 2.5 });
+            session.Store(new Movie { Id = "movies/2", Title = "mmm", Runtime = 120, Rating = 6.0 });
+            session.Store(new Movie { Id = "movies/3", Title = "zzz", Runtime = 320, Rating = 9.5 });
+            session.SaveChanges();
+        }
+
+        store.ExecuteIndex(new Movies_Showcase());
+        Indexes.WaitForIndexing(store);
+
+        return store;
+    }
+
+    private static string[] Query(IDocumentStore store, string where, params (string Name, object Value)[] parameters)
+    {
+        using var session = store.OpenSession();
+        var query = session.Advanced.RawQuery<Movie>($"from index 'Movies/Showcase' where {where}");
+        foreach (var (name, value) in parameters)
+            query = query.AddParameter(name, value);
+
+        var results = query.Statistics(out QueryStatistics stats).ToList();
+
+        Assert.Equal(results.Count, stats.TotalResults);
+
+        return results.Select(x => x.Id).OrderBy(x => x).ToArray();
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void NumericRangeWithLowAboveHighMatchesNothing(Options options)
+    {
+        using var store = SetupStore(options);
+
+        Assert.Empty(Query(store, "Runtime between $lo and $hi", ("lo", 300), ("hi", 30)));
+        Assert.Empty(Query(store, "Rating between $lo and $hi", ("lo", 9.0), ("hi", 3.0)));
+
+        // `> x and < y` is translated into a between with both ends exclusive.
+        Assert.Empty(Query(store, "Runtime > $lo and Runtime < $hi", ("lo", 300), ("hi", 30)));
+
+        Assert.Empty(Query(store, "Runtime > $lo and Runtime < $hi", ("lo", 120), ("hi", 120)));
+
+        // Sanity: ordinary ranges keep working.
+        Assert.Equal(new[] { "movies/3" }, Query(store, "Runtime between $lo and $hi", ("lo", 300), ("hi", 400)));
+        Assert.Equal(new[] { "movies/2" }, Query(store, "Runtime between $lo and $hi", ("lo", 120), ("hi", 120)));
+        Assert.Equal(new[] { "movies/2", "movies/3" }, Query(store, "Rating between $lo and $hi", ("lo", 3.0), ("hi", 9.9)));
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void StringRangeWithLowAboveHighMatchesNothing(Options options)
+    {
+        using var store = SetupStore(options);
+
+        Assert.Empty(Query(store, "Title between $lo and $hi", ("lo", "zzz"), ("hi", "aaa")));
+        Assert.Empty(Query(store, "Title between $lo and $hi", ("lo", "zzz"), ("hi", "mmm")));
+        Assert.Empty(Query(store, "Title > $lo and Title < $hi", ("lo", "mmm"), ("hi", "mmm")));
+
+        // Sanity: ordinary ranges keep working.
+        Assert.Equal(new[] { "movies/1", "movies/2" }, Query(store, "Title between $lo and $hi", ("lo", "aaa"), ("hi", "mmm")));
+        Assert.Equal(new[] { "movies/2" }, Query(store, "Title between $lo and $hi", ("lo", "mmm"), ("hi", "mmm")));
+    }
+}


### PR DESCRIPTION
`where Runtime between 300 and 30` returned documents with `Runtime = 320` instead of nothing. The range providers iterate from a start term to a stop term: `PrepareKeys` rewrites both bounds to terms actually present in the tree, so with low above high the stop term (first term >= 30, i.e. 120) ends up *behind* the start term (first term >= 300, i.e. 320). A forward iteration never reaches it, the stop condition never fires and the range collapses into "everything from low onwards". The `-1` branch of the boundary comparison there is even commented as "not expected" - the whole method assumes low <= high.

A range with low above high is empty by definition, so both providers now report the existing `_isEmpty` state before `PrepareKeys` runs - no data has to be looked at. The same check covers an empty open interval (`> x and < x`), since bound inclusiveness is encoded in the generic parameters. Fixed in the providers rather than in `CoraxQueryBuilder` because faceted ranges reach them directly (`IndexSearcher.Aggregations.cs`), and the string provider had the same defect - its `hasPreviousValue` guard only caught `between 'zzz' and 'aaa'`, not `between 'zzz' and 'mmm'`.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26957

### Additional description

The test runs on both engines, so Corax is verified to match Lucene rather than just to return an empty result.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Faceted ranges use the same providers, so a contradictory facet range now yields an empty facet instead of arbitrary entries above its lower bound.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed