### PR TITLE
Quill-304 Connection fields are active and misleading before a source database type is chosen

### DIFF
--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
@@ -12,6 +12,7 @@ import { TestConnectionButton } from "@/pages/setup/add-app-wizard/steps/connect
 import { toSlug } from "@/pages/setup/add-app-wizard/slugify";
 import { InputGroupAddon } from "@/components/shadcn/ui/input-group";
 import { Button } from "@/components/shadcn/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
 import { RefreshCw } from "lucide-react";
 
 export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
@@ -27,6 +28,8 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
         field: { value },
         fieldState: { error, invalid },
     } = useController({ control, name: "externalConnection.provider" });
+
+    const isProviderSelected = Boolean(value);
 
     return (
         <div className="grid gap-5">
@@ -106,8 +109,21 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
                 </div>
                 {error?.message && <FieldDescription className="text-destructive">{error.message}</FieldDescription>}
             </Field>
-            <ConnectionEditor isDisabled={isBusy} />
-            <TestConnectionButton disabled={isBusy} />
+            <TooltipProvider>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <div className="grid gap-5">
+                            <ConnectionEditor isDisabled={isBusy || !isProviderSelected} />
+                            <TestConnectionButton disabled={isBusy || !isProviderSelected} />
+                        </div>
+                    </TooltipTrigger>
+                    {!isProviderSelected && !isBusy && (
+                        <TooltipContent>
+                            Select a source database type to fill in its connection details.
+                        </TooltipContent>
+                    )}
+                </Tooltip>
+            </TooltipProvider>
         </div>
     );
 }

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connection-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connection-editor.tsx
@@ -8,9 +8,9 @@ import { DEFAULT_PORT_BY_PROVIDER, type Provider, type SslMode } from "@/pages/s
 import { useConnectionSync } from "@/pages/setup/add-app-wizard/steps/connect/use-connection-sync";
 
 const CONNECTION_STRING_PLACEHOLDER_BY_PROVIDER: Record<Provider, string> = {
-    Npgsql: "Host=localhost;Port=5432;Database=my_db;Username=admin;Password=pass",
-    SqlClient: "Server=localhost,1433;Database=my_db;User ID=sa;Password=pass",
-    MySqlConnectorFactory: "Server=localhost;Port=3306;Database=my_db;User ID=admin;Password=pass",
+    Npgsql: "e.g. Host=localhost;Port=5432;Database=my_db;Username=admin;Password=pass",
+    SqlClient: "e.g. Server=localhost,1433;Database=my_db;User ID=sa;Password=pass",
+    MySqlConnectorFactory: "e.g. Server=localhost;Port=3306;Database=my_db;User ID=admin;Password=pass",
 };
 
 const SSL_OPTIONS: FormToggleGroupOption<SslMode>[] = [
@@ -69,7 +69,7 @@ function ConnectionFieldsEditor({ isDisabled }: { isDisabled: boolean }) {
                     name="externalConnection.fields.port"
                     label="Port"
                     type="number"
-                    placeholder={provider ? String(DEFAULT_PORT_BY_PROVIDER[provider]) : undefined}
+                    placeholder={provider ? `e.g. ${DEFAULT_PORT_BY_PROVIDER[provider]}` : undefined}
                     disabled={isDisabled}
                 />
             </div>


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-304

### Additional description

In the "Connect to your source database" step, the connection editor and Test connection button are now disabled until a source database type is chosen. A tooltip on hover explains why the section is disabled ("Select a source database type to fill in its connection details").

Also prefixed the port and connection-string placeholders with "e.g." for consistency with the other fields.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
