### PR TITLE
RavenDB-27450 Walk nested groups when compiling the entry scan predicate

### DIFF
--- a/src/Corax/Querying/Planning/ResidualScanIlEmitter.cs
+++ b/src/Corax/Querying/Planning/ResidualScanIlEmitter.cs
@@ -87,7 +87,7 @@ public static class ResidualScanIlEmitter
         for (int p = 0; p < predicates.Length; p++)
         {
             d.CsLine("");
-            EmitPredicate(ref d, in predicates[p], rejected.Il, ref rootIdx, ref inSetIdx, ref paramSlotIdx, readerRefLocal, p);
+            EmitPredicate(ref d, in predicates[p], rejected.Il, ContinueTarget, ref rootIdx, ref inSetIdx, ref paramSlotIdx, readerRefLocal, p);
         }
 
         // All passed: entryIds[writeIdx] = entryIds[i]
@@ -177,11 +177,11 @@ public static class ResidualScanIlEmitter
     }
 
     /// <summary>If the predicate failed, we jump to the failLabel, success means falling from the end </summary>
-    private static void EmitPredicate(ref DualEmit d, in ScanPredicateInfo pred, Label failLabel, ref int rootIdx, ref int inSetIdx, ref int paramSlotIdx, LocalBuilder readerRefLocal, int pIdx)
+    private static void EmitPredicate(ref DualEmit d, in ScanPredicateInfo pred, Label failLabel, string failName, ref int rootIdx, ref int inSetIdx, ref int paramSlotIdx, LocalBuilder readerRefLocal, int pIdx)
     {
         if (pred.SubPredicates == null)
         {
-            EmitLeafPredicate(ref d, in pred, failLabel, ContinueTarget, rootIdx, ref inSetIdx, paramSlotIdx, readerRefLocal);
+            EmitLeafPredicate(ref d, in pred, failLabel, failName, rootIdx, ref inSetIdx, paramSlotIdx, readerRefLocal);
             if (ConsumesFieldRootPage(in pred))
                 rootIdx++;
             if (ConsumesScalarParam(in pred))
@@ -189,37 +189,31 @@ public static class ResidualScanIlEmitter
             return;
         }
 
+        // Recurse into nested groups: ScanParamExtractor counts every leaf, so folding a group into one
+        // would shift every later root page / param index.
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+
         if (pred.Group == GroupKind.Or)
         {
             var groupPassed = d.DefineLabelPair($"gp_{pIdx}");
             foreach (var predicate in pred.SubPredicates)
             {
                 var nextSub = d.DefineLabelPair("nextBranch");
-                EmitLeafPredicate(ref d, in predicate, nextSub.Il, nextSub.Name, rootIdx, ref inSetIdx, paramSlotIdx, readerRefLocal);
+                EmitPredicate(ref d, in predicate, nextSub.Il, nextSub.Name, ref rootIdx, ref inSetIdx, ref paramSlotIdx, readerRefLocal, pIdx);
                 // Branch succeeded — skip remaining alternatives.
                 d.GotoAlways(groupPassed);
                 d.MarkLabel(nextSub);
-                if (ConsumesFieldRootPage(in predicate))
-                    rootIdx++;
-                if (ConsumesScalarParam(in predicate))
-                    paramSlotIdx++;
             }
 
             // All branches fell through → group fails.
             d.Il.Emit(OpCodes.Br, failLabel);
-            d.CsLine(Jump(ContinueTarget));
+            d.CsLine(Jump(failName));
             d.MarkLabel(groupPassed);
         }
         else
         {
             foreach (var predicate in pred.SubPredicates)
-            {
-                EmitLeafPredicate(ref d, in predicate, failLabel, ContinueTarget, rootIdx, ref inSetIdx, paramSlotIdx, readerRefLocal);
-                if (ConsumesFieldRootPage(in predicate))
-                    rootIdx++;
-                if (ConsumesScalarParam(in predicate))
-                    paramSlotIdx++;
-            }
+                EmitPredicate(ref d, in predicate, failLabel, failName, ref rootIdx, ref inSetIdx, ref paramSlotIdx, readerRefLocal, pIdx);
         }
     }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_27450.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27450.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27450(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class Product
+    {
+        public string Id { get; set; }
+        public string Category { get; set; }
+        public string Region { get; set; }
+        public int Price { get; set; }
+        public string[] Tags { get; set; }
+    }
+
+    private class Products_ByAll : AbstractIndexCreationTask<Product>
+    {
+        public Products_ByAll()
+        {
+            Map = products => from p in products select new { p.Category, p.Region, p.Price, p.Tags };
+        }
+    }
+
+    // Both top-level clauses nest a group, so the entry-scan predicate must index every leaf inside them.
+    private const string Where =
+        "(Tags all in ('clearance', 'sale') and not (Tags all in ('sale', 'sale') and (Region = 'eu' or Category != 'electronics'))) " +
+        "and (Region = 'us' and (Price > 15 and not Tags all in ('new', 'sale')))";
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void NestedGroupsAreScannedWithTheirOwnValues()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+
+        var products = Products();
+        Store(store, products);
+
+        var expected = products
+            .Where(p => p.Tags.Contains("clearance") && p.Tags.Contains("sale")
+                        && (p.Tags.Contains("sale") && (p.Region == "eu" || p.Category != "electronics")) == false
+                        && p.Region == "us"
+                        && p.Price > 15
+                        && (p.Tags.Contains("new") && p.Tags.Contains("sale")) == false)
+            .Select(p => p.Id)
+            .ToHashSet();
+
+        // -1 disables every gate, 0..2 force one of them on, so the scan tail runs regardless of the cost heuristic.
+        foreach (int gate in (int[])[-1, 0, 1, 2])
+        {
+            using var session = store.OpenSession();
+            var actual = session.Advanced
+                .RawQuery<Product>($"from index 'Products/ByAll' where {Where} limit 1024")
+                .AddParameter("rvn_corax_entry_scan", gate)
+                .ToList()
+                .Select(p => p.Id)
+                .ToHashSet();
+
+            Assert.True(expected.SetEquals(actual), $"entry scan gate {gate}: expected {expected.Count}, got {actual.Count}");
+        }
+    }
+
+    private static List<Product> Products()
+    {
+        string[] categories = ["electronics", "books", "toys", "food"];
+        string[] regions = ["eu", "us", "apac"];
+        string[] tags = ["sale", "new", "clearance", "bulk"];
+
+        return Enumerable.Range(0, 1024)
+            .Select(i => new Product
+            {
+                Id = $"products/{i}",
+                Category = categories[i % categories.Length],
+                Region = regions[i % regions.Length],
+                Price = i % 100,
+                Tags = [tags[i % tags.Length], tags[(i / 4) % tags.Length]]
+            })
+            .ToList();
+    }
+
+    private void Store(IDocumentStore store, List<Product> products)
+    {
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var product in products)
+                bulk.Store(product);
+        }
+
+        new Products_ByAll().Execute(store);
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(2));
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27450

### Additional description

ResidualScanIlEmitter.EmitPredicate walked the entry-scan predicate tree one level deep: a sub-predicate was emitted with EmitLeafPredicate even when it was a group. BuildScanPredicateInfoCore builds that tree recursively and ScanParamExtractor.ExtractFromPredicate walks all of it — the plan depends on the two staying in lockstep ("the predicate tree stays 1:1 with the SubExecutions tree", BuildResolver.cs). A nested group therefore consumed a single field-root page / param slot for the whole group, leaving every later index short by the leaves it holds, so the compiled scan compared entries against another clause's values or read past the end of the arrays.

Fix: recurse into sub-groups, which also removes the manual index bookkeeping in the OR/AND loops.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
