### PR TITLE
RavenDB-27432 CDC MariaDB: fix silent loss of live changes for tables with native UUID columns

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -91,7 +91,7 @@
     <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
     <PackageVersion Include="MongoDB.Driver.GridFS" Version="2.30.0" />
     <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageVersion Include="MySqlCdc" Version="4.0.1" />
+    <PackageVersion Include="MySqlCdc" Version="5.0.0-preview2" />
     <PackageVersion Include="MySqlConnector" Version="2.6.2" />
     <PackageVersion Include="NCrontab.Advanced" Version="1.3.28" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -43,7 +43,7 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
     private bool _isMariaDb;
     private string _serverGtid; // Current GTID set fetched from server during startup
 
-    private enum MySqlColumnCategory { Other, Text, Decimal, Json, Boolean }
+    private enum MySqlColumnCategory { Other, Text, Decimal, Json, Boolean, Uuid }
 
     private readonly record struct ColumnInfo(string Name, MySqlColumnCategory Category, string DataType);
 
@@ -127,6 +127,7 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
         ["set"]        = 254, // MYSQL_TYPE_STRING (encoded as string)
         ["json"]       = 245, // MYSQL_TYPE_JSON
         ["geometry"]   = 255, // MYSQL_TYPE_GEOMETRY
+        ["uuid"]               = 254,
     };
 
     internal static byte MapDataTypeToBinlogType(string dataType)
@@ -296,6 +297,7 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
                     (_, "tinyint(1)") or (_, "tinyint(1) unsigned") => MySqlColumnCategory.Boolean,
                     ("bit", "bit(1)")                                => MySqlColumnCategory.Boolean,
                     ("json", _)                                      => MySqlColumnCategory.Json,
+                    ("uuid", _)                                      => MySqlColumnCategory.Uuid,
                     ("decimal" or "numeric", _)                      => MySqlColumnCategory.Decimal,
                     ("text" or "tinytext" or "mediumtext" or "longtext"
                         or "char" or "varchar" or "enum" or "set", _) => MySqlColumnCategory.Text,
@@ -771,6 +773,9 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
                     // Use MySqlCdc's JsonParser to convert to a JSON string.
                     byte[] bytes when col.Category is MySqlColumnCategory.Json
                         => MySqlCdc.Providers.MySql.JsonParser.Parse(bytes),
+
+                    byte[] bytes when col.Category is MySqlColumnCategory.Uuid
+                        => new Guid(bytes, bigEndian: true).ToString(),
 
                     // MySQL's binlog uses the same BLOB type codes for TEXT and BLOB columns.
                     // TEXT columns should be UTF-8 decoded; true binary columns pass through.

--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -127,6 +127,14 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
         ["set"]        = 254, // MYSQL_TYPE_STRING (encoded as string)
         ["json"]       = 245, // MYSQL_TYPE_JSON
         ["geometry"]   = 255, // MYSQL_TYPE_GEOMETRY
+        ["point"]              = 255,
+        ["linestring"]         = 255,
+        ["polygon"]            = 255,
+        ["multipoint"]         = 255,
+        ["multilinestring"]    = 255,
+        ["multipolygon"]       = 255,
+        ["geomcollection"]     = 255,
+        ["geometrycollection"] = 255,
         ["uuid"]               = 254,
     };
 
@@ -135,8 +143,6 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
         if (MySqlDataTypeToBinlogType.TryGetValue(dataType, out var binlogType))
             return binlogType;
 
-        // Unknown types are not fatal — we just can't do prefix comparison for this position.
-        // Use 0 as a wildcard that won't match anything, forcing a restart if it matters.
         return 0;
     }
 
@@ -321,7 +327,15 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
             var requiredLen = processor.RequiredPrefixLength;
             var expectedPrefix = new byte[requiredLen];
             for (int i = 0; i < requiredLen && i < columnsArray.Length; i++)
-                expectedPrefix[i] = MapDataTypeToBinlogType(columnsArray[i].DataType);
+            {
+                var binlogType = MapDataTypeToBinlogType(columnsArray[i].DataType);
+                if (binlogType == 0)
+                    throw new CdcSinkFaultedException(
+                        $"Column '{columnsArray[i].Name}' in table {tableInfo.Schema}.{tableInfo.TableName} has data type " +
+                        $"'{columnsArray[i].DataType}', which is not supported for binlog streaming. " +
+                        "Remove the column from the CDC Sink mapping, or change its type to a supported one.");
+                expectedPrefix[i] = binlogType;
+            }
 
             var tableKey = (tableInfo.Schema, tableInfo.TableName);
             _resolvedTables[tableKey] = new TableInfo

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
@@ -4451,6 +4451,51 @@ namespace SlowTests.Server.Documents.CdcSink
             Assert.True(await WaitForDocumentDeletionAsync(store, "UuidKeyed/11111111-1111-1111-1111-111111111111", timeoutMs: 60_000));
         }
 
+        [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
+        public async Task MariaDb_UnsupportedMappedColumnType_FaultsInsteadOfSilentSkip()
+        {
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            if (SupportsMariaDbNativeUuid(connectionString) == false)
+                return;
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE net_items (
+                    id   INT PRIMARY KEY,
+                    addr INET6
+                )");
+            ExecuteMySql(connectionString, "INSERT INTO net_items (id, addr) VALUES (1, '::1');");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-mariadb-unsupported-type",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "NetItems",
+                        SourceTableSchema = schemaName,
+                        SourceTableName = "net_items",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "addr", Name = "Addr" }
+                        }
+                    }
+                }
+            };
+            AddCdcSink(store, config);
+
+            var fault = await WaitForProcessFaultAsync(store, config.Name);
+            Assert.IsType<Raven.Server.Documents.CdcSink.CdcSinkFaultedException>(fault);
+            Assert.Contains("'addr'", fault.Message);
+            Assert.Contains("not supported for binlog streaming", fault.Message);
+        }
+
         // --- MySQL-specific DTO classes (different nested type structure) ---
 
         private class NestedEmployee

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkMySqlIntegrationTests.cs
@@ -4303,6 +4303,154 @@ namespace SlowTests.Server.Documents.CdcSink
             }
         }
 
