### PR TITLE
RavenDB-27439 Update Parquet.Net to 6.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -109,7 +109,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.26.300" />
-    <PackageVersion Include="Parquet.Net" Version="5.5.0" />
+    <PackageVersion Include="Parquet.Net" Version="6.1.0" />
     <PackageVersion Include="Pgvector" Version="0.3.2" />
     <PackageVersion Include="pgsqlparser" Version="1.0.0" />
     <PackageVersion Include="Polly" Version="8.7.0" />

--- a/bench/Vector.Benchmark/Program.cs
+++ b/bench/Vector.Benchmark/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Parquet;
+using Parquet.Schema;
 using Voron;
 using Voron.Data.Graphs;
 
@@ -129,13 +130,21 @@ static IEnumerable<(int[], float[])> YieldVectors(string filePath)
     var schema = file.Schema;
     for (int i = 0; i < file.RowGroupCount; i++)
     {
-        var reader = file.OpenRowGroupReader(i);
-        var wikiId = reader.ReadColumnAsync(schema.DataFields[4]).Result;
-        var vectors = reader.ReadColumnAsync(schema.DataFields[8]).Result;
-        var wikiIds = (int[])wikiId.DefinedData;
-        var vectorsArr = (float[])vectors.DefinedData;
+        using var reader = file.OpenRowGroupReader(i);
+        var wikiIds = ReadColumn<int>(reader, schema.DataFields[4]);
+        var vectorsArr = ReadColumn<float>(reader, schema.DataFields[8]);
         yield return (wikiIds, vectorsArr);
     }
+}
+
+// Parquet.Net 6 reads into a buffer supplied by the caller, size it from the column chunk
+// metadata so that the repeated 'vectors' field is covered as well, not just the row count.
+static T[] ReadColumn<T>(ParquetRowGroupReader reader, DataField field)
+    where T : struct
+{
+    var values = new T[reader.GetMetadata(field).MetaData.NumValues];
+    reader.ReadAsync<T>(field, values.AsMemory()).GetAwaiter().GetResult();
+    return values;
 }
 
 static async Task DownloadFile(string fullPath)

--- a/bench/Vector.Benchmark/Program.cs
+++ b/bench/Vector.Benchmark/Program.cs
@@ -142,8 +142,10 @@ static IEnumerable<(int[], float[])> YieldVectors(string filePath)
 static T[] ReadColumn<T>(ParquetRowGroupReader reader, DataField field)
     where T : struct
 {
-    var values = new T[reader.GetMetadata(field).MetaData.NumValues];
-    reader.ReadAsync<T>(field, values.AsMemory()).GetAwaiter().GetResult();
+    var numValues = reader.GetMetadata(field)!.MetaData!.NumValues;
+
+    var values = new T[numValues];
+    reader.ReadAsync<T>(field, values.AsMemory()).AsTask().GetAwaiter().GetResult();
     return values;
 }
 

--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/ParquetTransformedItems.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/ParquetTransformedItems.cs
@@ -149,7 +149,7 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
                 finally
                 {
                     // ParquetWriter is IAsyncDisposable only, disposing it writes the file footer
-                    parquetWriter.DisposeAsync().GetAwaiter().GetResult();
+                    parquetWriter.DisposeAsync().AsTask().GetAwaiter().GetResult();
                 }
             }
 

--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/ParquetTransformedItems.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/ParquetTransformedItems.cs
@@ -13,7 +13,6 @@ using Parquet.Schema;
 using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.SQL;
 using Sparrow.Json;
