### PR TITLE
RavenDB-27393 Fix AVE in HNSW parallel-placement race test hook

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -676,7 +676,7 @@ public partial class Hnsw
                 _edgeIndexSnapshot.Clear();
                 _edgeIndexSnapshot.AddRange(edgesIndexes.ToSpan());
 
-                parent._forTestingPurposes?.OnLltPreparedEdges(currentNodeIndex, level, ref n, ref edgesIndexes);
+                parent._forTestingPurposes?.OnLltPreparedEdges(_searchState, currentNodeIndex, level);
 
                 return true; // always dispatch; worker decides via _indexes.Count after fill
             }
@@ -706,7 +706,7 @@ public partial class Hnsw
                     _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
                 }
 
-                parent._forTestingPurposes?.OnWorkerCapturedEdgeListRef(currentNodeIndex, level);
+                parent._forTestingPurposes?.OnWorkerAboutToConsumeEdges(currentNodeIndex, level);
                 // Read the per-task snapshot captured on the LLT thread in PrepareEdgesOnLLT, NOT the
                 // shared EdgesIndexesPerLevel native buffer: that buffer's storage can be freed and
                 // reallocated by the LLT thread in a later round while this worker is still running

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -676,6 +676,8 @@ public partial class Hnsw
                 _edgeIndexSnapshot.Clear();
                 _edgeIndexSnapshot.AddRange(edgesIndexes.ToSpan());
 
+                parent._forTestingPurposes?.OnLltPreparedEdges(currentNodeIndex, level, ref n, ref edgesIndexes);
+
                 return true; // always dispatch; worker decides via _indexes.Count after fill
             }
 
@@ -704,7 +706,7 @@ public partial class Hnsw
                     _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
                 }
 
-                parent._forTestingPurposes?.OnWorkerCapturedEdgeListRef(_searchState, currentNodeIndex, level);
+                parent._forTestingPurposes?.OnWorkerCapturedEdgeListRef(currentNodeIndex, level);
                 // Read the per-task snapshot captured on the LLT thread in PrepareEdgesOnLLT, NOT the
                 // shared EdgesIndexesPerLevel native buffer: that buffer's storage can be freed and
                 // reallocated by the LLT thread in a later round while this worker is still running

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -1014,23 +1014,33 @@ public unsafe partial class Hnsw
             private readonly ManualResetEventSlim _workerParked = new(false);
             private readonly ManualResetEventSlim _lltMoved = new(false);
 
