### PR TITLE
Quill-283 - Resolve the dashboard's IP binding server-side

### DIFF
--- a/src/Raven.Quill.Web/src/api/api.ts
+++ b/src/Raven.Quill.Web/src/api/api.ts
@@ -19,6 +19,7 @@ import { createStatsQueries } from "@/api/queries/stats-queries";
 import { createSettingsQueries } from "@/api/queries/settings-queries";
 import { createSlackQueries } from "@/api/queries/slack-queries";
 import { createDiscordQueries } from "@/api/queries/discord-queries";
+import { createDnsQueries } from "@/api/queries/dns-queries";
 
 export type ApiServices = ServerApi & {
     agentTest: ReturnType<typeof createAgentTestService>;
@@ -43,6 +44,7 @@ export type ApiQueries = {
     stats: ReturnType<typeof createStatsQueries>;
     settings: ReturnType<typeof createSettingsQueries>;
     certificates: ReturnType<typeof createCertificatesQueries>;
+    dns: ReturnType<typeof createDnsQueries>;
 };
 
 export type Api = {
@@ -81,6 +83,7 @@ export function createApi(options?: ApiClientOptions): Api {
             stats: createStatsQueries(services.stats),
             settings: createSettingsQueries(services.settings),
             certificates: createCertificatesQueries(services.certificates),
+            dns: createDnsQueries(services.dns),
         },
     };
 }

