### PR TITLE
RavenDB-27447 Do not use entry scan for scored queries

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/PlanEmitter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/PlanEmitter.cs
@@ -21,7 +21,11 @@ internal sealed class PlanEmitter
             return ([new PlanOp { Kind = PlanOpKind.FillFromMatch, ParamIndex = 0 }], 2);
 
         var emitter = new PlanEmitter();
-        var (ops, bitmaps) = template.IsOr ? emitter.EmitOrPlan(executions) : emitter.EmitAndPlan(executions, scanEligible);
+        // Entry scan filters candidates without going through the matches, so a scored query cannot use it either:
+        // the scanned clauses would contribute nothing to the score.
+        var (ops, bitmaps) = template.IsOr
+            ? emitter.EmitOrPlan(executions)
+            : emitter.EmitAndPlan(executions, scanEligible && planParams.HasBoost == false);
         if (planParams.HasBoost)
         {
             // we require query match for boost, because the other options cannot compute it

--- a/test/SlowTests.Issues/Issues/RavenDB_27447.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27447.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27447(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class Doc
+    {
+        public string Id { get; set; }
+        public string A { get; set; }
+        public string B { get; set; }
+    }
+
+    private class Probe_Index : AbstractIndexCreationTask<Doc>
+    {
+        public Probe_Index()
+        {
+            Map = docs => from d in docs select new { d.A, d.B };
+            Configuration[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = "true";
+        }
+    }
+
+    private class ScoreOnly
+    {
+        public double Score { get; set; }
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void EntryScanMustNotDropClausesFromTheScore()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < 100_000; i++)
+                bulk.Store(new Doc { A = i % 100 == 0 ? "aaa" : "filler", B = i % 50 == 0 ? "bbb" : "other" });
+        }
+
+        new Probe_Index().Execute(store);
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(10));
+
+        double Score(string where, int? forcedEntryScanGate = null)
+        {
+            using var session = store.OpenSession();
+            var query = session.Advanced
+                .RawQuery<ScoreOnly>($@"from index 'Probe/Index' as m where {where} order by score()
+                                        select {{ Score: getMetadata(m)[""@index-score""] }} limit 1");
+
+            if (forcedEntryScanGate.HasValue)
+                query = query.AddParameter("rvn_corax_entry_scan", forcedEntryScanGate.Value);
+
+            return query.ToList().Select(x => x.Score).First();
+        }
+
+        var a = Score("m.A = 'aaa'");
+        var b = Score("m.B = 'bbb'");
+        var and = Score("m.A = 'aaa' and m.B = 'bbb'");
+
+        output.WriteLine($"a={a:G6} b={b:G6} and={and:G6}");
+
+        // BM25 sums the per-term contributions, so an AND of two terms scores as both of them together.
+        Assert.Equal(a + b, and, precision: 4);
+
+        // Forcing the entry-scan gate must not change that: scanning filters candidates without going through the
+        // matches, so the scanned clause used to contribute nothing and the score fell back to the first term alone.
+        for (int gate = 0; gate < 3; gate++)
+        {
+            var scanned = Score("m.A = 'aaa' and m.B = 'bbb'", gate);
+            output.WriteLine($"gate {gate}: {scanned:G6}");
+            Assert.Equal(and, scanned, precision: 4);
+        }
+    }
+}


### PR DESCRIPTION
A scored query that switches to entry scan loses the scanned clauses from `@index-score` - `A and B` scores as `A` alone (expected 1.62518 + 1.36062 = 2.9858, returned 1.62518). `PlanEmitter.Emit` already rewrites every op to its `*FromMatch` variant when `HasBoost` is set, but `ToMatchVariant` does not cover `MaybeEntryScan`, so the scan gate survives - and entry scan filters candidates without touching the matches, which is where frequencies reach BM25.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27447

### Additional description

Fix: do not emit the gate for scored queries. Everything else keeps the optimization.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Queries with `order by score()` / `boost()` no longer take the entry-scan path: they lose that optimization and return correct scores instead. Queries without scoring are unaffected.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed