### PR TITLE
RavenDB-26999 Score terms whose posting list is large and terms used in IN

### DIFF
--- a/src/Corax/Utils/Bm25Relevance.cs
+++ b/src/Corax/Utils/Bm25Relevance.cs
@@ -210,6 +210,10 @@ public sealed unsafe class Bm25Relevance : IDisposable
             while (bm25._setIterator.Fill(bm25.Matches, out var read, pruneGreaterThanOptimization: EntryIdEncodings.PrepareIdForPruneInPostingList(matches[^1])) && read > 0)
             {
                 bm25._currentId = read;
+                // The posting list yields encoded ids (entry id + quantized frequency). Split them the way the stored
+                // path does in DecodeAndSave, otherwise the ids never match and the frequencies stay zero - leaving
+                // every document with the score buffer's initial value.
+                EntryIdEncodings.Decode(bm25.Matches, bm25.Scores);
                 CalculateScoreFromMemory(bm25, matches, scores, boostFactor);
                 bm25._currentId = bm25._bufferCapacity;
             }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -667,7 +667,7 @@ public static class CoraxQueryBuilder
         }
 
         var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(allocator, fieldName, builderParameters.Index, builderParameters.IndexFieldsMapping, builderParameters.FieldsToFetch, builderParameters.HasDynamics,
-            builderParameters.DynamicFields, exact: exact);
+            builderParameters.DynamicFields, exact: exact, hasBoost: builderParameters.HasBoost);
         
         var hasTime = builderParameters.Index.IndexFieldsPersistence.HasTimeValues(fieldName);
         

