### PR TITLE
Quill-309 Add time utils and remove duration from tooltip

### DIFF
--- a/src/Raven.Quill.Web/src/api/queries/apps-queries.ts
+++ b/src/Raven.Quill.Web/src/api/queries/apps-queries.ts
@@ -1,10 +1,11 @@
 import { queryOptions } from "@tanstack/react-query";
 import type { ServerApi } from "@/api/generated/server-api";
 import { recordFetchStartedAt } from "@/lib/query-fetch-start";
+import { MS_IN } from "@/lib/time";
 
 const baseKey = "apps";
 
-const CDC_ERRORS_POLL_INTERVAL_MS = 5_000;
+const CDC_ERRORS_POLL_INTERVAL_MS = 5 * MS_IN.second;
 
 // Partial key covering every app's connection strings list, so mutations on the
 // (server-wide) connection strings can invalidate all of them at once.

--- a/src/Raven.Quill.Web/src/api/queries/discord-queries.ts
+++ b/src/Raven.Quill.Web/src/api/queries/discord-queries.ts
@@ -1,11 +1,12 @@
 import { queryOptions } from "@tanstack/react-query";
 import type { DiscordChannelHealthResponse, ServerApi } from "@/api/generated/server-api";
+import { MS_IN } from "@/lib/time";
 
 const baseKey = "discord";
 
-const CONNECTING_POLL_MS = 3_000;
-const IDLE_POLL_MS = 30_000;
-const CONNECTING_POLL_WINDOW_MS = 60_000;
+const CONNECTING_POLL_MS = 3 * MS_IN.second;
+const IDLE_POLL_MS = 30 * MS_IN.second;
+const CONNECTING_POLL_WINDOW_MS = MS_IN.minute;
 
 // When each channel was first seen connecting. Per channel, not per app: a bot wedged in "Connecting..."
 // must stop pulling the fast poll once its window is spent, without spending the window of a channel that

--- a/src/Raven.Quill.Web/src/api/queries/slack-queries.ts
+++ b/src/Raven.Quill.Web/src/api/queries/slack-queries.ts
@@ -1,5 +1,6 @@
 import { queryOptions } from "@tanstack/react-query";
 import type { ServerApi } from "@/api/generated/server-api";
+import { MS_IN } from "@/lib/time";
 
 const baseKey = "slack";
 
@@ -14,7 +15,7 @@ export function createSlackQueries(api: ServerApi["slack"]) {
             queryOptions({
                 queryKey: [baseKey, "health", slug],
                 queryFn: () => api.health(slug),
-                refetchInterval: 30_000,
+                refetchInterval: 30 * MS_IN.second,
             }),
     };
 }

--- a/src/Raven.Quill.Web/src/components/data/ai-progress-status.tsx
+++ b/src/Raven.Quill.Web/src/components/data/ai-progress-status.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { Text } from "@/components/typography";
 import { SparklesIcon } from "lucide-react";
