### PR TITLE
RavenDB-27435 Split tool turns from the structured-output turn on providers that grammar-enforce response_format (Ollama)

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -49,6 +49,8 @@ public class ChatCompletionClient : IDisposable
     private readonly HttpClient _client;
     private readonly IMemoryContextPool _contextPool;
 
+    internal bool SupportsToolsWithStructuredOutput => _settings.SupportsToolsWithStructuredOutput;
+
     public static readonly DocumentConventions ConventionsToUse = new DocumentConventions
     {
         SendApplicationIdentifier = DocumentConventions.DefaultForServer.SendApplicationIdentifier,

--- a/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
@@ -21,6 +21,8 @@ internal abstract class AbstractChatCompletionClientSettings
 
     public virtual bool SupportsToolChoiceNone => true;
 
+    public virtual bool SupportsToolsWithStructuredOutput => true;
+
     public virtual bool EnablePromptCaching => true;
 
     public Uri GetBaseEndpointUri() => _settings.GetBaseEndpointUri();

--- a/src/Raven.Server/Documents/AI/Settings/OllamaChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/OllamaChatCompletionClientSettings.cs
@@ -20,6 +20,8 @@ internal class OllamaChatCompletionClientSettings : AbstractChatCompletionClient
     // Instead, the tools array is omitted entirely once tools are disabled.
     public override bool SupportsToolChoiceNone => false;
 
+    public override bool SupportsToolsWithStructuredOutput => false;
+
     public override string GetRelativeCompletionUri() => "v1/" + base.GetRelativeCompletionUri();
 
     public override string GetRelativeModelsUri() => "v1/" + base.GetRelativeModelsUri();

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -423,6 +423,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
         var pendingAlertsDetails = new List<ExceededTokenThresholdDetails>();
         bool isFirstIteration = true;
+        bool pendingFinalTurn = false;
         var debugTraces = new AiDebugTraceCollector(_document.Debug, database);
 
         try
@@ -437,7 +438,8 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
                 var trace = debugTraces.CreateTrace();
 
-                using var request = talker.CreateCompletionRequest(attachments, trace);
+                using var request = talker.CreateCompletionRequest(attachments, trace, finalStructuredTurn: pendingFinalTurn);
+                pendingFinalTurn = false;
                 r = await talker.RunAsync(database.DocumentsStorage.ContextPool, request, trace, token);
 
                 var currentTurnUsage = AiUsage.GetUsageDifference(talker.AiUsage, _document.CurrentUsage);
@@ -448,7 +450,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                 }
                 isFirstIteration = false;
 
-                bool isNoSchema = r.Type is AiResponseType.Result && _schema == null;
+                bool isNoSchema = r.Type is AiResponseType.Result && (_schema == null || talker.RequiresStructuredFollowUp);
                 _document.AddMessage(context, r.Message, currentTurnUsage, isNoSchema);
                 _document.UpdateUsage(talker.AiUsage);
                 OnUpdateUsage?.Invoke(database.Name, currentTurnUsage);
@@ -472,8 +474,15 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                 toolsIterations++;
                 if (r.Type is AiResponseType.Result)
                 {
-                    _document.RemainingToolIterations = _maxModelIterationsPerCall;
-                    shouldContinueConversation = false;
+                    if (talker.RequiresStructuredFollowUp)
+                    {
+                        pendingFinalTurn = true;
+                    }
+                    else
+                    {
+                        _document.RemainingToolIterations = _maxModelIterationsPerCall;
+                        shouldContinueConversation = false;
+                    }
                 }
                 else
                 {
@@ -491,6 +500,9 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                 }
 
                 _document.CurrentUsage = talker.AiUsage;
+
+                if (pendingFinalTurn)
+                    continue;
 
                 // check if we should summarize or truncate the chat history
                 var reductionResult = await TryReduceChatSizeAsync(context, talker.Client, talker.AiUsage, token);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
