### PR TITLE
Quill-277 Discord channel UI adjustments

### DIFF
--- a/src/Raven.Quill.Web/src/mocks/discord-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/discord-mocks.ts
@@ -2,21 +2,46 @@ import type { DiscordChannelHealthResponse } from "@/api/generated/server-api";
 import { apiHttp } from "./api-http";
 import { SAMPLE_DISCORD_CHANNEL_ID } from "./channels-mocks";
 
-export const sampleDiscordHealth: DiscordChannelHealthResponse[] = [
+const HEALTHY: DiscordChannelHealthResponse = {
+    channelId: SAMPLE_DISCORD_CHANNEL_ID,
+    applicationId: "412873098765432100",
+    botUserId: "412873098765432100",
+    botUsername: "acme-helper",
+    enabled: true,
+    tokenValid: true,
+    tokenError: null,
+    gatewayConnected: true,
+    lastConnectedAt: "2026-08-21T11:41:00Z",
+    lastGatewayError: null,
+    lastInboundAt: "2026-08-21T12:05:00Z",
+    lastSendErrorAt: null,
+    lastSendError: null,
+};
+
+export const sampleDiscordHealth: DiscordChannelHealthResponse[] = [HEALTHY];
+
+// Variants for developing the destructive/idle states the happy-path row never exercises.
+export const pausedDiscordHealth: DiscordChannelHealthResponse[] = [
+    { ...HEALTHY, enabled: false, gatewayConnected: false, lastConnectedAt: null },
+];
+
+export const tokenRejectedDiscordHealth: DiscordChannelHealthResponse[] = [
     {
-        channelId: SAMPLE_DISCORD_CHANNEL_ID,
-        applicationId: "412873098765432100",
-        botUserId: "412873098765432100",
-        botUsername: "acme-helper",
-        enabled: true,
-        tokenValid: true,
-        tokenError: null,
-        gatewayConnected: true,
-        lastConnectedAt: "2026-08-21T11:41:00Z",
-        lastGatewayError: null,
-        lastInboundAt: "2026-08-21T12:05:00Z",
-        lastSendErrorAt: null,
-        lastSendError: null,
+        ...HEALTHY,
+        gatewayConnected: false,
+        lastConnectedAt: null,
+        tokenValid: false,
+        tokenError: "401: invalid bot token",
+    },
+];
+
+export const gatewayDisconnectedDiscordHealth: DiscordChannelHealthResponse[] = [
+    {
+        ...HEALTHY,
+        gatewayConnected: false,
+        lastGatewayError: "Gateway closed (4004): authentication failed",
+        lastSendErrorAt: "2026-08-21T12:06:00Z",
+        lastSendError: "Cannot send messages to this user",
     },
 ];
 

--- a/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.stories.tsx
@@ -6,7 +6,12 @@ import {
     SAMPLE_SLACK_CHANNEL_ID,
     SAMPLE_TELEGRAM_CHANNEL_ID,
 } from "@/mocks/channels-mocks";
-import { discordMocks, sampleDiscordHealth } from "@/mocks/discord-mocks";
+import {
+    discordMocks,
+    pausedDiscordHealth,
+    sampleDiscordHealth,
+    tokenRejectedDiscordHealth,
+} from "@/mocks/discord-mocks";
 import { embedLinksMocks } from "@/mocks/embed-links-mocks";
 import { sampleSlackHealth, slackMocks } from "@/mocks/slack-mocks";
 import { AppChannelDetail } from "./app-channel-detail";
@@ -134,6 +139,45 @@ export const DiscordGatewayDisconnected: Story = {
                 ],
             },
         },