-            // Worker thread: the first worker about to consume a node's edges at a level with real storage
-            // parks here until the LLT thread has moved that storage and the node array.
-            internal void OnWorkerCapturedEdgeListRef(SearchState searchState, int nodeIndex, int level)
+            // LLT thread: pick the victim here, where the node and its edge lists are stable because we
+            // own the allocator. Capturing it on a worker instead races the LLT thread's own SetCapacity /
+            // ResetAndEnsureCapacity on that node and dereferences a freed edge buffer (RavenDB-27393).
+            internal void OnLltPreparedEdges(int nodeIndex, int level, ref Node node, ref NativeList<int> edgeIndexes)
             {
-                if (SimulateConcurrentRealloc == false || Volatile.Read(ref _victim) >= 0)
+                if (SimulateConcurrentRealloc == false || _victim >= 0)
                     return;
-
-                ref var candidate = ref searchState.GetNodeByIndex(nodeIndex);
-                if (candidate.EdgesIndexesPerLevel.Count <= level || candidate.EdgesIndexesPerLevel[level].Count == 0)
-                    return;
-                if (Interlocked.CompareExchange(ref _victim, nodeIndex, -1) != -1)
+                if (edgeIndexes.Count == 0)
                     return;
 
                 _victimLevel = level;
-                _victimEdgeBufferBeforeMove = (nint)candidate.EdgesIndexesPerLevel[level].RawItems;
-                _victimNodePtr = (nint)Unsafe.AsPointer(ref candidate);
-                _victimNodeIdExpected = candidate.NodeId;
+                _victimEdgeBufferBeforeMove = (nint)edgeIndexes.RawItems;
+                _victimNodePtr = (nint)Unsafe.AsPointer(ref node);
+                _victimNodeIdExpected = node.NodeId;
+                // Published last: a worker that observes _victim also observes everything above it.
+                Volatile.Write(ref _victim, nodeIndex);
+            }
+
+            // Worker thread: the worker dispatched for the victim (node, level) parks here until the LLT
+            // thread has moved that storage and the node array. Reads no shared native state.
+            internal void OnWorkerCapturedEdgeListRef(int nodeIndex, int level)
+            {
+                if (SimulateConcurrentRealloc == false)
+                    return;
+                if (Volatile.Read(ref _victim) != nodeIndex || _victimLevel != level)
+                    return;
+
                 VictimSelected = true;
                 _workerParked.Set();
                 WakeLltLoop?.Invoke();

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -983,11 +983,11 @@ public unsafe partial class Hnsw
 
         internal TestingStuff ForTestingPurposesOnly() => _forTestingPurposes ??= new TestingStuff();
 
-        // Deterministically reproduces the RavenDB-26809 interleaving for tests: parks a placement worker
-        // while it holds a reference into a node's edges, then has the LLT thread move both that edge
-        // buffer and the node array before the worker resumes. With the fix in place the worker reads a
-        // private edge snapshot and the grown-from node buffer is retained, so the build completes and the
-        // graph stays queryable; reverting either guard turns this into a use-after-free.
+        // Deterministically reproduces the RavenDB-26809 interleaving for tests: the LLT thread picks a
+        // victim (node, level) in PrepareEdgesOnLLT, the worker dispatched for it parks, and the LLT thread
+        // then moves both that edge buffer and the node array before releasing it. With the fix in place
+        // the worker reads a private edge snapshot and the grown-from node buffer is retained, so the build
+        // completes and the graph stays queryable; reverting either guard turns this into a use-after-free.
         internal sealed class TestingStuff
         {
             internal bool SimulateConcurrentRealloc;
@@ -1008,7 +1008,6 @@ public unsafe partial class Hnsw
 
             private int _victim = -1;
             private int _victimLevel;
-            private nint _victimEdgeBufferBeforeMove;
             private nint _victimNodePtr;
             private long _victimNodeIdExpected;
             private readonly ManualResetEventSlim _workerParked = new(false);
@@ -1017,15 +1016,19 @@ public unsafe partial class Hnsw
             // LLT thread: pick the victim here, where the node and its edge lists are stable because we
             // own the allocator. Capturing it on a worker instead races the LLT thread's own SetCapacity /
             // ResetAndEnsureCapacity on that node and dereferences a freed edge buffer (RavenDB-27393).
-            internal void OnLltPreparedEdges(int nodeIndex, int level, ref Node node, ref NativeList<int> edgeIndexes)
+            // Refs are re-derived here rather than passed in: PrepareEdgesOnLLT's own ref into the node
+            // array can be pointing at a retired buffer by the time it calls us, since its mirror-rebuild
+            // loop can grow that array through GetNodeIndexById.
+            internal void OnLltPreparedEdges(SearchState searchState, int nodeIndex, int level)
             {
                 if (SimulateConcurrentRealloc == false || _victim >= 0)
                     return;
-                if (edgeIndexes.Count == 0)
+
+                ref var node = ref searchState.GetNodeByIndex(nodeIndex);
+                if (node.EdgesIndexesPerLevel[level].Count == 0)
                     return;
 
                 _victimLevel = level;
-                _victimEdgeBufferBeforeMove = (nint)edgeIndexes.RawItems;
                 _victimNodePtr = (nint)Unsafe.AsPointer(ref node);
                 _victimNodeIdExpected = node.NodeId;
                 // Published last: a worker that observes _victim also observes everything above it.
@@ -1034,9 +1037,9 @@ public unsafe partial class Hnsw
 
             // Worker thread: the worker dispatched for the victim (node, level) parks here until the LLT
             // thread has moved that storage and the node array. Reads no shared native state.
-            internal void OnWorkerCapturedEdgeListRef(int nodeIndex, int level)
+            internal void OnWorkerAboutToConsumeEdges(int nodeIndex, int level)
             {
-                if (SimulateConcurrentRealloc == false)
+                if (SimulateConcurrentRealloc == false || _lltMoved.IsSet)
                     return;
                 if (Volatile.Read(ref _victim) != nodeIndex || _victimLevel != level)
                     return;
@@ -1061,10 +1064,11 @@ public unsafe partial class Hnsw
 
                 ref var inner = ref searchState.GetNodeByIndex(_victim).EdgesIndexesPerLevel[_victimLevel];
                 var saved = inner.ToSpan().ToArray();
+                var before = (nint)inner.RawItems;
                 inner.ResetAndEnsureCapacity(searchState.Llt.Allocator, Math.Max(inner.Capacity * 2, saved.Length + 1));
                 foreach (var v in saved)
                     inner.AddUnsafe(v);
-                if ((nint)inner.RawItems != _victimEdgeBufferBeforeMove)
+                if ((nint)inner.RawItems != before)
                     InnerEdgeBufferMovedWhileWorkerParked = true;
 
                 if (searchState.GrowNodesAndPoisonVacatedForTesting())

--- a/test/SlowTests/Voron/Graphs/HnswParallelPlacementRaceTests.cs
+++ b/test/SlowTests/Voron/Graphs/HnswParallelPlacementRaceTests.cs
@@ -16,10 +16,10 @@ public unsafe class HnswParallelPlacementRaceTests(ITestOutputHelper output) : S
     private const int VectorDimensions = 16;
     private const int VectorSizeInBytes = VectorDimensions * sizeof(float);
 
-    // RavenDB-26809: reproduces the actual use-after-free. A placement worker is parked while it holds a
-    // reference into a node's edges, then the LLT thread moves both that edge buffer and the node array
-    // before the worker resumes. With the fix (per-task edge snapshot + retained node buffer) the build
-    // completes and the graph stays queryable; reverting either guard crashes here under the parked read.
+    // RavenDB-26809: reproduces the actual use-after-free. A placement worker is parked right before it
+    // consumes a node's edges, then the LLT thread moves both that edge buffer and the node array before
+    // the worker resumes. With the fix (per-task edge snapshot + retained node buffer) the build completes
+    // and the graph stays queryable; reverting either guard crashes here under the parked read.
     [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
     public void ParallelPlacementSurvivesEdgeAndNodeReallocUnderParkedWorker()
     {


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RRavenDB-27393

### Additional description

`HnswParallelPlacementRaceTests` killed the SlowTests process with an uncatchable `AccessViolationException` on two `Testsv80_Winx64` nightlies (#483, #492).

**Test-only bug, not Voron.** The changed methods live on `Hnsw.Registration.TestingStuff`, reachable only via `ForTestingPurposesOnly()`, which only that one test calls. Production path untouched apart from the hook call site.

## Root cause

The worker-side hook read `candidate.EdgesIndexesPerLevel[level].RawItems`, the exact shared-buffer read the RavenDB-26809 fix removed from the worker path. LLT reallocates that buffer in `PrepareEdgesOnLLT`, so the worker dereferenced a pointer the allocator had already handed out.

From the dumps: bad address `0x0000000C00000009` (#483) and `0x0000000400000015` (#492), both a pair of small ints, i.e. live payload of an `int` edge buffer. `_victim = 0` with `_victimEdgeBufferBeforeMove = 0` pins the fault to that one line; `VictimSelected = 0` rules out the test's own forced realloc and the poison buffer.

## Fix

Victim selection moves to `PrepareEdgesOnLLT`, on the LLT thread where the node and its edge lists are stable. The worker now only parks and reads no shared native state. CAS latch dropped: a repeat dispatch finds `_lltMoved` already set and returns immediately.

Related PR: https://github.com/ravendb/ravendb/pull/22981

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