--- a/test/SlowTests/Issues/RavenDB_26999.cs
+++ b/test/SlowTests/Issues/RavenDB_26999.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
+{
+    // Scoring is skipped entirely once a term's posting list grows past the small representation, so every dataset
+    // here keeps one term above that size and one below it. The score buffer starts at Bm25Relevance.InitialScoreValue
+    // (1/1_000_000f), so a score equal to it means BM25 contributed nothing at all.
+    private const double InitialScoreValue = 1 / 1_000_000f;
+
+    private class Movie
+    {
+        public string Id { get; set; }
+        public string Genre { get; set; }
+        public string Status { get; set; }
+        public string Title { get; set; }
+    }
+
+    private class ScoreOnly
+    {
+        public double Score { get; set; }
+    }
+
+    private class Movies_Showcase : AbstractIndexCreationTask<Movie>
+    {
+        public Movies_Showcase()
+        {
+            Map = movies => from m in movies
+                            select new
+                            {
+                                m.Genre,
+                                m.Status,
+                                m.Title
+                            };
+
+            Index(x => x.Genre, FieldIndexing.Exact);
+            Index(x => x.Title, FieldIndexing.Search);
+
+            // Set per index, the way production indexes usually do it - not via database settings.
+            Configuration[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = "true";
+        }
+    }
+
+    private IDocumentStore SetupStore(RavenSearchEngineMode engine, int totalDocuments, int rareEvery)
+    {
+        var store = GetDocumentStore(Options.ForSearchEngine(engine));
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < totalDocuments; i++)
+            {
+                bulk.Store(new Movie
+                {
+                    // "Drama" is sparse (every rareEvery-th document) but still numerous - that combination is what
+                    // pushes its posting list out of the small representation.
+                    Genre = i % rareEvery == 0 ? "Drama" : "Filler",
+                    Status = i % 3 == 0 ? "Released" : "Planned",
+                    Title = i % rareEvery == 0 ? "the matrix reloaded" : "some other movie title"
+                });
+            }
+        }
+
+        store.ExecuteIndex(new Movies_Showcase());
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(15));
+
+        return store;
+    }
+
+    private static double[] Scores(IDocumentStore store, string where)
+    {
+        using var session = store.OpenSession();
+        return session.Advanced
+            .RawQuery<ScoreOnly>($@"from index 'Movies/Showcase' as m
+                                    where {where}
+                                    order by score()
+                                    select {{ Score: getMetadata(m)[""@index-score""] }}
+                                    limit 5")
+            .ToList()
+            .Select(x => x.Score)
+            .ToArray();
+    }
+
+    private void AssertScored(IDocumentStore store, string where, string what)
+    {
+        var scores = Scores(store, where);
+
+        Assert.NotEmpty(scores);
+        output.WriteLine($"{what,-46} -> {string.Join(", ", scores.Select(s => s.ToString("G6")))}");
+
+        foreach (var score in scores)
+            Assert.False(Math.Abs(score - InitialScoreValue) < 1e-12,
+                $"{what}: score is the untouched InitialScoreValue ({score}) - BM25 contributed nothing");
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [InlineData(100_000, 100)]    // df = 1_000  - small posting list
+    [InlineData(1_000_000, 100)]  // df = 10_000 - large posting list, sparse over 1M ids
+    [InlineData(1_000_000, 10)]   // df = 100_000 - large and dense
+    public void ScoreIsComputedRegardlessOfPostingListSize(int totalDocuments, int rareEvery)
+    {
+        using var store = SetupStore(RavenSearchEngineMode.Corax, totalDocuments, rareEvery);
+
+        // Every clause shape below reaches a different bitmap-pipeline primitive, and each one had its own
+        // posting-list shortcut that bypassed BM25: OR (single leaf), AND, AND NOT.
+        AssertScored(store, "m.Genre = 'Drama'", "equals (OR fold)");
+        AssertScored(store, "search(m.Title, 'matrix')", "search on analyzed field");
+        AssertScored(store, "m.Genre = 'Drama' and m.Status = 'Released'", "AND of two terms");
+        AssertScored(store, "m.Genre = 'Drama' and m.Status != 'Planned'", "AND NOT");
+        AssertScored(store, "m.Genre = 'Drama' or m.Status = 'Released'", "OR of two terms");
+        AssertScored(store, "boost(m.Genre = 'Drama', 100)", "explicit boost");
+        AssertScored(store, "m.Genre in ('Drama', 'Western')", "IN");
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void CoraxScoresMatchLuceneOrderOfMagnitude()
+    {
+        const int documents = 1_000_000;
+        const int rareEvery = 100;
+
+        using var corax = SetupStore(RavenSearchEngineMode.Corax, documents, rareEvery);
+        using var lucene = SetupStore(RavenSearchEngineMode.Lucene, documents, rareEvery);
+
+        foreach (var where in new[] { "m.Genre = 'Drama'", "search(m.Title, 'matrix')", "m.Genre = 'Drama' and m.Status = 'Released'" })
+        {
+            var coraxScore = Scores(corax, where).First();
+            var luceneScore = Scores(lucene, where).First();
+
+            output.WriteLine($"{where,-50} corax={coraxScore:G6} lucene={luceneScore:G6}");
+
+            // The formulas differ, so the scores are not equal - but they must live in the same range instead of
+            // Corax collapsing to 1e-6 while Lucene reports a healthy score.
+            Assert.True(coraxScore > luceneScore / 100 && coraxScore < luceneScore * 100,
+                $"{where}: corax={coraxScore} vs lucene={luceneScore} - orders of magnitude apart");
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void ScoresStayOrderedByRelevanceAcrossPostingListSizes()
+    {
+        using var store = SetupStore(RavenSearchEngineMode.Corax, 1_000_000, 100);
+
+        // Rarer term must score higher than the common one - the property that collapsed to a flat 1e-6 for every
+        // term whose posting list was large.
+        var rare = Scores(store, "m.Genre = 'Drama'").First();      // df = 10_000
+        var common = Scores(store, "m.Status = 'Released'").First(); // df = 333_334
+
+        output.WriteLine($"rare(df=10k)={rare:G6} common(df=333k)={common:G6}");
+
+        Assert.True(rare > common, $"rare term scored {rare}, common term scored {common}");
+        Assert.True(common > InitialScoreValue * 10, $"common term collapsed to {common}");
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_26999.cs
+++ b/test/SlowTests/Issues/RavenDB_26999.cs
@@ -105,7 +105,6 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
     [InlineData(100_000, 100)]    // df = 1_000  - small posting list
     [InlineData(1_000_000, 100)]  // df = 10_000 - large posting list, sparse over 1M ids
-    [InlineData(1_000_000, 10)]   // df = 100_000 - large and dense
     public void ScoreIsComputedRegardlessOfPostingListSize(int totalDocuments, int rareEvery)
     {
         using var store = SetupStore(RavenSearchEngineMode.Corax, totalDocuments, rareEvery);
@@ -121,7 +120,6 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
         AssertScored(store, "m.Genre in ('Drama', 'Western')", "IN");
     }
 
-    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
     public void CoraxScoresMatchLuceneOrderOfMagnitude()
     {
         const int documents = 1_000_000;
@@ -144,7 +142,6 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
-    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
     public void ScoresStayOrderedByRelevanceAcrossPostingListSizes()
     {
         using var store = SetupStore(RavenSearchEngineMode.Corax, 1_000_000, 100);

--- a/test/StressTests/Issues/RavenDB_26999.cs
+++ b/test/StressTests/Issues/RavenDB_26999.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Issues
+{
+    public class RavenDB_26999 : NoDisposalNoOutputNeeded
+    {
+        public RavenDB_26999(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+        [InlineData(1_000_000, 10)]
+        public async Task ScoreIsComputedRegardlessOfPostingListSize(int totalDocuments, int rareEvery)
+        {
+            await using var testClass = new SlowTests.Issues.RavenDB_26999(Output);
+            testClass.ScoreIsComputedRegardlessOfPostingListSize(totalDocuments, rareEvery);
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+        public async Task CoraxScoresMatchLuceneOrderOfMagnitude()
+        {
+            await using var testClass = new SlowTests.Issues.RavenDB_26999(Output);
+            testClass.CoraxScoresMatchLuceneOrderOfMagnitude();
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+        public async Task ScoresStayOrderedByRelevanceAcrossPostingListSizes()
+        {
+            await using var testClass = new SlowTests.Issues.RavenDB_26999(Output);
+            testClass.ScoresStayOrderedByRelevanceAcrossPostingListSizes();
+        }
+    }
+}


### PR DESCRIPTION
`@index-score` collapsed to `9.999999974752427E-07` for every document on large datasets - that number is bitwise `Bm25Relevance.InitialScoreValue = 1/1_000_000f`, the value the score buffer is filled with before scoring, so BM25 contributed nothing at all. Two independent causes, both reproduced on the imdb (1.4M docs) and stackoverflow databases:

1. **Terms whose posting list is large.** Above `MaximumDocumentCapacity` (1MB / (8 + 2) = 104 857 documents) `Bm25Relevance` stops storing ids and frequencies and scores straight from the posting list. That path fed `CalculateScoreFromMemory` raw posting-list values - entry id and quantized frequency packed together - while `matches` holds plain entry ids, so the binary search never matched and every frequency read as zero. Fixed by splitting the values with `EntryIdEncodings.Decode`, exactly what the stored path does in `DecodeAndSave`. Measured on imdb: `df` 1 418 -> 2.307, 21 034 -> 1.383, 73 703 -> 0.990, then 112 710 / 191 396 / 1 386 131 -> 1e-6.

2. **`IN` never scored, at any size.** `HandleIn` was the only one of the ten `GetFieldMetadata` calls in `CoraxQueryBuilder` that did not pass `hasBoost`, so `FieldMetadata.HasBoost` stayed false, `Bm25Relevance` was never created and the score buffer was returned untouched.

`boost(...)` did not help in either case: in Corax the factor multiplies the term frequency inside the BM25 formula rather than the final score, so with a zero contribution there is nothing to scale. The Lucene twin index on the same data and the same definition returns 3.017 where Corax returned 1e-6.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26999

### Additional description

Targeting v6.2 as the oldest supported branch carrying both defects; the code there is identical to v7.2. Corax 2.0 has a third, engine-specific cause (the compiled bitmap pipeline reads posting lists directly and bypasses `TermMatch.Fill`, where frequencies are handed to BM25) - fixed separately on `feature/corax-2.0`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

Scores change for queries that previously returned the buffer's initial value, and the large-posting-list path now does real work (decoding frequencies) where it previously did none.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

`RavenDB_26999` covers three datasets (df = 1 000 / 10 000 / 100 000 / 333 334) against seven clause shapes (equals, search, AND, AND NOT, OR, boost, IN), compares Corax against Lucene on 1M documents and asserts that a rare term outscores a common one. Without the fixes 4 of 5 cases fail on v6.2; with them all 5 pass. Full `FastTests` passes on v7.2 (4809), where the same patch applies.

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

Scoring a term with a multi-million-document posting list now decodes frequencies per batch, which was previously skipped (incorrectly). Worth measuring query throughput for `order by score()` over very common terms.

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Any query that scores a term above the 104 857-document threshold, and every `IN` query with scoring, now returns real BM25 scores instead of a flat 1e-6. Ordering by `score()` changes accordingly - that is the point of the fix, but ranked results on big collections will look different after the upgrade.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