+    },
+};
+
+export const DiscordTokenRejected: Story = {
+    parameters: {
+        router: {
+            initialPath: `/apps/demo/channels/${SAMPLE_DISCORD_CHANNEL_ID}`,
+            path: "/apps/:slug/channels/:channelId",
+        },
+        msw: {
+            handlers: {
+                discord: [discordMocks.health(tokenRejectedDiscordHealth)],
+            },
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await canvas.findByText(/token rejected/i);
+        expect(canvas.getByText(/rotate bot token/i)).toBeInTheDocument();
+    },
+};
+
+export const DiscordPaused: Story = {
+    parameters: {
+        router: {
+            initialPath: `/apps/demo/channels/${SAMPLE_DISCORD_CHANNEL_ID}`,
+            path: "/apps/:slug/channels/:channelId",
+        },
+        msw: {
+            handlers: {
+                discord: [discordMocks.health(pausedDiscordHealth)],
+            },
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await canvas.findByText(/paused/i);
     },
 };
 

--- a/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-channel-detail.stories.tsx
@@ -159,6 +159,8 @@ export const DiscordTokenRejected: Story = {
 
         await canvas.findByText(/token rejected/i);
         expect(canvas.getByText(/rotate bot token/i)).toBeInTheDocument();
+        // A rejected token blocks the gateway, so the panel must not also claim it's "Connecting...".
+        expect(canvas.queryByText(/connecting/i)).not.toBeInTheDocument();
     },
 };
 
@@ -254,6 +256,8 @@ export const DiscordConnecting: Story = {
 
         await canvas.findByText(/connecting/i);
         expect(canvas.queryByText(/gateway disconnected/i)).not.toBeInTheDocument();
+        // No inbound message yet, so the connection card invites the first one instead of showing nothing.
+        expect(canvas.getByText(/waiting for the first message/i)).toBeInTheDocument();
     },
 };
 

--- a/src/Raven.Quill.Web/src/pages/apps/app-channels.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-channels.tsx
@@ -1,19 +1,10 @@
 import { useParams } from "react-router";