+        private static bool SupportsMariaDbNativeUuid(string connectionString)
+        {
+            using var conn = new MySqlConnector.MySqlConnection(connectionString);
+            conn.Open();
+            using var cmd = new MySqlConnector.MySqlCommand("SELECT VERSION()", conn);
+            var version = (string)cmd.ExecuteScalar();
+            if (version == null || version.Contains("MariaDB", StringComparison.OrdinalIgnoreCase) == false)
+                return false;
+            return Version.TryParse(version.Split('-')[0], out var v) && v >= new Version(10, 7);
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
+        public async Task MariaDb_NativeUuid_StreamsFromBothPaths()
+        {
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            if (SupportsMariaDbNativeUuid(connectionString) == false)
+                return;
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE uuid_items (
+                    id  INT PRIMARY KEY,
+                    val UUID
+                )");
+            ExecuteMySql(connectionString, "INSERT INTO uuid_items (id, val) VALUES (1, '11111111-1111-1111-1111-111111111111');");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-mariadb-uuid",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "UuidItems",
+                        SourceTableSchema = schemaName,
+                        SourceTableName = "uuid_items",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "val", Name = "Val" }
+                        }
+                    }
+                }
+            };
+            AddCdcSink(store, config);
+            await WaitForCdcInitialLoadAsync(store, "test-mariadb-uuid");
+
+            using var commands = store.Commands();
+
+            var doc1 = (await commands.GetAsync("UuidItems/1")).BlittableJson;
+            Assert.True(doc1.TryGet("Val", out object val1));
+            Assert.Equal("11111111-1111-1111-1111-111111111111", val1?.ToString());
+
+            ExecuteMySqlInTransaction(connectionString,
+                "INSERT INTO uuid_items (id, val) VALUES (2, '3b241101-e2bb-4255-8caf-4136c566a962')",
+                "INSERT INTO uuid_items (id, val) VALUES (3, NULL)");
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                return await session.LoadAsync<dynamic>("UuidItems/3") != null;
+            }, true, timeout: 60_000);
+
+            var doc2 = (await commands.GetAsync("UuidItems/2")).BlittableJson;
+            Assert.True(doc2.TryGet("Val", out object val2));
+            Assert.Equal("3b241101-e2bb-4255-8caf-4136c566a962", val2?.ToString());
+
+            var doc3 = (await commands.GetAsync("UuidItems/3")).BlittableJson;
+            Assert.True(doc3.TryGet("Val", out object val3));
+            Assert.Null(val3);
+
+            ExecuteMySql(connectionString, "UPDATE uuid_items SET val = 'aaaaaaaa-bbbb-1ccc-8ddd-eeeeeeeeeeee' WHERE id = 2;");
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var doc = await session.LoadAsync<dynamic>("UuidItems/2");
+                return (string)doc?.Val;
+            }, "aaaaaaaa-bbbb-1ccc-8ddd-eeeeeeeeeeee", timeout: 60_000);
+
+            ExecuteMySql(connectionString, "DELETE FROM uuid_items WHERE id = 1;");
+
+            Assert.True(await WaitForDocumentDeletionAsync(store, "UuidItems/1", timeoutMs: 60_000));
+        }
+
+        [RavenFact(RavenTestCategory.Sinks, MySqlCdcRequired = true)]
+        public async Task MariaDb_UuidPrimaryKey_StreamsFromBothPaths()
+        {
+            using var store = GetDocumentStore();
+            using var _ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out var schemaName, dataSet: null, includeData: false);
+
+            if (SupportsMariaDbNativeUuid(connectionString) == false)
+                return;
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE uuid_keyed (
+                    id   UUID PRIMARY KEY,
+                    name VARCHAR(64) NOT NULL
+                )");
+            ExecuteMySql(connectionString, "INSERT INTO uuid_keyed (id, name) VALUES ('11111111-1111-1111-1111-111111111111', 'Alpha');");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-mariadb-uuid-pk",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "UuidKeyed",
+                        SourceTableSchema = schemaName,
+                        SourceTableName = "uuid_keyed",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "SourceId" },
+                            new CdcColumnMapping { Column = "name", Name = "Name" }
+                        }
+                    }
+                }
+            };
+            AddCdcSink(store, config);
+            await WaitForCdcInitialLoadAsync(store, "test-mariadb-uuid-pk");
+
+            using var commands = store.Commands();
+
+            var doc1 = (await commands.GetAsync("UuidKeyed/11111111-1111-1111-1111-111111111111")).BlittableJson;
+            Assert.NotNull(doc1);
+
+            ExecuteMySql(connectionString, "INSERT INTO uuid_keyed (id, name) VALUES ('3b241101-e2bb-4255-8caf-4136c566a962', 'Beta');");
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                var doc = await session.LoadAsync<dynamic>("UuidKeyed/3b241101-e2bb-4255-8caf-4136c566a962");
+                return (string)doc?.Name;
+            }, "Beta", timeout: 60_000);
+
+            ExecuteMySql(connectionString, "DELETE FROM uuid_keyed WHERE id = '11111111-1111-1111-1111-111111111111';");
+
+            Assert.True(await WaitForDocumentDeletionAsync(store, "UuidKeyed/11111111-1111-1111-1111-111111111111", timeoutMs: 60_000));
+        }
+
         // --- MySQL-specific DTO classes (different nested type structure) ---
 
         private class NestedEmployee


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27432/CDC-MariaDB-tables-with-a-native-UUID-column-silently-lose-all-live-changes

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
