### PR TITLE
RavenDB-27449 Clear the bitmap slot when filling all entries

### DIFF
--- a/src/Corax/Querying/Primitives/QueryPrimitives.cs
+++ b/src/Corax/Querying/Primitives/QueryPrimitives.cs
@@ -50,7 +50,10 @@ public static class QueryPrimitives
     // Use as the complement for negation (NOT x means All Entries AND NOT x) 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void CtxFillAllEntries(Matches.CompiledQueryMatch ctx, int bitmapSlot)
-        => OrWithMatch(ctx.Searcher.AllEntries(), ref ctx.Bitmaps[bitmapSlot], ctx.OpLimit);
+    {
+        ctx.Bitmaps[bitmapSlot].Clear();
+        OrWithMatch(ctx.Searcher.AllEntries(), ref ctx.Bitmaps[bitmapSlot], ctx.OpLimit);
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void CtxFillFromTreeScan(Matches.CompiledQueryMatch ctx, int paramIndex, int bitmapSlot)

--- a/test/SlowTests.Issues/Issues/RavenDB_27449.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27449.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27449(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class Product
+    {
+        public string Id { get; set; }
+        public string Category { get; set; }
+        public int Price { get; set; }
+    }
+
+    private class Products_ByCategoryAndPrice : AbstractIndexCreationTask<Product>
+    {
+        public Products_ByCategoryAndPrice()
+        {
+            Map = products => from p in products select new { p.Category, p.Price };
+        }
+    }
+
+    // An OR of a negated clause and two groups makes the plan reuse a scratch bitmap slot that an earlier
+    // merge already consumed. FillAllEntries has to reset the slot before it seeds it, or the query throws.
+    private const string Query =
+        "from index 'Products/ByCategoryAndPrice' " +
+        "where Category != 'food' " +
+        "   or (Category in ('books', 'toys') and Price >= 46) " +
+        "   or (Price < 34 and not (Price > 10 and Price < 55)) " +
+        "limit 1024";
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void OrOfNegationAndTwoGroupsReturnsTheWholeSet()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+
+        var products = Products();
+        Store(store, products);
+
+        var expected = products
+            .Where(p => p.Category != "food"
+                        || (p.Category is "books" or "toys" && p.Price >= 46)
+                        || (p.Price < 34 && (p.Price > 10 && p.Price < 55) == false))
+            .Select(p => p.Id)
+            .ToHashSet();
+
+        Assert.NotEmpty(expected);
+
+        using var session = store.OpenSession();
+        var actual = session.Advanced.RawQuery<Product>(Query).ToList().Select(p => p.Id).ToHashSet();
+
+        Assert.Equal(expected.Count, actual.Count);
+        Assert.True(expected.SetEquals(actual));
+    }
+
+    private static List<Product> Products()
+    {
+        string[] categories = ["electronics", "books", "toys", "food"];
+
+        return Enumerable.Range(0, 512)
+            .Select(i => new Product { Id = $"products/{i}", Category = categories[i % categories.Length], Price = i % 100 })
+            .ToList();
+    }
+
+    private void Store(IDocumentStore store, List<Product> products)
+    {
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var product in products)
+                bulk.Store(product);
+        }
+
+        new Products_ByCategoryAndPrice().Execute(store);
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(2));
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27449

### Additional description

A query that ORs a negated clause with two groups makes the compiled plan reuse a scratch bitmap slot that a destructive merge already consumed. CtxFillAllEntries was the only Fill primitive that did not Clear() its target slot - the contract stated one line above it and honoured by CtxFillFromPostingSource, CtxFillFromTreeScan and CtxFillFromMatch - so it seeded on top of stolen containers and the query threw NullReferenceException from RoaringBitmap.AddRangeToContainer

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