-import { useQuery } from "@tanstack/react-query";
-import { api } from "@/api/api";
-import { DashboardStatCards, type DashboardStatCard } from "@/pages/dashboard/dashboard-stat-cards";
 import { AddChannelMenu } from "@/pages/apps/channels/add-channel-menu";
 import { ChannelGroups } from "@/pages/apps/channel-groups";
 import { Heading, Text } from "@/components/typography";
 
 export function AppChannels() {
     const { slug = "" } = useParams();
-    const channelStatsQuery = useQuery(api.queries.stats.channels(slug));
-
-    const stats = channelStatsQuery.data;
-    const cards: DashboardStatCard[] = [
-        { label: "Active channels", value: stats?.active, isLoading: channelStatsQuery.isPending },
-    ];
 
     return (
         <div className="space-y-6">
@@ -28,7 +19,6 @@ export function AppChannels() {
                 </div>
                 <AddChannelMenu slug={slug} label="New channel" variant="default" />
             </div>
-            <DashboardStatCards cards={cards} />
             <ChannelGroups slug={slug} />
         </div>
     );

--- a/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { Cable, CodeXml, Link2, MessageCircle, Palette, Pencil, Send, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Cable, CodeXml, Link2, MessageCircle, Palette, Pencil, Search, Send, Trash2 } from "lucide-react";
 import type { ComponentType, ReactNode, SVGProps } from "react";
 import { Link } from "react-router";
 import { api } from "@/api/api";
@@ -10,6 +11,8 @@ import { EnabledStatus } from "@/components/data/status-indicator";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/shadcn/ui/input-group";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/shadcn/ui/select";
 import { Skeleton } from "@/components/shadcn/ui/skeleton";
 import { Heading, Text } from "@/components/typography";
 import { appRoutes } from "@/lib/app-routes";
@@ -33,7 +36,13 @@ const CHANNEL_GROUPS: ChannelGroupConfig[] = [
     { type: "Discord", label: "Discord", icon: DiscordIcon },
 ];
 
+type ChannelTypeFilter = NonNullable<ChannelType> | "all";
+type ChannelStatusFilter = "all" | "active" | "paused";
+
 export function ChannelGroups({ slug }: { slug: string }) {
+    const [search, setSearch] = useState("");
+    const [typeFilter, setTypeFilter] = useState<ChannelTypeFilter>("all");
+    const [statusFilter, setStatusFilter] = useState<ChannelStatusFilter>("all");
     const agentsQuery = useQuery(api.queries.agents.list(slug));
     const channelsQuery = useQuery(api.queries.channels.list(slug));
     // Active-link counts are supplementary — kept out of the ApiState gate so a
@@ -55,18 +64,27 @@ export function ChannelGroups({ slug }: { slug: string }) {
     };
 
     const channels = channelsQuery.data ?? [];
+    const query = search.trim().toLowerCase();
+    const filteredChannels = channels.filter((channel) => {
+        const matchesType = typeFilter === "all" || channel.type === typeFilter;
+        const matchesStatus =
+            statusFilter === "all" || (statusFilter === "active" ? channel.enabled : !channel.enabled);
+        const matchesSearch = query === "" || channelSearchText(channel).includes(query);
+        return matchesType && matchesStatus && matchesSearch;
+    });
+
     const knownTypes = new Set<NonNullable<ChannelType>>(CHANNEL_GROUPS.map((group) => group.type));
     const groups = [
         ...CHANNEL_GROUPS.map((group) => ({
             label: group.label,
             icon: group.icon,
-            channels: channels.filter((channel) => channel.type === group.type),
+            channels: filteredChannels.filter((channel) => channel.type === group.type),
         })),
         // Catch-all so an unknown or untyped channel is never silently dropped.
         {
             label: "Other",
             icon: Cable,
-            channels: channels.filter((channel) => channel.type == null || !knownTypes.has(channel.type)),
+            channels: filteredChannels.filter((channel) => channel.type == null || !knownTypes.has(channel.type)),
         },
     ].filter((group) => group.channels.length > 0);
 
@@ -86,40 +104,149 @@ export function ChannelGroups({ slug }: { slug: string }) {
                     </Text>
                 ) : (
                     <div className="space-y-6">
-                        {groups.map((group) => (
-                            <section key={group.label} className="min-w-0">
-                                <div className="mb-3 flex items-center gap-2">
-                                    <group.icon className="size-4 text-muted-foreground" aria-hidden="true" />
-                                    <Heading variant="label">{group.label}</Heading>
-                                    <Badge variant="secondary" className="tabular-nums">
-                                        {group.channels.length}
-                                    </Badge>
-                                    {group.label === "Web widgets" && (
-                                        <Button asChild variant="outline">
-                                            <Link to={appRoutes.app(slug, "web-widget/default-customize")}>
-                                                <Palette aria-hidden="true" />
-                                                Customize default appearance
-                                            </Link>
-                                        </Button>
-                                    )}
-                                </div>
-                                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                                    {group.channels.map((channel) => (
-                                        <ChannelCard
-                                            key={channel.channelId}
-                                            slug={slug}
-                                            channel={channel}
-                                            agent={agentsQuery.data?.find((x) => x.agentId === channel.agentId)}
-                                            activeLinkCount={activeLinkCounts.get(channel.channelId) ?? 0}
-                                            isLinkCountLoading={embedLinksQuery.isPending}
-                                        />
-                                    ))}
-                                </div>
-                            </section>
-                        ))}
+                        <ChannelsToolbar
+                            search={search}
+                            onSearchChange={setSearch}
+                            typeFilter={typeFilter}
+                            onTypeFilterChange={setTypeFilter}
+                            statusFilter={statusFilter}
+                            onStatusFilterChange={setStatusFilter}
+                        />
+                        {groups.length === 0 ? (
+                            <Text as="div" variant="muted" className="rounded-lg border border-dashed p-10 text-center">
+                                No channels match your filters.
+                            </Text>
+                        ) : (
+                            <div className="space-y-6">
+                                {groups.map((group) => (
+                                    <section key={group.label} className="min-w-0">
+                                        <div className="mb-3 flex items-center gap-2">
+                                            <group.icon className="size-4 text-muted-foreground" aria-hidden="true" />
+                                            <Heading variant="label">{group.label}</Heading>
+                                            <Badge variant="secondary" className="tabular-nums">
+                                                {group.channels.length}
+                                            </Badge>
+                                            {group.label === "Web widgets" && (
+                                                <Button asChild variant="outline">
+                                                    <Link to={appRoutes.app(slug, "web-widget/default-customize")}>
+                                                        <Palette aria-hidden="true" />
+                                                        Customize default appearance
+                                                    </Link>
+                                                </Button>
+                                            )}
+                                        </div>
+                                        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                                            {group.channels.map((channel) => (
+                                                <ChannelCard
+                                                    key={channel.channelId}
+                                                    slug={slug}
+                                                    channel={channel}
+                                                    agent={agentsQuery.data?.find((x) => x.agentId === channel.agentId)}
+                                                    activeLinkCount={activeLinkCounts.get(channel.channelId) ?? 0}
+                                                    isLinkCountLoading={embedLinksQuery.isPending}
+                                                />
+                                            ))}
+                                        </div>
+                                    </section>
+                                ))}
+                            </div>
+                        )}
                     </div>
                 ))}
         </ApiState>
+    );
+}
+
+// The text a channel is matched against when searching by name — its display name plus the
+// provider identity shown on the card (bot username / workspace), so either finds the channel.
+function channelSearchText(channel: ChannelSummaryResponse): string {
+    return [channel.displayName, channel.telegram?.botUsername, channel.slack?.teamName, channel.discord?.botUsername]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+}
+
+const STATUS_FILTER_OPTIONS: { value: Exclude<ChannelStatusFilter, "all">; label: string }[] = [
+    { value: "active", label: "Active" },
+    { value: "paused", label: "Paused" },
+];
+
+function ChannelsToolbar({
+    search,
+    onSearchChange,
+    typeFilter,
+    onTypeFilterChange,
+    statusFilter,
+    onStatusFilterChange,
+}: {
+    search: string;
+    onSearchChange: (value: string) => void;
+    typeFilter: ChannelTypeFilter;
+    onTypeFilterChange: (value: ChannelTypeFilter) => void;
+    statusFilter: ChannelStatusFilter;
+    onStatusFilterChange: (value: ChannelStatusFilter) => void;
+}) {
+    return (
+        <div className="flex flex-wrap items-center gap-3">
+            <InputGroup className="w-full sm:max-w-xs">
+                <InputGroupAddon>
+                    <Search />
+                </InputGroupAddon>
+                <InputGroupInput
+                    placeholder="Search by name"
+                    value={search}
+                    onChange={(event) => onSearchChange(event.target.value)}
+                    aria-label="Search channels by name"
+                />
+            </InputGroup>
+
+            <div className="flex items-center gap-2 sm:ml-auto">
+                <FilterSelect
+                    value={typeFilter}
+                    onChange={onTypeFilterChange}
+                    options={CHANNEL_GROUPS.map((group) => ({ value: group.type, label: group.label }))}
+                    allLabel="All channels"
+                    ariaLabel="Filter by type"
+                />
+                <FilterSelect
+                    value={statusFilter}
+                    onChange={onStatusFilterChange}
+                    options={STATUS_FILTER_OPTIONS}
+                    allLabel="Any status"
+                    ariaLabel="Filter by status"
+                />
+            </div>
+        </div>
+    );
+}
+
+function FilterSelect<T extends string>({
+    value,
+    onChange,
+    options,
+    allLabel,
+    ariaLabel,
+}: {
+    value: T | "all";
+    onChange: (value: T | "all") => void;
+    options: { value: T; label: string }[];
+    allLabel: string;
+    ariaLabel: string;
+}) {
+    return (
+        <Select value={value} onValueChange={(next) => onChange(next as T | "all")}>
+            <SelectTrigger size="sm" aria-label={ariaLabel} className="w-auto max-w-48 min-w-32">
+                <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="end">
+                <SelectItem value="all">{allLabel}</SelectItem>
+                {options.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
     );
 }
 

--- a/src/Raven.Quill.Web/src/pages/apps/channels/discord-channel-form.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/discord-channel-form.tsx
@@ -10,9 +10,11 @@ import type { AgentSummaryResponse } from "@/api/generated/server-api";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Button } from "@/components/shadcn/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/shadcn/ui/collapsible";
+import { Separator } from "@/components/shadcn/ui/separator";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import { SheetClose, SheetFooter } from "@/components/shadcn/ui/sheet";
 import { ApiState } from "@/components/data/api-state";
