### PR TITLE
Quill-284 Custom link expiration duration is only configurable in seconds

### DIFF
--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-utils.test.ts
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+    MAX_TTL_SECONDS,
+    MIN_TTL_SECONDS,
+    TTL_UNIT_SECONDS,
+    ttlToSeconds,
+} from "@/pages/apps/channels/embed-link-utils";
+
+describe("ttlToSeconds", () => {
+    it("returns the value unchanged for seconds", () => {
+        expect(ttlToSeconds(90, "second")).toBe(90);
+    });
+
+    it("converts each unit to seconds", () => {
+        expect(ttlToSeconds(1, "minute")).toBe(60);
+        expect(ttlToSeconds(1, "hour")).toBe(3_600);
+        expect(ttlToSeconds(7, "day")).toBe(604_800);
+    });
+
+    it("scales linearly with the value", () => {
+        expect(ttlToSeconds(3, "hour")).toBe(3 * TTL_UNIT_SECONDS.hour);
+    });
+
+    it("maps the server bounds to selectable durations", () => {
+        // 60s min = 1 minute, 30-day max = the largest offered unit at the cap.
+        expect(ttlToSeconds(1, "minute")).toBe(MIN_TTL_SECONDS);
+        expect(ttlToSeconds(30, "day")).toBe(MAX_TTL_SECONDS);
+    });
+});

--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-utils.ts
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-utils.ts
@@ -24,3 +24,18 @@ export const MIN_INVOCATIONS = 1;
 export const MAX_INVOCATIONS = 1_000_000;
 export const DEFAULT_TTL_SECONDS = 3_600;
 export const DEFAULT_MAX_INVOCATIONS = 100;
+
+// Units offered by the custom-duration input. Days is the largest practical unit: the server caps
+// TTL at MAX_TTL_SECONDS (30 days), so weeks/months could not be honored.
+export const TTL_UNIT_SECONDS = {
+    second: 1,
+    minute: 60,
+    hour: 3_600,
+    day: 86_400,
+} as const;
+
+export type TtlUnit = keyof typeof TTL_UNIT_SECONDS;
+
+export function ttlToSeconds(value: number, unit: TtlUnit) {
+    return value * TTL_UNIT_SECONDS[unit];
+}

--- a/src/Raven.Quill.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
@@ -1,6 +1,6 @@
-import { useState, type ReactNode } from "react";
+import { useId, useState, type ReactNode } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm, useWatch, type Control } from "react-hook-form";
+import { useController, useForm, useWatch, type Control } from "react-hook-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import { api } from "@/api/api";
@@ -8,6 +8,8 @@ import { cn } from "@/lib/utils";
 import type { AgentParameterSummary, MintEmbedLinkRequest, MintEmbedLinkResponse } from "@/api/generated/server-api";
 import { Alert } from "@/components/shadcn/ui/alert";
 import { Field, FieldDescription, FieldLabel } from "@/components/shadcn/ui/field";
+import { InputGroup, InputGroupInput } from "@/components/shadcn/ui/input-group";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/shadcn/ui/select";
 import { Button } from "@/components/shadcn/ui/button";
 import { Spinner } from "@/components/shadcn/ui/spinner";
 import {
@@ -42,6 +44,8 @@ import {
     MAX_TTL_SECONDS,
     MIN_INVOCATIONS,
     MIN_TTL_SECONDS,
+    ttlToSeconds,
+    type TtlUnit,
 } from "@/pages/apps/channels/embed-link-utils";
 
 type GenerateEmbedLinkDialogProps = {
@@ -64,6 +68,15 @@ const TTL_PRESET_OPTIONS: readonly FormSelectOption<z.infer<typeof ttlPresetSche
     { value: "custom", label: "Custom" },
 ];
 
+const ttlUnitSchema = z.enum(["second", "minute", "hour", "day"]);
+
+const TTL_UNIT_OPTIONS: readonly { value: TtlUnit; label: string }[] = [
+    { value: "second", label: "Seconds" },
+    { value: "minute", label: "Minutes" },
+    { value: "hour", label: "Hours" },
+    { value: "day", label: "Days" },
+];
+
 const generateEmbedLinkSchema = z
     .object({
         parameters: z.array(
@@ -76,7 +89,8 @@ const generateEmbedLinkSchema = z
             }),
         ),
         ttlPreset: ttlPresetSchema,
-        customTtlSeconds: z.number().int().nullable(),
+        customTtlValue: z.number().int().positive().nullable(),
+        customTtlUnit: ttlUnitSchema,
         maxInvocations: z
             .number({ message: "Enter a number" })
             .int()
@@ -121,17 +135,20 @@ const generateEmbedLinkSchema = z
         if (values.ttlPreset !== "custom") {
             return;
         }
-        if (values.customTtlSeconds == null) {
+        if (values.customTtlValue == null) {
             ctx.addIssue({
                 code: "custom",
-                path: ["customTtlSeconds"],
-                message: "Enter a duration in seconds",
+                path: ["customTtlValue"],
+                message: "Enter a duration",
             });
-        } else if (values.customTtlSeconds < MIN_TTL_SECONDS || values.customTtlSeconds > MAX_TTL_SECONDS) {
+            return;
+        }
+        const seconds = ttlToSeconds(values.customTtlValue, values.customTtlUnit);
+        if (seconds < MIN_TTL_SECONDS || seconds > MAX_TTL_SECONDS) {
             ctx.addIssue({
                 code: "custom",
-                path: ["customTtlSeconds"],
-                message: `Enter ${MIN_TTL_SECONDS}–${MAX_TTL_SECONDS.toLocaleString()} seconds`,
+                path: ["customTtlValue"],
+                message: "Must be between 1 minute and 30 days",
             });
         }
     });
