### PR TITLE
Quill-142 Quill - Layout pass for large screens: excessive whitespace, poor column sizing

### DIFF
--- a/src/Raven.Quill.Web/src/app.tsx
+++ b/src/Raven.Quill.Web/src/app.tsx
@@ -17,6 +17,7 @@ import { AssistantPanel } from "@/components/layout/assistant-panel";
 import { ASSISTANT_PANEL_TITLE_ID, useAssistantPinning, useAssistantStore } from "@/components/layout/assistant-store";
 import { FeedbackSheet } from "@/components/layout/feedback-sheet";
 import { Heading } from "@/components/typography";
+import { PageContainer } from "@/components/page-container";
 import { Button } from "@/components/shadcn/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
 
@@ -153,9 +154,11 @@ function App() {
                 )}
             >
                 {!isPageTitleHidden && (
-                    <Heading as="h1" variant="page">
-                        {activeRoute?.title ?? "My apps"}
-                    </Heading>
+                    <PageContainer>
+                        <Heading as="h1" variant="page">
+                            {activeRoute?.title ?? "My apps"}
+                        </Heading>
+                    </PageContainer>
                 )}
                 <div
                     className={cn(
@@ -166,7 +169,15 @@ function App() {
                         isBareLayout ? "overflow-auto" : "-mx-4 overflow-x-clip overflow-y-auto px-4 lg:-mx-5 lg:px-5",
                     )}
                 >
-                    <Outlet />
+                    {/* Bare layouts (wizards) manage their own width; every other page is capped and
+                        centred here so content matches the title band instead of stretching on wide screens. */}
+                    {isBareLayout ? (
+                        <Outlet />
+                    ) : (
+                        <PageContainer>
+                            <Outlet />
+                        </PageContainer>
+                    )}
                 </div>
             </main>
 

--- a/src/Raven.Quill.Web/src/app.tsx
+++ b/src/Raven.Quill.Web/src/app.tsx
@@ -154,11 +154,16 @@ function App() {
                 )}
             >
                 {!isPageTitleHidden && (
-                    <PageContainer>
-                        <Heading as="h1" variant="page">
-                            {activeRoute?.title ?? "My apps"}
-                        </Heading>
-                    </PageContainer>
+                    // Mirror the scroll area below (same bleed + scrollbar-gutter) so the centred title lines up
+                    // with the centred content whether or not the content shows a scrollbar. `overflow-hidden`
+                    // makes this a scroll container so `scrollbar-gutter` reserves the same space here too.
+                    <div className="-mx-4 [scrollbar-gutter:stable] overflow-hidden px-4 lg:-mx-5 lg:px-5">
+                        <PageContainer>
+                            <Heading as="h1" variant="page">
+                                {activeRoute?.title ?? "My apps"}
+                            </Heading>
+                        </PageContainer>
+                    </div>
                 )}
                 <div
                     className={cn(
@@ -166,7 +171,11 @@ function App() {
                         // Bleed the scroll area to the panel's inner border (padding keeps content in place) so
                         // a full-bleed detail header can reach the edges instead of being clipped short. Clip
                         // horizontal overflow so the page never scrolls sideways; wide content self-scrolls.
-                        isBareLayout ? "overflow-auto" : "-mx-4 overflow-x-clip overflow-y-auto px-4 lg:-mx-5 lg:px-5",
+                        // `scrollbar-gutter: stable` reserves the scrollbar space even when no scrollbar shows; the
+                        // title band above mirrors this exact box, so the two centre on the same axis either way.
+                        isBareLayout
+                            ? "overflow-auto"
+                            : "-mx-4 [scrollbar-gutter:stable] overflow-x-clip overflow-y-auto px-4 lg:-mx-5 lg:px-5",
                     )}
                 >
                     {/* Bare layouts (wizards) manage their own width; every other page is capped and

--- a/src/Raven.Quill.Web/src/components/data/count-badge.tsx
+++ b/src/Raven.Quill.Web/src/components/data/count-badge.tsx
@@ -1,0 +1,9 @@
+import type { ComponentProps } from "react";
+import { Badge } from "@/components/shadcn/ui/badge";
+import { cn } from "@/lib/utils";
+
+// The one badge for numeric counts (items in a section, rows in a table). Keeps every count looking
+// the same — secondary tone, tabular figures so digits don't jitter as the number changes.
+export function CountBadge({ className, ...props }: ComponentProps<typeof Badge>) {
+    return <Badge variant="secondary" className={cn("tabular-nums", className)} {...props} />;
+}

--- a/src/Raven.Quill.Web/src/components/page-container.tsx
+++ b/src/Raven.Quill.Web/src/components/page-container.tsx
@@ -1,0 +1,25 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ComponentProps } from "react";
+import { cn } from "@/lib/utils";
+
+// Caps and centres page content so views don't stretch edge-to-edge on wide/2K monitors.
+// The `wide` guardrail is applied app-wide and is deliberately generous: it only bites above
+// ~1920px, so normal screens are untouched and only big monitors get reined in + centred.
+// `narrow`/`default` are for future per-content-type opt-ins (forms, compact detail pages).
+const pageContainerVariants = cva("mx-auto w-full", {
+    variants: {
+        size: {
+            narrow: "max-w-[768px]", // forms, focused config, single-record detail
+            default: "max-w-[1200px]", // compact lists / detail pages
+            wide: "max-w-[1760px]", // app-wide guardrail: only caps screens wider than ~1920
+            full: "max-w-none", // dense horizontal content that needs the whole viewport
+        },
+    },
+    defaultVariants: { size: "wide" },
+});
+
+export type PageContainerProps = ComponentProps<"div"> & VariantProps<typeof pageContainerVariants>;
+
+export function PageContainer({ size, className, ...props }: PageContainerProps) {
+    return <div className={cn(pageContainerVariants({ size }), className)} {...props} />;
+}

--- a/src/Raven.Quill.Web/src/components/page-container.tsx
+++ b/src/Raven.Quill.Web/src/components/page-container.tsx
@@ -1,25 +1,9 @@
-import { cva, type VariantProps } from "class-variance-authority";
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 // Caps and centres page content so views don't stretch edge-to-edge on wide/2K monitors.
-// The `wide` guardrail is applied app-wide and is deliberately generous: it only bites above
+// The guardrail is applied app-wide and is deliberately generous: it only bites above
 // ~1920px, so normal screens are untouched and only big monitors get reined in + centred.
-// `narrow`/`default` are for future per-content-type opt-ins (forms, compact detail pages).
-const pageContainerVariants = cva("mx-auto w-full", {
-    variants: {
-        size: {
-            narrow: "max-w-[768px]", // forms, focused config, single-record detail
-            default: "max-w-[1200px]", // compact lists / detail pages
-            wide: "max-w-[1760px]", // app-wide guardrail: only caps screens wider than ~1920
-            full: "max-w-none", // dense horizontal content that needs the whole viewport
-        },
-    },
-    defaultVariants: { size: "wide" },
-});
-
-export type PageContainerProps = ComponentProps<"div"> & VariantProps<typeof pageContainerVariants>;
-
-export function PageContainer({ size, className, ...props }: PageContainerProps) {
-    return <div className={cn(pageContainerVariants({ size }), className)} {...props} />;
+export function PageContainer({ className, ...props }: ComponentProps<"div">) {
+    return <div className={cn("mx-auto w-full max-w-[1760px]", className)} {...props} />;
 }

--- a/src/Raven.Quill.Web/src/components/section-header.tsx
+++ b/src/Raven.Quill.Web/src/components/section-header.tsx
@@ -15,12 +15,16 @@ type Level = keyof typeof LEVELS;
 export function SectionHeader({
     level = "section",
     title,
+    // A count sits inline next to the title (e.g. a total badge), unlike `action` which is pushed
+    // to the far edge for buttons/menus.
+    count,
     description,
     action,
     className,
 }: {
     level?: Level;
     title?: ReactNode;
+    count?: ReactNode;
     description?: ReactNode;
     action?: ReactNode;
     className?: string;
@@ -30,10 +34,15 @@ export function SectionHeader({
     return (
         <div className={cn("flex items-start justify-between gap-3", className)}>
             <div className="space-y-0.5">
-                {title && (
-                    <Heading as={as} variant={variant}>
-                        {title}
-                    </Heading>
+                {(title || count) && (
+                    <div className="flex items-center gap-2">
+                        {title && (
+                            <Heading as={as} variant={variant}>
+                                {title}
+                            </Heading>
+                        )}
+                        {count}
+                    </div>
                 )}
                 {description && <Text variant="muted">{description}</Text>}
             </div>

--- a/src/Raven.Quill.Web/src/index.css
+++ b/src/Raven.Quill.Web/src/index.css
@@ -38,7 +38,7 @@
        it respects the reader's browser font-size preference. Tailwind breakpoints use the initial
        font size in media queries, so they're unaffected by this. */
     html {
-        font-size: clamp(1rem, 0.8rem + 0.22vw, 1.125rem);
+        font-size: clamp(1rem, 0.77rem + 0.24vw, 1.125rem);
     }
 
     body {

--- a/src/Raven.Quill.Web/src/index.css
+++ b/src/Raven.Quill.Web/src/index.css
@@ -32,19 +32,13 @@
         height: 100%;
     }
 
-    /* Scale the whole rem-based UI up on very wide screens so it doesn't feel undersized on
-       large monitors. Media queries resolve rem against the browser's initial font size, so
-       Tailwind breakpoints are unaffected by this. */
-    @media (min-width: 2000px) {
-        html {
-            font-size: 17px;
-        }
-    }
-
-    @media (min-width: 2560px) {
-        html {
-            font-size: 18px;
-        }
+    /* Scale the whole rem-based UI up fluidly as the viewport widens, so it doesn't feel
+       undersized on large monitors. Below ~1536px it stays at the user's base size; it grows
+       gently to 1.125x (matching the original ceiling) by ~2360px. Expressed in rem (not px) so
+       it respects the reader's browser font-size preference. Tailwind breakpoints use the initial
+       font size in media queries, so they're unaffected by this. */
+    html {
+        font-size: clamp(1rem, 0.8rem + 0.22vw, 1.125rem);
     }
 
     body {

--- a/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
@@ -7,8 +7,8 @@ import { api } from "@/api/api";
 import type { AgentSummaryResponse, ChannelSummaryResponse, ChannelType } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
 import { CardListSkeleton } from "@/components/data/loading-skeletons";
+import { CountBadge } from "@/components/data/count-badge";
 import { EnabledStatus } from "@/components/data/status-indicator";
-import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/shadcn/ui/input-group";
@@ -123,9 +123,7 @@ export function ChannelGroups({ slug }: { slug: string }) {
                                         <div className="mb-3 flex items-center gap-2">
                                             <group.icon className="size-4 text-muted-foreground" aria-hidden="true" />
                                             <Heading variant="label">{group.label}</Heading>
-                                            <Badge variant="secondary" className="tabular-nums">
-                                                {group.channels.length}
-                                            </Badge>
+                                            <CountBadge>{group.channels.length}</CountBadge>
                                             {group.label === "Web widgets" && (
                                                 <Button asChild variant="outline">
                                                     <Link to={appRoutes.app(slug, "web-widget/default-customize")}>

--- a/src/Raven.Quill.Web/src/pages/apps/collections-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/collections-section.tsx
@@ -7,7 +7,7 @@ import { getCoreRowModel, useReactTable, type ColumnDef } from "@tanstack/react-
 import { api } from "@/api/api";
 import type { DataCollectionDto } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
-import { Badge } from "@/components/shadcn/ui/badge";
+import { CountBadge } from "@/components/data/count-badge";
 import { VirtualDataTable, VirtualDataTableSkeleton } from "@/components/table/virtual-data-table";
 import { formatCompact } from "@/lib/format";
 import { SectionCard } from "@/pages/apps/section-card";
@@ -42,13 +42,7 @@ export function CollectionsSection({ slug }: { slug: string }) {
     return (
         <SectionCard
             title="Collections"
-            count={
-                collectionsQuery.data && (
-                    <Badge variant="secondary" className="font-mono">
-                        {collectionsQuery.data.length}
-                    </Badge>
-                )
-            }
+            count={collectionsQuery.data && <CountBadge>{collectionsQuery.data.length}</CountBadge>}
         >
             <ApiState
                 isLoading={collectionsQuery.isPending}

--- a/src/Raven.Quill.Web/src/pages/apps/collections-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/collections-section.tsx
@@ -42,7 +42,7 @@ export function CollectionsSection({ slug }: { slug: string }) {
     return (
         <SectionCard
             title="Collections"
-            action={
+            count={
                 collectionsQuery.data && (
                     <Badge variant="secondary" className="font-mono">
                         {collectionsQuery.data.length}

--- a/src/Raven.Quill.Web/src/pages/apps/section-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/section-card.tsx
@@ -4,6 +4,7 @@ import { SectionHeader } from "@/components/section-header";
 
 export function SectionCard({
     title,
+    count,
     description,
     action,
     // Draw the section on a raised card instead of flush on the page background. For sections that are
@@ -15,6 +16,7 @@ export function SectionCard({
     level = "section",
 }: {
     title?: ReactNode;
+    count?: ReactNode;
     description?: ReactNode;
     action?: ReactNode;
     isRaised?: boolean;
@@ -23,8 +25,15 @@ export function SectionCard({
 }) {
     return (
         <section className={cn("min-w-0", isRaised && "rounded-md border bg-card p-4")}>
-            {(title || action) && (
-                <SectionHeader className="mb-2" level={level} title={title} description={description} action={action} />
+            {(title || count || action) && (
+                <SectionHeader
+                    className="mb-2"
+                    level={level}
+                    title={title}
+                    count={count}
+                    description={description}
+                    action={action}
+                />
             )}
             {children}
         </section>

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates.tsx
@@ -6,7 +6,7 @@ import type { CertificateItem, SecurityClearance } from "@/api/custom-services/c
 import type { AppResponse } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
 import { CardListSkeleton } from "@/components/data/loading-skeletons";
-import { Badge } from "@/components/shadcn/ui/badge";
+import { CountBadge } from "@/components/data/count-badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { CertificateCard } from "@/pages/dashboard/certificates/certificate-card";
 import {
@@ -133,7 +133,7 @@ function CertificateSection({
         <section className="space-y-3">
             <div className="flex items-center gap-2">
                 <Heading variant="label">{title}</Heading>
-                <Badge variant="secondary">{certificates.length}</Badge>
+                <CountBadge>{certificates.length}</CountBadge>
             </div>
             <div className="space-y-3">
                 {certificates.map((certificate) => (

--- a/src/Raven.Quill.Web/src/pages/dashboard/dashboard-apps-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/dashboard-apps-table.tsx
@@ -2,9 +2,9 @@ import type { ReactNode } from "react";
 import { Link } from "react-router";
 import { Database, Pencil, Plus, Trash2 } from "lucide-react";
 import type { ApplianceAppResponse, AppWrites } from "@/api/generated/server-api";
+import { CountBadge } from "@/components/data/count-badge";
 import { StatusIndicator } from "@/components/data/status-indicator";
 import { resolveStatusStyle } from "@/lib/app-status";
-import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Skeleton } from "@/components/shadcn/ui/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/ui/table";
@@ -16,6 +16,7 @@ import { formatCompact } from "@/lib/format";
 import { DeleteAppDialog } from "@/pages/apps/delete-app-dialog";
 import { EditAppConfirmDialog } from "@/pages/setup/add-app-wizard/edit-app-confirm-dialog";
 import { Heading, Text } from "@/components/typography";
+import { SectionHeader } from "@/components/section-header";
 
 export function DashboardAppsTable({
     apps,
@@ -35,12 +36,9 @@ export function DashboardAppsTable({
 
     return (
         <div className="space-y-4">
-            <AppsToolbar
-                count={
-                    <Badge variant="secondary" className="font-mono">
-                        {apps.length}
-                    </Badge>
-                }
+            <SectionHeader
+                title="Apps"
+                count={<CountBadge>{apps.length}</CountBadge>}
                 action={
                     <Button asChild size="sm">
                         <Link to={appRoutes.addApp()}>
@@ -64,25 +62,14 @@ export function DashboardAppsTableSkeleton({ period }: { period: DatePeriod }) {
         <div className="space-y-4">
             {/* The button is drawn rather than rendered: `ApiState` hides the skeleton from the
                 accessibility tree, and a real link in there would still take focus. */}
-            <AppsToolbar
+            <SectionHeader
+                title="Apps"
                 count={<Skeleton className="h-5 w-8 rounded-md" />}
                 action={<Skeleton className="h-8 w-36 rounded-md" />}
             />
             <AppsTableFrame period={period}>
                 <TableSkeletonRows columnCount={APPS_COLUMN_COUNT} rows={4} hasActionColumn />
             </AppsTableFrame>
-        </div>
-    );
-}
-
-function AppsToolbar({ count, action }: { count: ReactNode; action: ReactNode }) {
-    return (
-        <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-                <Heading variant="section">Apps</Heading>
-                {count}
-            </div>
-            {action}
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
@@ -15,7 +15,7 @@ import { ChevronRight } from "lucide-react";
 import type { QuillApplicationUsage } from "@/api/generated/server-api";
 import { InfoHint } from "@/components/data/info-hint";
 import { WruLabel } from "@/components/data/wru-label";
-import { Badge } from "@/components/shadcn/ui/badge";
+import { CountBadge } from "@/components/data/count-badge";
 import { VirtualDataTable, VirtualDataTableSkeleton } from "@/components/table/virtual-data-table";
 import { cn } from "@/lib/utils";
 import { rowKey, SYSTEM_GROUP_DESCRIPTION, toUsageGroups, type UsageGroup } from "@/pages/dashboard/usage-groups";
@@ -114,9 +114,7 @@ function GroupName({
                     <InfoHint content={SYSTEM_GROUP_DESCRIPTION} />
                 </span>
             )}
-            <Badge variant="secondary" className="tabular-nums">
-                {group.rows.length}
-            </Badge>
+            <CountBadge>{group.rows.length}</CountBadge>
         </span>
     );
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-142

### Additional description

**Improves layout on large/wide screens:**

- **`PageContainer` guardrail** — a new max-width container wired into the app shell. Content flows full-width up to ~1920px and only caps (at 1760px, centered) on bigger screens, so normal displays are untouched and 2K+ monitors stop stretching edge-to-edge.
- **Fluid font scaling** — replaces the two abrupt `@media` font-size jumps with a single rem-based `clamp()` that scales smoothly to an 18px ceiling. It now responds continuously to viewport width and honors the reader's browser font-size preference (accessibility improvement).
- **Inline count slot** — adds a `count` slot to `SectionHeader`/`SectionCard` so a total badge sits next to its title (matching "Apps 5") instead of floating at the far edge; applied to the Collections count.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

The changes are app-wide and presentation-only: the shell now caps + centres content on screens wider than ~1920px, and the root font-size scaling moved from stepped media queries to a fluid `clamp`. Both affect the *appearance* of every page on large screens (by design), not their behaviour. The `SectionHeader`/`SectionCard` `count` slot is additive — existing call sites are unchanged.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
