### PR TITLE
Quill-281 Missing vertical margin for schema group and table rows in Tables list (Map schema)

### DIFF
--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/explorer-rows.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/explorer-rows.tsx
@@ -41,10 +41,15 @@ export function ExplorerRowItem({ row }: { row: ExplorerRow }) {
 }
 
 export function SchemaRow({ label }: { label: string }) {
+    // The vertical padding sits outside the filled band: it separates the header from the
+    // previous group above and from its own first row below. Its height is part of
+    // SCHEMA_ROW_HEIGHT_PX in the explorer.
     return (
-        <Text variant="caption" as="div" className="rounded-sm bg-muted px-1.5 py-1 text-center font-mono">
-            {label}
-        </Text>
+        <div className="py-1">
+            <Text variant="caption" as="div" className="rounded-sm bg-muted px-1.5 py-1 text-center font-mono">
+                {label}
+            </Text>
+        </div>
     );
 }
 
@@ -143,8 +148,11 @@ function TableRowFrame({ row, depth, isDimmed, typeIcon, actions }: TableRowFram
     const collectionName = row.type === "root" ? row.table.collectionName : null;
 
     return (
+        // The frame stays taller than its inner controls so the rounded row highlights get a
+        // visible gap between them, while the frames themselves stay flush to keep the nested
+        // border-l connector line unbroken. Its height is TABLE_ROW_HEIGHT_PX in the explorer.
         <div
-            className={cn("flex h-8 items-center", depth > 0 && "border-l")}
+            className={cn("flex h-9 items-center", depth > 0 && "border-l")}
             style={{ marginLeft: depth * NESTED_TABLE_INDENT_PX }}
         >
             {expandableRow ? (

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/tables-explorer.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/map-tables/tables-explorer.tsx
@@ -17,8 +17,11 @@ import { ExplorerRowItem, SchemaRow } from "@/pages/setup/add-app-wizard/steps/m
 import { getRootTablePath, type ExplorerRow } from "@/pages/setup/add-app-wizard/steps/map-tables/map-tables-types";
 import { useTableActions } from "@/pages/setup/add-app-wizard/steps/map-tables/use-table-actions";
 
-const SCHEMA_ROW_HEIGHT_PX = 24;
-const TABLE_ROW_HEIGHT_PX = 32;
+// Band height (24) plus the py-1 (4 + 4) gap SchemaRow renders around it. The 4px pairs with
+// the 4px a row highlight sits inside its frame, so every inter-item gap lands at 8px.
+const SCHEMA_ROW_HEIGHT_PX = 32;
+// Frame height (h-9); its inner controls are shorter, leaving a gap between row highlights.
+const TABLE_ROW_HEIGHT_PX = 36;
 
 export function TablesExplorer() {
     const { control } = useFormContext<AppFormData>();
@@ -127,7 +130,10 @@ function VirtualizedExplorerRows({ rows }: { rows: ExplorerRow[] }) {
     });
 
     return (
-        <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-y-auto">
+        // -mt-1 cancels the first schema header's top padding (SchemaRow's py-1), so the gap from
+        // the filter input above lands at the same 8px (the container's gap-2) as every in-list gap,
+        // instead of 8 + 4. Headers still separate from each other by that padding inside the list.
+        <div ref={scrollContainerRef} className="-mt-1 min-h-0 flex-1 overflow-y-auto">
             {activeSchemaLabel !== null && (
                 // The negative margin keeps the overlay out of the flow so the list below
                 // starts at the container top. bg-background fills the corner pixels the


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-281

### Additional description

Gives every item in the **Map schema** Tables explorer a uniform **8px** vertical gap. Previously schema headers were flush against their rows, groups ran together, and rows had barely any separation.

Since the list is virtualized (fixed slot heights), the spacing is baked into the slots:

- `SchemaRow` — `py-1` around the band (slot 24 → 32) for separation above and below headers.
- `TableRowFrame` — `h-8` → `h-9` (slot 32 → 36); frames stay flush so the nested border-l line is unbroken, while the shorter highlight shows a gap between rows.
- `mt-1` on the scroll container so the filter→first-header gap is also 8px.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
