### PR TITLE
[v7.1] RavenDB-26882 Remove .tsx and .scss files from Prettier ignore rules

### DIFF
--- a/src/Raven.Studio/.prettierignore
+++ b/src/Raven.Studio/.prettierignore
@@ -10,14 +10,14 @@ obj/
 languageService/
 
 typescript/main.ts
-typescript/commands
-typescript/common
-typescript/models
-typescript/durandalPlugins
-typescript/transitions
-typescript/overrides
-typescript/viewmodels
-typescript/widgets
+typescript/commands/**/*.ts
+typescript/common/**/*.ts
+typescript/models/**/*.ts
+typescript/durandalPlugins/**/*.ts
+typescript/transitions/**/*.ts
+typescript/overrides/**/*.ts
+typescript/viewmodels/**/*.ts
+typescript/widgets/**/*.ts
 typings/
 
 wwwroot/App

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/EditIndexInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/EditIndexInfoHub.tsx
@@ -6,11 +6,13 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 import React from "react";
-import {Icon} from "components/common/Icon";
-import {useRavenLink} from "hooks/useRavenLink";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "hooks/useRavenLink";
 
 export function EditIndexInfoHub() {
-    const hasAdditionalAssembliesFromNuGet = useAppSelector(licenseSelectors.statusValue("HasAdditionalAssembliesFromNuGet"));
+    const hasAdditionalAssembliesFromNuGet = useAppSelector(
+        licenseSelectors.statusValue("HasAdditionalAssembliesFromNuGet")
+    );
 
     const featureAvailability = useLimitedFeatureAvailability({
         defaultFeatureAvailability,
@@ -22,7 +24,7 @@ export function EditIndexInfoHub() {
         ],
     });
     const indexViewDocsLink = useRavenLink({ hash: "XZXJP2" });
-    
+
     return (
         <AboutViewFloating>
             <AccordionItemWrapper
@@ -34,7 +36,7 @@ export function EditIndexInfoHub() {
             >
                 <p>
                     Create a new index or edit an existing one in this view.
-                    <br/>
+                    <br />
                     The indexing process will immediately start upon saving the index.
                 </p>
                 <ul>
@@ -52,7 +54,7 @@ export function EditIndexInfoHub() {
                         You can configure the index fields for:
                         <br />
                         Full-text search, Highlighting, Suggestions, Spatial queries,
-                        <br /> 
+                        <br />
                         and Store index fields.
                     </li>
                     <li className="margin-top-xxs">
@@ -64,9 +66,7 @@ export function EditIndexInfoHub() {
                         Add additional assemblies and sources to enhance your index functions by referencing classes and
                         methods from other files.
                     </li>
-                    <li className="margin-top-xxs">
-                        The index can be tested in this view before saving it.
-                    </li>
+                    <li className="margin-top-xxs">The index can be tested in this view before saving it.</li>
                     <li className="margin-top-xxs">
                         Index history is available when editing an existing index,
                         <br />
@@ -79,7 +79,10 @@ export function EditIndexInfoHub() {
                     <Icon icon="newtab" /> Docs - Index View
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper isUnlimited={hasAdditionalAssembliesFromNuGet} data={featureAvailability} />
+            <FeatureAvailabilitySummaryWrapper
+                isUnlimited={hasAdditionalAssembliesFromNuGet}
+                data={featureAvailability}
+            />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/settings/DocumentCompressionInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/DocumentCompressionInfoHub.tsx
@@ -4,13 +4,13 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import FeatureAvailabilitySummaryWrapper from "components/common/FeatureAvailabilitySummary";
-import {useRavenLink} from "hooks/useRavenLink";
+import { useRavenLink } from "hooks/useRavenLink";
 import { useEnterpriseLicenseAvailability } from "components/utils/licenseLimitsUtils";
 
 export function DocumentCompressionInfoHub() {
     const isFeatureInLicense = useAppSelector(licenseSelectors.statusValue("HasDocumentsCompression"));
     const featureAvailability = useEnterpriseLicenseAvailability(isFeatureInLicense);
-    
+
     const compressionDocsLink = useRavenLink({ hash: "E2WX16" });
 
     return (
@@ -22,9 +22,7 @@ export function DocumentCompressionInfoHub() {
                 heading="About this view"
                 description="Get additional info on this feature"
             >
-                <p>
-                    Reduce the database storage space by enabling document compression from this view.
-                </p>
+                <p>Reduce the database storage space by enabling document compression from this view.</p>
                 <div>
                     Document compression can be set for:
                     <ul>
@@ -33,8 +31,8 @@ export function DocumentCompressionInfoHub() {
                     </ul>
                 </div>
                 <p>
-                    Compression is not applied to attachments, counters, and time series data,
-                    only to the content of documents and revisions.
+                    Compression is not applied to attachments, counters, and time series data, only to the content of
+                    documents and revisions.
                 </p>
                 <div>
                     When enabled, compression will be triggered by the server when either of the following occurs for
@@ -42,7 +40,9 @@ export function DocumentCompressionInfoHub() {
                     <ul>
                         <li>Storing new documents.</li>
                         <li>Modifying & saving existing documents.</li>
-                        <li>When a compact operation is initiated by the Client API, existing documents will be compressed.
+                        <li>
+                            When a compact operation is initiated by the Client API, existing documents will be
+                            compressed.
                         </li>
                     </ul>
                 </div>
@@ -52,10 +52,7 @@ export function DocumentCompressionInfoHub() {
                     <Icon icon="newtab" /> Docs - Document Compression
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={isFeatureInLicense}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={isFeatureInLicense} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/settings/TimeSeriesInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/TimeSeriesInfoHub.tsx
@@ -1,14 +1,18 @@
 import AboutViewFloating, { AccordionItemWrapper } from "components/common/AboutView";
-import FeatureAvailabilitySummaryWrapper, {FeatureAvailabilityData} from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 import React from "react";
-import {useRavenLink} from "hooks/useRavenLink";
-import {Icon} from "components/common/Icon";
+import { useRavenLink } from "hooks/useRavenLink";
+import { Icon } from "components/common/Icon";
 
 export function TimeSeriesInfoHub() {
-    const hasTimeSeriesRollupsAndRetention = useAppSelector(licenseSelectors.statusValue("HasTimeSeriesRollupsAndRetention"));
+    const hasTimeSeriesRollupsAndRetention = useAppSelector(
+        licenseSelectors.statusValue("HasTimeSeriesRollupsAndRetention")
+    );
     const timeSeriesDocsLink = useRavenLink({ hash: "LNOMKT" });
 
     const featureAvailability = useLimitedFeatureAvailability({
@@ -31,8 +35,8 @@ export function TimeSeriesInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    In this view, you can add a <strong>Time Series Configuration per collection</strong> to
-                    help manage the large volume of time series data that accumulates.
+                    In this view, you can add a <strong>Time Series Configuration per collection</strong> to help manage
+                    the large volume of time series data that accumulates.
                 </p>
                 <div>
                     The following can be configured per collection:
@@ -40,32 +44,30 @@ export function TimeSeriesInfoHub() {
                         <li className="margin-top-xxs">
                             <strong>Rollup Policies</strong>:
                             <br />
-                            =&gt; Define a Rollup Policy to aggregate time series data into smaller, summarized
-                            datasets called <strong>Rollups</strong>.
-                            Each entry in the Rollup time series is a summary of data from a defined interval of
-                            the original time series.
+                            =&gt; Define a Rollup Policy to aggregate time series data into smaller, summarized datasets
+                            called <strong>Rollups</strong>. Each entry in the Rollup time series is a summary of data
+                            from a defined interval of the original time series.
                             <br />
                             =&gt; Multiple Rollup Policies can be defined, each aggregating the previous Rollup time
                             series. This reduces the granularity of the raw data and may simplify analysis.
                             <br />
-                            =&gt; Rollup entries are not created for time series with entries that have more
-                            than 5 values (even if a policy is defined).
+                            =&gt; Rollup entries are not created for time series with entries that have more than 5
+                            values (even if a policy is defined).
                         </li>
                         <li className="margin-top-xxs">
                             <strong>Retention Periods</strong>:
-                            <br/>
-                            A retention period can be defined for both the raw data entries and each Rollup Policy.
-                            Time series entries that exceed this time frame will be removed.
+                            <br />A retention period can be defined for both the raw data entries and each Rollup
+                            Policy. Time series entries that exceed this time frame will be removed.
                         </li>
                         <li className="margin-top-xxs">
                             <strong>Named Values</strong>:
-                            <br/>
-                            Each time series entry has a specific timestamp and a set of up to 32 data values.
-                            A meaningful name can be given to each value in the time series entry.
+                            <br />
+                            Each time series entry has a specific timestamp and a set of up to 32 data values. A
+                            meaningful name can be given to each value in the time series entry.
                         </li>
                     </ul>
                 </div>
-                <hr/>
+                <hr />
                 <div>
                     Applying the configurations:
                     <ul>
@@ -82,7 +84,7 @@ export function TimeSeriesInfoHub() {
                         </li>
                     </ul>
                 </div>
-                <hr/>
+                <hr />
                 <div className="small-label mb-2">useful links</div>
                 <a href={timeSeriesDocsLink} target="_blank">
                     <Icon icon="newtab" /> Docs - Time Series
@@ -102,6 +104,6 @@ const defaultFeatureAvailability: FeatureAvailabilityData[] = [
         featureIcon: "timeseries-settings",
         community: { value: false },
         professional: { value: true },
-        enterprise: { value: true }
-    }
+        enterprise: { value: true },
+    },
 ];

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditAmazonSqsEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditAmazonSqsEtlInfoHub.tsx
@@ -2,7 +2,9 @@ import AboutViewFloating, { AccordionItemWrapper } from "components/common/About
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import React from "react";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditAmazonSqsEtlInfoHub() {
@@ -16,7 +18,7 @@ export function EditAmazonSqsEtlInfoHub() {
             },
         ],
     });
-    
+
     return (
         <AboutViewFloating defaultOpen={hasQueueEtl ? null : "licensing"}>
             <AccordionItemWrapper
@@ -27,13 +29,13 @@ export function EditAmazonSqsEtlInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    An <strong>Amazon SQS ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
-                    that transfers data from this RavenDB database to Amazon SQS.
+                    An <strong>Amazon SQS ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process that
+                    transfers data from this RavenDB database to Amazon SQS.
                 </p>
                 <ul>
                     <li>
                         Data is extracted from documents only.
-                        <br/>
+                        <br />
                         Attachments, Counters, Time series, and Revisions are not sent.
                     </li>
                     <li className="margin-top-xxs">
@@ -48,34 +50,32 @@ export function EditAmazonSqsEtlInfoHub() {
                         (excluding deletes).
                     </li>
                     <li className="margin-top-xxs">
-                        You can test each script in this view to preview the messages that will be sent by the ETL
-                        task to the destination.
+                        You can test each script in this view to preview the messages that will be sent by the ETL task
+                        to the destination.
                     </li>
                 </ul>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul>
                         <li>A connection string to the Amazon SQS server.</li>
                         <li>The transformation scripts definitions.</li>
-                        <li>Per queue, select whether processed documents will be deleted from your source RavenDB database.
+                        <li>
+                            Per queue, select whether processed documents will be deleted from your source RavenDB
+                            database.
                         </li>
                         <li>A responsible node to handle this task can be set.</li>
                     </ul>
                 </div>
                 <hr />
-                {
-                /* TODO
+                {/* TODO
                 <div className="small-label mb-2">useful links</div>    
                 <a href={amazonSqsEtlDocsLink} target="_blank">
                     <Icon icon="newtab" /> Docs - Amazon SQS ETL
                 </a>
                  */}
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasQueueEtl}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasQueueEtl} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditAzureQueueStorageEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditAzureQueueStorageEtlInfoHub.tsx
@@ -2,7 +2,9 @@ import AboutViewFloating, { AccordionItemWrapper } from "components/common/About
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import React from "react";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditAzureQueueStorageEtlInfoHub() {
@@ -16,7 +18,7 @@ export function EditAzureQueueStorageEtlInfoHub() {
             },
         ],
     });
-    
+
     return (
         <AboutViewFloating defaultOpen={hasQueueEtl ? null : "licensing"}>
             <AccordionItemWrapper
@@ -27,13 +29,13 @@ export function EditAzureQueueStorageEtlInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    An <strong>Azure Queue Storage ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
-                    that transfers data from this RavenDB database to Azure Queue Storage.
+                    An <strong>Azure Queue Storage ETL</strong> ongoing-task is an ETL (Extract, Transform & Load)
+                    process that transfers data from this RavenDB database to Azure Queue Storage.
                 </p>
                 <ul>
                     <li>
                         Data is extracted from documents only.
-                        <br/>
+                        <br />
                         Attachments, Counters, Time series, and Revisions are not sent.
                     </li>
                     <li className="margin-top-xxs">
@@ -48,34 +50,32 @@ export function EditAzureQueueStorageEtlInfoHub() {
                         (excluding deletes).
                     </li>
                     <li className="margin-top-xxs">
-                        You can test each script in this view to preview the messages that will be sent by the ETL
-                        task to the destination.
+                        You can test each script in this view to preview the messages that will be sent by the ETL task
+                        to the destination.
                     </li>
                 </ul>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul>
                         <li>A connection string to the Azure Queue Storage server.</li>
                         <li>The transformation scripts definitions.</li>
-                        <li>Per queue, select whether processed documents will be deleted from your source RavenDB database.
+                        <li>
+                            Per queue, select whether processed documents will be deleted from your source RavenDB
+                            database.
                         </li>
                         <li>A responsible node to handle this task can be set.</li>
                     </ul>
                 </div>
                 <hr />
-                {
-                /* TODO
+                {/* TODO
                 <div className="small-label mb-2">useful links</div>    
                 <a href={azureQueueStorageEtlDocsLink} target="_blank">
                     <Icon icon="newtab" /> Docs - Azure Queue Storage ETL
                 </a>
                  */}
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasQueueEtl}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasQueueEtl} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditElasticSearchEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditElasticSearchEtlInfoHub.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditElasticSearchEtlInfoHub() {
@@ -18,7 +20,7 @@ export function EditElasticSearchEtlInfoHub() {
             },
         ],
     });
-    
+
     const elasticSearchEtlDocsLink = useRavenLink({ hash: "AHPBTX" });
 
     return (
@@ -37,7 +39,7 @@ export function EditElasticSearchEtlInfoHub() {
                 <ul>
                     <li>
                         Data is extracted from documents only.
-                        <br/>
+                        <br />
                         Attachments, Counters, Time series, and Revisions are not sent.
                     </li>
                     <li className="margin-top-xxs">
@@ -57,16 +59,16 @@ export function EditElasticSearchEtlInfoHub() {
                         Elasticsearch.
                     </li>
                 </ul>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul>
                         <li>The transformation scripts definitions.</li>
-                        <li>List of Elasticsearch indexes the ETL task will access, including the property
-                            used for the RavenDB document ID.
+                        <li>
+                            List of Elasticsearch indexes the ETL task will access, including the property used for the
+                            RavenDB document ID.
                         </li>
-                        <li>A connection string with URLs to the Elasticsearch nodes and the authentication method.
-                        </li>
+                        <li>A connection string with URLs to the Elasticsearch nodes and the authentication method.</li>
                         <li>A responsible node to handle this task can be set.</li>
                     </ul>
                 </div>
@@ -76,10 +78,7 @@ export function EditElasticSearchEtlInfoHub() {
                     <Icon icon="newtab" /> Docs - Elasticsearch ETL
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasElasticSearchEtl}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasElasticSearchEtl} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditEmbeddingsGenerationInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditEmbeddingsGenerationInfoHub.tsx
@@ -1,7 +1,9 @@
 ﻿import AboutViewFloating, { AccordionItemWrapper } from "components/common/AboutView";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 import { useAppUrls } from "hooks/useAppUrls";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
@@ -19,7 +21,7 @@ export function EditEmbeddingsGenerationInfoHub() {
     const embeddingsGenerationTaskDocsLink = useRavenLink({ hash: "MKXRLR" });
     const chunkingMethodsDocsLink = useRavenLink({ hash: "TLJF56" });
     const quantizationOptionsDocsLink = useRavenLink({ hash: "JWJPZE" });
-    
+
     const featureAvailability = useLimitedFeatureAvailability({
         defaultFeatureAvailability,
         overwrites: [

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditExternalReplicationInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditExternalReplicationInfoHub.tsx
@@ -3,9 +3,11 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
-import {useRavenLink} from "hooks/useRavenLink";
+import { useRavenLink } from "hooks/useRavenLink";
 
 export function EditExternalReplicationInfoHub() {
     const hasExternalReplication = useAppSelector(licenseSelectors.statusValue("HasExternalReplication"));
@@ -41,20 +43,22 @@ export function EditExternalReplicationInfoHub() {
                 <div>
                     What is replicated:
                     <ul className="margin-top-xxs">
-                        <li>Documents and their related data (attachments, revisions,
-                            counters,
-                            time series) will be replicated.
+                        <li>
+                            Documents and their related data (attachments, revisions, counters, time series) will be
+                            replicated.
                         </li>
-                        <li>Server and cluster-level items (e.g. indexes, identities,
-                            compare-exchange items, ongoing tasks definitions, etc.) are Not replicated.
+                        <li>
+                            Server and cluster-level items (e.g. indexes, identities, compare-exchange items, ongoing
+                            tasks definitions, etc.) are Not replicated.
                         </li>
                     </ul>
                 </div>
                 <div>
                     Task definition includes:
-                    <ul  className="margin-top-xxs">
-                        <li>A connection string to the destination database containing the URLs of
-                            the target cluster&apos;s servers.
+                    <ul className="margin-top-xxs">
+                        <li>
+                            A connection string to the destination database containing the URLs of the target
+                            cluster&apos;s servers.
                         </li>
                         <li>An optional delay time for data replication.</li>
                         <li>A responsible node to handle this task can be set.</li>
@@ -66,10 +70,7 @@ export function EditExternalReplicationInfoHub() {
                     <Icon icon="newtab" /> Docs - External Replication
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasExternalReplication}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasExternalReplication} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditKafkaEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditKafkaEtlInfoHub.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditKafkaEtlInfoHub() {
@@ -31,13 +33,13 @@ export function EditKafkaEtlInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    A <strong>Kafka ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
-                    that transfers data from this RavenDB database to topics of a Kafka broker.
+                    A <strong>Kafka ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process that
+                    transfers data from this RavenDB database to topics of a Kafka broker.
                 </p>
                 <ul>
                     <li>
                         Data is extracted from documents only.
-                        <br/>
+                        <br />
                         Attachments, Counters, Time series, and Revisions are not sent.
                     </li>
                     <li className="margin-top-xxs">
@@ -52,20 +54,22 @@ export function EditKafkaEtlInfoHub() {
                         (excluding deletes).
                     </li>
                     <li className="margin-top-xxs">
-                        You can test each script in this view to preview the messages that will be sent by the ETL
-                        task to the destination.
+                        You can test each script in this view to preview the messages that will be sent by the ETL task
+                        to the destination.
                     </li>
                 </ul>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul>
-                        <li>A connection string specifying Kafka&apos;s bootstrap servers.
-                            <br/>
+                        <li>
+                            A connection string specifying Kafka&apos;s bootstrap servers.
+                            <br />
                             Connection options can be specified.
                         </li>
                         <li>The transformation scripts definitions.</li>
-                        <li>Per topic, select whether processed documents will be deleted from your RavenDB database.
+                        <li>
+                            Per topic, select whether processed documents will be deleted from your RavenDB database.
                         </li>
                         <li>A responsible node to handle this task can be set.</li>
                     </ul>
@@ -76,10 +80,7 @@ export function EditKafkaEtlInfoHub() {
                     <Icon icon="newtab" /> Docs - Kafka ETL
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasQueueEtl}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasQueueEtl} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditKafkaSinkTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditKafkaSinkTaskInfoHub.tsx
@@ -1,7 +1,9 @@
 ﻿import AboutViewFloating, { AccordionItemWrapper } from "components/common/AboutView";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 import React from "react";
 
@@ -27,34 +29,35 @@ export function EditKafkaSinkTaskInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    Define a <strong>Kafka Sink</strong> ongoing-task in order to consume and process incoming messages from Kafka topics.
+                    Define a <strong>Kafka Sink</strong> ongoing-task in order to consume and process incoming messages
+                    from Kafka topics.
                 </p>
                 <p>
-                    Add one or more <strong>scripts</strong> that Load, Put, or Delete documents in RavenDB based on the incoming messages:
+                    Add one or more <strong>scripts</strong> that Load, Put, or Delete documents in RavenDB based on the
+                    incoming messages:
                 </p>
                 <ul>
                     <li className="margin-top-sm">
-                        In the task definition:<br />
+                        In the task definition:
+                        <br />
                         Define the connection string (bootstrap servers and any additional connection options).
                     </li>
                     <li className="margin-top-xxs">
-                        In the script definition:<br />
-                        Define the Kafka topic the script will subscribe to.<br />
+                        In the script definition:
+                        <br />
+                        Define the Kafka topic the script will subscribe to.
+                        <br />
                         The script can be tested to preview the resulting documents.
                     </li>
-                    <li className="margin-top-xxs">
-                        Incoming messages are expected only as JSON.
-                    </li>
+                    <li className="margin-top-xxs">Incoming messages are expected only as JSON.</li>
                 </ul>
                 <p>
-                    A database with a defined Kafka Sink task will Not become idle,<br />
+                    A database with a defined Kafka Sink task will Not become idle,
+                    <br />
                     ensuring continuous processing of incoming messages.
                 </p>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasQueueSink}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasQueueSink} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditManualBackupTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditManualBackupTaskInfoHub.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "components/hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, {FeatureAvailabilityData} from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditManualBackupTaskInfoHub() {
@@ -44,8 +46,13 @@ export function EditManualBackupTaskInfoHub() {
                 <div>
                     Generate a one-time backup of this database.
                     <ul className="margin-top-xxs">
-                        <li>Creating an ad-hoc backup may be essential before an upgrade or whenever an unscheduled backup is needed.</li>
-                        <li>No retention period is defined for this backup, so it will not be automatically deleted.</li>
+                        <li>
+                            Creating an ad-hoc backup may be essential before an upgrade or whenever an unscheduled
+                            backup is needed.
+                        </li>
+                        <li>
+                            No retention period is defined for this backup, so it will not be automatically deleted.
+                        </li>
                     </ul>
                 </div>
                 <div>
@@ -77,18 +84,20 @@ const defaultFeatureAvailability: FeatureAvailabilityData[] = [
         featureIcon: "encryption",
         community: { value: false },
         professional: { value: true },
-        enterprise: { value: true }
-    },{
+        enterprise: { value: true },
+    },
+    {
         featureName: "Remote destinations",
         featureIcon: "cloud",
         community: { value: false },
         professional: { value: true },
-        enterprise: { value: true }
-    },{
+        enterprise: { value: true },
+    },
+    {
         featureName: "Snapshot backups",
         featureIcon: "snapshot-backup",
         community: { value: false },
         professional: { value: false },
-        enterprise: { value: true }
+        enterprise: { value: true },
     },
 ];

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditOlapEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditOlapEtlInfoHub.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditOlapEtlInfoHub() {
@@ -32,13 +34,13 @@ export function EditOlapEtlInfoHub() {
             >
                 <p>
                     An <strong>OLAP ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process that
-                    converts documents&apos; data from this RavenDB database to the Apache Parquet file format, and sends
-                    it to the specified destinations.
+                    converts documents&apos; data from this RavenDB database to the Apache Parquet file format, and
+                    sends it to the specified destinations.
                 </p>
                 <ul>
                     <li>
                         Data is extracted from documents only.
-                        <br/>
+                        <br />
                         Attachments, Counters, Time series, and Revisions are not sent.
                     </li>
                     <li className="margin-top-xxs">
@@ -58,14 +60,15 @@ export function EditOlapEtlInfoHub() {
                         task to the destination.
                     </li>
                 </ul>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul>
                         <li>The frequency at which scripts will execute.</li>
                         <li>A connection string specifying the storage destinations.</li>
                         <li>The transformation scripts definitions.</li>
-                        <li>Optional - a column name that will override the default ID column name in the generated
+                        <li>
+                            Optional - a column name that will override the default ID column name in the generated
                             Parquet file.
                         </li>
                         <li>A responsible node to handle this task can be set.</li>
@@ -77,10 +80,7 @@ export function EditOlapEtlInfoHub() {
                     <Icon icon="newtab" /> Docs - OLAP ETL
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasOlapEtl}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasOlapEtl} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditPeriodicBackupTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditPeriodicBackupTaskInfoHub.tsx
@@ -4,10 +4,10 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "components/hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, {FeatureAvailabilityData} from "components/common/FeatureAvailabilitySummary";
-import {
-    useLimitedFeatureAvailability
-} from "components/utils/licenseLimitsUtils";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
+import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditPeriodicBackupTaskInfoHub() {
     const hasPeriodicBackups = useAppSelector(licenseSelectors.statusValue("HasPeriodicBackup"));
@@ -23,7 +23,7 @@ export function EditPeriodicBackupTaskInfoHub() {
             {
                 featureName: defaultFeatureAvailability[1].featureName,
                 value: hasSnapshotBackups,
-            }
+            },
         ],
     });
 
@@ -80,12 +80,13 @@ const defaultFeatureAvailability: FeatureAvailabilityData[] = [
         featureIcon: "periodic-backup",
         community: { value: false },
         professional: { value: true },
-        enterprise: { value: true }
-    },{
+        enterprise: { value: true },
+    },
+    {
         featureName: "Snapshot Backups",
         featureIcon: "snapshot-backup",
         community: { value: false },
         professional: { value: false },
-        enterprise: { value: true }
-    }
+        enterprise: { value: true },
+    },
 ];

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRabbitMqEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRabbitMqEtlInfoHub.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditRabbitMqEtlInfoHub() {
@@ -31,13 +33,13 @@ export function EditRabbitMqEtlInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    A <strong>RabbitMQ ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
-                    that transfers data from this RavenDB database to a RabbitMQ exchange.
+                    A <strong>RabbitMQ ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process that
+                    transfers data from this RavenDB database to a RabbitMQ exchange.
                 </p>
                 <ul>
                     <li>
                         Data is extracted from documents only.
-                        <br/>
+                        <br />
                         Attachments, Counters, Time series, and Revisions are not sent.
                     </li>
                     <li className="margin-top-xxs">
@@ -52,20 +54,23 @@ export function EditRabbitMqEtlInfoHub() {
                         (excluding deletes).
                     </li>
                     <li className="margin-top-xxs">
-                        You can test each script in this view to preview the messages that will be sent by the ETL
-                        task to the destination.
+                        You can test each script in this view to preview the messages that will be sent by the ETL task
+                        to the destination.
                     </li>
                 </ul>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul>
                         <li>A connection string to the RabbitMQ exchange server.</li>
                         <li>The transformation scripts definitions.</li>
-                        <li>Per queue, select whether processed documents will be deleted from your RavenDB database.
+                        <li>
+                            Per queue, select whether processed documents will be deleted from your RavenDB database.
                         </li>
-                        <li>When defining the RabbitMQ Exchanges, Queues & Bindings manually, 
-                            you can request to skip their automatic creation.</li>
+                        <li>
+                            When defining the RabbitMQ Exchanges, Queues & Bindings manually, you can request to skip
+                            their automatic creation.
+                        </li>
                         <li>A responsible node to handle this task can be set.</li>
                     </ul>
                 </div>
@@ -75,10 +80,7 @@ export function EditRabbitMqEtlInfoHub() {
                     <Icon icon="newtab" /> Docs - RabbitMQ ETL
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasQueueEtl}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasQueueEtl} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRabbitMqSinkTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRabbitMqSinkTaskInfoHub.tsx
@@ -1,7 +1,9 @@
 ﻿import AboutViewFloating, { AccordionItemWrapper } from "components/common/AboutView";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useAppSelector } from "components/store";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 import React from "react";
 
@@ -50,14 +52,12 @@ export function EditRabbitMqSinkTaskInfoHub() {
                     <li className="margin-top-xxs">Incoming messages are expected only as JSON.</li>
                 </ul>
                 <p>
-                    A database with a defined RabbitMQ Sink task will Not become idle,<br />
+                    A database with a defined RabbitMQ Sink task will Not become idle,
+                    <br />
                     ensuring continuous processing of incoming messages.
                 </p>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasQueueSink}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasQueueSink} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRavenEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRavenEtlInfoHub.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditRavenEtlInfoHub() {
@@ -18,7 +20,7 @@ export function EditRavenEtlInfoHub() {
             },
         ],
     });
-    
+
     const ravenDbEtlDocsLink = useRavenLink({ hash: "GFSWLI" });
 
     return (
@@ -35,14 +37,15 @@ export function EditRavenEtlInfoHub() {
                     transfers data from documents from this RavenDB database to another RavenDB database.
                 </p>
                 <ul>
-                    <li>The sent data can be filtered and modified by multiple transformation JavaScript scripts that
+                    <li>
+                        The sent data can be filtered and modified by multiple transformation JavaScript scripts that
                         are added to the task.
                     </li>
                     <li className="margin-top-xxs">
                         Custom logic for Attachments, Counters, Time series,
-                        <br/>
+                        <br />
                         and deletion behavior can also be applied.
-                        <br/>
+                        <br />
                         Revisions are not sent by the ETL process.
                     </li>
                     <li className="margin-top-xxs">
@@ -57,7 +60,7 @@ export function EditRavenEtlInfoHub() {
                         You can test each script in this view to preview the resulting documents that will be sent.
                     </li>
                 </ul>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul>
@@ -72,10 +75,7 @@ export function EditRavenEtlInfoHub() {
                     <Icon icon="newtab" /> Docs - RavenDB ETL
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasRavenEtl}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasRavenEtl} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditReplicationHubInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditReplicationHubInfoHub.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditReplicationHubInfoHub() {
@@ -31,28 +33,31 @@ export function EditReplicationHubInfoHub() {
                 description="Get additional info on this feature"
             >
                 <div>
-                    Define a <strong>Replication Hub</strong> for replicating documents to and/or from multiple Replication
-                    Sink tasks that are defined in other RavenDB databases in other clusters:
+                    Define a <strong>Replication Hub</strong> for replicating documents to and/or from multiple
+                    Replication Sink tasks that are defined in other RavenDB databases in other clusters:
                     <ul className="margin-top-xxs">
                         <li>A Replication Hub can serve many Sinks.</li>
                         <li>The connection to the Hub is always initiated by the Sink.</li>
-                        <li>Only documents and their related data (attachments, revisions, counters & time series) will
+                        <li>
+                            Only documents and their related data (attachments, revisions, counters & time series) will
                             be replicated.
                         </li>
                     </ul>
                 </div>
-                <hr/>
+                <hr />
                 <div>
                     When running with a SECURE server:
                     <ul>
-                        <li className="margin-top-xxs"><strong>Replication Access</strong>:
-                            <br/>
-                            You can set up multiple Replication Access definitions on the Hub task with
-                            an associated certificate, which will be used by the Sink tasks to authenticate and
-                            establish a connection with the Replication Hub.
+                        <li className="margin-top-xxs">
+                            <strong>Replication Access</strong>:
+                            <br />
+                            You can set up multiple Replication Access definitions on the Hub task with an associated
+                            certificate, which will be used by the Sink tasks to authenticate and establish a connection
+                            with the Replication Hub.
                         </li>
-                        <li className="margin-top-xxs"><strong>Filtered Replication</strong>:
-                            <br/>
+                        <li className="margin-top-xxs">
+                            <strong>Filtered Replication</strong>:
+                            <br />
                             Within each Access definition, you can filter the documents that will be replicated by their
                             ID paths.
                         </li>
@@ -61,7 +66,7 @@ export function EditReplicationHubInfoHub() {
                         </li>
                     </ul>
                 </div>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul className="margin-top-xxs">
@@ -78,10 +83,7 @@ export function EditReplicationHubInfoHub() {
                     <Icon icon="newtab" /> Docs - Replication Hub
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasPullReplicationAsHub}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasPullReplicationAsHub} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditReplicationSinkInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditReplicationSinkInfoHub.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditReplicationSinkInfoHub() {
@@ -37,31 +39,34 @@ export function EditReplicationSinkInfoHub() {
                         <li>The connection to the Hub is always initiated by the Sink.</li>
                         <li>Multiple Sinks can connect to the same Replication Hub.</li>
                         <li>Data replication can be bi-directional.</li>
-                        <li>Only documents and their related data (attachments, revisions, counters & time series) will
+                        <li>
+                            Only documents and their related data (attachments, revisions, counters & time series) will
                             be replicated.
                         </li>
                     </ul>
                 </div>
-                <hr/>
+                <hr />
                 <div>
                     When running with a SECURE server:
                     <ul>
-                        <li className="margin-top-xxs"><strong>Replication Access</strong>:
-                            <br/>
-                            Set up a Replication Access definition on the Sink task with
-                            a certificate that will be used by the Sink task to authenticate and
-                            establish a connection with the Replication Hub.
+                        <li className="margin-top-xxs">
+                            <strong>Replication Access</strong>:
+                            <br />
+                            Set up a Replication Access definition on the Sink task with a certificate that will be used
+                            by the Sink task to authenticate and establish a connection with the Replication Hub.
                         </li>
-                        <li className="margin-top-xxs"><strong>Filtered Replication</strong>:
-                            <br/>
-                            Within the Access definition, you can filter the documents that will be replicated by their ID paths.
+                        <li className="margin-top-xxs">
+                            <strong>Filtered Replication</strong>:
+                            <br />
+                            Within the Access definition, you can filter the documents that will be replicated by their
+                            ID paths.
                         </li>
                         <li className="margin-top-xxs">
                             <strong>Sink to Hub Replication</strong> is only available with a secure server.
                         </li>
                     </ul>
                 </div>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul className="margin-top-xxs">
@@ -77,10 +82,7 @@ export function EditReplicationSinkInfoHub() {
                     <Icon icon="newtab" /> Docs - Replication Sink
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasPullReplicationAsSink}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasPullReplicationAsSink} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSnowflakeEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSnowflakeEtlInfoHub.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditSnowflakeEtlInfoHub() {
@@ -20,7 +22,7 @@ export function EditSnowflakeEtlInfoHub() {
     });
 
     const snowflakeEtlDocsLink = useRavenLink({ hash: "TODO" }); //TODO: HASH
-    
+
     return (
         <AboutViewFloating defaultOpen={hasSnowflakeEtl ? null : "licensing"}>
             <AccordionItemWrapper
@@ -31,13 +33,13 @@ export function EditSnowflakeEtlInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    A <strong>Snowflake ETL</strong> ongoing-task is an ETL (Extract, Transform & Load)
-                    process that transfers data from this RavenDB database to a Snowflake data warehouse.
+                    A <strong>Snowflake ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process that
+                    transfers data from this RavenDB database to a Snowflake data warehouse.
                 </p>
                 <ul>
                     <li>
                         Data is extracted from documents & attachments only.
-                        <br/>
+                        <br />
                         Counters, Time series, and Revisions are not sent.
                     </li>
                     <li className="margin-top-xxs">
@@ -52,36 +54,36 @@ export function EditSnowflakeEtlInfoHub() {
                         deleted.
                     </li>
                     <li className="margin-top-xxs">
-                        You can test each script in this view to preview the SQL statements the ETL task would send
-                        the Snowflake database.
+                        You can test each script in this view to preview the SQL statements the ETL task would send the
+                        Snowflake database.
                     </li>
                 </ul>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul>
                         <li>The transformation scripts definitions.</li>
-                        <li>List of Snowflake tables the ETL task will access,
-                            <br/>    
+                        <li>
+                            List of Snowflake tables the ETL task will access,
+                            <br />
                             including the column name used for the RavenDB document ID.
                         </li>
-                        <li>A connection string specifying the Snowflake storage destination,
-                            <br/>
-                            where &quot;<i>Account</i>&quot;, &quot;<i>Database</i>&quot;, and &quot;<i>Schema</i>&quot; are mandatory parameters.
+                        <li>
+                            A connection string specifying the Snowflake storage destination,
+                            <br />
+                            where &quot;<i>Account</i>&quot;, &quot;<i>Database</i>&quot;, and &quot;<i>Schema</i>&quot;
+                            are mandatory parameters.
                         </li>
                         <li>A responsible node to handle this task can be set.</li>
                     </ul>
                 </div>
-                <hr/>
+                <hr />
                 <div className="small-label mb-2">useful links</div>
                 <a href={snowflakeEtlDocsLink} target="_blank">
                     <Icon icon="newtab" /> Docs - Snowflake ETL
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasSnowflakeEtl}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasSnowflakeEtl} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSqlEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSqlEtlInfoHub.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditSqlEtlInfoHub() {
@@ -31,13 +33,13 @@ export function EditSqlEtlInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    A <strong>SQL ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
-                    that transfers data from this RavenDB database to a relational database.
+                    A <strong>SQL ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process that transfers
+                    data from this RavenDB database to a relational database.
                 </p>
                 <ul>
                     <li>
                         Data is extracted from documents & attachments only.
-                        <br/>
+                        <br />
                         Counters, Time series, and Revisions are not sent.
                     </li>
                     <li className="margin-top-xxs">
@@ -52,20 +54,20 @@ export function EditSqlEtlInfoHub() {
                         deleted.
                     </li>
                     <li className="margin-top-xxs">
-                        You can test each script in this view to preview the SQL statements the ETL task would send
-                        the relational database.
+                        You can test each script in this view to preview the SQL statements the ETL task would send the
+                        relational database.
                     </li>
                 </ul>
-                <hr/>
+                <hr />
                 <div>
                     Task definition includes:
                     <ul>
                         <li>The transformation scripts definitions.</li>
-                        <li>List of SQL tables the ETL task will access, including the column name used for the RavenDB
+                        <li>
+                            List of SQL tables the ETL task will access, including the column name used for the RavenDB
                             document ID.
                         </li>
-                        <li>The destination RDBMS factory name and its corresponding connection string.
-                        </li>
+                        <li>The destination RDBMS factory name and its corresponding connection string.</li>
                         <li>A responsible node to handle this task can be set.</li>
                     </ul>
                 </div>
@@ -75,10 +77,7 @@ export function EditSqlEtlInfoHub() {
                     <Icon icon="newtab" /> Docs - SQL ETL
                 </a>
             </AccordionItemWrapper>
-            <FeatureAvailabilitySummaryWrapper
-                isUnlimited={hasSqlEtl}
-                data={featureAvailability}
-            />
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasSqlEtl} data={featureAvailability} />
         </AboutViewFloating>
     );
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
@@ -10,9 +10,11 @@ import FeatureAvailabilitySummaryWrapper, {
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditSubscriptionTaskInfoHub() {
-    const hasConcurrentDataSubscriptions = useAppSelector(licenseSelectors.statusValue("HasConcurrentDataSubscriptions"));
+    const hasConcurrentDataSubscriptions = useAppSelector(
+        licenseSelectors.statusValue("HasConcurrentDataSubscriptions")
+    );
     const hasRevisionsInSubscriptions = useAppSelector(licenseSelectors.statusValue("HasRevisionsInSubscriptions"));
-    
+
     const featureAvailability = useLimitedFeatureAvailability({
         defaultFeatureAvailability,
         overwrites: [
@@ -60,8 +62,8 @@ export function EditSubscriptionTaskInfoHub() {
                         The <strong>starting point</strong> from where to send the matching documents can be configured.
                     </li>
                     <li className="margin-top-xxs">
-                        You can <strong>test the subscription query</strong> in this view to preview sample document results
-                        that will be sent to the client.
+                        You can <strong>test the subscription query</strong> in this view to preview sample document
+                        results that will be sent to the client.
                     </li>
                 </ul>
                 <hr />
@@ -93,5 +95,5 @@ const defaultFeatureAvailability: FeatureAvailabilityData[] = [
         community: { value: false },
         professional: { value: false },
         enterprise: { value: true },
-    }
+    },
 ];

--- a/src/Raven.Studio/typescript/viewmodels/manage/EditServerWideBackupInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/manage/EditServerWideBackupInfoHub.tsx
@@ -4,10 +4,10 @@ import { useAppSelector } from "components/store";
 import React from "react";
 import { Icon } from "components/common/Icon";
 import { useRavenLink } from "components/hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, {FeatureAvailabilityData} from "components/common/FeatureAvailabilitySummary";
-import {
-    useLimitedFeatureAvailability
-} from "components/utils/licenseLimitsUtils";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
+import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
 export function EditServerWideBackupInfoHub() {
     const hasServerWideBackups = useAppSelector(licenseSelectors.statusValue("HasServerWideBackups"));
@@ -23,7 +23,7 @@ export function EditServerWideBackupInfoHub() {
             {
                 featureName: defaultFeatureAvailability[1].featureName,
                 value: hasSnapshotBackups,
-            }
+            },
         ],
     });
 
@@ -87,12 +87,13 @@ const defaultFeatureAvailability: FeatureAvailabilityData[] = [
         featureIcon: "server-wide-backup",
         community: { value: false },
         professional: { value: true },
-        enterprise: { value: true }
-    },{
+        enterprise: { value: true },
+    },
+    {
         featureName: "Snapshot Backups",
         featureIcon: "snapshot-backup",
         community: { value: false },
         professional: { value: false },
-        enterprise: { value: true }
-    }
+        enterprise: { value: true },
+    },
 ];

--- a/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
@@ -29,7 +29,7 @@ export default function UpgradeModal(props: { close: () => void }) {
     const isReplaceLicenseEnabled = canActivate && isClusterAdminOrClusterNode;
 
     const licenseStatus = useAppSelector(licenseSelectors.status);
-    
+
     const registerLicense = () => {
         registration.showRegistrationDialog(licenseStatus, false, true);
 
@@ -74,11 +74,12 @@ export default function UpgradeModal(props: { close: () => void }) {
                                     message={`${allowDismissUntilUtc.local().format(dateFormat)} your local time`}
                                 >
                                     <Icon icon="info" color="info" margin="ms-1" />
-                                </PopoverWithHoverWrapper> 
+                                </PopoverWithHoverWrapper>
                             </span>
                             <br />
                             <span className="text-muted">
-                                Afterwards the <strong>RavenDB Studio</strong> will be <strong className="text-danger">blocked</strong>.
+                                Afterwards the <strong>RavenDB Studio</strong> will be{" "}
+                                <strong className="text-danger">blocked</strong>.
                             </span>
                         </>
                     )}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26882

### Additional description

Don't check in all the commits, just the first one with changes to `.prettierignore` is enough, the rest are just reformatted files.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