+import { MS_IN, SECONDS_IN } from "@/lib/time";
 
 export type AiProgressStage = {
     fromSeconds: number;
@@ -40,17 +41,17 @@ function useElapsedSeconds(startedAt?: number) {
     const [now, setNow] = useState(mountedAt);
 
     useEffect(() => {
-        const interval = setInterval(() => setNow(Date.now()), 1_000);
+        const interval = setInterval(() => setNow(Date.now()), MS_IN.second);
 
         return () => clearInterval(interval);
     }, []);
 
-    return Math.max(0, Math.round((now - (startedAt ?? mountedAt)) / 1_000));
+    return Math.max(0, Math.round((now - (startedAt ?? mountedAt)) / MS_IN.second));
 }
 
 function formatElapsed(totalSeconds: number): string {
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
+    const minutes = Math.floor(totalSeconds / SECONDS_IN.minute);
+    const seconds = totalSeconds % SECONDS_IN.minute;
 
     return minutes > 0 ? `${minutes}m ${String(seconds).padStart(2, "0")}s` : `${seconds}s`;
 }

--- a/src/Raven.Quill.Web/src/components/data/timestamp.stories.tsx
+++ b/src/Raven.Quill.Web/src/components/data/timestamp.stories.tsx
@@ -5,9 +5,10 @@ import { Badge } from "@/components/shadcn/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/shadcn/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/ui/table";
 import { Heading, Text } from "@/components/typography";
+import { MS_IN } from "@/lib/time";
 import { Timestamp } from "./timestamp";
 
-const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60_000).toISOString();
+const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * MS_IN.minute).toISOString();
 
 const SAMPLE_CHANNELS = [
     { name: "Support widget", type: "Web widget", createdAt: minutesAgo(0.5) },
@@ -53,7 +54,8 @@ function TimestampGallery() {
                     Timestamp
                 </Heading>
                 <Text variant="muted">
-                    Hover any value for the relative reading. The short variant carries the time of day there too.
+                    The full variant shows the date and time outright. The short variant drops the time of day and
+                    carries it in a tooltip instead.
                 </Text>
             </div>
 

--- a/src/Raven.Quill.Web/src/components/data/timestamp.tsx
+++ b/src/Raven.Quill.Web/src/components/data/timestamp.tsx
@@ -1,15 +1,15 @@
 import type { ComponentProps, ReactNode } from "react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/ui/tooltip";
 import { Text, type TextVariant } from "@/components/typography";
-import { formatDate, formatDateTime, formatRelativeTime } from "@/lib/format";
+import { formatDate, formatDateTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
-// The one way to show a moment in time: an exact date, with the relative reading in a tooltip.
-// `dateVariant="short"` drops the time of day, which the tooltip then carries instead.
+// The one way to show a moment in time: an exact date.
+// `dateVariant="short"` drops the time of day, which a tooltip then carries instead.
 // `textVariant="inherit"` leaves the type to whatever the value sits inside (an alert, a badge).
 //
 // When the visible trigger is something other than the date itself — a badge that names a state,
-// with the time behind it — wrap that trigger in <TimestampTooltip> so the tooltip reads the same.
+// with the time behind it — wrap that trigger in <TimestampTooltip>.
 
 type TimestampDateVariant = "full" | "short";
 type TimestampTextVariant = TextVariant | "inherit";
@@ -35,55 +35,33 @@ export function Timestamp({
         );
     }
 
-    return (
-        <TimestampTooltip value={value} withDateTime={dateVariant === "short"}>
+    if (dateVariant === "full") {
+        return (
             <TimestampLabel textVariant={textVariant} className={className}>
-                {dateVariant === "short" ? formatDate(value) : formatDateTime(value)}
+                {formatDateTime(value)}
+            </TimestampLabel>
+        );
+    }
+
+    return (
+        <TimestampTooltip value={value}>
+            <TimestampLabel textVariant={textVariant} className={className}>
+                {formatDate(value)}
             </TimestampLabel>
         </TimestampTooltip>
     );
 }
 
-export function TimestampTooltip({
-    value,
-    prefix,
-    withDateTime = true,
-    children,
-}: {
-    value: string;
-    prefix?: string;
-    withDateTime?: boolean;
-    children: ReactNode;
-}) {
+export function TimestampTooltip({ value, prefix, children }: { value: string; prefix?: string; children: ReactNode }) {
+    const dateTime = formatDateTime(value);
+
     return (
         <TooltipProvider>
             <Tooltip>
                 <TooltipTrigger asChild>{children}</TooltipTrigger>
-                <TooltipContent className="flex-col items-start gap-0.5">
-                    <TimestampTooltipBody value={value} prefix={prefix} withDateTime={withDateTime} />
-                </TooltipContent>
+                <TooltipContent>{prefix ? `${prefix} ${dateTime}` : dateTime}</TooltipContent>
             </Tooltip>
         </TooltipProvider>
-    );
-}
-
-// Its own component so the age is read when the tooltip opens rather than when the trigger rendered
-function TimestampTooltipBody({
-    value,
-    prefix,
-    withDateTime,
-}: {
-    value: string;
-    prefix?: string;
-    withDateTime: boolean;
-}) {
-    const relative = formatRelativeTime(value);
-
-    return (
-        <>
-            <span>{prefix ? `${prefix} ${relative}` : relative}</span>
-            {withDateTime && <span>{formatDateTime(value)}</span>}
-        </>
     );
 }
 

--- a/src/Raven.Quill.Web/src/lib/format.ts
+++ b/src/Raven.Quill.Web/src/lib/format.ts
@@ -30,53 +30,6 @@ export function formatDateTime(value: string): string {
     return Number.isNaN(date.getTime()) ? value : dateTimeFormatter.format(date);
 }
 
-const MINUTE_MS = 60_000;
-const HOUR_MS = 60 * MINUTE_MS;
-const DAY_MS = 24 * HOUR_MS;
-
-// Largest unit first: a duration is shown in the biggest unit it fills at least once.
-const RELATIVE_TIME_UNITS: { unit: Intl.RelativeTimeFormatUnit; ms: number }[] = [
-    { unit: "year", ms: 365 * DAY_MS },
-    { unit: "month", ms: 30 * DAY_MS },
-    { unit: "week", ms: 7 * DAY_MS },
-    { unit: "day", ms: DAY_MS },
-    { unit: "hour", ms: HOUR_MS },
-    { unit: "minute", ms: MINUTE_MS },
-];
-
-const relativeTimeFormatter = new Intl.RelativeTimeFormat("en-US", { numeric: "always", style: "long" });
-
-// e.g. "17 hours ago", "1 day ago", "in 3 days".
-export function formatRelativeTime(value: string): string {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return value;
-    }
-
-    const elapsedMs = date.getTime() - Date.now();
-    for (const { unit, ms } of RELATIVE_TIME_UNITS) {
-        if (Math.abs(elapsedMs) >= ms) {
-            return relativeTimeFormatter.format(Math.round(elapsedMs / ms), unit);
-        }
-    }
-    return "just now";
-}
-
-const DURATION_UNITS = [
-    { label: "day", seconds: 86_400 },
-    { label: "hour", seconds: 3_600 },
-    { label: "minute", seconds: 60 },
-    { label: "second", seconds: 1 },
-] as const;
-
-// Duration rounded down to its largest whole unit, e.g. 5 -> "5 seconds", 7_200 -> "2 hours".
-export function formatDuration(totalSeconds: number): string {
-    const unit =
-        DURATION_UNITS.find(({ seconds }) => totalSeconds >= seconds) ?? DURATION_UNITS[DURATION_UNITS.length - 1];
-    const value = Math.floor(totalSeconds / unit.seconds);
-    return `${value} ${unit.label}${value === 1 ? "" : "s"}`;
-}
-
 const currencyFormatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
 
 // Currency display, e.g. 128.4 -> "$128.40".

--- a/src/Raven.Quill.Web/src/lib/license.ts
+++ b/src/Raven.Quill.Web/src/lib/license.ts
@@ -1,7 +1,6 @@
 import type { ServerLicenseResponse } from "@/api/generated/server-api";
 import { parseStartDate } from "@/lib/date-period";
-
-const DAY_MS = 24 * 60 * 60 * 1000;
+import { MS_IN } from "@/lib/time";
 
 // Days until the license expires, replacing the daysLeft the server used to send.
 export function getLicenseDaysLeft(license: ServerLicenseResponse): number {
@@ -12,7 +11,7 @@ export function getLicenseDaysLeft(license: ServerLicenseResponse): number {
     if (Number.isNaN(expiration)) {
         return 0;
     }
-    return Math.max(0, Math.ceil((expiration - Date.now()) / DAY_MS));
+    return Math.max(0, Math.ceil((expiration - Date.now()) / MS_IN.day));
 }
 
 // Day one of this setup: the server behind it has never run before this date, so nothing

--- a/src/Raven.Quill.Web/src/lib/query-client.ts
+++ b/src/Raven.Quill.Web/src/lib/query-client.ts
@@ -1,6 +1,7 @@
 import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 import { isApiError } from "@/api/http-client";
 import { AUTH_STATUS_QUERY_KEY, UNAUTHENTICATED_STATUS } from "@/lib/auth-query";
+import { MS_IN } from "@/lib/time";
 
 export function markSessionExpired() {
     queryClient.setQueryData(AUTH_STATUS_QUERY_KEY, UNAUTHENTICATED_STATUS);
@@ -18,7 +19,7 @@ export const queryClient = new QueryClient({
     mutationCache: new MutationCache({ onError: handleUnauthorized }),
     defaultOptions: {
         queries: {
-            staleTime: 60_000,
+            staleTime: MS_IN.minute,
             refetchOnWindowFocus: false,
             retry: 1,
         },

--- a/src/Raven.Quill.Web/src/lib/time.ts
+++ b/src/Raven.Quill.Web/src/lib/time.ts
@@ -1,0 +1,28 @@
+import {
+    millisecondsInDay,
+    millisecondsInHour,
+    millisecondsInMinute,
+    millisecondsInSecond,
+    millisecondsInWeek,
+    secondsInDay,
+    secondsInHour,
+    secondsInMinute,
+    secondsInWeek,
+} from "date-fns/constants";
+
+// A multiplication table for durations, e.g. `14 * MS_IN.day`. It stops at week on purpose:
+// months and years have no fixed length, so they belong to date arithmetic (date-fns, date-period.ts).
+export const SECONDS_IN = {
+    minute: secondsInMinute,
+    hour: secondsInHour,
+    day: secondsInDay,
+    week: secondsInWeek,
+} as const;
+
+export const MS_IN = {
+    second: millisecondsInSecond,
+    minute: millisecondsInMinute,
+    hour: millisecondsInHour,
+    day: millisecondsInDay,
+    week: millisecondsInWeek,
+} as const;

--- a/src/Raven.Quill.Web/src/mocks/apps-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/apps-mocks.ts
@@ -1,4 +1,5 @@
 import { delay, http, HttpResponse, ws, type RequestHandler } from "msw";
+import { MS_IN } from "@/lib/time";
 import type {
     AiConnectionString,
     AppCdcConfigurationResponse,
@@ -128,7 +129,7 @@ export function sampleCdcProgressFrame(): CdcLiveRawFrame {
                 Stats: [
                     {
                         Performance: Array.from({ length: 51 }, (_, index) => {
-                            const startedMs = Date.now() - 5_000 - index * 90_000;
+                            const startedMs = Date.now() - 5 * MS_IN.second - index * 90 * MS_IN.second;
                             const durationInMs = 900 + Math.round(Math.abs(Math.sin(index)) * 800);
                             const read = 480 + index * 7;
 

--- a/src/Raven.Quill.Web/src/mocks/embed-links-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/embed-links-mocks.ts
@@ -1,6 +1,7 @@
 import type { ApiErrorResponse, EmbedLinkSummaryResponse, MintEmbedLinkResponse } from "@/api/generated/server-api";
 import { SAMPLE_CHANNEL_ID } from "./channels-mocks";
 import { apiHttp } from "./api-http";
+import { MS_IN } from "@/lib/time";
 
 export const embedLinksMocks = {
     list: (links: EmbedLinkSummaryResponse[] = sampleEmbedLinks) =>
@@ -13,8 +14,6 @@ export const embedLinksMocks = {
     revoke: () => apiHttp.delete("/api/apps/{slug}/embed-links/{token}", ({ response }) => response(204).empty()),
 };
 
-const HOUR_MS = 60 * 60 * 1000;
-const DAY_MS = 24 * HOUR_MS;
 const fromNow = (offsetMs: number) => new Date(Date.now() + offsetMs).toISOString();
 
 // Dates are relative to "now" so the channel detail always shows the full spread of
@@ -25,8 +24,8 @@ export const sampleEmbedLinks: EmbedLinkSummaryResponse[] = [
         channelId: SAMPLE_CHANNEL_ID,
         agentId: "agents/sales",
         parameters: { customerId: "users/1" },
-        createdAt: fromNow(-3 * DAY_MS),
-        expiresAt: fromNow(6 * DAY_MS),
+        createdAt: fromNow(-3 * MS_IN.day),
+        expiresAt: fromNow(6 * MS_IN.day),
         maxInvocations: 100,
         invocationCount: 12,
     },
@@ -35,8 +34,8 @@ export const sampleEmbedLinks: EmbedLinkSummaryResponse[] = [
         channelId: SAMPLE_CHANNEL_ID,
         agentId: "agents/sales",
         parameters: { customerId: "users/42" },
-        createdAt: fromNow(-2 * DAY_MS),
-        expiresAt: fromNow(8 * HOUR_MS),
+        createdAt: fromNow(-2 * MS_IN.day),
+        expiresAt: fromNow(8 * MS_IN.hour),
         maxInvocations: 50,
         invocationCount: 44,
     },
@@ -45,8 +44,8 @@ export const sampleEmbedLinks: EmbedLinkSummaryResponse[] = [
         channelId: SAMPLE_CHANNEL_ID,
         agentId: "agents/sales",
         parameters: { customerId: "users/108" },
-        createdAt: fromNow(-10 * DAY_MS),
-        expiresAt: fromNow(-2 * DAY_MS),
+        createdAt: fromNow(-10 * MS_IN.day),
+        expiresAt: fromNow(-2 * MS_IN.day),
         maxInvocations: 200,
         invocationCount: 200,
     },

--- a/src/Raven.Quill.Web/src/mocks/settings-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/settings-mocks.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw";
 import type { LicenseResponse, QuillApplicationUsage, QuillUsageResponse } from "@/api/generated/server-api";
 import type { CertificateItem } from "@/api/custom-services/certificates-service";
 import { apiHttp } from "./api-http";
+import { MS_IN } from "@/lib/time";
 
 export const settingsMocks = {
     feedback: () => apiHttp.post("/api/settings/feedback", ({ response }) => response(204).empty()),
@@ -89,7 +90,7 @@ export const sampleCertificates: CertificateItem[] = [
         securityClearance: "ValidUser",
         notBefore: "2025-08-01T00:00:00Z",
         // Expires one week from now so the "About to expire" badge always renders.
-        notAfter: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        notAfter: new Date(Date.now() + MS_IN.week).toISOString(),
         permissions: { "demo-shop": "ReadWrite" },
         disabled: false,
     },

--- a/src/Raven.Quill.Web/src/mocks/stats-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/stats-mocks.ts
@@ -1,3 +1,4 @@
+import { MS_IN } from "@/lib/time";
 import type {
     ApplianceAppResponse,
     AppUsageResponse,
@@ -141,7 +142,7 @@ export const sampleDashboardApps: ApplianceAppResponse[] = [
         adaptersCount: 0,
         agentsCount: 2,
         channelsLabel: "Telegram",
-        statusSubtitle: "Sync failed · 2h ago",
+        statusSubtitle: "Sync failed · stalled for 2h",
         createdAt: "2026-04-28T12:00:00Z",
         updatedAt: "2026-06-25T07:05:00Z",
     },
@@ -173,9 +174,8 @@ export const sampleCollections: DataCollectionDto[] = [
     { appId: "demo", name: "Customers", documentsCount: 23000, fields: ["Email", "Name"] },
 ];
 
-// Timestamps are relative to "now" so the "Last activity" column always reads like a live feed
-// ("19m ago", "1h ago") regardless of when the mocks are served.
-const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60_000).toISOString();
+// Timestamps are relative to "now" so the conversations always look recent regardless of when the mocks are served.
+const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * MS_IN.minute).toISOString();
 
 export const sampleConversations: ConversationDto[] = [
     {

--- a/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/cdc-batch-log.tsx
@@ -8,6 +8,7 @@ import { Switch } from "@/components/shadcn/ui/switch";
 import { formatCompact } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { CdcLiveBatch, CdcLiveBatchState } from "@/pages/apps/use-cdc-live-performance";
+import { MS_IN } from "@/lib/time";
 
 // The h-10 header button plus the 1px row separator, so an unmeasured collapsed row already
 // estimates to its real height and the total size barely moves once measuring catches up.
@@ -304,10 +305,8 @@ function format(formatter: Intl.DateTimeFormat, value: string): string {
     return Number.isNaN(date.getTime()) ? value : formatter.format(date);
 }
 
-const SECOND_IN_MS = 1000;
-
 function formatBatchDuration(durationInMs: number): string {
-    return durationInMs < SECOND_IN_MS
+    return durationInMs < MS_IN.second
         ? `${Math.round(durationInMs)} ms`
-        : `${(durationInMs / SECOND_IN_MS).toFixed(2)} s`;
+        : `${(durationInMs / MS_IN.second).toFixed(2)} s`;
 }

--- a/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channel-groups.tsx
@@ -266,7 +266,8 @@ function ChannelCard({
 
     return (
         // The title's stretched ::after overlay turns the whole card into the "open details" link;
-        // interactive children (the footer actions) sit above it with `relative z-10`.
+        // children that need their own pointer events (the footer actions, the hoverable date) sit above
+        // it with `relative z-10`.
         <Card
             size="sm"
             className="relative gap-3 transition-[background-color,box-shadow] hover:bg-muted/40 hover:ring-foreground/25 has-[a:focus-visible]:ring-2 has-[a:focus-visible]:ring-ring"
@@ -321,7 +322,14 @@ function ChannelCard({
                     )}
                     <StatBox
                         label="Added"
-                        value={<Timestamp value={channel.createdAt} dateVariant="short" textVariant="inherit" />}
+                        value={
+                            <Timestamp
+                                value={channel.createdAt}
+                                dateVariant="short"
+                                textVariant="inherit"
+                                className="relative z-10"
+                            />
+                        }
                     />
                 </div>
             </CardContent>

--- a/src/Raven.Quill.Web/src/pages/apps/channels/discord-status-panel.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/discord-status-panel.tsx
@@ -161,7 +161,7 @@ function DiscordGatewayBadge({ health }: { health: DiscordChannelHealthResponse 
         }
 
         return (
-            <TimestampTooltip value={health.lastConnectedAt} prefix="Connected">
+            <TimestampTooltip value={health.lastConnectedAt} prefix="Connected on">
                 {badge}
             </TimestampTooltip>
         );

--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-status.ts
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-status.ts
@@ -1,9 +1,11 @@
+import { MS_IN } from "@/lib/time";
+
 // "normal" links need no attention; "warning" links are close to expiry/limit;
 // "critical" links have already expired or exhausted their invocations.
 export type EmbedLinkStatusTone = "normal" | "warning" | "critical";
 
 // A link within this window of its expiry is flagged as expiring soon.
-const EXPIRY_SOON_MS = 24 * 60 * 60 * 1000;
+const EXPIRY_SOON_MS = MS_IN.day;
 // Fraction of the invocation cap at which usage is flagged as nearing the limit.
 const USAGE_WARNING_RATIO = 0.8;
 

--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-utils.test.ts
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-utils.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
-import {
-    MAX_TTL_SECONDS,
-    MIN_TTL_SECONDS,
-    TTL_UNIT_SECONDS,
-    ttlToSeconds,
-} from "@/pages/apps/channels/embed-link-utils";
+import { SECONDS_IN } from "@/lib/time";
+import { MAX_TTL_SECONDS, MIN_TTL_SECONDS, ttlToSeconds } from "@/pages/apps/channels/embed-link-utils";
 
 describe("ttlToSeconds", () => {
     it("returns the value unchanged for seconds", () => {
@@ -18,7 +14,7 @@ describe("ttlToSeconds", () => {
     });
 
     it("scales linearly with the value", () => {
-        expect(ttlToSeconds(3, "hour")).toBe(3 * TTL_UNIT_SECONDS.hour);
+        expect(ttlToSeconds(3, "hour")).toBe(3 * SECONDS_IN.hour);
     });
 
     it("maps the server bounds to selectable durations", () => {

--- a/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-utils.ts
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/embed-link-utils.ts
@@ -1,4 +1,5 @@
 import { originForSubdomain } from "@/lib/subdomain-origin";
+import { SECONDS_IN } from "@/lib/time";
 
 /** Builds the absolute, paste-ready embed URL from the app slug and a token. The embed surface is
  *  served on the public.* subdomain only, so swap the operator host's leading label (dashboard.* /
@@ -18,24 +19,21 @@ export function buildMintEmbedLinkUrl(slug: string) {
 
 // Server-enforced bounds for minting embed links (see the embed-links mint contract). Shared by the
 // generate dialog (range validation + defaults) and the API docs (documented ranges + example body).
-export const MIN_TTL_SECONDS = 60;
-export const MAX_TTL_SECONDS = 2_592_000;
+export const MIN_TTL_SECONDS = SECONDS_IN.minute;
+export const MAX_TTL_SECONDS = 30 * SECONDS_IN.day;
 export const MIN_INVOCATIONS = 1;
 export const MAX_INVOCATIONS = 1_000_000;
-export const DEFAULT_TTL_SECONDS = 3_600;
+export const DEFAULT_TTL_SECONDS = SECONDS_IN.hour;
 export const DEFAULT_MAX_INVOCATIONS = 100;
 
 // Units offered by the custom-duration input. Days is the largest practical unit: the server caps
 // TTL at MAX_TTL_SECONDS (30 days), so weeks/months could not be honored.
-export const TTL_UNIT_SECONDS = {
-    second: 1,
-    minute: 60,
-    hour: 3_600,
-    day: 86_400,
-} as const;
-
-export type TtlUnit = keyof typeof TTL_UNIT_SECONDS;
+export type TtlUnit = "second" | "minute" | "hour" | "day";
 
 export function ttlToSeconds(value: number, unit: TtlUnit) {
-    return value * TTL_UNIT_SECONDS[unit];
+    if (unit === "second") {
+        return value;
+    }
+
+    return value * SECONDS_IN[unit];
 }

--- a/src/Raven.Quill.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/channels/generate-embed-link-dialog.tsx
@@ -47,6 +47,7 @@ import {
     ttlToSeconds,
     type TtlUnit,
 } from "@/pages/apps/channels/embed-link-utils";
+import { SECONDS_IN } from "@/lib/time";
 
 type GenerateEmbedLinkDialogProps = {
     slug: string;
@@ -56,15 +57,24 @@ type GenerateEmbedLinkDialogProps = {
     trigger: ReactNode;
 };
 
-const DEFAULT_TTL_PRESET = "3600";
+const ttlPresetSchema = z.enum(["1h", "4h", "24h", "7d", "custom"]);
 
-const ttlPresetSchema = z.enum(["3600", "14400", "86400", "604800", "custom"]);
+type TtlPreset = z.infer<typeof ttlPresetSchema>;
 
-const TTL_PRESET_OPTIONS: readonly FormSelectOption<z.infer<typeof ttlPresetSchema>>[] = [
-    { value: "3600", label: "1 hour" },
-    { value: "14400", label: "4 hours" },
-    { value: "86400", label: "24 hours" },
-    { value: "604800", label: "7 days" },
+const DEFAULT_TTL_PRESET: TtlPreset = "1h";
+
+const TTL_PRESET_SECONDS: Record<Exclude<TtlPreset, "custom">, number> = {
+    "1h": SECONDS_IN.hour,
+    "4h": 4 * SECONDS_IN.hour,
+    "24h": SECONDS_IN.day,
+    "7d": SECONDS_IN.week,
+};
+
+const TTL_PRESET_OPTIONS: readonly FormSelectOption<TtlPreset>[] = [
+    { value: "1h", label: "1 hour" },
+    { value: "4h", label: "4 hours" },
+    { value: "24h", label: "24 hours" },
+    { value: "7d", label: "7 days" },
     { value: "custom", label: "Custom" },
 ];
 
@@ -194,10 +204,9 @@ export function GenerateEmbedLinkDialog({
     const result = mintMutation.data;
 
     const submit = form.handleSubmit((values) => {
-        const ttlSeconds =
-            values.ttlPreset === "custom" && values.customTtlValue != null
-                ? ttlToSeconds(values.customTtlValue, values.customTtlUnit)
-                : Number(values.ttlPreset);
+        const customTtlSeconds =
+            values.customTtlValue == null ? null : ttlToSeconds(values.customTtlValue, values.customTtlUnit);
+        const ttlSeconds = values.ttlPreset === "custom" ? customTtlSeconds : TTL_PRESET_SECONDS[values.ttlPreset];
         const bound = Object.fromEntries(
             values.parameters.map((parameter) => [parameter.name, toJsonValue(parameter)]),
         );

--- a/src/Raven.Quill.Web/src/pages/apps/use-cdc-live-performance.ts
+++ b/src/Raven.Quill.Web/src/pages/apps/use-cdc-live-performance.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { MS_IN } from "@/lib/time";
 
 // Frame shape of RavenDB's cdc-sink live stats feed, relayed verbatim by the WS-only
 // /api/apps/{slug}/cdc/progress route, so it is not part of the generated OpenAPI client.
@@ -152,7 +153,7 @@ function mergeFrame(batches: Map<string, TrackedBatch>, frame: CdcLiveRawFrame) 
 
 // Client-side twin of the backend CdcPerformanceShaper, minus the inputs the live feed
 // does not carry (task disabled flag, persisted last-activity timestamp).
-const ACTIVE_WINDOW_MS = 60_000;
+const ACTIVE_WINDOW_MS = MS_IN.minute;
 
 function shape(batches: Map<string, TrackedBatch>, nowMs: number): CdcLivePerformance {
     const orderedBatches = [...batches.values()]

--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-labels.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/certificate-labels.ts
@@ -2,6 +2,7 @@ import type { CertificateItem, SecurityClearance } from "@/api/custom-services/c
 import type { AppResponse, DatabaseAccess } from "@/api/generated/server-api";
 import type { FormSelectOption } from "@/components/form/form-select";
 import { GRANTABLE_DATABASE_ACCESS } from "@/pages/dashboard/certificates/certificate-permissions";
+import { MS_IN } from "@/lib/time";
 
 export const DATABASE_ACCESS_LABELS: Record<DatabaseAccess, string> = {
     Admin: "Admin",
@@ -38,7 +39,7 @@ export function isExpiredCertificate(certificate: CertificateItem, now: number =
     return certificate.notAfter != null && new Date(certificate.notAfter).getTime() < now;
 }
 
-const ABOUT_TO_EXPIRE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+const ABOUT_TO_EXPIRE_WINDOW_MS = 14 * MS_IN.day;
 
 export function isAboutToExpireCertificate(certificate: CertificateItem, now: number = Date.now()): boolean {
     return (


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/Quill-309

### Additional description

Adds `SECONDS_IN` and `MS_IN` object utils.
Removes duration from `Timestamp` tooltip.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
