### PR TITLE
Quill-29 Standardize how dates are displayed

### DIFF
--- a/src/Raven.Quill.Web/src/components/data/status-indicator.tsx
+++ b/src/Raven.Quill.Web/src/components/data/status-indicator.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { CircleAlert, Loader2Icon, TriangleAlert } from "lucide-react";
 
 import { Badge } from "@/components/shadcn/ui/badge";
@@ -38,7 +38,7 @@ export function StatusIndicator({
     className,
 }: {
     tone: StatusTone;
-    label: string;
+    label: ReactNode;
     title?: string;
     className?: string;
 }) {

--- a/src/Raven.Quill.Web/src/components/data/timestamp.stories.tsx
+++ b/src/Raven.Quill.Web/src/components/data/timestamp.stories.tsx
@@ -1,0 +1,146 @@
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Alert, AlertDescription } from "@/components/shadcn/ui/alert";
+import { Badge } from "@/components/shadcn/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/ui/table";
+import { Heading, Text } from "@/components/typography";
+import { Timestamp } from "./timestamp";
+
+const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60_000).toISOString();
+
+const SAMPLE_CHANNELS = [
+    { name: "Support widget", type: "Web widget", createdAt: minutesAgo(0.5) },
+    { name: "Sales chat", type: "Web widget", createdAt: minutesAgo(19) },
+    { name: "#help-desk", type: "Slack", createdAt: minutesAgo(3 * 60) },
+    { name: "#general", type: "Discord", createdAt: minutesAgo(17 * 60) },
+    { name: "Order updates", type: "Telegram", createdAt: minutesAgo(4 * 24 * 60) },
+    { name: "Returns bot", type: "Slack", createdAt: minutesAgo(3 * 7 * 24 * 60) },
+    { name: "Legacy embed", type: "Web widget", createdAt: minutesAgo(8 * 30 * 24 * 60) },
+    { name: "Pilot widget", type: "Web widget", createdAt: minutesAgo(2 * 365 * 24 * 60) },
+];
+
+// Mirrors the channel cards' stat box, the tightest place a timestamp has to fit.
+function StatBox({ label, value }: { label: string; value: ReactNode }) {
+    return (
+        <div className="rounded-md border bg-muted/30 px-2.5 py-1.5">
+            <div className="text-[11px] text-muted-foreground">{label}</div>
+            <Text as="div" variant="label" className="tabular-nums">
+                {value}
+            </Text>
+        </div>
+    );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+    return (
+        <section className="space-y-2">
+            <Heading as="h3" variant="label">
+                {title}
+            </Heading>
+            {children}
+        </section>
+    );
+}
+
+function TimestampGallery() {
+    const recent = SAMPLE_CHANNELS[3].createdAt;
+
+    return (
+        <div className="space-y-8 p-6">
+            <div className="space-y-1">
+                <Heading as="h2" variant="section">
+                    Timestamp
+                </Heading>
+                <Text variant="muted">
+                    Hover any value for the relative reading. The short variant carries the time of day there too.
+                </Text>
+            </div>
+
+            <Section title={'dateVariant="full" in a table'}>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Channel</TableHead>
+                            <TableHead>Type</TableHead>
+                            <TableHead>Created</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {SAMPLE_CHANNELS.map((channel) => (
+                            <TableRow key={channel.name}>
+                                <TableCell className="font-medium">{channel.name}</TableCell>
+                                <TableCell>
+                                    <Text as="span" variant="muted">
+                                        {channel.type}
+                                    </Text>
+                                </TableCell>
+                                <TableCell>
+                                    <Timestamp value={channel.createdAt} />
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </Section>
+
+            <Section title={'dateVariant="short" on cards'}>
+                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    {SAMPLE_CHANNELS.slice(0, 3).map((channel) => (
+                        <Card key={channel.name}>
+                            <CardHeader>
+                                <CardTitle>{channel.name}</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <div className="grid grid-cols-2 gap-2">
+                                    <StatBox label="Active links" value="3" />
+                                    <StatBox
+                                        label="Added"
+                                        value={
+                                            <Timestamp
+                                                value={channel.createdAt}
+                                                dateVariant="short"
+                                                textVariant="inherit"
+                                            />
+                                        }
+                                    />
+                                </div>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+            </Section>
+
+            <Section title={'textVariant="inherit" inside a sentence'}>
+                <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="success">Token valid</Badge>
+                    <Text as="span" variant="caption">
+                        Last message <Timestamp value={recent} textVariant="inherit" />
+                    </Text>
+                </div>
+                <Alert variant="destructive">
+                    <AlertDescription>
+                        A delivery failed signature verification at <Timestamp value={recent} textVariant="inherit" /> —
+                        the signing secret configured here likely differs from the Slack app&apos;s.
+                    </AlertDescription>
+                </Alert>
+            </Section>
+
+            <Section title="Missing value">
+                <Timestamp value={null} />
+            </Section>
+        </div>
+    );
+}
+
+const meta = {
+    title: "Components/Timestamp",
+    component: TimestampGallery,
+    parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof TimestampGallery>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Gallery: Story = {};

--- a/src/Raven.Quill.Web/src/components/data/timestamp.tsx
+++ b/src/Raven.Quill.Web/src/components/data/timestamp.tsx
@@ -1,0 +1,109 @@
+import type { ComponentProps, ReactNode } from "react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
+import { Text, type TextVariant } from "@/components/typography";
+import { formatDate, formatDateTime, formatRelativeTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+// The one way to show a moment in time: an exact date, with the relative reading in a tooltip.
+// `dateVariant="short"` drops the time of day, which the tooltip then carries instead.
+// `textVariant="inherit"` leaves the type to whatever the value sits inside (an alert, a badge).
+//
+// When the visible trigger is something other than the date itself — a badge that names a state,
+// with the time behind it — wrap that trigger in <TimestampTooltip> so the tooltip reads the same.
+
+type TimestampDateVariant = "full" | "short";
+type TimestampTextVariant = TextVariant | "inherit";
+
+export function Timestamp({
+    value,
+    dateVariant = "full",
+    textVariant = "muted",
+    fallback = "—",
+    className,
+}: {
+    value: string | null | undefined;
+    dateVariant?: TimestampDateVariant;
+    textVariant?: TimestampTextVariant;
+    fallback?: string;
+    className?: string;
+}) {
+    if (!value) {
+        return (
+            <TimestampLabel textVariant={textVariant} className={className}>
+                {fallback}
+            </TimestampLabel>
+        );
+    }
+
+    return (
+        <TimestampTooltip value={value} withDateTime={dateVariant === "short"}>
+            <TimestampLabel textVariant={textVariant} className={className}>
+                {dateVariant === "short" ? formatDate(value) : formatDateTime(value)}
+            </TimestampLabel>
+        </TimestampTooltip>
+    );
+}
+
+export function TimestampTooltip({
+    value,
+    prefix,
+    withDateTime = true,
+    children,
+}: {
+    value: string;
+    prefix?: string;
+    withDateTime?: boolean;
+    children: ReactNode;
+}) {
+    return (
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger asChild>{children}</TooltipTrigger>
+                <TooltipContent className="flex-col items-start gap-0.5">
+                    <TimestampTooltipBody value={value} prefix={prefix} withDateTime={withDateTime} />
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    );
+}
+
+// Its own component so the age is read when the tooltip opens rather than when the trigger rendered
+function TimestampTooltipBody({
+    value,
+    prefix,
+    withDateTime,
+}: {
+    value: string;
+    prefix?: string;
+    withDateTime: boolean;
+}) {
+    const relative = formatRelativeTime(value);
+
+    return (
+        <>
+            <span>{prefix ? `${prefix} ${relative}` : relative}</span>
+            {withDateTime && <span>{formatDateTime(value)}</span>}
+        </>
+    );
+}
+
+function TimestampLabel({
+    textVariant,
+    className,
+    children,
+    ...props
+}: ComponentProps<"span"> & { textVariant: TimestampTextVariant }) {
+    if (textVariant === "inherit") {
+        return (
+            <span className={cn("whitespace-nowrap", className)} {...props}>
+                {children}
+            </span>
+        );
+    }
+
+    return (
+        <Text as="span" variant={textVariant} className={cn("whitespace-nowrap", className)} {...props}>
+            {children}
+        </Text>
+    );
+}

--- a/src/Raven.Quill.Web/src/components/typography.tsx
+++ b/src/Raven.Quill.Web/src/components/typography.tsx
@@ -81,6 +81,8 @@ const textVariants = cva("", {
 
 type TextElement = "p" | "span" | "div";
 
+type TextVariant = NonNullable<VariantProps<typeof textVariants>["variant"]>;
+
 function Text({
     className,
     variant = "body",
@@ -97,4 +99,4 @@ function Text({
     );
 }
 
-export { Heading, headingVariants, Text, textVariants };
+export { Heading, headingVariants, Text, textVariants, type TextVariant };

--- a/src/Raven.Quill.Web/src/lib/format.ts
+++ b/src/Raven.Quill.Web/src/lib/format.ts
@@ -8,12 +8,58 @@ export function formatCompact(value: number): string {
     return compactNumberFormatter.format(value);
 }
 
-const fullDateFormatter = new Intl.DateTimeFormat("en-US", { month: "long", day: "numeric", year: "numeric" });
+// Prefer <Timestamp> over calling these directly.
+const dateFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" });
+const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+});
 
-// Full date, e.g. "July 14, 2026". Falls back to the raw value if it doesn't parse.
+// e.g. "Jul 14, 2026". Falls back to the raw value if it doesn't parse.
 export function formatDate(value: string): string {
     const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? value : fullDateFormatter.format(date);
+    return Number.isNaN(date.getTime()) ? value : dateFormatter.format(date);
+}
+
+// e.g. "Jul 14, 2026, 3:28 PM". Falls back to the raw value if it doesn't parse.
+export function formatDateTime(value: string): string {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? value : dateTimeFormatter.format(date);
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+// Largest unit first: a duration is shown in the biggest unit it fills at least once.
+const RELATIVE_TIME_UNITS: { unit: Intl.RelativeTimeFormatUnit; ms: number }[] = [
+    { unit: "year", ms: 365 * DAY_MS },
+    { unit: "month", ms: 30 * DAY_MS },
+    { unit: "week", ms: 7 * DAY_MS },
+    { unit: "day", ms: DAY_MS },
+    { unit: "hour", ms: HOUR_MS },
+    { unit: "minute", ms: MINUTE_MS },
+];
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat("en-US", { numeric: "always", style: "long" });
+
+// e.g. "17 hours ago", "1 day ago", "in 3 days".
+export function formatRelativeTime(value: string): string {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    const elapsedMs = date.getTime() - Date.now();
+    for (const { unit, ms } of RELATIVE_TIME_UNITS) {
+        if (Math.abs(elapsedMs) >= ms) {
+            return relativeTimeFormatter.format(Math.round(elapsedMs / ms), unit);
+        }
+    }
+    return "just now";
 }
 
 const DURATION_UNITS = [

--- a/src/Raven.Quill.Web/src/lib/utils.ts
+++ b/src/Raven.Quill.Web/src/lib/utils.ts
@@ -14,53 +14,6 @@ export function tryParseJson<T>(value: string): T | null {
     }
 }
 
-// Renders an ISO timestamp in the viewer's locale; falls back to the raw value
-// if it isn't a parseable date.
-export function formatDateTime(value: string) {
-    const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
-}
-
-const SECOND_MS = 1000;
-const MINUTE_MS = 60 * SECOND_MS;
-const HOUR_MS = 60 * MINUTE_MS;
-const DAY_MS = 24 * HOUR_MS;
-const WEEK_MS = 7 * DAY_MS;
-const MONTH_MS = 30 * DAY_MS;
-const YEAR_MS = 365 * DAY_MS;
-
-// Largest unit first: a duration is shown in the biggest unit it fills at least once.
-const RELATIVE_TIME_UNITS: { unit: Intl.RelativeTimeFormatUnit; ms: number }[] = [
-    { unit: "year", ms: YEAR_MS },
-    { unit: "month", ms: MONTH_MS },
-    { unit: "week", ms: WEEK_MS },
-    { unit: "day", ms: DAY_MS },
-    { unit: "hour", ms: HOUR_MS },
-    { unit: "minute", ms: MINUTE_MS },
-    { unit: "second", ms: SECOND_MS },
-];
-
-// "always" (not "auto") so a value just past the day boundary reads "in 1 day" rather than
-// "tomorrow" — the vaguer word can clash with a caller's own warning threshold (see getExpiryStatus).
-const relativeTimeFormatter = new Intl.RelativeTimeFormat("en", { numeric: "always", style: "narrow" });
-
-// Renders an ISO timestamp or epoch milliseconds as a short relative label (e.g. "19m ago",
-// "1h ago"); falls back to the raw value if it isn't a parseable date.
-export function formatRelativeTime(value: string | number) {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return String(value);
-    }
-
-    const elapsedMs = date.getTime() - Date.now();
-    for (const { unit, ms } of RELATIVE_TIME_UNITS) {
-        if (Math.abs(elapsedMs) >= ms) {
-            return relativeTimeFormatter.format(Math.round(elapsedMs / ms), unit);
-        }
-    }
-    return "now"; // sub-second differences
-}
-
 export async function copyToClipboard(value: string) {
     try {
         await navigator.clipboard.writeText(value);

--- a/src/Raven.Quill.Web/src/pages/apps/agents-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/agents-section.tsx
@@ -7,9 +7,9 @@ import { EnabledStatus } from "@/components/data/status-indicator";
 import { Button } from "@/components/shadcn/ui/button";
 import { TableCell, TableRow } from "@/components/shadcn/ui/table";
 import { SectionTable, SectionTableSkeleton } from "@/components/table/section-table";
+import { Timestamp } from "@/components/data/timestamp";
 import { appRoutes } from "@/lib/app-routes";
 import { formatCompact } from "@/lib/format";
-import { formatDateTime } from "@/lib/utils";
 import { DeleteAgentDialog } from "@/pages/apps/agents/delete-agent-dialog";
 import { SectionCard } from "@/pages/apps/section-card";
 
@@ -50,8 +50,8 @@ export function AgentsTable({ slug }: { slug: string }) {
                             <TableCell className="font-mono text-xs text-muted-foreground">
                                 {agent.model ?? "—"}
                             </TableCell>
-                            <TableCell className="whitespace-nowrap text-muted-foreground">
-                                {agent.lastInvokedAt ? formatDateTime(agent.lastInvokedAt) : "—"}
+                            <TableCell>
+                                <Timestamp value={agent.lastInvokedAt} />
                             </TableCell>
                             <TableCell className="tabular-nums">{formatCompact(agent.conversations)}</TableCell>
                             <TableCell className="tabular-nums">{formatCompact(agent.messages)}</TableCell>

--- a/src/Raven.Quill.Web/src/pages/apps/app-data-source.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-data-source.tsx
@@ -8,8 +8,8 @@ import { DetailHeader, DetailHeaderMenu, DetailHeaderMetaItem } from "@/componen
 import { StatusIndicator } from "@/components/data/status-indicator";
 import { ConfirmDialog } from "@/components/shadcn/ui/confirm-dialog";
 import { DropdownMenuItem } from "@/components/shadcn/ui/dropdown-menu";
+import { Timestamp } from "@/components/data/timestamp";
 import { resolveStatusStyle } from "@/lib/app-status";
-import { formatDate } from "@/lib/format";
 import { CdcPerformanceSection } from "@/pages/apps/cdc-performance-section";
 import { CollectionsSection } from "@/pages/apps/collections-section";
 import { appRoutes } from "@/lib/app-routes";
@@ -44,8 +44,9 @@ export function AppDataSource() {
                             <DetailHeaderMetaItem icon={Database} mono tooltip="Source database">
                                 {appQuery.data.database}
                             </DetailHeaderMetaItem>
-                            <DetailHeaderMetaItem icon={CalendarClock} tooltip="Connected">
-                                {formatDate(appQuery.data.createdAt)}
+                            <DetailHeaderMetaItem icon={CalendarClock}>
+                                Connected{" "}
+                                <Timestamp value={appQuery.data.createdAt} dateVariant="short" textVariant="inherit" />
                             </DetailHeaderMetaItem>
                         </>
                     )

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-errors-sheet.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-errors-sheet.tsx
@@ -7,6 +7,7 @@ import { ApiState } from "@/components/data/api-state";
 import { ErrorDetails } from "@/components/data/error-details";
 import { CardListSkeleton } from "@/components/data/loading-skeletons";
 import { Badge } from "@/components/shadcn/ui/badge";
+import { Timestamp } from "@/components/data/timestamp";
 import {
     Sheet,
     SheetContent,
@@ -16,7 +17,6 @@ import {
     SheetTrigger,
 } from "@/components/shadcn/ui/sheet";
 import { formatCompact } from "@/lib/format";
-import { formatDateTime } from "@/lib/utils";
 
 export function CdcErrorsSheet({ slug, trigger }: { slug: string; trigger: ReactNode }) {
     const [isOpen, setIsOpen] = useState(false);
@@ -66,9 +66,7 @@ function CdcErrorCard({ error }: { error: CdcError }) {
                 <Text as="span" variant="label">
                     {error.taskName}
                 </Text>
-                <Text as="span" variant="caption">
-                    {formatDateTime(error.createdAt)}
-                </Text>
+                <Timestamp value={error.createdAt} textVariant="caption" />
             </div>
             <Badge variant="secondary">{error.step}</Badge>
             {shortMessage && <p className="text-sm break-words whitespace-pre-wrap text-destructive">{shortMessage}</p>}

--- a/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
@@ -15,8 +15,9 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/shadc
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/shadcn/ui/select";
 import { Skeleton } from "@/components/shadcn/ui/skeleton";
 import { Heading, Text } from "@/components/typography";
+import { Timestamp } from "@/components/data/timestamp";
 import { appRoutes } from "@/lib/app-routes";
-import { cn, formatDateTime, formatRelativeTime } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { DiscordIcon, SlackIcon } from "@/pages/apps/channels/channel-brand-icons";
 import { DeleteChannelDialog } from "@/pages/apps/channels/delete-channel-dialog";
 import { GenerateEmbedLinkDialog } from "@/pages/apps/channels/generate-embed-link-dialog";
@@ -322,11 +323,7 @@ function ChannelCard({
                     )}
                     <StatBox
                         label="Added"
-                        value={
-                            <span title={formatDateTime(channel.createdAt)}>
-                                {formatRelativeTime(channel.createdAt)}
-                            </span>
-                        }
+                        value={<Timestamp value={channel.createdAt} dateVariant="short" textVariant="inherit" />}
                     />
                 </div>
             </CardContent>

--- a/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels-section.tsx
@@ -10,13 +10,13 @@ import { TableCell, TableRow } from "@/components/shadcn/ui/table";
 import { SectionTable, SectionTableSkeleton } from "@/components/table/section-table";
 import { appRoutes } from "@/lib/app-routes";
 import { CHANNEL_TYPE_LABELS } from "@/lib/channel-type-labels";
-import { formatDateTime } from "@/lib/utils";
 import { AddChannelMenu } from "@/pages/apps/channels/add-channel-menu";
 import type { FixedAgent } from "@/pages/apps/channels/web-widget-channel-form";
 import { GenerateEmbedLinkDialog } from "@/pages/apps/channels/generate-embed-link-dialog";
 import { DeleteChannelDialog } from "@/pages/apps/channels/delete-channel-dialog";
 import { SectionCard } from "@/pages/apps/section-card";
 import { Text } from "@/components/typography";
+import { Timestamp } from "@/components/data/timestamp";
 
 // When `agent` is set the section is scoped to that single agent: only its channels are listed,
 // the agent name column is dropped, and new channels are routed to it (e.g. the capability wizard).
@@ -123,8 +123,8 @@ export function ChannelsSection({
                                             (activeLinkCounts.get(channel.channelId) ?? 0).toLocaleString()
                                         )}
                                     </TableCell>
-                                    <TableCell className="text-muted-foreground">
-                                        {formatDateTime(channel.createdAt)}
+                                    <TableCell>
+                                        <Timestamp value={channel.createdAt} />
                                     </TableCell>
                                     <TableCell className="text-right">
                                         <div className="flex items-center justify-end gap-1">

--- a/src/Raven.Quill.Web/src/pages/apps/channels/channel-active-links-columns.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/channel-active-links-columns.tsx
@@ -6,8 +6,9 @@ import type { EmbedLinkSummaryResponse } from "@/api/generated/server-api";
 import { Parameters } from "@/components/data/parameters";
 import { StatusIndicator } from "@/components/data/status-indicator";
 import { Button } from "@/components/shadcn/ui/button";
-import { copyToClipboard, formatDateTime } from "@/lib/utils";
-import { type EmbedLinkStatusTone, getExpiryStatus, getUsageStatus } from "@/pages/apps/channels/embed-link-status";
+import { Timestamp } from "@/components/data/timestamp";
+import { copyToClipboard } from "@/lib/utils";
+import { type EmbedLinkStatusTone, getExpiryTone, getUsageStatus } from "@/pages/apps/channels/embed-link-status";
 import { buildEmbedUrl } from "@/pages/apps/channels/embed-link-utils";
 import { PreviewEmbedLinkDialog } from "@/pages/apps/channels/preview-embed-link-dialog";
 import { RevokeEmbedLinkDialog } from "@/pages/apps/channels/revoke-embed-link-dialog";
@@ -35,15 +36,12 @@ export function createActiveLinkColumns(slug: string): ColumnDef<EmbedLinkSummar
         {
             accessorKey: "createdAt",
             header: "Created",
-            cell: ({ row }) => <span className="text-muted-foreground">{formatDateTime(row.original.createdAt)}</span>,
+            cell: ({ row }) => <Timestamp value={row.original.createdAt} />,
         },
         {
             accessorKey: "expiresAt",
             header: "Expires",
-            cell: ({ row }) => {
-                const status = getExpiryStatus(row.original.expiresAt);
-                return <StatusValue tone={status.tone} title={status.title} label={status.label} />;
-            },
+            cell: ({ row }) => <ExpiryValue expiresAt={row.original.expiresAt} />,
         },
         {
             id: "usage",
@@ -63,8 +61,27 @@ export function createActiveLinkColumns(slug: string): ColumnDef<EmbedLinkSummar
     ];
 }
 
-// Renders an expiry/usage value, escalating from plain text to a status badge once the
-// link needs attention so problem rows stand out at a glance.
+// Escalates from plain text to a status badge once the link needs attention, so problem rows
+// stand out at a glance. Usage values below follow the same rule.
+function ExpiryValue({ expiresAt }: { expiresAt: string }) {
+    const tone = getExpiryTone(expiresAt);
+    if (tone === "normal") {
+        return <Timestamp value={expiresAt} />;
+    }
+
+    return (
+        <StatusIndicator
+            tone={tone === "critical" ? "danger" : "warning"}
+            label={
+                <>
+                    {tone === "critical" ? "Expired" : "Expires"}
+                    <Timestamp value={expiresAt} textVariant="inherit" />
+                </>
+            }
+        />
+    );
+}
+
 function StatusValue({ tone, title, label }: { tone: EmbedLinkStatusTone; title: string; label: string }) {
     if (tone === "normal") {
         return (

--- a/src/Raven.Quill.Web/src/pages/apps/channels/discord-status-panel.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/discord-status-panel.tsx
@@ -7,9 +7,9 @@ import { NumberedSteps, type NumberedStep } from "@/components/data/numbered-ste
 import { Alert, AlertDescription } from "@/components/shadcn/ui/alert";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Text } from "@/components/typography";
+import { Timestamp, TimestampTooltip } from "@/components/data/timestamp";
 import { DiscordIcon } from "@/pages/apps/channels/channel-brand-icons";
 import { discordInstallUrl } from "@/pages/apps/channels/discord-app-setup";
-import { formatDateTime, formatRelativeTime } from "@/lib/utils";
 
 function useDiscordHealth(slug: string, channelId: string) {
     const healthQuery = useQuery(api.queries.discord.health(slug));
@@ -71,8 +71,8 @@ function DiscordConnectionCardBody({ health }: { health: DiscordChannelHealthRes
                         <DiscordGatewayBadge health={health} />
                     </div>
                     {health.lastInboundAt ? (
-                        <Text as="span" variant="caption" title={formatDateTime(health.lastInboundAt)}>
-                            Last message {formatRelativeTime(health.lastInboundAt)}
+                        <Text as="span" variant="caption">
+                            Last message <Timestamp value={health.lastInboundAt} textVariant="inherit" />
                         </Text>
                     ) : (
                         <Text as="span" variant="caption">
@@ -155,13 +155,15 @@ function DiscordGatewayBadge({ health }: { health: DiscordChannelHealthResponse 
     }
 
     if (health.gatewayConnected) {
+        const badge = <Badge variant="success">Gateway connected</Badge>;
+        if (!health.lastConnectedAt) {
+            return badge;
+        }
+
         return (
-            <Badge
-                variant="success"
-                title={health.lastConnectedAt ? formatDateTime(health.lastConnectedAt) : undefined}
-            >
-                Gateway connected
-            </Badge>
+            <TimestampTooltip value={health.lastConnectedAt} prefix="Connected">
+                {badge}
+            </TimestampTooltip>
         );
     }
 

--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-preview.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-preview.tsx
@@ -3,7 +3,8 @@ import { Text } from "@/components/typography";
 import { CopyableCode } from "@/components/data/copyable-code";
 import { Field, FieldLabel } from "@/components/shadcn/ui/field";
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/shadcn/ui/input-group";
-import { formatDateTime, copyToClipboard } from "@/lib/utils";
+import { Timestamp } from "@/components/data/timestamp";
+import { copyToClipboard } from "@/lib/utils";
 
 type EmbedLinkPreviewProps = {
     url: string;
@@ -41,7 +42,8 @@ export function EmbedLinkPreview({ url, expiresAt, maxInvocations }: EmbedLinkPr
                 <CopyableCode code={iframeSnippet} copyLabel="Copy embed snippet" />
             </Field>
             <Text variant="caption">
-                Expires {formatDateTime(expiresAt)} · up to {maxInvocations.toLocaleString()} chats.
+                Expires <Timestamp value={expiresAt} textVariant="inherit" /> · up to {maxInvocations.toLocaleString()}{" "}
+                chats.
             </Text>
             <iframe
                 src={url}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-status.ts
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-status.ts
@@ -1,5 +1,3 @@
-import { formatDateTime, formatRelativeTime } from "@/lib/utils";
-
 // "normal" links need no attention; "warning" links are close to expiry/limit;
 // "critical" links have already expired or exhausted their invocations.
 export type EmbedLinkStatusTone = "normal" | "warning" | "critical";
@@ -17,19 +15,17 @@ export type EmbedLinkStatus = {
     title: string;
 };
 
-export function getExpiryStatus(expiresAt: string, now: number = Date.now()): EmbedLinkStatus {
+export function getExpiryTone(expiresAt: string, now: number = Date.now()): EmbedLinkStatusTone {
     const expiry = new Date(expiresAt).getTime();
     if (Number.isNaN(expiry)) {
-        return { tone: "normal", label: expiresAt, title: expiresAt };
+        return "normal";
     }
 
     const remainingMs = expiry - now;
     if (remainingMs <= 0) {
-        return { tone: "critical", label: "Expired", title: `Expired ${formatDateTime(expiresAt)}` };
+        return "critical";
     }
-
-    const tone: EmbedLinkStatusTone = remainingMs <= EXPIRY_SOON_MS ? "warning" : "normal";
-    return { tone, label: formatRelativeTime(expiresAt), title: `Expires ${formatDateTime(expiresAt)}` };
+    return remainingMs <= EXPIRY_SOON_MS ? "warning" : "normal";
 }
 
 export function getUsageStatus(invocationCount: number, maxInvocations: number): EmbedLinkStatus {

--- a/src/Raven.Quill.Web/src/pages/apps/channels/slack-connection-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/slack-connection-card.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import type { SlackSummaryResponse } from "@/api/generated/server-api";
-import { Alert } from "@/components/shadcn/ui/alert";
+import { Alert, AlertDescription } from "@/components/shadcn/ui/alert";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Text } from "@/components/typography";
+import { Timestamp } from "@/components/data/timestamp";
 import { SlackIcon } from "@/pages/apps/channels/channel-brand-icons";
-import { formatDateTime, formatRelativeTime } from "@/lib/utils";
 
 // The connection identity + live health for a Slack channel: which workspace and bot it is wired to,
 // whether the token still works, when the last message arrived, and any recent delivery failure. Shown
@@ -49,8 +49,8 @@ export function SlackConnectionCard({
                 <div className="flex flex-wrap items-center gap-2 text-sm">
                     <SlackTokenBadge tokenValid={health?.tokenValid} tokenError={health?.tokenError} />
                     {health?.lastInboundAt ? (
-                        <Text as="span" variant="caption" title={formatDateTime(health.lastInboundAt)}>
-                            Last message {formatRelativeTime(health.lastInboundAt)}
+                        <Text as="span" variant="caption">
+                            Last message <Timestamp value={health.lastInboundAt} textVariant="inherit" />
                         </Text>
                     ) : (
                         <Text as="span" variant="caption">
@@ -62,17 +62,27 @@ export function SlackConnectionCard({
 
             {hasRecentSignatureFailure && health?.lastSignatureFailureAt && (
                 <Alert variant="destructive">
-                    A delivery failed signature verification {formatRelativeTime(health.lastSignatureFailureAt)} — the
-                    signing secret configured here likely differs from the Slack app&apos;s. Rotate the signing secret
-                    on this channel to match.
+                    <AlertDescription>
+                        A delivery failed signature verification at{" "}
+                        <Timestamp value={health.lastSignatureFailureAt} textVariant="inherit" /> — the signing secret
+                        configured here likely differs from the Slack app&apos;s. Rotate the signing secret on this
+                        channel to match.
+                    </AlertDescription>
                 </Alert>
             )}
 
             {health?.lastSendError && (
                 <Alert variant="destructive">
-                    The bot couldn&apos;t deliver a reply
-                    {health.lastSendErrorAt ? ` ${formatRelativeTime(health.lastSendErrorAt)}` : ""}:{" "}
-                    {health.lastSendError}
+                    <AlertDescription>
+                        The bot couldn&apos;t deliver a reply
+                        {health.lastSendErrorAt ? (
+                            <>
+                                {" at "}
+                                <Timestamp value={health.lastSendErrorAt} textVariant="inherit" />
+                            </>
+                        ) : null}
+                        : {health.lastSendError}
+                    </AlertDescription>
                 </Alert>
             )}
         </div>

--- a/src/Raven.Quill.Web/src/pages/apps/conversations/conversation-transcript-sheet.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/conversations/conversation-transcript-sheet.tsx
@@ -7,6 +7,7 @@ import { api } from "@/api/api";
 import type { AiConversationMessage, ConversationParam } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
 import { CardListSkeleton } from "@/components/data/loading-skeletons";
+import { Timestamp } from "@/components/data/timestamp";
 import {
     Sheet,
     SheetContent,
@@ -15,7 +16,7 @@ import {
     SheetTitle,
     SheetTrigger,
 } from "@/components/shadcn/ui/sheet";
-import { cn, formatDateTime } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { ConversationParams } from "@/pages/apps/conversations/conversation-params";
 import { ConversationSystemPrompt } from "@/pages/apps/conversations/conversation-system-prompt";
 import { ConversationToolCall } from "@/pages/apps/conversations/conversation-tool-call";
@@ -175,11 +176,7 @@ function TranscriptTurn({ turn, turnKey }: { turn: AiConversationMessage; turnKe
                         <Streamdown>{content}</Streamdown>
                     </div>
                 ))}
-            {turn.timestamp && (
-                <Text as="span" variant="caption">
-                    {formatDateTime(turn.timestamp)}
-                </Text>
-            )}
+            {turn.timestamp && <Timestamp value={turn.timestamp} textVariant="caption" />}
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/apps/conversations/conversations-columns.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/conversations/conversations-columns.tsx
@@ -5,7 +5,7 @@ import { MessageSquareText } from "lucide-react";
 import type { ConversationDto } from "@/api/generated/server-api";
 import { Parameters } from "@/components/data/parameters";
 import { Button } from "@/components/shadcn/ui/button";
-import { formatDateTime, formatRelativeTime } from "@/lib/utils";
+import { Timestamp } from "@/components/data/timestamp";
 import { agentAvatarColor } from "@/lib/palette";
 import { ConversationStateDot } from "@/pages/apps/conversations/conversation-state";
 import { ConversationTranscriptSheet } from "@/pages/apps/conversations/conversation-transcript-sheet";
@@ -41,13 +41,11 @@ export function createConversationColumns(slug: string): ColumnDef<ConversationD
         {
             accessorKey: "lastActivityAt",
             header: "Last activity",
-            size: 140,
+            size: 200,
             cell: ({ row }) => (
-                <span className="flex items-center gap-2 whitespace-nowrap text-muted-foreground">
+                <span className="flex items-center gap-2">
                     <ConversationStateDot state={row.original.state} />
-                    <span title={formatDateTime(row.original.lastActivityAt)}>
-                        {formatRelativeTime(row.original.lastActivityAt)}
-                    </span>
+                    <Timestamp value={row.original.lastActivityAt} />
                 </span>
             ),
         },

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-card.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-card.tsx
@@ -3,10 +3,10 @@ import { Copy } from "lucide-react";
 import type { CertificateItem } from "@/api/custom-services/certificates-service";
 import type { AppResponse } from "@/api/generated/server-api";
 import { StatusIndicator, type StatusTone } from "@/components/data/status-indicator";
+import { Timestamp } from "@/components/data/timestamp";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Heading, Text } from "@/components/typography";
-import { formatDate } from "@/lib/format";
 import { cn, copyToClipboard } from "@/lib/utils";
 import {
     CERTIFICATE_STATE_LABELS,
@@ -81,13 +81,13 @@ export function CertificateCard({ certificate, apps }: { certificate: Certificat
                         {SECURITY_CLEARANCE_LABELS[certificate.securityClearance]}
                     </CertificateField>
                     <CertificateField label="Valid from">
-                        {certificate.notBefore ? formatDate(certificate.notBefore) : "—"}
+                        <Timestamp value={certificate.notBefore} dateVariant="short" textVariant="inherit" />
                     </CertificateField>
                     <CertificateField label="Expiration">
                         <span
                             className={cn(state === "expired" && "text-destructive", isAboutToExpire && "text-warning")}
                         >
-                            {certificate.notAfter ? formatDate(certificate.notAfter) : "—"}
+                            <Timestamp value={certificate.notAfter} dateVariant="short" textVariant="inherit" />
                         </span>
                     </CertificateField>
                     <CertificateField label="App access">

--- a/src/Raven.Quill.Web/src/pages/dashboard/license.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/license.tsx
@@ -5,10 +5,10 @@ import type { ConnectivityStatus, LicensePlan, ServerLicenseResponse } from "@/a
 import { ApiState } from "@/components/data/api-state";
 import { DetailGridSkeleton } from "@/components/data/loading-skeletons";
 import { ConnectivityMetric } from "@/components/data/connectivity-metric";
+import { Timestamp } from "@/components/data/timestamp";
 import { Badge } from "@/components/shadcn/ui/badge";
 import { Button } from "@/components/shadcn/ui/button";
 import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
-import { formatDate } from "@/lib/format";
 import { getSupportUrl } from "@/lib/help-links";
 import { cn } from "@/lib/utils";
 import { Heading, Text } from "@/components/typography";
@@ -78,7 +78,7 @@ function LicenseSummaryCard({ license }: { license: ServerLicenseResponse }) {
                         Expiration date
                     </Text>
                     <Text as="div" variant="label">
-                        {formatDate(license.expiration)}
+                        <Timestamp value={license.expiration} dateVariant="short" textVariant="inherit" />
                     </Text>
                 </div>
                 <div className="space-y-1">


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/Quill-29/Quill-Standardise-how-dates-are-displayed

### Additional description

<img width="1208" height="916" alt="image" src="https://github.com/user-attachments/assets/3bfb308c-1de5-4967-bd6d-f574c046b3fa" />

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
