### PR TITLE
RavenDB-27453 Do not short-circuit the plan inside an OR branch

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/PlanEmitter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/PlanEmitter.cs
@@ -303,11 +303,15 @@ internal sealed class PlanEmitter
         if (firstNegated)
             _ops.Add(new PlanOp { Kind = PlanOpKind.FillAllEntries, BitmapLocal = destSlot });
         var followupAction = isOr ? MergeKind.AndInto : MergeKind.OrInto;
-        EmitClauseInto(subExecs[0], firstNegated ? MergeKind.AndNotInto : MergeKind.Fill, suppressEarlyExit, destSlot);
+
+        // An emptied OR branch is not an empty result: the other branches still get unioned in, so no short-circuit here.
+        bool suppress = suppressEarlyExit || isOr == false;
+
+        EmitClauseInto(subExecs[0], firstNegated ? MergeKind.AndNotInto : MergeKind.Fill, suppress, destSlot);
         for (int i = 1; i < subExecs.Count; i++)
         {
             MergeKind kind = isOr && subExecs[i].IsNegated ? MergeKind.AndNotInto : followupAction;
-            EmitClauseInto(subExecs[i], kind, suppressEarlyExit, destSlot);
+            EmitClauseInto(subExecs[i], kind, suppress, destSlot);
         }
     }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_27453.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27453.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27453(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private class Product
+    {
+        public string Id { get; set; }
+        public string Region { get; set; }
+        public int Price { get; set; }
+    }
+
+    private class Products_ByRegionAndPrice : AbstractIndexCreationTask<Product>
+    {
+        public Products_ByRegionAndPrice()
+        {
+            Map = products => from p in products select new { p.Region, p.Price };
+        }
+    }
+
+    // The first OR branch can never match; with a negation applied to the OR it used to wipe out the whole result.
+    private const string Where = "((Region = 'apac' and Region = 'eu') or Price between 32 and 66) and not Region = 'eu'";
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void EmptyBranchDoesNotEmptyTheOr()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+
+        var products = Products();
+        Store(store, products);
+
+        var expected = products
+            .Where(p => (p.Region == "apac" && p.Region == "eu" || p.Price is >= 32 and <= 66) && p.Region != "eu")
+            .Select(p => p.Id)
+            .ToHashSet();
+
+        Assert.NotEmpty(expected);
+
+        using var session = store.OpenSession();
+        var actual = session.Advanced
+            .RawQuery<Product>($"from index 'Products/ByRegionAndPrice' where {Where} limit 1024")
+            .ToList()
+            .Select(p => p.Id)
+            .ToHashSet();
+
+        Assert.True(expected.SetEquals(actual), $"expected {expected.Count}, got {actual.Count}");
+    }
+
+    private static List<Product> Products()
+    {
+        string[] regions = ["eu", "us", "apac"];
+
+        return Enumerable.Range(0, 512)
+            .Select(i => new Product { Id = $"products/{i}", Region = regions[i % regions.Length], Price = i % 100 })
+            .ToList();
+    }
+
+    private void Store(IDocumentStore store, List<Product> products)
+    {
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var product in products)
+                bulk.Store(product);
+        }
+
+        new Products_ByRegionAndPrice().Execute(store);
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(2));
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27453

### Additional description

An OR branch is emitted into the accumulator slot, and the intersections inside it kept the default early exit - a jump to the end of the whole plan. A branch that can never match (Region = 'apac' and Region = 'eu') therefore aborted the plan before the remaining branches were unioned in, and the query returned no documents. Only reachable when the OR is not the whole WHERE: EmitOrPlan passes suppressEarlyExit: true, but as a clause of an AND plan the group is emitted with false and EmitGroupContents handed that flag straight to the branches.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
