### PR TITLE
Quill-293 Usage view: Rename “Name” column to “Database”

### DIFF
--- a/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
@@ -124,7 +124,7 @@ function GroupName({
 const COLUMNS: ColumnDef<UsageRow>[] = [
     {
         id: "name",
-        header: "Name",
+        header: "Database",
         cell: ({ row }) =>
             isGroup(row.original) ? (
                 <GroupName group={row.original} isExpandable={row.getCanExpand()} isExpanded={row.getIsExpanded()} />

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage.tsx
@@ -84,7 +84,7 @@ export function DashboardUsage() {
             <Card>
                 <CardHeader>
                     <CardTitle asChild>
-                        <h2>Usage per app</h2>
+                        <h2>Usage by database</h2>
                     </CardTitle>
                     <CardDescription>Totals for {periodLabel}.</CardDescription>
                 </CardHeader>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/Quill-293/Usage-view-Rename-Name-column-to-Database

### Additional description
Rename the `Name` column in `Dashboard > Usage > Usage per app` to `Database`.
The rows represent RavenDB app databases, while expanded rows show their topology IDs.
Database describes the column more clearly and still accommodates the @system row.

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