+import { NumberedSteps, type NumberedStep } from "@/components/data/numbered-steps";
 import { Heading, Text } from "@/components/typography";
 import { FormInput } from "@/components/form/form-input";
 import { FormSelect, type FormSelectOption } from "@/components/form/form-select";
@@ -33,6 +35,32 @@ import {
 } from "@/pages/apps/channels/discord-parameter-sources";
 import { DiscordStatusPanel } from "@/pages/apps/channels/discord-status-panel";
 import type { FixedAgent } from "@/pages/apps/channels/web-widget-channel-form";
+
+const DISCORD_APP_SETUP_STEPS: NumberedStep[] = [
+    {
+        title: "Create the application",
+        content: (
+            <Text variant="caption">
+                At{" "}
+                <a href={DISCORD_DEVELOPER_PORTAL_URL} target="_blank" rel="noreferrer" className="underline">
+                    discord.com/developers/applications
+                </a>
+                , choose <span className="font-medium">New Application</span> and name it.
+            </Text>
+        ),
+    },
+    {
+        title: "Reset and copy the bot token",
+        content: (
+            <Text variant="caption">
+                Open the <span className="font-medium">Bot</span> page, choose{" "}
+                <span className="font-medium">Reset Token</span> and copy the token it shows — Discord never shows it
+                again. Direct messages use a non-privileged intent, so nothing under Privileged Gateway Intents needs
+                turning on.
+            </Text>
+        ),
+    },
+];
 
 const parameterBindingSchema = z
     .object({
@@ -193,32 +221,16 @@ function LoadedDiscordChannelForm({
                                 />
                             </CollapsibleTrigger>
                             <CollapsibleContent className="grid gap-2">
-                                <ol className="list-decimal space-y-1.5 ps-5 text-xs text-muted-foreground">
-                                    <li>
-                                        At{" "}
-                                        <a
-                                            href={DISCORD_DEVELOPER_PORTAL_URL}
-                                            target="_blank"
-                                            rel="noreferrer"
-                                            className="underline"
-                                        >
-                                            discord.com/developers/applications
-                                        </a>
-                                        , choose <span className="font-medium">New Application</span> and name it.
-                                    </li>
-                                    <li>
-                                        Open the <span className="font-medium">Bot</span> page, choose{" "}
-                                        <span className="font-medium">Reset Token</span> and copy the token it shows —
-                                        Discord never shows it again. Direct messages use a non-privileged intent, so
-                                        nothing under Privileged Gateway Intents needs turning on.
-                                    </li>
-                                </ol>
+                                <NumberedSteps steps={DISCORD_APP_SETUP_STEPS} size="sm" />
                                 <Text variant="caption">
                                     After the channel is created you get an invite link. A person can only DM a bot they
                                     share a server with, so the bot has to be invited to a server your users are in.
                                 </Text>
                             </CollapsibleContent>
                         </Collapsible>
+
+                        <Separator />
+
                         {!agent && (
                             <FormSelect
                                 control={form.control}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/discord-connect-tab.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/discord-connect-tab.tsx
@@ -1,8 +1,10 @@
 import type { ChannelSummaryResponse } from "@/api/generated/server-api";
 import { Alert } from "@/components/shadcn/ui/alert";
-import { DiscordStatusPanel } from "@/pages/apps/channels/discord-status-panel";
+import { DiscordConnectionCard, DiscordSetupSteps } from "@/pages/apps/channels/discord-status-panel";
 import { SectionCard } from "@/pages/apps/section-card";
 
+// "How this bot reaches Discord" — the Discord analogue of the Slack Connect tab. The connection card
+// confirms which bot is wired up and how it's doing; the install card is the one-time bot setup.
 export function DiscordConnectTab({ slug, channel }: { slug: string; channel: ChannelSummaryResponse }) {
     return (
         <div className="grid gap-5">
@@ -11,12 +13,22 @@ export function DiscordConnectTab({ slug, channel }: { slug: string; channel: Ch
             )}
 
             <SectionCard
-                title="Discord bot connection"
-                description="How this bot reaches Discord, and how the connection is doing."
+                title="Connection"
+                description="The Discord bot this channel is wired to, and how the connection is doing."
                 isRaised
             >
                 <div className="mt-4">
-                    <DiscordStatusPanel slug={slug} channelId={channel.channelId} />
+                    <DiscordConnectionCard slug={slug} channelId={channel.channelId} />
+                </div>
+            </SectionCard>
+
+            <SectionCard
+                title="Invite the bot"
+                description="Add the bot to a server your users are in, then open a direct message to start chatting."
+                isRaised
+            >
+                <div className="mt-4">
+                    <DiscordSetupSteps slug={slug} channelId={channel.channelId} />
                 </div>
             </SectionCard>
         </div>

--- a/src/Raven.Quill.Web/src/pages/apps/channels/discord-status-panel.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/discord-status-panel.tsx
@@ -70,9 +70,13 @@ function DiscordConnectionCardBody({ health }: { health: DiscordChannelHealthRes
                         <DiscordTokenBadge tokenValid={health.tokenValid} tokenError={health.tokenError} />
                         <DiscordGatewayBadge health={health} />
                     </div>
-                    {health.lastInboundAt && (
+                    {health.lastInboundAt ? (
                         <Text as="span" variant="caption" title={formatDateTime(health.lastInboundAt)}>
                             Last message {formatRelativeTime(health.lastInboundAt)}
+                        </Text>
+                    ) : (
+                        <Text as="span" variant="caption">
+                            Waiting for the first message...
                         </Text>
                     )}
                 </div>
@@ -96,14 +100,26 @@ function DiscordConnectionCardBody({ health }: { health: DiscordChannelHealthRes
     );
 }
 
-// The one-time install walkthrough: invite the bot to a shared server, then DM it. Renders nothing until
-// health loads (the connection card above owns the loading/error state for the same, deduped query).
+// The one-time install walkthrough: invite the bot to a shared server, then DM it. Carries its own
+// loading/error state (off the same deduped health query) so the Connect tab's bordered "Invite the
+// bot" card never renders empty while health is still loading.
 export function DiscordSetupSteps({ slug, channelId }: { slug: string; channelId: string }) {
-    const { health } = useDiscordHealth(slug, channelId);
-    if (!health) {
-        return null;
-    }
+    const { healthQuery, health } = useDiscordHealth(slug, channelId);
 
+    return (
+        <ApiState
+            isLoading={healthQuery.isPending}
+            isError={healthQuery.isError}
+            errorTitle="Could not load the Discord setup steps"
+            onRetry={() => void healthQuery.refetch()}
+            loadingLabel="Loading setup steps..."
+        >
+            {health && <DiscordSetupStepsBody health={health} />}
+        </ApiState>
+    );
+}
+
+function DiscordSetupStepsBody({ health }: { health: DiscordChannelHealthResponse }) {
     const steps: NumberedStep[] = [
         {
             title: "Invite the bot to a server",
@@ -132,6 +148,12 @@ export function DiscordSetupSteps({ slug, channelId }: { slug: string; channelId
 }
 
 function DiscordGatewayBadge({ health }: { health: DiscordChannelHealthResponse }) {
+    // A rejected token blocks the gateway entirely, so don't also claim it's "Connecting...".
+    // The token badge already surfaces the blocking problem, so the gateway state is just noise here.
+    if (health.tokenValid === false) {
+        return null;
+    }
+
     if (health.gatewayConnected) {
         return (
             <Badge

--- a/src/Raven.Quill.Web/src/pages/apps/channels/discord-status-panel.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/discord-status-panel.tsx
@@ -3,15 +3,35 @@ import { api } from "@/api/api";
 import type { DiscordChannelHealthResponse } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
 import { CopyableCode } from "@/components/data/copyable-code";
-import { Alert } from "@/components/shadcn/ui/alert";
+import { NumberedSteps, type NumberedStep } from "@/components/data/numbered-steps";
+import { Alert, AlertDescription } from "@/components/shadcn/ui/alert";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Text } from "@/components/typography";
-import { formatDateTime, formatRelativeTime } from "@/lib/utils";
+import { DiscordIcon } from "@/pages/apps/channels/channel-brand-icons";
 import { discordInstallUrl } from "@/pages/apps/channels/discord-app-setup";
+import { formatDateTime, formatRelativeTime } from "@/lib/utils";
 
-export function DiscordStatusPanel({ slug, channelId }: { slug: string; channelId: string }) {
+function useDiscordHealth(slug: string, channelId: string) {
     const healthQuery = useQuery(api.queries.discord.health(slug));
-    const health = healthQuery.data?.find((row) => row.channelId === channelId);
+    return { healthQuery, health: healthQuery.data?.find((row) => row.channelId === channelId) };
+}
+
+// Combined connection + install steps for the create sheet's success step, where both belong in one
+// scrolling column. The Connect tab instead composes DiscordConnectionCard and DiscordSetupSteps into
+// their own SectionCards, mirroring how Slack splits Connection from its event subscription.
+export function DiscordStatusPanel({ slug, channelId }: { slug: string; channelId: string }) {
+    return (
+        <div className="space-y-4">
+            <DiscordConnectionCard slug={slug} channelId={channelId} />
+            <DiscordSetupSteps slug={slug} channelId={channelId} />
+        </div>
+    );
+}
+
+// Identity + live health for the connection: which bot it is wired to, whether the token and gateway
+// are healthy, and when it last saw traffic. Mirrors SlackConnectionCard so the two channels read the same.
+export function DiscordConnectionCard({ slug, channelId }: { slug: string; channelId: string }) {
+    const { healthQuery, health } = useDiscordHealth(slug, channelId);
 
     return (
         <ApiState
@@ -21,27 +41,12 @@ export function DiscordStatusPanel({ slug, channelId }: { slug: string; channelI
             onRetry={() => void healthQuery.refetch()}
             loadingLabel="Loading Discord connection status..."
         >
-            {health && (
-                <div className="space-y-4">
-                    <ol className="list-decimal space-y-3 ps-5 text-sm">
-                        <li>
-                            Invite the bot to a server your users are already in — on Discord a person can only DM a bot
-                            they share a server with:
-                            <CopyableCode code={discordInstallUrl(health.applicationId)} copyLabel="Copy invite link" />
-                        </li>
-                        <li>
-                            Open a direct message with <span className="font-medium">{health.botUsername}</span> and
-                            send it a message.
-                        </li>
-                    </ol>
-                    <DiscordHealthStrip health={health} />
-                </div>
-            )}
+            {health && <DiscordConnectionCardBody health={health} />}
         </ApiState>
     );
 }
 
-export function DiscordHealthStrip({ health }: { health: DiscordChannelHealthResponse }) {
+function DiscordConnectionCardBody({ health }: { health: DiscordChannelHealthResponse }) {
     const hasRecentSendError =
         health.lastSendError != null &&
         health.lastSendErrorAt != null &&
@@ -49,28 +54,81 @@ export function DiscordHealthStrip({ health }: { health: DiscordChannelHealthRes
             new Date(health.lastSendErrorAt).getTime() > new Date(health.lastInboundAt).getTime());
 
     return (
-        <div className="space-y-2">
-            <div className="flex flex-wrap items-center gap-2 text-sm">
-                <DiscordTokenBadge tokenValid={health.tokenValid} tokenError={health.tokenError} />
-                <DiscordGatewayBadge health={health} />
-                {health.lastInboundAt ? (
-                    <Text as="span" variant="caption" title={formatDateTime(health.lastInboundAt)}>
-                        Last message {formatRelativeTime(health.lastInboundAt)}
-                    </Text>
-                ) : (
-                    <Text as="span" variant="caption">
-                        Waiting for the first message...
-                    </Text>
-                )}
+        <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-background p-3">
+                <div className="flex min-w-0 items-center gap-3">
+                    <DiscordIcon className="size-5 shrink-0 text-muted-foreground" aria-hidden={true} />
+                    <div className="min-w-0">
+                        <Text variant="label" className="truncate">
+                            {health.botUsername}
+                        </Text>
+                        <Text variant="caption">Discord bot</Text>
+                    </div>
+                </div>
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
+                    <div className="flex items-center gap-2">
+                        <DiscordTokenBadge tokenValid={health.tokenValid} tokenError={health.tokenError} />
+                        <DiscordGatewayBadge health={health} />
+                    </div>
+                    {health.lastInboundAt && (
+                        <Text as="span" variant="caption" title={formatDateTime(health.lastInboundAt)}>
+                            Last message {formatRelativeTime(health.lastInboundAt)}
+                        </Text>
+                    )}
+                </div>
             </div>
+
             {!health.gatewayConnected && health.lastGatewayError && (
                 <Alert variant="destructive">{health.lastGatewayError}</Alert>
             )}
             {hasRecentSendError && (
                 <Alert variant="destructive">Last reply could not be delivered: {health.lastSendError}</Alert>
             )}
+            {health.tokenValid === false && (
+                <Alert variant="destructive">
+                    <AlertDescription>
+                        Discord rejected this bot token. Reset it on the app&apos;s Bot page, then open{" "}
+                        <span className="font-medium">Edit &rarr; Rotate bot token</span> to paste the new one.
+                    </AlertDescription>
+                </Alert>
+            )}
         </div>
     );
+}
+
+// The one-time install walkthrough: invite the bot to a shared server, then DM it. Renders nothing until
+// health loads (the connection card above owns the loading/error state for the same, deduped query).
+export function DiscordSetupSteps({ slug, channelId }: { slug: string; channelId: string }) {
+    const { health } = useDiscordHealth(slug, channelId);
+    if (!health) {
+        return null;
+    }
+
+    const steps: NumberedStep[] = [
+        {
+            title: "Invite the bot to a server",
+            content: (
+                <div className="space-y-2">
+                    <Text variant="muted">
+                        On Discord a person can only DM a bot they already share a server with, so invite it to a server
+                        your users are in:
+                    </Text>
+                    <CopyableCode code={discordInstallUrl(health.applicationId)} copyLabel="Copy invite link" />
+                </div>
+            ),
+        },
+        {
+            title: "Open a direct message",
+            content: (
+                <Text variant="muted">
+                    Open a direct message with <span className="font-medium">{health.botUsername}</span> and send it a
+                    message.
+                </Text>
+            ),
+        },
+    ];
+
+    return <NumberedSteps steps={steps} />;
 }
 
 function DiscordGatewayBadge({ health }: { health: DiscordChannelHealthResponse }) {


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-277

### Additional description

**Discord channel** - brings the Connect tab and create form in line with the Slack channel:

- Splits the Connect tab into two raised `SectionCards` (Connection / Invite the bot) with a connection-identity header row, mirroring `SlackConnectTab`.
- Uses the shared `NumberedSteps` component + a `Separator` in the create sheet instead of hand-rolled markup.
- Fixes badge ordering and the token-rejected alert layout (now points to Edit → Rotate bot token).
- Adds paused / token-rejected / gateway-disconnected mocks + stories.

**Channels page** - removes the "Active channels" stat card and adds a toolbar with search-by-name plus type and status filters, matching the Conversations styling.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
