### PR TITLE
Quill-288 Fix originForSubdomain

### DIFF
--- a/src/Raven.Quill.Web/src/lib/subdomain-origin.test.ts
+++ b/src/Raven.Quill.Web/src/lib/subdomain-origin.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { containerNameForHost, originForSubdomain } from "@/lib/subdomain-origin";
+
+function setLocation(href: string) {
+    const { protocol, hostname, port, origin } = new URL(href);
+    vi.stubGlobal("window", { location: { protocol, hostname, port, origin } });
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("originForSubdomain", () => {
+    it("swaps the leading label on appliance hosts", () => {
+        setLocation("https://dashboard.user-test.myquill.ai");
+        expect(originForSubdomain("api")).toBe("https://api.user-test.myquill.ai");
+    });
+
+    it("swaps the leading label whatever the current role is", () => {
+        setLocation("https://api.acme.example.com");
+        expect(originForSubdomain("public")).toBe("https://public.acme.example.com");
+    });
+
+    it("keeps a non-default port", () => {
+        setLocation("https://dashboard.acme.example.com:8443");
+        expect(originForSubdomain("public")).toBe("https://public.acme.example.com:8443");
+    });
+
+    it("falls back to the current origin on apex hosts instead of handing out a foreign domain", () => {
+        setLocation("https://example.com");
+        expect(originForSubdomain("api")).toBe("https://example.com");
+
+        setLocation("https://example.co.uk");
+        expect(originForSubdomain("api")).toBe("https://example.co.uk");
+    });
+
+    it("falls back to the current origin on hosts with no slug label", () => {
+        setLocation("https://dashboard.example.com");
+        expect(originForSubdomain("api")).toBe("https://dashboard.example.com");
+    });
+
+    it("falls back to the current origin on single-label and LAN hosts", () => {
+        setLocation("http://localhost:5173");
+        expect(originForSubdomain("api")).toBe("http://localhost:5173");
+
+        setLocation("https://quill.local");
+        expect(originForSubdomain("api")).toBe("https://quill.local");
+    });
+
+    it("falls back to the current origin on bare IPs, which have four labels of their own", () => {
+        setLocation("https://10.0.0.5");
+        expect(originForSubdomain("api")).toBe("https://10.0.0.5");
+    });
+});
+
+describe("containerNameForHost", () => {
+    it("reads the slug from appliance hosts", () => {
+        expect(containerNameForHost("dashboard.user-test.myquill.ai")).toBe("user-test");
+        expect(containerNameForHost("dashboard.acme.example.com")).toBe("acme");
+    });
+
+    it("falls back to the compose name for shorter hosts and bare IPs", () => {
+        expect(containerNameForHost("dashboard.example.com")).toBe("quill");
+        expect(containerNameForHost("example.com")).toBe("quill");
+        expect(containerNameForHost("localhost")).toBe("quill");
+        expect(containerNameForHost("10.0.0.5")).toBe("quill");
+    });
+});

--- a/src/Raven.Quill.Web/src/lib/subdomain-origin.ts
+++ b/src/Raven.Quill.Web/src/lib/subdomain-origin.ts
@@ -1,30 +1,34 @@
 import { z } from "zod";
 
+const DEFAULT_CONTAINER_NAME = "quill";
+const APPLIANCE_HOST_LABEL_COUNT = 4;
+
 export function isIpV4(value: string): boolean {
     return z.ipv4().safeParse(value).success;
 }
 
-// Swaps the operator host's leading label (dashboard.* / api.*) for the given subdomain, falling back
-// to the current origin when there is no subdomain to swap (dev/localhost / bare IP).
+// Appliance hosts are <role>.<slug>.myquill.ai, served by a *.<slug>.myquill.ai wildcard cert, so the
+// role is the only label safe to swap and the slug is also the Docker container name. Anything shorter
+// (dev/localhost, a bare IP, an apex host) has no role label to swap and no cert to match, so it falls
+// back to the current origin and the compose container name.
+function applianceLabels(hostname: string): string[] | null {
+    if (isIpV4(hostname)) {
+        return null;
+    }
+    const labels = hostname.split(".");
+    return labels.length >= APPLIANCE_HOST_LABEL_COUNT ? labels : null;
+}
+
 export function originForSubdomain(label: string) {
     const { protocol, hostname, port } = window.location;
-    const dot = hostname.indexOf(".");
-    if (dot <= 0 || isIpV4(hostname)) {
+    const labels = applianceLabels(hostname);
+    if (!labels) {
         return window.location.origin;
     }
-    const host = `${label}.${hostname.slice(dot + 1)}`;
+    const host = [label, ...labels.slice(1)].join(".");
     return `${protocol}//${host}${port ? `:${port}` : ""}`;
 }
 
-const DEFAULT_CONTAINER_NAME = "quill";
-
-// Appliance hosts look like <role>.<slug>.<domain>.<tld>, where the slug is also the Docker
-// container name. Dev/localhost and bare-IP hosts carry no slug, so they fall back to the
-// name the compose file uses.
 export function containerNameForHost(hostname: string): string {
-    if (isIpV4(hostname)) {
-        return DEFAULT_CONTAINER_NAME;
-    }
-    const labels = hostname.split(".");
-    return labels.length >= 4 ? labels[1] : DEFAULT_CONTAINER_NAME;
+    return applianceLabels(hostname)?.[1] ?? DEFAULT_CONTAINER_NAME;
 }


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/Quill-288/Apex-hosts-yield-api.com

### Additional description

`originForSubdomain` swapped the leading DNS label on any host containing a dot, so on a host with no role label it handed out a domain someone else owns — `example.com` became `api.com`. It now swaps only on appliance hosts (`<role>.<slug>.myquill.ai`, four labels, matching the `*.<slug>.myquill.ai` wildcard cert) and otherwise returns the current origin. `containerNameForHost` already used the four-label rule; it now shares one helper with `originForSubdomain` instead of keeping a second definition of what an appliance host is.

Adds unit coverage for the swap, port preservation, and each fallback: apex hosts (including `example.co.uk`, which a three-label rule gets wrong), single-label and LAN hosts, and bare IPs.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