@@ -14,10 +14,15 @@ namespace Raven.Server.Documents.Handlers.AI.Agents;
 internal class Talker(ConversationHandler handler, JsonOperationContext context, AiAgentConfiguration configuration, string schema, ConversationDocument document, string firstStreamPropertyPath, Func<Memory<byte>, Task> streaming) : IDisposable
 {
     private List<BlittableJsonReaderObject> _tools;
+    private string _turnSchema;
+    private bool _turnStreaming;
 
     public AiUsage AiUsage;
     public ChatCompletionClient Client;
     public ConversationDocument Document => document;
+    public bool RequiresStructuredFollowUp { get; private set; }
+
+    private bool SplitToolsAndSchema => schema != null && Client.SupportsToolsWithStructuredOutput == false;
 
     public void Init()
     {
@@ -27,21 +32,31 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
         _tools = Client.GenerateTools(context, configuration, handler);
     }
 
-    public HttpRequestMessage CreateCompletionRequest(List<AiAttachment> attachments, AiDebugTrace trace)
+    public HttpRequestMessage CreateCompletionRequest(List<AiAttachment> attachments, AiDebugTrace trace, bool finalStructuredTurn = false)
     {
         AiUsage = new();
-        return Client.CreateCompletionRequest(context, document.Messages, attachments, _tools, useTools: document.RemainingToolIterations-- > 0, streaming != null, schema, promptCacheKey: document.Id, trace: trace);
+
+        var useTools = finalStructuredTurn == false && document.RemainingToolIterations-- > 0;
+        var toolTurnWithoutSchema = SplitToolsAndSchema && useTools;
+
+        _turnSchema = toolTurnWithoutSchema ? null : schema;
+        _turnStreaming = streaming != null && toolTurnWithoutSchema == false;
+        RequiresStructuredFollowUp = toolTurnWithoutSchema;
+
+        var turnTools = SplitToolsAndSchema && useTools == false ? null : _tools;
+
+        return Client.CreateCompletionRequest(context, document.Messages, attachments, turnTools, useTools, _turnStreaming, _turnSchema, promptCacheKey: document.Id, trace: trace);
     }
 
     public async Task<AiResponse> RunAsync(IMemoryContextPool contextPool, HttpRequestMessage request, AiDebugTrace trace, CancellationToken token)
     {
-        if (streaming is null)
+        if (_turnStreaming == false)
         {
             return await Client.CompleteAsync(
                 context,
                 request,
                 AiUsage,
-                schema,
+                _turnSchema,
                 trace,
                 token
             );
@@ -54,7 +69,7 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
             request,
             streaming,
             AiUsage,
-            schema,
+            _turnSchema,
             trace,
             token
         );

--- a/test/SlowTests/Server/Documents/AI/AiAgent/MockLlmHelper.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/MockLlmHelper.cs
@@ -24,7 +24,8 @@ internal class MockLlmConversationHandler(
     DocumentDatabase database,
     Func<JObject, HttpResponseMessage> onRequest = null,
     Func<JObject, string, HttpResponseMessage> onToolResult = null,
-    AbstractChatCompletionClientSettings clientSettings = null)
+    AbstractChatCompletionClientSettings clientSettings = null,
+    Func<JObject, HttpResponseMessage> onStreamingRequest = null)
     : ConversationHandler(server, database)
 {
     private readonly DocumentDatabase _database = database;
@@ -32,7 +33,7 @@ internal class MockLlmConversationHandler(
     protected internal override ChatCompletionClient CreateClient()
     {
         var settings = clientSettings ?? new OpenAiChatCompletionClientSettings(new OpenAiSettings("fake-key", "https://fake.openai.com", "gpt-4o"));
-        return new MockLlm(_database.DocumentsStorage.ContextPool, settings, onRequest, onToolResult, ChatCompletionClient.ConventionsToUse);
+        return new MockLlm(_database.DocumentsStorage.ContextPool, settings, onRequest, onToolResult, ChatCompletionClient.ConventionsToUse, onStreamingRequest);
     }
 }
 
@@ -50,17 +51,32 @@ internal class MockLlm : ChatCompletionClient
 {
     private readonly Func<JObject, HttpResponseMessage> _onRequest;
     private readonly Func<JObject, string, HttpResponseMessage> _onToolResult;
+    private readonly Func<JObject, HttpResponseMessage> _onStreamingRequest;
 
     internal MockLlm(
         IMemoryContextPool contextPool,
         AbstractChatCompletionClientSettings settings,
         Func<JObject, HttpResponseMessage> onRequest = null,
         Func<JObject, string, HttpResponseMessage> onToolResult = null,
-        DocumentConventions conventions = null)
+        DocumentConventions conventions = null,
+        Func<JObject, HttpResponseMessage> onStreamingRequest = null)
         : base(contextPool, settings, conventions)
     {
         _onRequest = onRequest;
         _onToolResult = onToolResult;
+        _onStreamingRequest = onStreamingRequest;
+    }
+
+    protected override async Task<HttpResponseMessage> SendStreamingRequestAsync(HttpRequestMessage request, CancellationToken token)
+    {
+        var body = await request.Content!.ReadAsStringAsync(token);
+        var payload = JObject.Parse(body);
+
+        var response = _onStreamingRequest?.Invoke(payload);
+        if (response == null)
+            throw new InvalidOperationException("Streaming request reached MockLlm without an onStreamingRequest handler. Payload: " + body);
+
+        return response;
     }
 
     protected override async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token)
@@ -191,6 +207,62 @@ internal class MockLlm : ChatCompletionClient
                 "system_fingerprint": "fp_mock"
             }
             """;
+    }
+
+    public static string CreateProseAnswerResponse(string content, int promptTokens = 100)
+    {
+        var escapedContent = content.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        return $$"""
+            {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "created": 1754549498,
+                "model": "test-model",
+                "choices": [{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "{{escapedContent}}",
+                        "refusal": null,
+                        "annotations": []
+                    },
+                    "logprobs": null,
+                    "finish_reason": "stop"
+                }],
+                {{UsageJson(promptTokens)}},
+                "service_tier": "default",
+                "system_fingerprint": "fp_mock"
+            }
+            """;
+    }
+
+    public static HttpResponseMessage CreateSseAnswerResponse(string content, int promptTokens = 100)
+    {
+        var sse = new StringBuilder();
+        var half = content.Length / 2;
+        foreach (var chunk in new[] { content[..half], content[half..] })
+        {
+            if (chunk.Length == 0)
+                continue;
+
+            var payload = new JObject
+            {
+                ["choices"] = new JArray(new JObject
+                {
+                    ["index"] = 0,
+                    ["delta"] = new JObject { ["content"] = chunk }
+                })
+            };
+            sse.Append("data: ").Append(payload.ToString(Newtonsoft.Json.Formatting.None)).Append("\n\n");
+        }
+
+        sse.Append("data: {\"choices\":[],").Append(UsageJson(promptTokens).Replace('\n', ' ').Replace('\r', ' ')).Append('}').Append("\n\n");
+        sse.Append("data: [DONE]\n\n");
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(sse.ToString(), Encoding.UTF8, "text/event-stream")
+        };
     }
 
     /// <summary>

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_27435.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_27435.cs
@@ -1,0 +1,378 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Orders;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Server.Documents;
+using Raven.Server.Documents.AI.Settings;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_27435 : RavenTestBase
+    {
+        public RavenDB_27435(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const string ProseAnswer = "Chai costs 18.0 according to the data.";
+        private const string StructuredAnswer = "{\"Answer\":\"Chai costs 18.0\"}";
+
+        private static OllamaChatCompletionClientSettings CreateOllamaSettings() =>
+            new(new OllamaSettings { Uri = "http://localhost:11434", Model = "test-model" });
+
+        private static AiAgentConfiguration CreateAgent()
+        {
+            var agent = new AiAgentConfiguration("shopping assistant", "fake-connection",
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only.");
+            agent.Queries =
+            [
+                new AiAgentToolQuery("RecentOrders", "Get the recent orders", "from Orders limit 5")
+                {
+                    ParametersSampleObject = "{}"
+                }
+            ];
+            agent.SampleObject = "{\"Answer\":\"The answer to the query\"}";
+            return agent;
+        }
+
+        private async Task<DocumentDatabase> CreateDatabaseWithOrderAsync(Raven.Client.Documents.DocumentStore store)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order
+                {
+                    Company = "companies/1-A",
+                    Lines = [new OrderLine { ProductName = "Chai", Quantity = 2 }]
+                });
+                await session.SaveChangesAsync();
+            }
+
+            return await Databases.GetDocumentDatabaseInstanceFor(store);
+        }
+
+        private static HttpResponseMessage Ok(string content) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content)
+        };
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task SplitMode_ToolTurnSendsToolsWithoutResponseFormat_FinalTurnSendsResponseFormatWithoutTools()
+        {
+            using var store = GetDocumentStore();
+            var database = await CreateDatabaseWithOrderAsync(store);
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var payloads = new List<JObject>();
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: payload =>
+                    {
+                        payloads.Add(payload);
+                        return payloads.Count switch
+                        {
+                            1 => Ok(MockLlm.CreateToolCallResponse("RecentOrders")),
+                            2 => Ok(MockLlm.CreateProseAnswerResponse(ProseAnswer)),
+                            _ => Ok(MockLlm.CreateAnswerResponse("\"Chai costs 18.0\""))
+                        };
+                    },
+                    clientSettings: CreateOllamaSettings())
+                {
+                    Authentication = null
+                };
+
+                handler.Initialize(CreateAgent(), "Dummy", new RequestBody
+                {
+                    Parameters = context.ReadObject(new DynamicJsonValue(), "params"),
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "how much does Chai cost?"
+                }, changeVector: null);
+
+                var r = await handler.HandleRequestAsync(context, CancellationToken.None);
+
+                Assert.Equal(3, payloads.Count);
+
+                Assert.NotNull(payloads[0]["tools"]);
+                Assert.Null(payloads[0]["response_format"]);
+                Assert.Null(payloads[0]["tool_choice"]);
+
+                Assert.NotNull(payloads[1]["tools"]);
+                Assert.Null(payloads[1]["response_format"]);
+                Assert.Null(payloads[1]["tool_choice"]);
+
+                Assert.Null(payloads[2]["tools"]);
+                Assert.NotNull(payloads[2]["response_format"]);
+                Assert.Null(payloads[2]["tool_choice"]);
+
+                Assert.Contains("Chai costs 18.0", r.Response.ToString());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task SplitMode_ProseAndStructuredMessagesPersisted_IterationsReset()
+        {
+            using var store = GetDocumentStore();
+            var database = await CreateDatabaseWithOrderAsync(store);
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var requestCount = 0;
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: _ =>
+                    {
+                        requestCount++;
+                        return requestCount switch
+                        {
+                            1 => Ok(MockLlm.CreateToolCallResponse("RecentOrders")),
+                            2 => Ok(MockLlm.CreateProseAnswerResponse(ProseAnswer)),
+                            _ => Ok(MockLlm.CreateAnswerResponse("\"Chai costs 18.0\""))
+                        };
+                    },
+                    clientSettings: CreateOllamaSettings())
+                {
+                    Authentication = null
+                };
+
+                handler.Initialize(CreateAgent(), "Dummy", new RequestBody
+                {
+                    Parameters = context.ReadObject(new DynamicJsonValue(), "params"),
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "how much does Chai cost?"
+                }, changeVector: null);
+
+                await handler.HandleRequestAsync(context, CancellationToken.None);
+            }
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var conversation = database.DocumentsStorage.Get(context, "Dummy");
+                Assert.NotNull(conversation);
+
+                Assert.True(conversation.Data.TryGet(nameof(ConversationDocument.RemainingToolIterations), out int remaining));
+                Assert.Equal(ConversationHandler.DefaultMaxModelIterationsPerCall, remaining);
+
+                Assert.True(conversation.Data.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray messages));
+
+                BlittableJsonReaderObject proseMessage = null;
+                BlittableJsonReaderObject structuredMessage = null;
+                foreach (BlittableJsonReaderObject message in messages)
+                {
+                    if (message.TryGet("role", out string role) == false || role != "assistant")
+                        continue;
+                    if (message.TryGet("content", out object content) == false || content == null)
+                        continue;
+
+                    if (content is BlittableJsonReaderObject)
+                        structuredMessage = message;
+                    else if (content.ToString() == ProseAnswer)
+                        proseMessage = message;
+                }
+
+                Assert.NotNull(proseMessage);
+                Assert.True(proseMessage.TryGet(ConversationDocument.OutputSchemaProperty, out string proseSchemaMarker));
+                Assert.Equal("none", proseSchemaMarker);
+
+                Assert.NotNull(structuredMessage);
+                Assert.False(structuredMessage.TryGet(ConversationDocument.OutputSchemaProperty, out string _));
+                Assert.Contains("Chai costs 18.0", structuredMessage.ToString());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task SplitMode_ImmediateProse_TriggersSingleFollowUp()
+        {
+            using var store = GetDocumentStore();
+            var database = await CreateDatabaseWithOrderAsync(store);
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var payloads = new List<JObject>();
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: payload =>
+                    {
+                        payloads.Add(payload);
+                        return payloads.Count == 1
+                            ? Ok(MockLlm.CreateProseAnswerResponse("Hello, how can I help?"))
+                            : Ok(MockLlm.CreateAnswerResponse("\"Hello, how can I help?\""));
+                    },
+                    clientSettings: CreateOllamaSettings())
+                {
+                    Authentication = null
+                };
+
+                handler.Initialize(CreateAgent(), "Dummy", new RequestBody
+                {
+                    Parameters = context.ReadObject(new DynamicJsonValue(), "params"),
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "hi"
+                }, changeVector: null);
+
+                var r = await handler.HandleRequestAsync(context, CancellationToken.None);
+
+                Assert.Equal(2, payloads.Count);
+                Assert.NotNull(payloads[0]["tools"]);
+                Assert.Null(payloads[0]["response_format"]);
+                Assert.Null(payloads[1]["tools"]);
+                Assert.NotNull(payloads[1]["response_format"]);
+                Assert.Contains("how can I help", r.Response.ToString());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task OpenAiSettings_SinglePhase_Unchanged()
+        {
+            using var store = GetDocumentStore();
+            var database = await CreateDatabaseWithOrderAsync(store);
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var payloads = new List<JObject>();
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: payload =>
+                    {
+                        payloads.Add(payload);
+                        return payloads.Count == 1
+                            ? Ok(MockLlm.CreateToolCallResponse("RecentOrders"))
+                            : Ok(MockLlm.CreateAnswerResponse("\"Chai costs 18.0\""));
+                    })
+                {
+                    Authentication = null
+                };
+
+                handler.Initialize(CreateAgent(), "Dummy", new RequestBody
+                {
+                    Parameters = context.ReadObject(new DynamicJsonValue(), "params"),
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "how much does Chai cost?"
+                }, changeVector: null);
+
+                var r = await handler.HandleRequestAsync(context, CancellationToken.None);
+
+                Assert.Equal(2, payloads.Count);
+                foreach (var payload in payloads)
+                {
+                    Assert.NotNull(payload["tools"]);
+                    Assert.NotNull(payload["response_format"]);
+                }
+
+                Assert.Contains("Chai costs 18.0", r.Response.ToString());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task SplitMode_Streaming_ToolTurnsNonStreaming_FinalTurnStreamsSchemaOnly()
+        {
+            using var store = GetDocumentStore();
+            var database = await CreateDatabaseWithOrderAsync(store);
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var payloads = new List<JObject>();
+                var streamingPayloads = new List<JObject>();
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: payload =>
+                    {
+                        payloads.Add(payload);
+                        return payloads.Count == 1
+                            ? Ok(MockLlm.CreateToolCallResponse("RecentOrders"))
+                            : Ok(MockLlm.CreateProseAnswerResponse(ProseAnswer));
+                    },
+                    clientSettings: CreateOllamaSettings(),
+                    onStreamingRequest: payload =>
+                    {
+                        streamingPayloads.Add(payload);
+                        return MockLlm.CreateSseAnswerResponse(StructuredAnswer);
+                    })
+                {
+                    Authentication = null
+                };
+
+                handler.Initialize(CreateAgent(), "Dummy", new RequestBody
+                {
+                    Parameters = context.ReadObject(new DynamicJsonValue(), "params"),
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "how much does Chai cost?"
+                }, changeVector: null);
+
+                using var output = new MemoryStream();
+                var r = await handler.HandleStreamingRequestAsync(context, output, "Answer", CancellationToken.None);
+
+                Assert.Equal(2, payloads.Count);
+                foreach (var payload in payloads)
+                {
+                    Assert.NotNull(payload["tools"]);
+                    Assert.Null(payload["response_format"]);
+                    Assert.Null(payload["stream"]);
+                }
+
+                var streamingPayload = Assert.Single(streamingPayloads);
+                Assert.Null(streamingPayload["tools"]);
+                Assert.NotNull(streamingPayload["response_format"]);
+                Assert.True(streamingPayload["stream"].Value<bool>());
+
+                var streamed = Encoding.UTF8.GetString(output.ToArray());
+                Assert.Contains("Chai costs 18.0", streamed.Replace("\"", "").Replace("\r\n", ""));
+                Assert.DoesNotContain("according to the data", streamed);
+
+                Assert.Contains("Chai costs 18.0", r.Response.ToString());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task SplitMode_NoSchemaConversation_Unchanged()
+        {
+            using var store = GetDocumentStore();
+            var database = await CreateDatabaseWithOrderAsync(store);
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var payloads = new List<JObject>();
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: payload =>
+                    {
+                        payloads.Add(payload);
+                        return payloads.Count == 1
+                            ? Ok(MockLlm.CreateToolCallResponse("RecentOrders"))
+                            : Ok(MockLlm.CreateProseAnswerResponse(ProseAnswer));
+                    },
+                    clientSettings: CreateOllamaSettings())
+                {
+                    Authentication = null
+                };
+
+                handler.Initialize(CreateAgent(), "Dummy", new RequestBody
+                {
+                    Parameters = context.ReadObject(new DynamicJsonValue(), "params"),
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "how much does Chai cost?",
+                    OutputOptions = new AiServerOutputOptions { NoSchema = true }
+                }, changeVector: null);
+
+                var r = await handler.HandleRequestAsync(context, CancellationToken.None);
+
+                Assert.Equal(2, payloads.Count);
+                foreach (var payload in payloads)
+                {
+                    Assert.NotNull(payload["tools"]);
+                    Assert.Null(payload["response_format"]);
+                }
+
+                Assert.Equal(ProseAnswer, r.Response.ToString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/RavenDB-27435

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