--- a/src/Raven.Quill.Web/src/api/generated/server-api.ts
+++ b/src/Raven.Quill.Web/src/api/generated/server-api.ts
@@ -84,6 +84,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/dns/ip-binding": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["dns.ipBinding"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/assistant/chat": {
         parameters: {
             query?: never;
@@ -1561,6 +1577,10 @@ export interface components {
             /** Format: int32 */
             embeddingsMaxConcurrentBatches?: null | number;
         };
+        IpBindingResponse: {
+            hostname: string;
+            addresses: string[];
+        };
         JsonElement: unknown;
         LicensePlan: {
             slug: string;
@@ -2127,6 +2147,44 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    "dns.ipBinding": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IpBindingResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Bad Gateway */
+            502: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4364,6 +4422,7 @@ export type GenerateClientCertificateRequest = components["schemas"]["GenerateCl
 export type GoogleAIVersion = components["schemas"]["GoogleAIVersion"];
 export type GoogleSettings = components["schemas"]["GoogleSettings"];
 export type HuggingFaceSettings = components["schemas"]["HuggingFaceSettings"];
+export type IpBindingResponse = components["schemas"]["IpBindingResponse"];
 export type JsonElement = components["schemas"]["JsonElement"];
 export type LicensePlan = components["schemas"]["LicensePlan"];
 export type LicenseResponse = components["schemas"]["LicenseResponse"];
@@ -4486,6 +4545,9 @@ export const API_ENDPOINTS = {
     discord: {
         health: (slug: string) => `/apps/${encodeURIComponent(slug)}/discord/health`,
     },
+    dns: {
+        ipBinding: "/dns/ip-binding",
+    },
     embedLinks: {
         list: (slug: string) => `/apps/${encodeURIComponent(slug)}/embed-links`,
         mint: (slug: string) => `/apps/${encodeURIComponent(slug)}/embed-links`,
@@ -4588,6 +4650,9 @@ export function createServerApi(client: ApiClient) {
         },
         discord: {
             health: (slug: string) => client.get<DiscordChannelHealthResponse[], ApiErrorResponse>(API_ENDPOINTS.discord.health(slug)),
+        },
+        dns: {
+            ipBinding: () => client.get<IpBindingResponse, ApiErrorResponse>(API_ENDPOINTS.dns.ipBinding),
         },
         embedLinks: {
             list: (slug: string) => client.get<EmbedLinkSummaryResponse[], ApiErrorResponse>(API_ENDPOINTS.embedLinks.list(slug)),

--- a/src/Raven.Quill.Web/src/api/queries/dns-queries.ts
+++ b/src/Raven.Quill.Web/src/api/queries/dns-queries.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from "@tanstack/react-query";
+import type { ServerApi } from "@/api/generated/server-api";
+
+const baseKey = "dns";
+
+export function createDnsQueries(api: ServerApi["dns"]) {
+    return {
+        ipBinding: () =>
+            queryOptions({
+                queryKey: [baseKey, "ip-binding"],
+                queryFn: () => api.ipBinding(),
+            }),
+    };
+}
+
+export type DnsQueries = ReturnType<typeof createDnsQueries>;

--- a/src/Raven.Quill.Web/src/mocks/default-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/default-mocks.ts
@@ -55,7 +55,7 @@ export const defaultApiMocks = {
     channels: [channelsMocks.list(), channelsMocks.create(), channelsMocks.update(), channelsMocks.delete()],
     slack: [slackMocks.webhookInfo(), slackMocks.health()],
     discord: [discordMocks.health()],
-    dns: [dnsMocks.resolve()],
+    dns: [dnsMocks.ipBinding()],
     embedLinks: [embedLinksMocks.list(), embedLinksMocks.mint(), embedLinksMocks.revoke()],
     iframe: iframeHandlers(),
     settings: [

--- a/src/Raven.Quill.Web/src/mocks/dns-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/dns-mocks.ts
@@ -1,13 +1,12 @@
-import { http, HttpResponse } from "msw";
+import { apiHttp } from "./api-http";
 
-// Mirrors the DNS-over-HTTPS lookup the IP configuration page performs.
 export const dnsMocks = {
-    resolve: (ips: string[] = ["51.210.14.7"]) =>
-        http.get("https://dns.google/resolve", () =>
-            HttpResponse.json({
-                Status: 0,
-                Answer: ips.map((ip) => ({ type: 1, data: ip })),
-            }),
+    ipBinding: (addresses: string[] = ["51.210.14.7"]) =>
+        apiHttp.get("/api/dns/ip-binding", ({ response }) =>
+            response(200).json({ hostname: "dashboard.acme.ravendb.run", addresses }),
         ),
-    resolveError: () => http.get("https://dns.google/resolve", () => HttpResponse.json({ Status: 2 })),
+    ipBindingError: () =>
+        apiHttp.get("/api/dns/ip-binding", ({ response }) =>
+            response(502).json({ error: "DNS lookup for 'dashboard.acme.ravendb.run' failed" }),
+        ),
 };

--- a/src/Raven.Quill.Web/src/pages/dashboard/ip-configuration.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/ip-configuration.stories.tsx
@@ -25,7 +25,7 @@ export const LookupFailed: Story = {
     parameters: {
         msw: {
             handlers: {
-                dns: [dnsMocks.resolveError()],
+                dns: [dnsMocks.ipBindingError()],
             },
         },
     },

--- a/src/Raven.Quill.Web/src/pages/dashboard/ip-configuration.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/ip-configuration.tsx
@@ -10,34 +10,14 @@ import { Field, FieldError, FieldLabel } from "@/components/shadcn/ui/field";
 import { Input } from "@/components/shadcn/ui/input";
 import { containerNameForHost, isIpV4 } from "@/lib/subdomain-origin";
 import { Heading, Text } from "@/components/typography";
+import { api } from "@/api/api";
 
 const NEW_IP_PLACEHOLDER = "<new-ip>";
-const DNS_A_RECORD_TYPE = 1;
-
-type DnsJsonResponse = {
-    Status: number;
-    Answer?: Array<{ type: number; data: string }>;
-};
-
-// The browser cannot inspect DNS directly, so the current binding is read from
-// the public record through DNS-over-HTTPS.
-async function resolveIpBinding(hostname: string): Promise<string[]> {
-    const response = await fetch(`https://dns.google/resolve?name=${encodeURIComponent(hostname)}&type=A`);
-    if (!response.ok) {
-        throw new Error(`DNS lookup failed with status ${response.status}`);
-    }
-    const result = (await response.json()) as DnsJsonResponse;
-    if (result.Status !== 0) {
-        throw new Error(`DNS lookup failed with response code ${result.Status}`);
-    }
-    return (result.Answer ?? []).flatMap((record) => (record.type === DNS_A_RECORD_TYPE ? [record.data] : []));
-}
 
 export function DashboardIpConfiguration({ hostname = window.location.hostname }: { hostname?: string }) {
     const hasResolvableDomain = hostname.includes(".") && !isIpV4(hostname);
     const bindingQuery = useQuery({
-        queryKey: ["ip-configuration", "binding", hostname],
-        queryFn: () => resolveIpBinding(hostname),
+        ...api.queries.dns.ipBinding(),
         enabled: hasResolvableDomain,
     });
 
@@ -89,8 +69,8 @@ export function DashboardIpConfiguration({ hostname = window.location.hostname }
                                         IP address
                                     </Text>
                                     <Text as="div" variant="label" className="tabular-nums">
-                                        {bindingQuery.data?.length
-                                            ? bindingQuery.data.join(", ")
+                                        {bindingQuery.data?.addresses.length
+                                            ? bindingQuery.data.addresses.join(", ")
                                             : "No DNS record found"}
                                     </Text>
                                 </div>

--- a/src/Raven.Quill/Contracts/IpBindingResponse.cs
+++ b/src/Raven.Quill/Contracts/IpBindingResponse.cs
@@ -1,0 +1,3 @@
+namespace Raven.Quill.Contracts;
+
+public sealed record IpBindingResponse(string Hostname, string[] Addresses);

--- a/src/Raven.Quill/Endpoints/DnsEndpoints.cs
+++ b/src/Raven.Quill/Endpoints/DnsEndpoints.cs
@@ -1,0 +1,38 @@
+using System.Net.Sockets;
+using Raven.Quill.Contracts;
+using Raven.Quill.Infrastructure;
+
+namespace Raven.Quill.Endpoints;
+
+public static class DnsEndpoints
+{
+    public static void Map(WebApplication app)
+    {
+        app.MapGet("/api/dns/ip-binding", GetIpBindingAsync)
+            .WithTags("dns")
+            .WithName("dns.ipBinding")
+            .RequireAuthorization()
+            .Produces<IpBindingResponse>()
+            .Produces<ApiErrorResponse>(StatusCodes.Status400BadRequest)
+            .Produces<ApiErrorResponse>(StatusCodes.Status502BadGateway);
+    }
+
+    private static async Task<IResult> GetIpBindingAsync(HttpContext context, IDnsResolver resolver, CancellationToken token)
+    {
+        var hostname = context.Request.Host.Host;
+        if (Uri.CheckHostName(hostname) != UriHostNameType.Dns)
+            return Results.BadRequest(new ApiErrorResponse($"'{hostname}' is not a DNS name"));
+
+        try
+        {
+            var addresses = await resolver.ResolveIPv4Async(hostname, token);
+            return Results.Ok(new IpBindingResponse(hostname, addresses));
+        }
+        catch (SocketException)
+        {
+            return Results.Json(
+                new ApiErrorResponse($"DNS lookup for '{hostname}' failed"),
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+}

--- a/src/Raven.Quill/Infrastructure/IDnsResolver.cs
+++ b/src/Raven.Quill/Infrastructure/IDnsResolver.cs
@@ -1,0 +1,6 @@
+namespace Raven.Quill.Infrastructure;
+
+public interface IDnsResolver
+{
+    Task<string[]> ResolveIPv4Async(string hostname, CancellationToken token);
+}

--- a/src/Raven.Quill/Infrastructure/SystemDnsResolver.cs
+++ b/src/Raven.Quill/Infrastructure/SystemDnsResolver.cs
@@ -1,0 +1,20 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Raven.Quill.Infrastructure;
+
+public sealed class SystemDnsResolver : IDnsResolver
+{
+    public async Task<string[]> ResolveIPv4Async(string hostname, CancellationToken token)
+    {
+        try
+        {
+            var addresses = await Dns.GetHostAddressesAsync(hostname, AddressFamily.InterNetwork, token);
+            return Array.ConvertAll(addresses, static address => address.ToString());
+        }
+        catch (SocketException ex) when (ex.SocketErrorCode is SocketError.HostNotFound or SocketError.NoData)
+        {
+            return [];
+        }
+    }
+}

--- a/src/Raven.Quill/Program.cs
+++ b/src/Raven.Quill/Program.cs
@@ -147,6 +147,7 @@ builder.Services.AddSingleton<IBootstrapState, BootstrapStateFlag>();
 builder.Services.AddSingleton<IAgentRouter, AgentRouter>();
 builder.Services.AddSingleton<WebhookActionExecutor>();
 builder.Services.AddSingleton<IApiKeyStore, ApiKeyStore>();
+builder.Services.AddSingleton<IDnsResolver, SystemDnsResolver>();
 
 // Read once at startup: the widget manifest only changes when the image is rebuilt, and a missing one is
 // worth logging loudly the moment the process starts rather than on the first visitor's request.
@@ -348,6 +349,7 @@ AiModelsEndpoints.Map(app);
 AgentsEndpoints.Map(app);
 StatsEndpoints.Map(app);
 SettingsEndpoints.Map(app);
+DnsEndpoints.Map(app);
 WizardEndpoints.Map(app);
 ChatEndpoints.Map(app);
 AssistantEndpoints.Map(app);

--- a/test/QuillTests/DnsEndpointsTests.cs
+++ b/test/QuillTests/DnsEndpointsTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using QuillTests.E2E.Fixtures;
+using Raven.Quill.Auth;
+using Raven.Quill.Contracts;
+using Raven.Quill.Infrastructure;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace QuillTests;
+
+public class DnsEndpointsTests(ITestOutputHelper output) : QuillTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Ip_binding_resolves_the_request_host_through_the_registered_resolver()
+    {
+        var resolver = new FakeDnsResolver { Handler = _ => ["51.210.14.7", "51.210.14.8"] };
+        await using var host = await NewHostAsync(configureServices: services =>
+        {
+            services.RemoveAll<IDnsResolver>();
+            services.AddSingleton<IDnsResolver>(resolver);
+        });
+
+        var resp = await host.Client.GetAsync(QuillRoutes.DnsIpBinding);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var binding = await resp.Content.ReadFromJsonAsync<IpBindingResponse>();
+        Assert.NotNull(binding);
+        Assert.Equal("localhost", binding.Hostname);
+        Assert.Equal(["51.210.14.7", "51.210.14.8"], binding.Addresses);
+        Assert.Equal("localhost", resolver.Hostname);
+
+        resolver.Handler = _ => [];
+        binding = await host.Client.GetFromJsonAsync<IpBindingResponse>(QuillRoutes.DnsIpBinding);
+        Assert.NotNull(binding);
+        Assert.Empty(binding.Addresses);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task A_failing_lookup_is_502()
+    {
+        await using var host = await NewHostAsync(configureServices: services =>
+        {
+            services.RemoveAll<IDnsResolver>();
+            services.AddSingleton<IDnsResolver>(new FakeDnsResolver
+            {
+                Handler = _ => throw new SocketException((int)SocketError.TryAgain)
+            });
+        });
+
+        var resp = await host.Client.GetAsync(QuillRoutes.DnsIpBinding);
+        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+
+        var error = await resp.Content.ReadFromJsonAsync<ApiErrorResponse>();
+        Assert.NotNull(error);
+        Assert.Contains("DNS lookup", error.Error);
+    }
+
+    [RavenFact(RavenTestCategory.Quill)]
+    public async Task Ip_binding_without_credential_is_401()
+    {
+        using var client = Host.Factory.CreateClient();
+        client.DefaultRequestHeaders.Remove(ApiKeyAuthenticationHandler.HeaderName);
+
+        var resp = await client.GetAsync(QuillRoutes.DnsIpBinding);
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    private sealed class FakeDnsResolver : IDnsResolver
+    {
+        public required Func<string, string[]> Handler { get; set; }
+        public string? Hostname { get; private set; }
+
+        public Task<string[]> ResolveIPv4Async(string hostname, CancellationToken token)
+        {
+            Hostname = hostname;
+            return Task.FromResult(Handler(hostname));
+        }
+    }
+}

--- a/test/QuillTests/E2E/Fixtures/QuillHttpExtensions.cs
+++ b/test/QuillTests/E2E/Fixtures/QuillHttpExtensions.cs
@@ -110,6 +110,7 @@ internal static class QuillRoutes
     public const string AiModels = "/api/ai/models";
     public const string SettingsLicense = "/api/settings/license";
     public const string SettingsUsage = "/api/settings/usage";
+    public const string DnsIpBinding = "/api/dns/ip-binding";
 
     // wizard (config-DB scoped)
     public const string SetupConnect = "/api/setup/connect";


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/Quill-283

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