-using DataColumn = Parquet.Data.DataColumn;
 
 namespace Raven.Server.Documents.ETL.Providers.OLAP
 {
@@ -51,7 +50,7 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
         private double[] _doubleArr;
         private decimal[] _decimalArr;
         private DateTime[] _dtArr;
-        private TimeSpan[] _tsArr;
+        private int[] _timeMillisArr;
 
         private const string DateTimeFormat = "yyyy-MM-dd-HH-mm-ss.ffffff";
         private const string Extension = "parquet";
@@ -141,9 +140,17 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
                 Directory.CreateDirectory(Path.Combine(_tmpFilePath, _localFolderName));
 
             using (Stream fileStream = File.Open(localPath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
-            using (var parquetWriter = ParquetWriter.CreateAsync(new ParquetSchema(Fields.Values), fileStream).GetAwaiter().GetResult())
             {
-                WriteGroup(parquetWriter);
+                var parquetWriter = ParquetWriter.CreateAsync(new ParquetSchema(Fields.Values), fileStream).GetAwaiter().GetResult();
+                try
+                {
+                    WriteGroup(parquetWriter);
+                }
+                finally
+                {
+                    // ParquetWriter is IAsyncDisposable only, disposing it writes the file footer
+                    parquetWriter.DisposeAsync().GetAwaiter().GetResult();
+                }
             }
 
             _count = _group.Count;
@@ -161,7 +168,7 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
                 if (kvp.Value == null)
                     continue;
 
-                fields[kvp.Key] = new DataField(kvp.Key, kvp.Value);
+                fields[kvp.Key] = CreateDataField(kvp.Key, kvp.Value);
             }
 
             fields[_documentIdColumn] = new DataField(_documentIdColumn, typeof(string));
@@ -170,97 +177,102 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
             return fields;
         }
 
+        private static DataField CreateDataField(string name, Type dataType)
+        {
+            // TimeSpan is not a supported Parquet.Net type anymore, a TIME column with
+            // millisecond precision is what earlier versions used to write for it
+            if (dataType == typeof(TimeSpan))
+                return new TimeDataField(name, TimeUnitPrecision.Millis);
+
+            return new DataField(name, dataType);
+        }
+
         private void WriteGroup(ParquetWriter parquetWriter)
         {
             AddMandatoryFields();
 
             using (ParquetRowGroupWriter groupWriter = parquetWriter.CreateRowGroup())
             {
-                foreach (var kvp in _group.Data)
+                // columns must be written in the order they appear in the schema,
+                // and the schema is generated from 'Fields', so we iterate over it
+                foreach (var kvp in Fields)
                 {
-                    if (Fields.TryGetValue(kvp.Key, out var field) == false)
-                        continue;
+                    var field = kvp.Value;
+                    var data = _group.Data[kvp.Key];
 
-                    var data = kvp.Value;
-                    Array array;
-
-                    if (field.ClrType == typeof(bool))
+                    // 'ClrType' is the type Parquet stores the column as, which is not the type we
+                    // asked for in a couple of cases, so those are matched on the field itself
+                    if (field is TimeDataField)
                     {
-                        array = _boolArr ??= new bool[data.Count];
+                        WriteTimeColumn(groupWriter, field, data, ref _timeMillisArr);
+                    }
+                    else if (field.ClrType == typeof(ReadOnlyMemory<char>))
+                    {
+                        WriteStringColumn(groupWriter, field, data, ref _strArr);
+                    }
+                    else if (field.ClrType == typeof(bool))
+                    {
+                        WriteColumn(groupWriter, field, data, ref _boolArr);
                     }
                     else if (field.ClrType == typeof(byte))
                     {
-                        array = _byteArr ??= new byte[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _byteArr);
                     }
                     else if (field.ClrType == typeof(sbyte))
                     {
-                        array = _sbyteArr ??= new sbyte[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _sbyteArr);
                     }
                     else if (field.ClrType == typeof(short))
                     {
-                        array = _shortArr ??= new short[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _shortArr);
                     }
                     else if (field.ClrType == typeof(int))
                     {
-                        array = _intArr ??= new int[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _intArr);
                     }
                     else if (field.ClrType == typeof(long))
                     {
-                        array = _longArr ??= new long[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _longArr);
                     }
                     else if (field.ClrType == typeof(ushort))
                     {
-                        array = _ushortArr ??= new ushort[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _ushortArr);
                     }
                     else if (field.ClrType == typeof(uint))
                     {
-                        array = _uintArr ??= new uint[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _uintArr);
                     }
                     else if (field.ClrType == typeof(ulong))
                     {
-                        array = _ulongArr ??= new ulong[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _ulongArr);
                     }
                     else if (field.ClrType == typeof(float))
                     {
-                        array = _floatArr ??= new float[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _floatArr);
                     }
                     else if (field.ClrType == typeof(double))
                     {
-                        array = _doubleArr ??= new double[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _doubleArr);
                     }
                     else if (field.ClrType == typeof(decimal))
                     {
-                        array = _decimalArr ??= new decimal[data.Count];
-                    }
-                    else if (field.ClrType == typeof(string))
-                    {
-                        array = _strArr ??= new string[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _decimalArr);
                     }
                     else if (field.ClrType == typeof(DateTime))
                     {
-                        array = _dtArr ??= new DateTime[data.Count];
-                    }
-                    else if (field.ClrType == typeof(TimeSpan))
-                    {
-                        array = _tsArr ??= new TimeSpan[data.Count];
+                        WriteColumn(groupWriter, field, data, ref _dtArr);
                     }
                     else
                     {
                         ThrowUnsupportedDataType(field.ClrType);
-                        return;
                     }
-
-                    Debug.Assert(array.Length == data.Count, $"Invalid field data on property '{kvp.Key}'");
-
-                    data.CopyTo(array, 0);
-                    groupWriter.WriteColumnAsync(new DataColumn(field, array)).GetAwaiter().GetResult();
                 }
             }
 
             _boolArr = null;
             _strArr = null;
             _dtArr = null;
-            _tsArr = null;
+            _timeMillisArr = null;
             _byteArr = null;
             _sbyteArr = null;
             _shortArr = null;
@@ -272,6 +284,41 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
             _floatArr = null;
             _doubleArr = null;
             _decimalArr = null;
+        }
+
+        private static void WriteColumn<T>(ParquetRowGroupWriter groupWriter, DataField field, IList data, ref T[] array)
+            where T : struct
+        {
+            array ??= new T[data.Count];
+
+            Debug.Assert(array.Length == data.Count, $"Invalid field data on property '{field.Name}'");
+
+            data.CopyTo(array, 0);
+            groupWriter.WriteAsync(field, new ReadOnlyMemory<T>(array)).GetAwaiter().GetResult();
+        }
+
+        private static void WriteTimeColumn(ParquetRowGroupWriter groupWriter, DataField field, IList data, ref int[] array)
+        {
+            array ??= new int[data.Count];
+
+            Debug.Assert(array.Length == data.Count, $"Invalid field data on property '{field.Name}'");
+
+            for (int i = 0; i < data.Count; i++)
+                array[i] = (int)((TimeSpan)data[i]).TotalMilliseconds;
+
+            groupWriter.WriteAsync(field, new ReadOnlyMemory<int>(array)).GetAwaiter().GetResult();
+        }
+
+        private static void WriteStringColumn(ParquetRowGroupWriter groupWriter, DataField field, IList data, ref string[] array)
+        {
+            array ??= new string[data.Count];
+
+            Debug.Assert(array.Length == data.Count, $"Invalid field data on property '{field.Name}'");
+
+            data.CopyTo(array, 0);
+
+            // strings are reference types, so they need the dedicated overload
+            groupWriter.WriteAsync(field, array).GetAwaiter().GetResult();
         }
 
         internal void AddMandatoryFields()

--- a/test/SlowTests/Server/Documents/ETL/Olap/AzureTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/AzureTests.cs
@@ -167,7 +167,7 @@ loadToOrders(partitionBy(key),
                         await using var ms = new MemoryStream();
                         await blob.Data.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -180,7 +180,7 @@ loadToOrders(partitionBy(key),
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 10);
 
                                 if (field.Name == ParquetTransformedItems.LastModifiedColumn)
@@ -340,7 +340,7 @@ loadToOrders(partitionBy(key), orderData);
                         await using var ms = new MemoryStream();
                         await blob.Data.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -352,7 +352,7 @@ loadToOrders(partitionBy(key), orderData);
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 31);
                             }
                         }
