### PR TITLE
Quill-279 Frontend review comments

### DIFF
--- a/src/Raven.Quill.Web/AGENTS.md
+++ b/src/Raven.Quill.Web/AGENTS.md
@@ -20,6 +20,7 @@ Frontend for Raven Quill. It is a Vite + React + TypeScript app and is finally b
 - Keep components focused and reasonably small. If a component or hook grows awkward, step back and simplify the design before continuing.
 - Put reusable hooks/helpers in shared project utilities only when there is a realistic second use.
 - Boolean names must clearly read as booleans, e.g. `is`, `has`, `can`, `should`, `was`.
+- Test booleans by negation or truthiness, not by comparing to a literal: `!isSaving`, not `isSaving !== true`.
 - Use kebab-case filenames, PascalCase React components, `@/*` imports, and `SCREAMING_SNAKE_CASE` module constants.
 - Install new dependencies only when they remove real complexity. Prefer popular, maintained packages and latest versions.
 

--- a/src/Raven.Quill.Web/CLAUDE.md
+++ b/src/Raven.Quill.Web/CLAUDE.md
@@ -20,6 +20,7 @@ Frontend for Raven Quill. It is a Vite + React + TypeScript app and is finally b
 - Keep components focused and reasonably small. If a component or hook grows awkward, step back and simplify the design before continuing.
 - Put reusable hooks/helpers in shared project utilities only when there is a realistic second use.
 - Boolean names must clearly read as booleans, e.g. `is`, `has`, `can`, `should`, `was`.
+- Test booleans by negation or truthiness, not by comparing to a literal: `!isSaving`, not `isSaving !== true`.
 - Use kebab-case filenames, PascalCase React components, `@/*` imports, and `SCREAMING_SNAKE_CASE` module constants.
 - Install new dependencies only when they remove real complexity. Prefer popular, maintained packages and latest versions.
 

--- a/src/Raven.Quill.Web/packages/widget/src/transport.test.ts
+++ b/src/Raven.Quill.Web/packages/widget/src/transport.test.ts
@@ -50,3 +50,21 @@ describe("streamChat on a dead link", () => {
         }
     });
 });
+
+describe("streamChat on a malformed frame", () => {
+    it("skips the bad line and finishes the turn", async () => {
+        const body = [
+            JSON.stringify({ type: "chunk", text: "one" }),
+            "{not json",
+            JSON.stringify({ type: "chunk", text: "two" }),
+            JSON.stringify({ type: "done", answer: { reply: null } }),
+        ].join("\n");
+        const events = await eventsFor(new Response(`${body}\n`, { status: 200 }));
+
+        expect(events).toEqual([
+            { type: "chunk", text: "one" },
+            { type: "chunk", text: "two" },
+            { type: "done", reply: null },
+        ]);
+    });
+});

--- a/src/Raven.Quill.Web/packages/widget/src/transport.ts
+++ b/src/Raven.Quill.Web/packages/widget/src/transport.ts
@@ -1,3 +1,5 @@
+import { tryParseJson } from "@/utils";
+
 /** The chat endpoint's NDJSON wire protocol. Fixed by the server - see `EmbedEndpoints.StreamEmbedChatAsync`. */
 type ServerEvent =
     | { type: "chunk"; text?: string }
@@ -39,14 +41,6 @@ async function statusFailure(response: Response): Promise<ChatEvent | null> {
     return null;
 }
 