@@ -150,7 +167,8 @@ export function GenerateEmbedLinkDialog({
     const getDefaultValues = (): GenerateEmbedLinkFormData => ({
         parameters: parameters.map(defaultFormValue),
         ttlPreset: DEFAULT_TTL_PRESET,
-        customTtlSeconds: null,
+        customTtlValue: null,
+        customTtlUnit: "hour",
         maxInvocations: DEFAULT_MAX_INVOCATIONS,
     });
 
@@ -177,8 +195,8 @@ export function GenerateEmbedLinkDialog({
 
     const submit = form.handleSubmit((values) => {
         const ttlSeconds =
-            values.ttlPreset === "custom" && values.customTtlSeconds != null
-                ? values.customTtlSeconds
+            values.ttlPreset === "custom" && values.customTtlValue != null
+                ? ttlToSeconds(values.customTtlValue, values.customTtlUnit)
                 : Number(values.ttlPreset);
         const bound = Object.fromEntries(
             values.parameters.map((parameter) => [parameter.name, toJsonValue(parameter)]),
@@ -248,17 +266,7 @@ export function GenerateEmbedLinkDialog({
                             label="Link expires after"
                             options={TTL_PRESET_OPTIONS}
                         />
-                        {ttlPreset === "custom" && (
-                            <FormInput
-                                control={form.control}
-                                name="customTtlSeconds"
-                                type="number"
-                                label="Custom duration (seconds)"
-                                placeholder="e.g. 7200"
-                                min={MIN_TTL_SECONDS}
-                                max={MAX_TTL_SECONDS}
-                            />
-                        )}
+                        {ttlPreset === "custom" && <CustomDurationField control={form.control} />}
 
                         <FormInput
                             control={form.control}
@@ -351,6 +359,53 @@ function ParameterField({
             description={description}
             placeholder={placeholderFor(parameter.type)}
         />
+    );
+}
+
+function CustomDurationField({ control }: { control: Control<GenerateEmbedLinkFormData> }) {
+    const inputId = useId();
+    const {
+        field: { onBlur, onChange, ref, value },
+        fieldState: { error, invalid },
+        formState,
+    } = useController({ control, name: "customTtlValue" });
+    const { field: unit } = useController({ control, name: "customTtlUnit" });
+
+    const isDisabled = formState.isSubmitting;
+
+    return (
+        <Field data-invalid={invalid}>
+            <FieldLabel htmlFor={inputId}>Custom duration</FieldLabel>
+            <div className="flex items-center gap-2">
+                <InputGroup className="flex-1">
+                    <InputGroupInput
+                        id={inputId}
+                        type="number"
+                        min={1}
+                        placeholder="e.g. 12"
+                        value={value ?? ""}
+                        onChange={(event) => onChange(event.target.value === "" ? null : Number(event.target.value))}
+                        onBlur={onBlur}
+                        ref={ref}
+                        aria-invalid={invalid}
+                        disabled={isDisabled}
+                    />
+                </InputGroup>
+                <Select value={unit.value} onValueChange={unit.onChange} disabled={isDisabled}>
+                    <SelectTrigger className="w-32" aria-label="Duration unit">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {TTL_UNIT_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+            {error?.message && <FieldDescription className="text-destructive">{error.message}</FieldDescription>}
+        </Field>
     );
 }
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-284

### Additional description

<img width="893" height="780" alt="image" src="https://github.com/user-attachments/assets/2b64f57e-0399-4c7e-a9c5-3d851a657d66" />

Replaces the raw "seconds" input for a link's custom expiration with a numeric input + unit selector (seconds / minutes / hours / days), reusing existing shadcn/form components.

- Added `TTL_UNIT_SECONDS` +` ttlToSeconds()` helper in `embed-link-utils.ts`.
- Reworked the custom-duration fields, validation (still enforcing the 60s–30d server bounds), and submit in `generate-embed-link-dialog.tsx`.
- Units stop at days (server caps TTL at 30 days).
- Added unit tests for `ttlToSeconds`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
