### PR TITLE
RavenDB-26999 Keep BM25 fed when the bitmap pipeline reads posting lists

### DIFF
--- a/src/Corax/Querying/Matches/TermMatch.cs
+++ b/src/Corax/Querying/Matches/TermMatch.cs
@@ -24,6 +24,8 @@ namespace Corax.Querying.Matches
         private PostingList.Iterator _set;
         private FastPForBufferedReader _containerReader;
         public bool IsBoosting => _scoreFunc != null;
+        // Scoring reads what Fill saved only in the stored mode; bigger posting lists are re-read at score time.
+        internal bool ScoringNeedsFill => _scoreFunc != null && _bm25Relevance is { IsStored: true };
         public long Count => _totalResults;
 
 #if DEBUG

--- a/src/Corax/Querying/Primitives/QueryPrimitives.cs
+++ b/src/Corax/Querying/Primitives/QueryPrimitives.cs
@@ -378,10 +378,9 @@ public static class QueryPrimitives
             bitmap.OrWith(ref srcData);
             return;
         }
-        // A boosting term must go through Fill: that is where TermMatch hands ids and frequencies to Bm25Relevance.
-        // Reading the posting list directly here leaves BM25 without data, and the score pass then returns the score
-        // buffer's initial value for every document.
-        if (match is Matches.TermMatch tm && tm.IsBoosting == false && tm.TryGetPostingListIterator(out var iter))
+        // A term whose relevance is stored must go through Fill: that is where TermMatch hands ids and frequencies
+        // to Bm25Relevance. Bigger posting lists are re-read at score time, so they keep the fast path.
+        if (match is Matches.TermMatch tm && tm.ScoringNeedsFill == false && tm.TryGetPostingListIterator(out var iter))
         {
             FillFromPostings(ref iter, ref bitmap, token, limit);
             return;
@@ -426,7 +425,7 @@ public static class QueryPrimitives
             bitmap.AndWith(ref srcData);
             return;
         }
-        if (match is Matches.TermMatch tm && tm.IsBoosting == false && tm.TryGetPostingListIterator(out var iter))
+        if (match is Matches.TermMatch tm && tm.ScoringNeedsFill == false && tm.TryGetPostingListIterator(out var iter))
         {
             AndWithPostings(ref iter, ref bitmap, ref tempBitmap, token);
             return;
@@ -458,7 +457,8 @@ public static class QueryPrimitives
             bitmap.AndNotWith(ref srcData);
             return;
         }
-        if (match is Matches.TermMatch tm && tm.IsBoosting == false && tm.TryGetPostingListIterator(out var iter))
+        // A negated term is subtracted from the result and must not contribute to the score, so it never needs Fill.
+        if (match is Matches.TermMatch tm && tm.TryGetPostingListIterator(out var iter))
         {
             AndNotWithPostings(ref iter, ref bitmap, ref tempBitmap, token);
             return;

--- a/src/Corax/Querying/Primitives/QueryPrimitives.cs
+++ b/src/Corax/Querying/Primitives/QueryPrimitives.cs
@@ -457,7 +457,7 @@ public static class QueryPrimitives
             bitmap.AndNotWith(ref srcData);
             return;
         }
-        // A negated term is subtracted from the result and must not contribute to the score, so it never needs Fill.
+        // A negated leaf is resolved without boost (see QueryPlanBuilder.ResolveFieldMetadata), so it never feeds BM25 and never needs Fill.
         if (match is Matches.TermMatch tm && tm.TryGetPostingListIterator(out var iter))
         {
             AndNotWithPostings(ref iter, ref bitmap, ref tempBitmap, token);

--- a/src/Corax/Querying/Primitives/QueryPrimitives.cs
+++ b/src/Corax/Querying/Primitives/QueryPrimitives.cs
@@ -378,7 +378,10 @@ public static class QueryPrimitives
             bitmap.OrWith(ref srcData);
             return;
         }