-function parseServerEvent(line: string): ServerEvent | null {
-    try {
-        return JSON.parse(line) as ServerEvent;
-    } catch {
-        return null;
-    }
-}
-
 async function* readLines(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
     const reader = body.getReader();
     const decoder = new TextDecoder();
@@ -72,7 +66,7 @@ async function* readLines(body: ReadableStream<Uint8Array>): AsyncGenerator<stri
 }
 
 function toChatEvent(line: string): ChatEvent | null {
-    const parsed = parseServerEvent(line);
+    const parsed = tryParseJson<ServerEvent>(line);
     if (parsed === null) return null;
 
     switch (parsed.type) {

--- a/src/Raven.Quill.Web/packages/widget/src/transport.ts
+++ b/src/Raven.Quill.Web/packages/widget/src/transport.ts
@@ -39,6 +39,14 @@ async function statusFailure(response: Response): Promise<ChatEvent | null> {
     return null;
 }
 
+function parseServerEvent(line: string): ServerEvent | null {
+    try {
+        return JSON.parse(line) as ServerEvent;
+    } catch {
+        return null;
+    }
+}
+
 async function* readLines(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
     const reader = body.getReader();
     const decoder = new TextDecoder();
@@ -64,7 +72,9 @@ async function* readLines(body: ReadableStream<Uint8Array>): AsyncGenerator<stri
 }
 
 function toChatEvent(line: string): ChatEvent | null {
-    const parsed = JSON.parse(line) as ServerEvent;
+    const parsed = parseServerEvent(line);
+    if (parsed === null) return null;
+
     switch (parsed.type) {
         case "chunk":
             return typeof parsed.text === "string" ? { type: "chunk", text: parsed.text } : null;

--- a/src/Raven.Quill.Web/packages/widget/src/utils.ts
+++ b/src/Raven.Quill.Web/packages/widget/src/utils.ts
@@ -1,0 +1,9 @@
+// Duplicated from the app's `src/lib/utils.ts` on purpose: this bundle ships to third-party
+// sites and must not reach outside the widget package.
+export function tryParseJson<T>(value: string): T | null {
+    try {
+        return JSON.parse(value) as T;
+    } catch {
+        return null;
+    }
+}

--- a/src/Raven.Quill.Web/src/api/queries/discord-queries.ts
+++ b/src/Raven.Quill.Web/src/api/queries/discord-queries.ts
@@ -1,7 +1,37 @@
 import { queryOptions } from "@tanstack/react-query";
-import type { ServerApi } from "@/api/generated/server-api";
+import type { DiscordChannelHealthResponse, ServerApi } from "@/api/generated/server-api";
 
 const baseKey = "discord";
+
+const CONNECTING_POLL_MS = 3_000;
+const IDLE_POLL_MS = 30_000;
+const CONNECTING_POLL_WINDOW_MS = 60_000;
+
+// When each channel was first seen connecting. Per channel, not per app: a bot wedged in "Connecting..."
+// must stop pulling the fast poll once its window is spent, without spending the window of a channel that
+// starts connecting later.
+const connectingSinceByChannel = new Map<string, number>();
+
+function isAnyChannelWithinConnectingWindow(slug: string, rows: DiscordChannelHealthResponse[]) {
+    const now = Date.now();
+    const startedAt: number[] = [];
+
+    for (const row of rows) {
+        const key = `${slug}/${row.channelId}`;
+        const isConnecting = row.enabled && !row.gatewayConnected && !row.lastGatewayError;
+
+        if (isConnecting === false) {
+            connectingSinceByChannel.delete(key);
+            continue;
+        }
+
+        const since = connectingSinceByChannel.get(key) ?? now;
+        connectingSinceByChannel.set(key, since);
+        startedAt.push(since);
+    }
+
+    return startedAt.some((since) => now - since < CONNECTING_POLL_WINDOW_MS);
+}
 
 export function createDiscordQueries(api: ServerApi["discord"]) {
     return {
@@ -10,11 +40,9 @@ export function createDiscordQueries(api: ServerApi["discord"]) {
                 queryKey: [baseKey, "health", slug],
                 queryFn: () => api.health(slug),
                 refetchInterval: (query) =>
-                    query.state.data?.some((row) => row.enabled && !row.gatewayConnected && !row.lastGatewayError)
-                        ? 3_000
-                        : 30_000,
+                    isAnyChannelWithinConnectingWindow(slug, query.state.data ?? [])
+                        ? CONNECTING_POLL_MS
+                        : IDLE_POLL_MS,
             }),
     };
 }
-
-export type DiscordQueries = ReturnType<typeof createDiscordQueries>;

--- a/src/Raven.Quill.Web/src/app.tsx
+++ b/src/Raven.Quill.Web/src/app.tsx
@@ -11,6 +11,7 @@ import { UserMenu } from "@/components/layout/user-menu";
 import { appRoutes } from "@/lib/app-routes";
 import { COMPACT_LAYOUT_MEDIA_QUERY, useMediaQuery } from "@/lib/use-media-query";
 import { cn } from "@/lib/utils";
+import { readStoredValue, writeStoredValue } from "@/lib/safe-storage";
 import QuillMark from "@/components/brand/quill-mark.svg?react";
 import { AssistantPanel } from "@/components/layout/assistant-panel";
 import { ASSISTANT_PANEL_TITLE_ID, useAssistantPinning, useAssistantStore } from "@/components/layout/assistant-store";
@@ -22,7 +23,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "sidebar-collapsed";
 
 function readStoredSidebarCollapsed() {
-    return localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true";
+    return readStoredValue(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true";
 }
 
 function App() {
@@ -65,7 +66,7 @@ function App() {
     const toggleSidebarCollapsed = () => {
         const isCollapsed = !isSidebarCollapsed;
         setIsSidebarCollapsed(isCollapsed);
-        localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, String(isCollapsed));
+        writeStoredValue(SIDEBAR_COLLAPSED_STORAGE_KEY, String(isCollapsed));
     };
 
     return (

--- a/src/Raven.Quill.Web/src/components/form/unsaved-changes/use-unsaved-changes.ts
+++ b/src/Raven.Quill.Web/src/components/form/unsaved-changes/use-unsaved-changes.ts
@@ -27,12 +27,17 @@ export function useUnsavedChanges(hasUnsavedChanges: boolean) {
 }
 
 /** Asks for confirmation before a dirty form is abandoned - by route change, overlay close, or page unload. */
-export function useFormUnsavedChanges<TValues extends FieldValues>(form: UseFormReturn<TValues>): UnsavedChangesHandle {
+export function useFormUnsavedChanges<TValues extends FieldValues>(
+    form: UseFormReturn<TValues>,
+    /** Pass the mutation's pending state when the save is mutation-driven: `isSubmitting` drops the moment
+     *  `mutate` returns, long before the save has settled. */
+    options: { isSaving?: boolean } = {},
+): UnsavedChangesHandle {
     const formId = useId();
     const { isDirty, isSubmitting } = useFormState({ control: form.control });
 
     // A save that navigates on success must not prompt on its way out.
-    const hasUnsavedChanges = isDirty && !isSubmitting;
+    const hasUnsavedChanges = isDirty && !isSubmitting && options.isSaving !== true;
     useRegisterUnsavedChanges(formId, hasUnsavedChanges);
 
     return {

--- a/src/Raven.Quill.Web/src/components/form/unsaved-changes/use-unsaved-changes.ts
+++ b/src/Raven.Quill.Web/src/components/form/unsaved-changes/use-unsaved-changes.ts
@@ -37,7 +37,7 @@ export function useFormUnsavedChanges<TValues extends FieldValues>(
     const { isDirty, isSubmitting } = useFormState({ control: form.control });
 
     // A save that navigates on success must not prompt on its way out.
-    const hasUnsavedChanges = isDirty && !isSubmitting && options.isSaving !== true;
+    const hasUnsavedChanges = isDirty && !isSubmitting && !options.isSaving;
     useRegisterUnsavedChanges(formId, hasUnsavedChanges);
 
     return {

--- a/src/Raven.Quill.Web/src/components/layout/assistant-store.ts
+++ b/src/Raven.Quill.Web/src/components/layout/assistant-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { readStoredValue, writeStoredValue } from "@/lib/safe-storage";
 import { COMPACT_LAYOUT_MEDIA_QUERY, useMediaQuery } from "@/lib/use-media-query";
 
 const ASSISTANT_OPEN_STORAGE_KEY = "assistant-open";
@@ -27,11 +28,11 @@ export function clampAssistantSize(sizePx: number, minPx: number, maxPx: number)
 }
 
 function persistSize(storageKey: string, sizePx: number) {
-    localStorage.setItem(storageKey, String(sizePx));
+    writeStoredValue(storageKey, String(sizePx));
 }
 
 function readStoredSize(storageKey: string, defaultPx: number, minPx: number, maxPx = Number.POSITIVE_INFINITY) {
-    const storedPx = Number(localStorage.getItem(storageKey));
+    const storedPx = Number(readStoredValue(storageKey));
     return Number.isFinite(storedPx) && storedPx > 0 ? clampAssistantSize(storedPx, minPx, maxPx) : defaultPx;
 }
 
@@ -53,8 +54,8 @@ type AssistantState = {
 };
 
 export const useAssistantStore = create<AssistantState>((set, get) => ({
-    isOpen: localStorage.getItem(ASSISTANT_OPEN_STORAGE_KEY) === "true",
-    isPinned: localStorage.getItem(ASSISTANT_PINNED_STORAGE_KEY) !== "false",
+    isOpen: readStoredValue(ASSISTANT_OPEN_STORAGE_KEY) === "true",
+    isPinned: readStoredValue(ASSISTANT_PINNED_STORAGE_KEY) !== "false",
     isResizing: false,
     openCount: 0,
     widthPx: readStoredSize(
@@ -66,11 +67,11 @@ export const useAssistantStore = create<AssistantState>((set, get) => ({
     heightPx: readStoredSize(ASSISTANT_HEIGHT_STORAGE_KEY, ASSISTANT_DEFAULT_HEIGHT_PX, ASSISTANT_MIN_HEIGHT_PX),
     setOpen: (isOpen) =>
         set((state) => {
-            localStorage.setItem(ASSISTANT_OPEN_STORAGE_KEY, String(isOpen));
+            writeStoredValue(ASSISTANT_OPEN_STORAGE_KEY, String(isOpen));
             return { isOpen, openCount: isOpen ? state.openCount + 1 : state.openCount };
         }),
     setPinned: (isPinned) => {
-        localStorage.setItem(ASSISTANT_PINNED_STORAGE_KEY, String(isPinned));
+        writeStoredValue(ASSISTANT_PINNED_STORAGE_KEY, String(isPinned));
         set({ isPinned });
     },
     setResizing: (isResizing) => {

--- a/src/Raven.Quill.Web/src/components/shadcn/theme-provider.tsx
+++ b/src/Raven.Quill.Web/src/components/shadcn/theme-provider.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
+import { isLocalStorageEvent, readStoredValue, writeStoredValue } from "@/lib/safe-storage";
 
 export type Theme = "dark" | "light" | "system";
 type ResolvedTheme = "dark" | "light";
@@ -62,7 +63,7 @@ export function ThemeProvider({
     ...props
 }: ThemeProviderProps) {
     const [theme, setThemeState] = React.useState<Theme>(() => {
-        const storedTheme = localStorage.getItem(storageKey);
+        const storedTheme = readStoredValue(storageKey);
         if (isTheme(storedTheme)) {
             return storedTheme;
         }
@@ -72,7 +73,7 @@ export function ThemeProvider({
 
     const setTheme = React.useCallback(
         (nextTheme: Theme) => {
-            localStorage.setItem(storageKey, nextTheme);
+            writeStoredValue(storageKey, nextTheme);
             setThemeState(nextTheme);
         },
         [storageKey],
@@ -115,7 +116,7 @@ export function ThemeProvider({
 
     React.useEffect(() => {
         const handleStorageChange = (event: StorageEvent) => {
-            if (event.storageArea !== localStorage) {
+            if (isLocalStorageEvent(event) === false) {
                 return;
             }
 

--- a/src/Raven.Quill.Web/src/lib/safe-storage.ts
+++ b/src/Raven.Quill.Web/src/lib/safe-storage.ts
@@ -1,0 +1,27 @@
+// Touching localStorage throws outright where site data is blocked - Safari's "Block all cookies",
+// enterprise policies, a sandboxed iframe. Everything the dashboard keeps there is a remembered
+// preference, never worth taking the app down for, so a blocked store reads empty and drops writes.
+
+export function readStoredValue(key: string): string | null {
+    try {
+        return localStorage.getItem(key);
+    } catch {
+        return null;
+    }
+}
+
+export function writeStoredValue(key: string, value: string) {
+    try {
+        localStorage.setItem(key, value);
+    } catch {
+        // Nothing to recover: the preference simply does not survive this session.
+    }
+}
+
+export function isLocalStorageEvent(event: StorageEvent) {
+    try {
+        return event.storageArea === localStorage;
+    } catch {
+        return false;
+    }
+}

--- a/src/Raven.Quill.Web/src/lib/utils.ts
+++ b/src/Raven.Quill.Web/src/lib/utils.ts
@@ -6,6 +6,14 @@ export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }
 
+export function tryParseJson<T>(value: string): T | null {
+    try {
+        return JSON.parse(value) as T;
+    } catch {
+        return null;
+    }
+}
+
 // Renders an ISO timestamp in the viewer's locale; falls back to the raw value
 // if it isn't a parseable date.
 export function formatDateTime(value: string) {

--- a/src/Raven.Quill.Web/src/pages/apps/channels/channel-config-form.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/channel-config-form.tsx
@@ -11,6 +11,11 @@ import { FieldDescription, FieldLabel } from "@/components/shadcn/ui/field";
 import { Switch } from "@/components/shadcn/ui/switch";
 import { FormInput } from "@/components/form/form-input";
 import { FormStringList } from "@/components/form/form-string-list";
+import {
+    DISCORD_BOT_TOKEN_FORMAT,
+    SLACK_BOT_TOKEN_FORMAT,
+    rotatedTokenField,
+} from "@/pages/apps/channels/channel-token-fields";
 import { useFormUnsavedChanges } from "@/components/form/unsaved-changes/use-unsaved-changes";
 import { withNestedSubmit } from "@/lib/form-utils";
 import { cn } from "@/lib/utils";
@@ -20,9 +25,9 @@ const editChannelSchema = z.object({
     displayName: z.string().trim().min(1, "Channel name is required"),
     allowedOrigins: z.array(z.object({ value: z.string().trim() })),
     botToken: z.string().trim(),
-    slackBotToken: z.string().trim(),
+    slackBotToken: rotatedTokenField(SLACK_BOT_TOKEN_FORMAT),
     slackSigningSecret: z.string().trim(),
-    discordBotToken: z.string().trim(),
+    discordBotToken: rotatedTokenField(DISCORD_BOT_TOKEN_FORMAT),
 });
 
 type EditChannelFormData = z.infer<typeof editChannelSchema>;

--- a/src/Raven.Quill.Web/src/pages/apps/channels/channel-token-fields.ts
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/channel-token-fields.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+// Token format rules shared by the create forms, which must be given a token, and the edit sheet's
+// rotation fields, where blank means "leave the stored token alone".
+
+type TokenFormat = {
+    isValid: (token: string) => boolean;
+    message: string;
+};
+
+export const SLACK_BOT_TOKEN_FORMAT: TokenFormat = {
+    isValid: (token) => token.startsWith("xoxb-"),
+    message: "The bot token starts with xoxb- (not a user or app-level token)",
+};
+
+export const DISCORD_BOT_TOKEN_FORMAT: TokenFormat = {
+    isValid: (token) => /^\S+$/.test(token),
+    message: "A bot token contains no spaces",
+};
+
+export function newTokenField(format: TokenFormat, missingMessage: string) {
+    return z.string().trim().min(1, missingMessage).refine(format.isValid, format.message);
+}
+
+export function rotatedTokenField(format: TokenFormat) {
+    return z
+        .string()
+        .trim()
+        .refine((token) => token.length === 0 || format.isValid(token), format.message);
+}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/discord-channel-form.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/discord-channel-form.tsx
@@ -17,6 +17,7 @@ import { Heading, Text } from "@/components/typography";
 import { FormInput } from "@/components/form/form-input";
 import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
 import { ParameterBindingFields } from "@/pages/apps/channels/parameter-binding-fields";
+import { DISCORD_BOT_TOKEN_FORMAT, newTokenField } from "@/pages/apps/channels/channel-token-fields";
 import {
     hasSameParameterNames,
     seedParameterRows,
@@ -49,11 +50,7 @@ const parameterBindingSchema = z
 const discordChannelSchema = z.object({
     agentId: z.string().min(1, "Select an agent to route conversations to"),
     displayName: z.string().trim(),
-    botToken: z
-        .string()
-        .trim()
-        .min(1, "Paste the bot token from the app's Bot page")
-        .refine((token) => /^\S+$/.test(token), "A bot token contains no spaces"),
+    botToken: newTokenField(DISCORD_BOT_TOKEN_FORMAT, "Paste the bot token from the app's Bot page"),
     parameters: z.array(parameterBindingSchema),
 });
 

--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-api-docs.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-api-docs.tsx
@@ -4,6 +4,7 @@ import { ShieldAlertIcon } from "lucide-react";
 import { CodeBlockTabs } from "@/components/data/code-block-tabs";
 import { Alert, AlertDescription, AlertTitle } from "@/components/shadcn/ui/alert";
 import { originForSubdomain } from "@/lib/subdomain-origin";
+import { readStoredValue, writeStoredValue } from "@/lib/safe-storage";
 import {
     buildMintEmbedLinkUrl,
     DEFAULT_MAX_INVOCATIONS,
@@ -49,7 +50,7 @@ const LANGUAGE_OPTIONS: LanguageOption[] = [
 ];
 
 function readLanguage(): Language {
-    const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+    const stored = readStoredValue(LANGUAGE_STORAGE_KEY);
     return LANGUAGE_OPTIONS.some((language) => language.value === stored) ? (stored as Language) : "bash";
 }
 
@@ -68,7 +69,7 @@ export function EmbedLinkApiDocs({ slug, channelId, parameters }: EmbedLinkApiDo
 
     const onLanguageChange = (value: string) => {
         const next = value as Language;
-        localStorage.setItem(LANGUAGE_STORAGE_KEY, next);
+        writeStoredValue(LANGUAGE_STORAGE_KEY, next);
         setLanguage(next);
     };
 

--- a/src/Raven.Quill.Web/src/pages/apps/channels/slack-channel-form.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/slack-channel-form.tsx
@@ -20,6 +20,7 @@ import { NumberedSteps } from "@/components/data/numbered-steps";
 import { FormInput } from "@/components/form/form-input";
 import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
 import { ParameterBindingFields } from "@/pages/apps/channels/parameter-binding-fields";
+import { SLACK_BOT_TOKEN_FORMAT, newTokenField } from "@/pages/apps/channels/channel-token-fields";
 import {
     hasSameParameterNames,
     seedParameterRows,
@@ -53,11 +54,7 @@ const parameterBindingSchema = z
 const slackChannelSchema = z.object({
     agentId: z.string().min(1, "Select an agent to route conversations to"),
     displayName: z.string().trim(),
-    botToken: z
-        .string()
-        .trim()
-        .min(1, "Paste the bot token from the Slack app's OAuth page")
-        .startsWith("xoxb-", "The bot token starts with xoxb- (not a user or app-level token)"),
+    botToken: newTokenField(SLACK_BOT_TOKEN_FORMAT, "Paste the bot token from the Slack app's OAuth page"),
     signingSecret: z.string().trim().min(1, "Paste the signing secret (Basic Information > App Credentials)"),
     parameters: z.array(parameterBindingSchema),
 });

--- a/src/Raven.Quill.Web/src/pages/apps/channels/web-widget-theme-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/web-widget-theme-editor.tsx
@@ -12,6 +12,7 @@ import { FormSelect } from "@/components/form/form-select";
 import { FormStringList } from "@/components/form/form-string-list";
 import { FormSwitch } from "@/components/form/form-switch";
 import { FormToggleGroup } from "@/components/form/form-toggle-group";
+import { useFormUnsavedChanges } from "@/components/form/unsaved-changes/use-unsaved-changes";
 import { Heading, Text } from "@/components/typography";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Button } from "@/components/shadcn/ui/button";
@@ -127,6 +128,10 @@ export function WebWidgetThemeEditor({
         // what the operator is already looking at instead of from the built-in.
         values: toFormData(savedTheme),
     });
+
+    // The save is mutation-driven, so the window to suppress is the request itself - the saved theme comes
+    // back through `values`, which resets the form. A failed save leaves the edits dirty, re-arming the guard.
+    useFormUnsavedChanges(form, { isSaving });
 
     // One state drives both the colors tabs and the previewed scheme, so the colors on screen are always
     // the colors in the frame and editing dark never means guessing.

--- a/src/Raven.Quill.Web/src/pages/apps/conversations/conversation-tool-call.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/conversations/conversation-tool-call.tsx
@@ -3,6 +3,7 @@ import type { AiToolCallResult } from "@/api/generated/server-api";
 import { Parameters } from "@/components/data/parameters";
 import { CodeBlock, TranscriptDisclosure } from "@/pages/apps/conversations/transcript-disclosure";
 import { Text } from "@/components/typography";
+import { tryParseJson } from "@/lib/utils";
 
 // A collapsed transcript entry for one tool the agent ran during a turn. Kept operator-friendly:
 // only the parameters the model filled in and the tool's response — no raw query internals.
@@ -93,13 +94,5 @@ function formatParameterValue(value: unknown): string {
 
 function prettifyJson(value: string): string {
     const parsed = tryParseJson(value);
-    return parsed === undefined ? value : JSON.stringify(parsed, null, 2);
-}
-
-function tryParseJson(value: string): unknown {
-    try {
-        return JSON.parse(value);
-    } catch {
-        return undefined;
-    }
+    return parsed === null ? value : JSON.stringify(parsed, null, 2);
 }

--- a/src/Raven.Quill.Web/src/pages/apps/welcome-panel.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/welcome-panel.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import { Button } from "@/components/shadcn/ui/button";
 import { appRoutes } from "@/lib/app-routes";
+import { readStoredValue, writeStoredValue } from "@/lib/safe-storage";
 import { cn } from "@/lib/utils";
 import { Heading, Text } from "@/components/typography";
 
@@ -15,7 +16,7 @@ function dismissedStorageKey(slug: string) {
 }
 
 function readDismissed(slug: string) {
-    return localStorage.getItem(dismissedStorageKey(slug)) === "true";
+    return readStoredValue(dismissedStorageKey(slug)) === "true";
 }
 
 export function WelcomePanel({ slug }: { slug: string }) {
@@ -53,7 +54,7 @@ export function WelcomePanel({ slug }: { slug: string }) {
     }
 
     const dismiss = () => {
-        localStorage.setItem(dismissedStorageKey(slug), "true");
+        writeStoredValue(dismissedStorageKey(slug), "true");
         setIsDismissed(true);
     };
 

--- a/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-capability-wizard/steps/review/test-agent-tool-call.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronUp, Database } from "lucide-react";
 import type { AgentToolCall } from "@/api/custom-services/agent-stream";
 import AceEditor from "@/components/ace-editor/ace-editor";
 import type { AceEditorMode } from "@/components/ace-editor/ace-editor-types";
+import { tryParseJson } from "@/lib/utils";
 
 // A collapsed transcript of one query tool the agent ran this turn: the RQL it executed, the
 // parameters the model filled in, and the content the query returned. Mirrors Studio's query
@@ -90,13 +91,5 @@ function prettifyJson(value: string | null | undefined): string {
     }
 
     const parsed = tryParseJson(value);
-    return parsed === undefined ? value : JSON.stringify(parsed, null, 4);
-}
-
-function tryParseJson(value: string): unknown {
-    try {
-        return JSON.parse(value);
-    } catch {
-        return undefined;
-    }
+    return parsed === null ? value : JSON.stringify(parsed, null, 4);
 }


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/Quill-279/Frontend-review-comments

### Additional description

**1. Unsaved-changes guard** — [web-widget-theme-editor.tsx:132](src/pages/apps/channels/web-widget-theme-editor.tsx:132) now registers with the store, so both the tab-switch gate and the route/unload guard cover it. Used the lower-level `useUnsavedChanges(isDirty && !isSaving)` rather than `useFormUnsavedChanges` because the save is mutation-driven: `isSubmitting` goes false the instant `mutate` returns, so the sibling pattern would prompt spuriously for the length of the PUT. A failed save leaves the edits dirty and re-arms the guard.

**2. Rotation token validation** — Extracted the format rules into [channel-token-fields.ts](src/pages/apps/channels/channel-token-fields.ts) and pointed both paths at them: `newTokenField` for create, `rotatedTokenField` (blank means "don't rotate") for [channel-config-form.tsx:29](src/pages/apps/channels/channel-config-form.tsx:29). Since the drift itself was the bug, sharing the rule beats copying the refinement. Left Telegram's token and Slack's signing secret without a format rule — create doesn't check those either, so adding one here would be new validation, not parity.

**3. Discord poll cap** — [discord-queries.ts](src/api/queries/discord-queries.ts) keeps the 3s interval only for the first 60s of a connecting state, then falls back to 30s. Dropped the backend half of the finding: the identity cache is filled by the first response, so the repeated `GetBotIdentityAsync` calls the comment describes don't happen.

**4. Malformed NDJSON frame** — `parseServerEvent` returns `null` on a parse failure, so a bad line is skipped like an unrecognized frame instead of ending the turn ([transport.ts:42](packages/widget/src/transport.ts:42)). Added a test covering chunk / bad line / chunk / done.

**5. Unguarded `localStorage`** — New [safe-storage.ts](src/lib/safe-storage.ts) (`readStoredValue`, `writeStoredValue`, `isLocalStorageEvent`), and all five files now go through it — assistant-store plus theme-provider, app.tsx, welcome-panel, and embed-link-api-docs, which had the same exposure on the boot path. Writes are wrapped too, which the original finding didn't mention. No raw `localStorage` remains outside the helper.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