@@ -374,7 +374,7 @@ loadToOrders(partitionBy(key), orderData);
                         await using var ms = new MemoryStream();
                         await blob.Data.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -386,7 +386,7 @@ loadToOrders(partitionBy(key), orderData);
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 28 * 5);
                             }
                         }
@@ -550,7 +550,7 @@ loadToOrders(noPartition(),
                         await using var ms = new MemoryStream();
                         await blob.Data.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -563,7 +563,7 @@ loadToOrders(noPartition(),
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 100);
 
                                 if (field.Name == ParquetTransformedItems.LastModifiedColumn)
@@ -702,7 +702,7 @@ loadToOrders(partitionBy(
                             await using var ms = new MemoryStream();
                             await blob.Data.CopyToAsync(ms);
 
-                            using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                            await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                             {
                                 Assert.Equal(1, parquetReader.RowGroupCount);
                                 Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -711,7 +711,7 @@ loadToOrders(partitionBy(
                                 foreach (var field in parquetReader.Schema.Fields)
                                 {
                                     Assert.True(field.Name.In(expectedFields));
-                                    var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                    var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
 
                                     Assert.True(data.Length == 31 || data.Length == 28 || data.Length == 27 || data.Length == 10);
                                     if (field.Name != "RequireAt")

--- a/test/SlowTests/Server/Documents/ETL/Olap/GoogleCloudTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/GoogleCloudTests.cs
@@ -165,7 +165,7 @@ loadToOrders(partitionBy(key),
                         var ms = new MemoryStream();
                         await stream.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -178,7 +178,7 @@ loadToOrders(partitionBy(key),
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 10);
 
                                 if (field.Name == ParquetTransformedItems.LastModifiedColumn)
@@ -334,7 +334,7 @@ loadToOrders(partitionBy(key), orderData);
                         var ms = new MemoryStream();
                         await stream.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -346,7 +346,7 @@ loadToOrders(partitionBy(key), orderData);
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 31);
                             }
                         }
@@ -367,7 +367,7 @@ loadToOrders(partitionBy(key), orderData);
                         var ms = new MemoryStream();
                         await stream.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -379,7 +379,7 @@ loadToOrders(partitionBy(key), orderData);
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 28 * 5);
                             }
                         }
@@ -542,7 +542,7 @@ loadToOrders(noPartition(),
                         var ms = new MemoryStream();
                         await stream.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -555,7 +555,7 @@ loadToOrders(noPartition(),
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 100);
 
                                 if (field.Name == ParquetTransformedItems.LastModifiedColumn)

--- a/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
@@ -141,7 +141,7 @@ loadTo(""Orders"", partitionBy(key),
                 foreach (var fileName in files)
                 {
                     using (var fs = File.OpenRead(fileName))
-                    using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                    await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                     {
                         Assert.Equal(1, parquetReader.RowGroupCount);
                         Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -150,7 +150,7 @@ loadTo(""Orders"", partitionBy(key),
                         foreach (var field in parquetReader.Schema.Fields)
                         {
                             Assert.True(field.Name.In(expectedFields));
-                            var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                            var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
 
                             Assert.True(data.Length == 31 || data.Length == 28);
                             var count = data.Length == 31 ? 0 : 31;
@@ -247,7 +247,7 @@ loadToOrders(partitionBy(key), o);
                 var expectedFields = new[] { "RequireAt", "Total", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -257,7 +257,7 @@ loadToOrders(partitionBy(key), o);
                     {
                         Assert.True(field.Name.In(expectedFields));
 
-                        var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                        var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                         Assert.True(data.Length == 10);
 
                         if (field.Name == ParquetTransformedItems.LastModifiedColumn)
@@ -357,7 +357,7 @@ loadToOrders(partitionBy(key), o);
                 var expectedFields = new[] { "RequireAt", "Total", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -367,7 +367,7 @@ loadToOrders(partitionBy(key), o);
                     {
                         Assert.True(field.Name.In(expectedFields));
 
-                        var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                        var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                         Assert.True(data.Length == 24);
                     }
                 }
@@ -445,7 +445,7 @@ loadToOrders(partitionBy(key), o);
                 foreach (var file in files)
                 {
                     using (var fs = File.OpenRead(file))
-                    using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                    await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                     {
                         Assert.Equal(1, parquetReader.RowGroupCount);
                         Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -455,7 +455,7 @@ loadToOrders(partitionBy(key), o);
                         {
                             Assert.True(field.Name.In(expectedFields));
 
-                            var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                            var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                             Assert.True(data.Length == 60);
                         }
                     }
@@ -519,7 +519,7 @@ loadToOrders(partitionBy(key), o);
                 var expectedFields = new[] { "Company", "Freight", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -529,7 +529,7 @@ loadToOrders(partitionBy(key), o);
                     {
                         Assert.True(field.Name.In(expectedFields));
 
-                        var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                        var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                         Assert.True(data.Length == 10);
 
                         if (field.Name == ParquetTransformedItems.LastModifiedColumn)
@@ -613,7 +613,7 @@ loadToOrders(partitionBy(key), o);
                 var expectedFields = new[] { "Company", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -623,7 +623,7 @@ loadToOrders(partitionBy(key), o);
                     {
                         Assert.True(field.Name.In(expectedFields));
 
-                        var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                        var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                         Assert.True(data.Length == 10);
 
                         if (field.Name == ParquetTransformedItems.LastModifiedColumn)
@@ -818,7 +818,7 @@ loadToOrders(partitionBy(key), o);
                     long[] lsatModifiedFieldData = null;
 
                     using (var fs = File.OpenRead(files[0]))
-                    using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                    await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                     {
                         Assert.Equal(1, parquetReader.RowGroupCount);
                         Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -828,7 +828,7 @@ loadToOrders(partitionBy(key), o);
                         {
                             Assert.True(field.Name.In(expectedFields));
 
-                            var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                            var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                             Assert.True(data.Length == 10);
 
                             switch (field.Name)
@@ -959,7 +959,7 @@ loadToOrders(partitionBy(key), o);
                 var expectedFields = new[] { "RequireAt", "Total", idColumn, ParquetTransformedItems.LastModifiedColumn };
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -969,7 +969,7 @@ loadToOrders(partitionBy(key), o);
                     {
                         Assert.True(field.Name.In(expectedFields));
 
-                        var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                        var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                         Assert.True(data.Length == 10);
 
                         if (field.Name == ParquetTransformedItems.LastModifiedColumn)
@@ -1047,7 +1047,7 @@ loadToOrders(noPartition(),
                 foreach (var fileName in files)
                 {
                     using (var fs = File.OpenRead(fileName))
-                    using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                    await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                     {
                         Assert.Equal(1, parquetReader.RowGroupCount);
                         Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -1056,7 +1056,7 @@ loadToOrders(noPartition(),
                         foreach (var field in parquetReader.Schema.Fields)
                         {
                             Assert.True(field.Name.In(expectedFields));
-                            var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                            var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
 
                             Assert.True(data.Length == 100);
 
@@ -1167,7 +1167,7 @@ loadToOrders(partitionBy(
                 foreach (var fileName in files)
                 {
                     using (var fs = File.OpenRead(fileName))
-                    using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                    await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                     {
                         Assert.Equal(1, parquetReader.RowGroupCount);
                         Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -1176,7 +1176,7 @@ loadToOrders(partitionBy(
                         foreach (var field in parquetReader.Schema.Fields)
                         {
                             Assert.True(field.Name.In(expectedFields));
-                            var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                            var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
 
                             Assert.True(data.Length == 31 || data.Length == 28 || data.Length == 27 || data.Length == 10);
                             if (field.Name != "RequireAt")
@@ -1282,7 +1282,7 @@ loadToOrders(partitionBy(
                 var expectedFields = new[] { "double", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -1291,7 +1291,7 @@ loadToOrders(partitionBy(
                     foreach (var field in parquetReader.Schema.Fields)
                     {
                         Assert.True(field.Name.In(expectedFields));
-                        var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                        var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
 
                         Assert.True(data.Length == 5);
 
@@ -1430,7 +1430,7 @@ for (var i = 0; i < this.Lines.length; i++) {
                 var expectedFields = new[] { "Quantity", "Product", "Cost", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -1441,7 +1441,7 @@ for (var i = 0; i < this.Lines.length; i++) {
                         Assert.True(field.Name.In(expectedFields));
 
                         var dataField = (DataField)field;
-                        var data = (await rowGroupReader.ReadColumnAsync(dataField)).Data;
+                        var data = await rowGroupReader.ReadColumnDataAsync(dataField);
 
                         Assert.True(data.Length == 3);
 
@@ -1533,7 +1533,7 @@ loadToUsers(noPartition(), {
                 Assert.Equal(1, files.Length);
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(13, parquetReader.Schema.Fields.Count);
@@ -1542,7 +1542,7 @@ loadToUsers(noPartition(), {
                     foreach (var field in parquetReader.Schema.Fields)
                     {
                         var dataField = (DataField)field;
-                        var data = (await rowGroupReader.ReadColumnAsync(dataField)).Data;
+                        var data = await rowGroupReader.ReadColumnDataAsync(dataField);
                         Assert.Equal(1, data.Length);
 
                         object expected = default;
@@ -1965,7 +1965,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 var expectedFields = new[] { "company", "employee", documentIdColumn, ParquetTransformedItems.LastModifiedColumn };
                 var newFile = files[5];
                 using (var fs = File.OpenRead(newFile))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -2459,7 +2459,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 var expectedFields = new[] { "company", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -2472,7 +2472,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                             continue;
 
                         var expected = ParquetTransformedItems.UnixTimestampFromDateTime(lastModifiedDateTime.Value);
-                        var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                        var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                         Assert.True(data.Length == 1);
 
                         foreach (var val in data)
@@ -2481,6 +2481,48 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                             Assert.Equal(expected, l);
                         }
                     }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Etl)]
+        public async Task CanWriteTimeSpanColumn()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Order { Id = "orders/1" });
+                    await session.SaveChangesAsync();
+                }
+
+                var etlDone = Etl.WaitForEtlToComplete(store);
+
+                var script = @"
+loadToOrders(noPartition(), {
+    Duration: '01:30:00'
+});";
+
+                var path = NewDataPath(forceCreateDir: true);
+                SetupLocalOlapEtl(store, script, path);
+
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
+
+                var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
+                Assert.Equal(1, files.Length);
+
+                using (var fs = File.OpenRead(files[0]))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                {
+                    var durationField = Assert.IsType<TimeDataField>(parquetReader.Schema.Fields.Single(x => x.Name == "Duration"));
+
+                    // a TimeSpan is stored as a TIME column with millisecond precision
+                    Assert.Equal(TimeUnitPrecision.Millis, durationField.Precision);
+
+                    using var rowGroupReader = parquetReader.OpenRowGroupReader(0);
+                    var data = Assert.IsType<TimeSpan[]>(await rowGroupReader.ReadColumnDataAsync(durationField));
+
+                    Assert.Equal(new[] { TimeSpan.FromMinutes(90) }, data);
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
@@ -168,7 +168,7 @@ loadToOrders(partitionBy(key),
                         await using var ms = new MemoryStream();
                         await blob.Data.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -181,7 +181,7 @@ loadToOrders(partitionBy(key),
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 10);
 
                                 if (field.Name == ParquetTransformedItems.LastModifiedColumn)
@@ -352,7 +352,7 @@ loadToOrders(partitionBy(key), orderData);
                         await using var ms = new MemoryStream();
                         await blob.Data.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -364,7 +364,7 @@ loadToOrders(partitionBy(key), orderData);
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 31);
                             }
                         }
@@ -386,7 +386,7 @@ loadToOrders(partitionBy(key), orderData);
                         await using var ms = new MemoryStream();
                         await blob.Data.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -398,7 +398,7 @@ loadToOrders(partitionBy(key), orderData);
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 28 * 5);
                             }
                         }
@@ -562,7 +562,7 @@ loadToOrders(noPartition(),
                         await using var ms = new MemoryStream();
                         await blob.Data.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -575,7 +575,7 @@ loadToOrders(noPartition(),
                             {
                                 Assert.True(field.Name.In(expectedFields));
 
-                                var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                                 Assert.True(data.Length == 100);
 
                                 if (field.Name == ParquetTransformedItems.LastModifiedColumn)
@@ -712,7 +712,7 @@ loadToOrders(partitionBy(
                             await using var ms = new MemoryStream();
                             await blob.Data.CopyToAsync(ms);
 
-                            using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                            await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                             {
                                 Assert.Equal(1, parquetReader.RowGroupCount);
                                 Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -721,7 +721,7 @@ loadToOrders(partitionBy(
                                 foreach (var field in parquetReader.Schema.Fields)
                                 {
                                     Assert.True(field.Name.In(expectedFields));
-                                    var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                                    var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
 
                                     Assert.True(data.Length == 31 || data.Length == 28 || data.Length == 27 || data.Length == 10);
                                     if (field.Name != "RequireAt")

--- a/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
@@ -1308,7 +1308,7 @@ loadToOrders(partitionBy(key), o);
                 var expectedFields = new[] { "RequireAt", "Total", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -1464,7 +1464,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
                         await using var ms = new MemoryStream();
                         await blob.Data.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 
@@ -1509,7 +1509,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
                         await using var ms = new MemoryStream();
                         await blob.Data.CopyToAsync(ms);
 
-                        using (var parquetReader = await ParquetReader.CreateAsync(ms))
+                        await using (var parquetReader = await ParquetReader.CreateAsync(ms))
                         {
                             Assert.Equal(1, parquetReader.RowGroupCount);
 

--- a/test/StressTests/Server/Documents/ETL/Olap/LocalTestsStress.cs
+++ b/test/StressTests/Server/Documents/ETL/Olap/LocalTestsStress.cs
@@ -84,7 +84,7 @@ loadToOrders(partitionBy(key), o);
                 var expectedFields = new[] { "Company", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
                 using (var fs = File.OpenRead(files[0]))
-                using (var parquetReader = await ParquetReader.CreateAsync(fs))
+                await using (var parquetReader = await ParquetReader.CreateAsync(fs))
                 {
                     Assert.Equal(1, parquetReader.RowGroupCount);
                     Assert.Equal(expectedFields.Length, parquetReader.Schema.Fields.Count);
@@ -94,7 +94,7 @@ loadToOrders(partitionBy(key), o);
                     {
                         Assert.True(field.Name.In(expectedFields));
 
-                        var data = (await rowGroupReader.ReadColumnAsync((DataField)field)).Data;
+                        var data = await rowGroupReader.ReadColumnDataAsync((DataField)field);
                         Assert.True(data.Length == 10);
 
                         if (field.Name == ParquetTransformedItems.LastModifiedColumn)

--- a/test/Tests.Infrastructure/ParquetRowGroupReaderExtensions.cs
+++ b/test/Tests.Infrastructure/ParquetRowGroupReaderExtensions.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Threading.Tasks;
+using Parquet;
+using Parquet.Schema;
+
+namespace Tests.Infrastructure;
+
+public static class ParquetRowGroupReaderExtensions
+{
+    /// <summary>
+    /// Reads a whole flat column and returns it as an untyped array.
+    /// Parquet.Net 6.0 dropped the untyped 'DataColumn' read API in favour of typed,
+    /// caller allocated buffers, so we dispatch on the field's CLR type here instead.
+    /// Nullable columns come back as 'T?[]', non nullable ones as 'T[]', which is what
+    /// the old 'DataColumn.Data' used to hand out.
+    /// </summary>
+    public static async ValueTask<Array> ReadColumnDataAsync(this ParquetRowGroupReader rowGroupReader, DataField field)
+    {
+        var count = checked((int)rowGroupReader.RowCount);
+        var clrType = field.ClrType;
+
+        // TIME columns are backed by an integer, turn them back into the TimeSpan
+        // values that were handed to the ETL in the first place
+        if (field is TimeDataField timeField)
+        {
+            var ticksPerUnit = timeField.Precision switch
+            {
+                TimeUnitPrecision.Millis => TimeSpan.TicksPerMillisecond,
+                TimeUnitPrecision.Micros => TimeSpan.TicksPerMicrosecond,
+                _ => 1
+            };
+
+            var timeSpans = new TimeSpan[count];
+            if (clrType == typeof(int))
+            {
+                var millis = new int[count];
+                await rowGroupReader.ReadAsync<int>(field, millis.AsMemory());
+                for (var i = 0; i < count; i++)
+                    timeSpans[i] = TimeSpan.FromTicks(millis[i] * ticksPerUnit);
+            }
+            else
+            {
+                var units = new long[count];
+                await rowGroupReader.ReadAsync<long>(field, units.AsMemory());
+                for (var i = 0; i < count; i++)
+                    timeSpans[i] = TimeSpan.FromTicks(units[i] * ticksPerUnit);
+            }
+
+            return timeSpans;
+        }
+
+        // strings are stored as UTF-8, so a string column reports its type as char memory
+        if (clrType == typeof(string) || clrType == typeof(ReadOnlyMemory<char>))
+        {
+            var strings = new string[count];
+            await rowGroupReader.ReadAsync(field, strings.AsMemory());
+            return strings;
+        }
+
+        if (clrType == typeof(byte[]) || clrType == typeof(ReadOnlyMemory<byte>))
+        {
+            var byteArrays = new byte[count][];
+            await rowGroupReader.ReadAsync(field, byteArrays.AsMemory());
+            return byteArrays;
+        }
+
+        if (clrType == typeof(bool))
+            return await ReadValuesAsync<bool>(rowGroupReader, field, count);
+        if (clrType == typeof(byte))
+            return await ReadValuesAsync<byte>(rowGroupReader, field, count);
+        if (clrType == typeof(sbyte))
+            return await ReadValuesAsync<sbyte>(rowGroupReader, field, count);
+        if (clrType == typeof(short))
+            return await ReadValuesAsync<short>(rowGroupReader, field, count);
+        if (clrType == typeof(ushort))
+            return await ReadValuesAsync<ushort>(rowGroupReader, field, count);
+        if (clrType == typeof(int))
+            return await ReadValuesAsync<int>(rowGroupReader, field, count);
+        if (clrType == typeof(uint))
+            return await ReadValuesAsync<uint>(rowGroupReader, field, count);
+        if (clrType == typeof(long))
+            return await ReadValuesAsync<long>(rowGroupReader, field, count);
+        if (clrType == typeof(ulong))
+            return await ReadValuesAsync<ulong>(rowGroupReader, field, count);
+        if (clrType == typeof(float))
+            return await ReadValuesAsync<float>(rowGroupReader, field, count);
+        if (clrType == typeof(double))
+            return await ReadValuesAsync<double>(rowGroupReader, field, count);
+        if (clrType == typeof(decimal))
+            return await ReadValuesAsync<decimal>(rowGroupReader, field, count);
+        if (clrType == typeof(DateTime))
+            return await ReadValuesAsync<DateTime>(rowGroupReader, field, count);
+        if (clrType == typeof(DateOnly))
+            return await ReadValuesAsync<DateOnly>(rowGroupReader, field, count);
+        if (clrType == typeof(Guid))
+            return await ReadValuesAsync<Guid>(rowGroupReader, field, count);
+
+        throw new NotSupportedException($"Unsupported column type '{clrType}' on field '{field.Name}'");
+    }
+
+    private static async ValueTask<Array> ReadValuesAsync<T>(ParquetRowGroupReader rowGroupReader, DataField field, int count)
+        where T : struct
+    {
+        if (field.IsNullable)
+        {
+            var nullableValues = new T?[count];
+            await rowGroupReader.ReadAsync<T>(field, nullableValues.AsMemory());
+            return nullableValues;
+        }
+
+        var values = new T[count];
+        await rowGroupReader.ReadAsync<T>(field, values.AsMemory());
+        return values;
+    }
+}


### PR DESCRIPTION
6.0 is a rewrite of the library, so this is an API migration rather than a version bump. DataColumn is gone in favour of typed, caller-allocated buffers, ParquetWriter and ParquetReader are IAsyncDisposable only, and column writes are validated against the schema order - WriteGroup iterated RowGroup.Data, so it iterates Fields now, which is what the schema is built from. Every transitive dependency is already satisfied by the versions pinned in Directory.Packages.props.

DataField.ClrType reports the type Parquet stores the column as rather than the one it was asked for, so a string field reports ReadOnlyMemory<char> and the ClrType == typeof(string) branch stopped matching. Every string column fell through to ThrowUnsupportedDataType, which the ETL then retried. The dispatch is driven off the schema field itself now.

TimeSpan is no longer a supported type at all, and the OLAP ETL detects it from string document properties, so those columns are written as a TimeDataField with millisecond precision instead. That is the same physical column 5.5.0 wrote - INT32 / TIME_MILLIS / TIME(MILLIS, utc=True) / REQUIRED - and 5.5.0 truncated TotalMilliseconds when encoding, so the conversion truncates as well and matches byte for byte. The emitted schema was compared between both versions for all 15 types the ETL can write and is identical throughout, and 6.1.0 reads files written by 5.5.0, so existing OLAP output stays valid.

The untyped read API the OLAP tests used is gone, so ParquetRowGroupReaderExtensions.ReadColumnDataAsync restores the old DataColumn.Data shape on top of the typed buffers, which keeps the 29 read sites to a one line change each. CanWriteTimeSpanColumn covers the TimeSpan path, which had no coverage at all.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27439 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