-        if (match is Matches.TermMatch tm && tm.TryGetPostingListIterator(out var iter))
+        // A boosting term must go through Fill: that is where TermMatch hands ids and frequencies to Bm25Relevance.
+        // Reading the posting list directly here leaves BM25 without data, and the score pass then returns the score
+        // buffer's initial value for every document.
+        if (match is Matches.TermMatch tm && tm.IsBoosting == false && tm.TryGetPostingListIterator(out var iter))
         {
             FillFromPostings(ref iter, ref bitmap, token, limit);
             return;
@@ -423,7 +426,7 @@ public static class QueryPrimitives
             bitmap.AndWith(ref srcData);
             return;
         }
-        if (match is Matches.TermMatch tm && tm.TryGetPostingListIterator(out var iter))
+        if (match is Matches.TermMatch tm && tm.IsBoosting == false && tm.TryGetPostingListIterator(out var iter))
         {
             AndWithPostings(ref iter, ref bitmap, ref tempBitmap, token);
             return;
@@ -455,7 +458,7 @@ public static class QueryPrimitives
             bitmap.AndNotWith(ref srcData);
             return;
         }
-        if (match is Matches.TermMatch tm && tm.TryGetPostingListIterator(out var iter))
+        if (match is Matches.TermMatch tm && tm.IsBoosting == false && tm.TryGetPostingListIterator(out var iter))
         {
             AndNotWithPostings(ref iter, ref bitmap, ref tempBitmap, token);
             return;

--- a/src/Corax/Utils/Bm25Relevance.cs
+++ b/src/Corax/Utils/Bm25Relevance.cs
@@ -218,8 +218,13 @@ public sealed unsafe class Bm25Relevance : IDisposable
     /// chunk). Stops early once every match has been decided.</summary>
     private static void PostingListCalculateScoreSorted(Bm25Relevance bm25, Span<long> matches, Span<float> scores, float boostFactor)
     {
-        if (bm25._idf.AlmostEquals(0f))
+        if (bm25._idf.AlmostEquals(0f) || matches.IsEmpty)
             return;
+
+        // TermMatch has already drained this posting list to build the candidate set, and both iterators navigate the
+        // same PostingList tree cursor - without re-seating, this one would only ever see the leaf its own reader was
+        // parked on. Seeking to the first candidate also skips every leaf below it.
+        bm25._setIterator.Seek(EntryIdEncodings.PrepareIdForSeekInPostingList(matches[0]));
 
         int matchIdx = 0;
         bm25._currentId = bm25._bufferCapacity;
@@ -307,6 +312,12 @@ public sealed unsafe class Bm25Relevance : IDisposable
     {
         static void PostingListCalculateScoreDynamically(Bm25Relevance bm25, Span<long> matches, Span<float> scores, float boostFactor)
         {
+            if (matches.IsEmpty)
+                return;
+
+            // Same shared tree cursor as PostingListCalculateScoreSorted; `matches` is unsorted here, so start from the top.
+            bm25._setIterator.Seek();
+
             bm25._currentId = bm25._bufferCapacity;
             while (bm25._setIterator.Fill(bm25.Matches, out var read, pruneGreaterThanOptimization: EntryIdEncodings.PrepareIdForPruneInPostingList(matches[^1])) && read > 0)
             {

--- a/src/Corax/Utils/Bm25Relevance.cs
+++ b/src/Corax/Utils/Bm25Relevance.cs
@@ -227,6 +227,10 @@ public sealed unsafe class Bm25Relevance : IDisposable
                bm25._setIterator.Fill(bm25.Matches, out var read, pruneGreaterThanOptimization: EntryIdEncodings.PrepareIdForPruneInPostingList(matches[^1])) && read > 0)
         {
             bm25._currentId = read;
+            // Same decode as the stored path (DecodeAndSave): the posting list yields entry id + quantized frequency
+            // packed together, while `matches` holds plain entry ids. Without splitting them ScoreSortedRun never
+            // finds a match and every frequency reads as zero.
+            EntryIdEncodings.Decode(bm25.Matches, bm25.Scores);
             ScoreSortedRun(bm25, matches, ref matchIdx, scores, boostFactor);
             bm25._currentId = bm25._bufferCapacity;
         }
@@ -307,6 +311,10 @@ public sealed unsafe class Bm25Relevance : IDisposable
             while (bm25._setIterator.Fill(bm25.Matches, out var read, pruneGreaterThanOptimization: EntryIdEncodings.PrepareIdForPruneInPostingList(matches[^1])) && read > 0)
             {
                 bm25._currentId = read;
+                // The posting list yields encoded ids (entry id + quantized frequency). Split them the way the stored
+                // path does in DecodeAndSave, otherwise the ids never match and the frequencies stay zero - leaving
+                // every document with the score buffer's initial value.
+                EntryIdEncodings.Decode(bm25.Matches, bm25.Scores);
                 CalculateScoreFromMemory(bm25, matches, scores, boostFactor);
                 bm25._currentId = bm25._bufferCapacity;
             }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.ResolveClause.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.ResolveClause.cs
@@ -126,7 +126,7 @@ internal static partial class QueryPlanBuilder
                 builderParams.Allocator, searchFieldName, builderParams.Index,
                 builderParams.IndexFieldsMapping,
                 builderParams.HasDynamics, builderParams.DynamicFields,
-                handleSearch: true, hasBoost: builderParams.HasBoost,
+                handleSearch: true, hasBoost: builderParams.HasBoost && clause.IsNegated == false,
                 forceDefaultSearchAnalyzer: forceSearch);
 
             var searchTerm = root.StringValues[packed.Param1];

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
@@ -831,8 +831,9 @@ internal static partial class QueryPlanBuilder
                                    && clause.ClauseType != ClauseType.Search
                                    && builderParams.Index.Configuration.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery;
         
+        // A negated clause only subtracts from the result, it never adds relevance - same as Lucene's MUST_NOT.
         return QueryBuilderHelper.GetFieldMetadata(in builderParams, resolvedFieldName, exact: clause.IsExact,
-            hasBoost: builderParams.HasBoost, forceDefaultSearchAnalyzer: forceSearchAnalyzer);
+            hasBoost: builderParams.HasBoost && clause.IsNegated == false, forceDefaultSearchAnalyzer: forceSearchAnalyzer);
     }
 
     private static bool IsClauseBoosted(ClauseExecution exec) => exec.Clause.HasBoost || exec.BoostFactor > 0;

--- a/test/SlowTests.Issues/Issues/RavenDB_26999.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26999.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
+{
+    // Scoring is skipped entirely once a term's posting list grows past the small representation, so every dataset
+    // here keeps one term above that size and one below it. The score buffer starts at Bm25Relevance.InitialScoreValue
+    // (1/1_000_000f), so a score equal to it means BM25 contributed nothing at all.
+    private const double InitialScoreValue = 1 / 1_000_000f;
+
+    private class Movie
+    {
+        public string Id { get; set; }
+        public string Genre { get; set; }
+        public string Status { get; set; }
+        public string Title { get; set; }
+    }
+
+    private class ScoreOnly
+    {
+        public double Score { get; set; }
+    }
+
+    private class Movies_Showcase : AbstractIndexCreationTask<Movie>
+    {
+        public Movies_Showcase()
+        {
+            Map = movies => from m in movies
+                            select new
+                            {
+                                m.Genre,
+                                m.Status,
+                                m.Title
+                            };
+
+            Index(x => x.Genre, FieldIndexing.Exact);
+            Index(x => x.Title, FieldIndexing.Search);
+
+            // Set per index, the way production indexes usually do it - not via database settings.
+            Configuration[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = "true";
+        }
+    }
+
+    private IDocumentStore SetupStore(RavenSearchEngineMode engine, int totalDocuments, int rareEvery)
+    {
+        var store = GetDocumentStore(Options.ForSearchEngine(engine));
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < totalDocuments; i++)
+            {
+                bulk.Store(new Movie
+                {
+                    // "Drama" is sparse (every rareEvery-th document) but still numerous - that combination is what
+                    // pushes its posting list out of the small representation.
+                    Genre = i % rareEvery == 0 ? "Drama" : "Filler",
+                    Status = i % 3 == 0 ? "Released" : "Planned",
+                    Title = i % rareEvery == 0 ? "the matrix reloaded" : "some other movie title"
+                });
+            }
+        }
+
+        store.ExecuteIndex(new Movies_Showcase());
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(15));
+
+        return store;
+    }
+
+    private static double[] Scores(IDocumentStore store, string where)
+    {
+        using var session = store.OpenSession();
+        return session.Advanced
+            .RawQuery<ScoreOnly>($@"from index 'Movies/Showcase' as m
+                                    where {where}
+                                    order by score()
+                                    select {{ Score: getMetadata(m)[""@index-score""] }}
+                                    limit 5")
+            .ToList()
+            .Select(x => x.Score)
+            .ToArray();
+    }
+
+    private void AssertScored(IDocumentStore store, string where, string what)
+    {
+        var scores = Scores(store, where);
+
+        Assert.NotEmpty(scores);
+        output.WriteLine($"{what,-46} -> {string.Join(", ", scores.Select(s => s.ToString("G6")))}");
+
+        foreach (var score in scores)
+            Assert.False(Math.Abs(score - InitialScoreValue) < 1e-12,
+                $"{what}: score is the untouched InitialScoreValue ({score}) - BM25 contributed nothing");
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [InlineData(100_000, 100)]    // df = 1_000  - small posting list
+    [InlineData(1_000_000, 100)]  // df = 10_000 - large posting list, sparse over 1M ids
+    [InlineData(1_000_000, 10)]   // df = 100_000 - large and dense
+    public void ScoreIsComputedRegardlessOfPostingListSize(int totalDocuments, int rareEvery)
+    {
+        using var store = SetupStore(RavenSearchEngineMode.Corax, totalDocuments, rareEvery);
+
+        // Every clause shape below reaches a different bitmap-pipeline primitive, and each one had its own
+        // posting-list shortcut that bypassed BM25: OR (single leaf), AND, AND NOT.
+        AssertScored(store, "m.Genre = 'Drama'", "equals (OR fold)");
+        AssertScored(store, "search(m.Title, 'matrix')", "search on analyzed field");
+        AssertScored(store, "m.Genre = 'Drama' and m.Status = 'Released'", "AND of two terms");
+        AssertScored(store, "m.Genre = 'Drama' and m.Status != 'Planned'", "AND NOT");
+        AssertScored(store, "m.Genre = 'Drama' or m.Status = 'Released'", "OR of two terms");
+        AssertScored(store, "boost(m.Genre = 'Drama', 100)", "explicit boost");
+        AssertScored(store, "m.Genre in ('Drama', 'Western')", "IN");
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void CoraxScoresMatchLuceneOrderOfMagnitude()
+    {
+        const int documents = 1_000_000;
+        const int rareEvery = 100;
+
+        using var corax = SetupStore(RavenSearchEngineMode.Corax, documents, rareEvery);
+        using var lucene = SetupStore(RavenSearchEngineMode.Lucene, documents, rareEvery);
+
+        foreach (var where in new[] { "m.Genre = 'Drama'", "search(m.Title, 'matrix')", "m.Genre = 'Drama' and m.Status = 'Released'" })
+        {
+            var coraxScore = Scores(corax, where).First();
+            var luceneScore = Scores(lucene, where).First();
+
+            output.WriteLine($"{where,-50} corax={coraxScore:G6} lucene={luceneScore:G6}");
+
+            // The formulas differ, so the scores are not equal - but they must live in the same range instead of
+            // Corax collapsing to 1e-6 while Lucene reports a healthy score.
+            Assert.True(coraxScore > luceneScore / 100 && coraxScore < luceneScore * 100,
+                $"{where}: corax={coraxScore} vs lucene={luceneScore} - orders of magnitude apart");
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void ScoresStayOrderedByRelevanceAcrossPostingListSizes()
+    {
+        using var store = SetupStore(RavenSearchEngineMode.Corax, 1_000_000, 100);
+
+        // Rarer term must score higher than the common one - the property that collapsed to a flat 1e-6 for every
+        // term whose posting list was large.
+        var rare = Scores(store, "m.Genre = 'Drama'").First();      // df = 10_000
+        var common = Scores(store, "m.Status = 'Released'").First(); // df = 333_334
+
+        output.WriteLine($"rare(df=10k)={rare:G6} common(df=333k)={common:G6}");
+
+        Assert.True(rare > common, $"rare term scored {rare}, common term scored {common}");
+        Assert.True(common > InitialScoreValue * 10, $"common term collapsed to {common}");
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_26999.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26999.cs
@@ -138,6 +138,10 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
         // Every 'Released' document holds the term exactly once, so BM25 gives all of them the same score. The lowest
         // one is where a partially read posting list shows up: whatever the score pass never reached stays at 1e-6.
         Assert.Equal(TopScore(store, "m.Status = 'Released'"), LowestScore(store, "m.Status = 'Released'"), 6);
+
+        // A negated term is subtracted, never scored (Lucene's MUST_NOT does the same): documents that reach the result
+        // through 'Drama' score exactly as they do without the negated branch, whatever the size of 'Planned'.
+        Assert.Equal(TopScore(store, "m.Genre = 'Drama'"), TopScore(store, "m.Genre = 'Drama' or m.Status != 'Planned'"), 6);
     }
 
     // Shared body, no attribute on purpose: two 1M-document stores belong in StressTests - see StressTests.Issues.RavenDB_26999.

--- a/test/SlowTests.Issues/Issues/RavenDB_26999.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26999.cs
@@ -94,7 +94,6 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
         var scores = Scores(store, where);
 
         Assert.NotEmpty(scores);
-        output.WriteLine($"{what,-46} -> {string.Join(", ", scores.Select(s => s.ToString("G6")))}");
 
         foreach (var score in scores)
             Assert.False(Math.Abs(score - InitialScoreValue) < 1e-12,
@@ -132,8 +131,6 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
             var coraxScore = Scores(corax, where).First();
             var luceneScore = Scores(lucene, where).First();
 
-            output.WriteLine($"{where,-50} corax={coraxScore:G6} lucene={luceneScore:G6}");
-
             // The formulas differ, so the scores are not equal - but they must live in the same range instead of
             // Corax collapsing to 1e-6 while Lucene reports a healthy score.
             Assert.True(coraxScore > luceneScore / 100 && coraxScore < luceneScore * 100,
@@ -149,8 +146,6 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
         // term whose posting list was large.
         var rare = Scores(store, "m.Genre = 'Drama'").First();      // df = 10_000
         var common = Scores(store, "m.Status = 'Released'").First(); // df = 333_334
-
-        output.WriteLine($"rare(df=10k)={rare:G6} common(df=333k)={common:G6}");
 
         Assert.True(rare > common, $"rare term scored {rare}, common term scored {common}");
         Assert.True(common > InitialScoreValue * 10, $"common term collapsed to {common}");

--- a/test/SlowTests.Issues/Issues/RavenDB_26999.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26999.cs
@@ -12,9 +12,11 @@ namespace SlowTests.Issues;
 
 public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
 {
-    // Scoring is skipped entirely once a term's posting list grows past the small representation, so every dataset
-    // here keeps one term above that size and one below it. The score buffer starts at Bm25Relevance.InitialScoreValue
-    // (1/1_000_000f), so a score equal to it means BM25 contributed nothing at all.
+    // Two things broke for terms backed by a posting list: the bitmap pipeline skipped TermMatch.Fill (the only place
+    // that feeds BM25), and the score pass over a large posting list never decoded what it read. Bm25Relevance keeps a
+    // term's frequencies in memory only below ~105k entries (MaximumDocumentCapacity) and re-reads the posting list
+    // above that, so every dataset here has a term on each side of the line. The score buffer starts at
+    // Bm25Relevance.InitialScoreValue (1/1_000_000f); a score equal to it means BM25 contributed nothing at all.
     private const double InitialScoreValue = 1 / 1_000_000f;
 
     private class Movie
@@ -75,18 +77,33 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
         return store;
     }
 
-    private static double[] Scores(IDocumentStore store, string where)
+    private static double[] Scores(IDocumentStore store, string where, string orderBy = "order by score()")
     {
         using var session = store.OpenSession();
         return session.Advanced
             .RawQuery<ScoreOnly>($@"from index 'Movies/Showcase' as m
                                     where {where}
-                                    order by score()
+                                    {orderBy}
                                     select {{ Score: getMetadata(m)[""@index-score""] }}
                                     limit 5")
             .ToList()
             .Select(x => x.Score)
             .ToArray();
+    }
+
+    private static double TopScore(IDocumentStore store, string where)
+    {
+        var scores = Scores(store, where);
+        Assert.NotEmpty(scores);
+        return scores[0];
+    }
+
+    // RQL quirk, same on both engines: 'order by score()' is most relevant first, so 'desc' puts the least relevant first.
+    private static double LowestScore(IDocumentStore store, string where)
+    {
+        var scores = Scores(store, where, "order by score() desc");
+        Assert.NotEmpty(scores);
+        return scores[0];
     }
 
     private void AssertScored(IDocumentStore store, string where, string what)
@@ -101,35 +118,48 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
-    [InlineData(100_000, 100)]    // df = 1_000  - small posting list
-    [InlineData(1_000_000, 100)]  // df = 10_000 - large posting list, sparse over 1M ids
+    [InlineData(100_000, 100)]    // Drama df = 1_000, Released df = 33_334 - both stored in memory at score time
+    [InlineData(1_000_000, 100)]  // Drama df = 10_000, Released df = 333_334 - Released is re-read from the posting list at score time
     public void ScoreIsComputedRegardlessOfPostingListSize(int totalDocuments, int rareEvery)
     {
         using var store = SetupStore(RavenSearchEngineMode.Corax, totalDocuments, rareEvery);
 
-        // Every clause shape below reaches a different bitmap-pipeline primitive, and each one had its own
-        // posting-list shortcut that bypassed BM25: OR (single leaf), AND, AND NOT.
+        // Single terms first: they are the only way to pin one code path at a time. The compound shapes below pass as
+        // soon as any one leaf scores, so they cover the primitives (OR, AND, AND NOT, IN) but not each leaf in them.
         AssertScored(store, "m.Genre = 'Drama'", "equals (OR fold)");
+        AssertScored(store, "m.Status = 'Released'", "equals, term above the stored threshold in the 1M case");
         AssertScored(store, "search(m.Title, 'matrix')", "search on analyzed field");
         AssertScored(store, "m.Genre = 'Drama' and m.Status = 'Released'", "AND of two terms");
         AssertScored(store, "m.Genre = 'Drama' and m.Status != 'Planned'", "AND NOT");
         AssertScored(store, "m.Genre = 'Drama' or m.Status = 'Released'", "OR of two terms");
         AssertScored(store, "boost(m.Genre = 'Drama', 100)", "explicit boost");
         AssertScored(store, "m.Genre in ('Drama', 'Western')", "IN");
+
+        // Every 'Released' document holds the term exactly once, so BM25 gives all of them the same score. The lowest
+        // one is where a partially read posting list shows up: whatever the score pass never reached stays at 1e-6.
+        Assert.Equal(TopScore(store, "m.Status = 'Released'"), LowestScore(store, "m.Status = 'Released'"), 6);
     }
 
+    // Shared body, no attribute on purpose: two 1M-document stores belong in StressTests - see StressTests.Issues.RavenDB_26999.
     public void CoraxScoresMatchLuceneOrderOfMagnitude()
     {
         const int documents = 1_000_000;
         const int rareEvery = 100;
+        string[] clauses = ["m.Genre = 'Drama'", "search(m.Title, 'matrix')", "m.Genre = 'Drama' and m.Status = 'Released'"];
 
-        using var corax = SetupStore(RavenSearchEngineMode.Corax, documents, rareEvery);
-        using var lucene = SetupStore(RavenSearchEngineMode.Lucene, documents, rareEvery);
-
-        foreach (var where in new[] { "m.Genre = 'Drama'", "search(m.Title, 'matrix')", "m.Genre = 'Drama' and m.Status = 'Released'" })
+        // One 1M-document store at a time - the two engines never need to coexist.
+        var coraxScores = new Dictionary<string, double>();
+        using (var corax = SetupStore(RavenSearchEngineMode.Corax, documents, rareEvery))
         {
-            var coraxScore = Scores(corax, where).First();
-            var luceneScore = Scores(lucene, where).First();
+            foreach (var where in clauses)
+                coraxScores[where] = TopScore(corax, where);
+        }
+
+        using var lucene = SetupStore(RavenSearchEngineMode.Lucene, documents, rareEvery);
+        foreach (var where in clauses)
+        {
+            var coraxScore = coraxScores[where];
+            var luceneScore = TopScore(lucene, where);
 
             // The formulas differ, so the scores are not equal - but they must live in the same range instead of
             // Corax collapsing to 1e-6 while Lucene reports a healthy score.
@@ -138,14 +168,16 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
+    // Shared body, no attribute on purpose: a 1M-document store belongs in StressTests - see StressTests.Issues.RavenDB_26999.
     public void ScoresStayOrderedByRelevanceAcrossPostingListSizes()
     {
         using var store = SetupStore(RavenSearchEngineMode.Corax, 1_000_000, 100);
 
         // Rarer term must score higher than the common one - the property that collapsed to a flat 1e-6 for every
-        // term whose posting list was large.
-        var rare = Scores(store, "m.Genre = 'Drama'").First();      // df = 10_000
-        var common = Scores(store, "m.Status = 'Released'").First(); // df = 333_334
+        // term whose posting list was large. The common term is judged by its lowest score, so a score pass that
+        // gives up partway through its posting list cannot hide behind the documents it did reach.
+        var rare = TopScore(store, "m.Genre = 'Drama'");           // df = 10_000
+        var common = LowestScore(store, "m.Status = 'Released'");  // df = 333_334
 
         Assert.True(rare > common, $"rare term scored {rare}, common term scored {common}");
         Assert.True(common > InitialScoreValue * 10, $"common term collapsed to {common}");

--- a/test/SlowTests.Issues/Issues/RavenDB_26999.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26999.cs
@@ -104,7 +104,6 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
     [InlineData(100_000, 100)]    // df = 1_000  - small posting list
     [InlineData(1_000_000, 100)]  // df = 10_000 - large posting list, sparse over 1M ids
-    [InlineData(1_000_000, 10)]   // df = 100_000 - large and dense
     public void ScoreIsComputedRegardlessOfPostingListSize(int totalDocuments, int rareEvery)
     {
         using var store = SetupStore(RavenSearchEngineMode.Corax, totalDocuments, rareEvery);
@@ -120,7 +119,6 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
         AssertScored(store, "m.Genre in ('Drama', 'Western')", "IN");
     }
 
-    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
     public void CoraxScoresMatchLuceneOrderOfMagnitude()
     {
         const int documents = 1_000_000;
@@ -143,7 +141,6 @@ public class RavenDB_26999(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
-    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
     public void ScoresStayOrderedByRelevanceAcrossPostingListSizes()
     {
         using var store = SetupStore(RavenSearchEngineMode.Corax, 1_000_000, 100);

--- a/test/StressTests/Issues/RavenDB_26999.cs
+++ b/test/StressTests/Issues/RavenDB_26999.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace StressTests.Issues;
+
+public class RavenDB_26999(ITestOutputHelper output) : NoDisposalNoOutputNeeded(output)
+{
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [InlineData(1_000_000, 10)]
+    public async Task ScoreIsComputedRegardlessOfPostingListSize(int totalDocuments, int rareEvery)
+    {
+        await using var testClass = new SlowTests.Issues.RavenDB_26999(Output);
+        testClass.ScoreIsComputedRegardlessOfPostingListSize(totalDocuments, rareEvery);
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public async Task CoraxScoresMatchLuceneOrderOfMagnitude()
+    {
+        await using var testClass = new SlowTests.Issues.RavenDB_26999(Output);
+        testClass.CoraxScoresMatchLuceneOrderOfMagnitude();
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public async Task ScoresStayOrderedByRelevanceAcrossPostingListSizes()
+    {
+        await using var testClass = new SlowTests.Issues.RavenDB_26999(Output);
+        testClass.ScoresStayOrderedByRelevanceAcrossPostingListSizes();
+    }
+}


### PR DESCRIPTION
`@index-score` collapsed to `9.999999974752427E-07` for every document - bitwise `Bm25Relevance.InitialScoreValue = 1/1_000_000f`, the value the score buffer is filled with before scoring, so BM25 contributed nothing. 

**The compiled bitmap pipeline bypassed the only place that feeds BM25.** `OrWithMatch` / `AndWithMatch` / `AndNotWithMatch` shortcut a `TermMatch` backed by a large posting list straight into `FillFromPostings`, skipping `TermMatch.Fill` - and `Fill` is where `bm25Relevance.Process(...)` hands ids and frequencies to BM25. The shortcut now applies only to terms that are not scoring (`tm.IsBoosting == false`), so the optimization is kept for every query without scoring, which is the vast majority. This also explains why `boost(...)` appeared to work: the wrapper made `match is TermMatch` false, so the match went through `Fill` anyway.

Additionally `PostingListCalculateScoreSorted` (2.0 only, the sorted counterpart of the dynamic path) needs the same decode: the posting list yields entry id and quantized frequency packed together, while `matches` holds plain ids, so `ScoreSortedRun` never found a match and read zero frequencies.

Measured on the imdb database (1.4M docs): `df` 1 418 scored 2.307 on both engines, while `df` 6 488 / 73 703 / 112 710 / 191 396 returned 1e-6 on Corax 2.0 and healthy scores on Corax 1.0 and Lucene.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26999

### Additional description

Overlaps in spirit with the v6.2 fix for the same ticket (two causes shared with Corax 1.0: the dynamic scoring path not decoding posting-list values, and `HandleIn` not passing `hasBoost`).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

Scoring queries over large posting lists lose the native `FillFromPostings` shortcut and go through `Fill` instead - correct, but slower for that case. Queries without scoring are untouched.

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

`RavenDB_26999` covers three datasets (df = 1 000 / 10 000 / 100 000 / 333 334) against seven clause shapes (equals, search, AND, AND NOT, OR, boost, IN) - each shape reaches a different pipeline primitive - compares Corax against Lucene on 1M documents and asserts that a rare term outscores a common one. Without the fixes the 1M cases fail; with them all 5 pass. Full `FastTests` passes (5048). The five failures in the Corax/Boost/Score/Facet `SlowTests` sweep all pass when run in isolation (16 cases) - parallel-load flakes, not regressions.

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

`order by score()` over very common terms now walks the match path instead of the native posting-list fill; worth measuring throughput on a large collection.

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Every scoring query over a term with more than a few thousand documents now returns real BM25 scores instead of a flat 1e-6, so ordering by `score()` changes - that is the fix, but ranked results will look different after the upgrade.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed