### PR TITLE
Quill-286 Check out before running paths-filter in the Quill Dashboard jobs

### DIFF
--- a/.github/workflows/StudioTests.yml
+++ b/.github/workflows/StudioTests.yml
@@ -70,15 +70,16 @@ jobs:
       run:
         working-directory: ./src/Raven.Quill.Web
     steps:
+    # paths-filter reads the REST API on pull_request but shells out to git on push,
+    # so the checkout has to come first and stay ungated.
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
     - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
       id: changes
       with:
         filters: |
           quillWeb:
             - 'src/Raven.Quill.Web/**'
-
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      if: steps.changes.outputs.quillWeb == 'true'
 
     - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       if: steps.changes.outputs.quillWeb == 'true'

--- a/.github/workflows/studioConventions.yml
+++ b/.github/workflows/studioConventions.yml
@@ -62,15 +62,16 @@ jobs:
       run:
         working-directory: ./src/Raven.Quill.Web
     steps:
+    # paths-filter reads the REST API on pull_request but shells out to git on push,
+    # so the checkout has to come first and stay ungated.
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
     - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
       id: changes
       with:
         filters: |
           quillWeb:
             - 'src/Raven.Quill.Web/**'
-
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      if: steps.changes.outputs.quillWeb == 'true'
 
     - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       if: steps.changes.outputs.quillWeb == 'true'


### PR DESCRIPTION
dorny/paths-filter resolves changed files through the REST API only for pull_request; for push and every other event it shells out to git and needs the repository already checked out. Both Quill Dashboard jobs ran it as their first step, so they passed on the PR and failed on the first push to feature/ai-appliance with 'git rev-parse --abbrev-ref HEAD failed with exit code 128'.

Gating the checkout on the filter output was circular for the same reason, so the checkout now runs unconditionally and only the steps after the filter stay gated. Default fetch depth is fine - the action doubles its initial-fetch-depth until it finds the base commit.

compile.yml is unaffected: its filter already sits after the checkout the build needs anyway.

### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-286

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
