### PR TITLE
Quill-300 Showcase the apps in the Usage table in descending usage order

### DIFF
--- a/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.test.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.test.ts
@@ -53,14 +53,21 @@ describe("toUsageGroups", () => {
         expect(group!.isExpandable).toBe(true);
     });
 
-    it("sorts the system group last and keeps apps in the order they arrived", () => {
+    it("sorts apps by usage descending and keeps the system group last", () => {
         const groups = toUsageGroups([
-            row("t9", "quill-config", 40, true),
+            row("t9", "quill-config", 5000, true),
             row("t1", "zeta", 1),
             row("t2", "alpha", 2),
         ]);
 
-        expect(groups.map((g) => g.label)).toEqual(["zeta", "alpha", SYSTEM_GROUP_LABEL]);
+        // System stays last despite its far larger usage; apps above it order by usage descending.
+        expect(groups.map((g) => g.label)).toEqual(["alpha", "zeta", SYSTEM_GROUP_LABEL]);
+    });
+
+    it("breaks a usage tie between apps by label", () => {
+        const groups = toUsageGroups([row("t1", "beta", 10), row("t2", "alpha", 10)]);
+
+        expect(groups.map((g) => g.label)).toEqual(["alpha", "beta"]);
     });
 
     it("never groups an app with a system row that shares its name", () => {

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.ts
@@ -42,7 +42,7 @@ function toGroup(key: string, label: string, isSystem: boolean, rows: QuillAppli
     };
 }
 
-// Apps first, in the order the licence server listed them, then the system group last.
+// Apps first, ordered by usage descending, then the system group last.
 export function toUsageGroups(apps: QuillApplicationUsage[]): UsageGroup[] {
     const byName = new Map<string, QuillApplicationUsage[]>();
     const system: QuillApplicationUsage[] = [];
@@ -58,7 +58,9 @@ export function toUsageGroups(apps: QuillApplicationUsage[]): UsageGroup[] {
         else byName.set(app.applicationName, [app]);
     }
 
-    const groups = Array.from(byName, ([name, rows]) => toGroup(`app/${name}`, name, false, rows));
+    const groups = Array.from(byName, ([name, rows]) => toGroup(`app/${name}`, name, false, rows)).sort(
+        (a, b) => b.usage - a.usage || a.label.localeCompare(b.label),
+    );
 
     if (system.length > 0) groups.push(toGroup(SYSTEM_GROUP_KEY, SYSTEM_GROUP_LABEL, true, system));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-300

### Additional description

The "Usage per app" table previously listed apps in the order the licence server returned them, which had no meaningful ordering for the reader. This sorts the app groups by total WRU descending (ties broken by name) so the heaviest consumers surface first. The @system group is still pinned to the bottom regardless of its usage.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
