### PR TITLE
Quill-182 Enforce repo test conventions on the QuillTests assembly

### DIFF
--- a/test/QuillTests/AgentParameterValueTests.cs
+++ b/test/QuillTests/AgentParameterValueTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using FastTests;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Quill.Agents;
 using Tests.Infrastructure;
@@ -6,7 +7,7 @@ using Xunit;
 
 namespace QuillTests;
 
-public class AgentParameterValueTests
+public class AgentParameterValueTests(ITestOutputHelper output) : NoDisposalNeeded(output)
 {
     [RavenTheory(RavenTestCategory.Quill)]
     [InlineData(AiAgentParameterValueType.Number, "42", "42")]

--- a/test/QuillTests/TestsInheritanceTests.cs
+++ b/test/QuillTests/TestsInheritanceTests.cs
@@ -1,0 +1,5 @@
+using Xunit;
+
+namespace QuillTests;
+
+public class TestsInheritanceTests(ITestOutputHelper output) : SlowTests.Tests.TestsInheritanceTests(output);

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -23,7 +23,7 @@ namespace SlowTests.Tests
         [RavenMultiplatformFact(RavenTestCategory.Codebase, RavenPlatform.Windows | RavenPlatform.OsX)]
         public void NonDisposableTestShouldNotExist()
         {
-            var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
+            var types = from assembly in GetAssemblies(GetType().Assembly)
                         from test in GetAssemblyTypes(assembly)
                         where test.GetMethods().Any(x => x.GetCustomAttributes(typeof(FactAttribute), true).Count() != 0 || x.GetCustomAttributes(typeof(TheoryAttribute), true).Count() != 0)
                         where typeof(IAsyncDisposable).IsAssignableFrom(test) == false
@@ -40,7 +40,7 @@ namespace SlowTests.Tests
         [RavenMultiplatformFact(RavenTestCategory.Codebase, RavenPlatform.Windows | RavenPlatform.OsX)]
         public void TestsShouldInheritFromRightBaseClasses()
         {
-            var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
+            var types = from assembly in GetAssemblies(GetType().Assembly)
                         from test in GetAssemblyTypes(assembly)
                         where test.GetMethods().Any(x => x.GetCustomAttributes(typeof(FactAttribute), true).Count() != 0 || x.GetCustomAttributes(typeof(TheoryAttribute), true).Count() != 0)
                         where test.IsSubclassOf(typeof(ParallelTestBase)) == false
@@ -57,7 +57,7 @@ namespace SlowTests.Tests
         [RavenMultiplatformFact(RavenTestCategory.Codebase, RavenPlatform.Windows | RavenPlatform.OsX)]
         public void HandlersShouldNotInheritStraightFromRequestHandler()
         {
-            var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
+            var types = from assembly in GetAssemblies(GetType().Assembly)
                         from handler in GetAssemblyTypes(assembly)
                         where handler.IsAbstract == false
                         where handler != typeof(DatabaseRequestHandler) && handler != typeof(ServerRequestHandler) && handler != typeof(ShardedDatabaseRequestHandler)
@@ -75,7 +75,7 @@ namespace SlowTests.Tests
         [RavenFact(RavenTestCategory.Codebase)]
         public void AllTestsShouldUseRavenFactOrRavenTheoryAttributes()
         {
-            var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
+            var types = from assembly in GetAssemblies(GetType().Assembly)
                         from test in GetAssemblyTypes(assembly)
                         from method in test.GetMethods()
                         where Filter(method)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-182

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
