### PR TITLE
Quill-312 Move date period picker into the main header when it affects the whole view display

### DIFF
--- a/src/Raven.Quill.Web/src/pages/apps/app-analytics.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-analytics.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Text } from "@/components/typography";
+import { Heading, Text } from "@/components/typography";
 import { useParams } from "react-router";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
@@ -9,7 +9,7 @@ import { SeriesBarChart } from "@/components/data/charts";
 import { DatePeriodPicker } from "@/components/data/date-period-picker";
 import { ChartSkeleton, DetailGridSkeleton } from "@/components/data/loading-skeletons";
 import { PagePanel } from "@/components/data/page-panel";
-import { canDrillInto, drillInto, getDefaultDatePeriod, type DatePeriod } from "@/lib/date-period";
+import { canDrillInto, drillInto, getDefaultDatePeriod } from "@/lib/date-period";
 import { useAppStartDate } from "@/lib/use-start-date";
 import { TableCell, TableRow } from "@/components/shadcn/ui/table";
 import { SectionTable } from "@/components/table/section-table";
@@ -39,61 +39,56 @@ export function AppAnalytics() {
 
     return (
         <PagePanel>
-            <ApiState
-                isLoading={appUsageQuery.isPending}
-                isError={appUsageQuery.isError}
-                errorTitle="Could not load analytics"
-                onRetry={() => void appUsageQuery.refetch()}
-                loadingLabel="Loading analytics..."
-                skeleton={
-                    <div className="space-y-8">
-                        <DetailGridSkeleton count={4} className="sm:grid-cols-4" />
-                        <ChartSkeleton />
-                    </div>
-                }
-            >
-                {appUsageQuery.data && (
-                    <div className="space-y-8">
-                        <AnalyticsMetricCards
-                            usage={appUsageQuery.data}
-                            period={period}
-                            earliest={appStartDate}
-                            onPeriodChange={setPeriod}
-                        />
-                        <AnalyticsSeriesSection
-                            title="Tokens by capability"
-                            series={appUsageQuery.data.tokensByCapability}
-                            onBarClick={drillFromBar}
-                        />
-                        <AnalyticsSeriesSection
-                            title="Tokens by model"
-                            series={appUsageQuery.data.tokensByModel}
-                            onBarClick={drillFromBar}
-                        />
-                        <AnalyticsSeriesSection
-                            title="Conversations by channel"
-                            series={appUsageQuery.data.conversationsByChannel}
-                            onBarClick={drillFromBar}
-                        />
-                        <TopCapabilitiesSection capabilities={appUsageQuery.data.topCapabilities} />
-                    </div>
-                )}
-            </ApiState>
+            <div className="space-y-6">
+                {/* The period governs the whole view (metric cards and every chart below), so its
+                    picker rides in the page header. The route hides the shell title in favour of this. */}
+                <header className="flex items-center justify-between gap-3">
+                    <Heading as="h1" variant="page">
+                        Analytics
+                    </Heading>
+                    <DatePeriodPicker value={period} earliest={appStartDate} onChange={setPeriod} />
+                </header>
+                <ApiState
+                    isLoading={appUsageQuery.isPending}
+                    isError={appUsageQuery.isError}
+                    errorTitle="Could not load analytics"
+                    onRetry={() => void appUsageQuery.refetch()}
+                    loadingLabel="Loading analytics..."
+                    skeleton={
+                        <div className="space-y-8">
+                            <DetailGridSkeleton count={4} className="sm:grid-cols-4" />
+                            <ChartSkeleton />
+                        </div>
+                    }
+                >
+                    {appUsageQuery.data && (
+                        <div className="space-y-8">
+                            <AnalyticsMetricCards usage={appUsageQuery.data} />
+                            <AnalyticsSeriesSection
+                                title="Tokens by capability"
+                                series={appUsageQuery.data.tokensByCapability}
+                                onBarClick={drillFromBar}
+                            />
+                            <AnalyticsSeriesSection
+                                title="Tokens by model"
+                                series={appUsageQuery.data.tokensByModel}
+                                onBarClick={drillFromBar}
+                            />
+                            <AnalyticsSeriesSection
+                                title="Conversations by channel"
+                                series={appUsageQuery.data.conversationsByChannel}
+                                onBarClick={drillFromBar}
+                            />
+                            <TopCapabilitiesSection capabilities={appUsageQuery.data.topCapabilities} />
+                        </div>
+                    )}
+                </ApiState>
+            </div>
         </PagePanel>
     );
 }
 
-function AnalyticsMetricCards({
-    usage,
-    period,
-    earliest,
-    onPeriodChange,
-}: {
-    usage: AppUsageResponse;
-    period: DatePeriod;
-    earliest: Date | undefined;
-    onPeriodChange: (value: DatePeriod) => void;
-}) {
+function AnalyticsMetricCards({ usage }: { usage: AppUsageResponse }) {
     const { conversations, tokens } = usage.metrics;
     const cards: DashboardStatCard[] = [
         {
@@ -106,12 +101,7 @@ function AnalyticsMetricCards({
         { label: "Tokens", value: tokens.value, isLoading: false, delta: tokens.delta, series: tokens.sparkline },
     ];
 
-    return (
-        <StatCardsSection
-            cards={cards}
-            action={<DatePeriodPicker value={period} earliest={earliest} onChange={onPeriodChange} />}
-        />
-    );
+    return <StatCardsSection cards={cards} />;
 }
 
 function AnalyticsSeriesSection({

--- a/src/Raven.Quill.Web/src/pages/apps/app-analytics.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-analytics.tsx
@@ -40,8 +40,6 @@ export function AppAnalytics() {
     return (
         <PagePanel>
             <div className="space-y-6">
-                {/* The period governs the whole view (metric cards and every chart below), so its
-                    picker rides in the page header. The route hides the shell title in favour of this. */}
                 <header className="flex items-center justify-between gap-3">
                     <Heading as="h1" variant="page">
                         Analytics

--- a/src/Raven.Quill.Web/src/pages/apps/app-conversations.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-conversations.tsx
@@ -14,8 +14,6 @@ export function AppConversations() {
     return (
         <div className="space-y-8">
             <div className="space-y-6">
-                {/* The period governs the whole view (the stat cards and the conversations
-                    table below), so its picker rides in the page header. */}
                 <div className="flex items-start justify-between gap-3">
                     <div className="space-y-1">
                         <Heading as="h1" variant="page">

--- a/src/Raven.Quill.Web/src/pages/apps/app-conversations.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/app-conversations.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useParams } from "react-router";
+import { DatePeriodPicker } from "@/components/data/date-period-picker";
 import { getDefaultDatePeriod } from "@/lib/date-period";
 import { useAppStartDate } from "@/lib/use-start-date";
 import { ConversationStatsCards, ConversationsSection } from "@/pages/apps/conversations-section";
@@ -13,18 +14,18 @@ export function AppConversations() {
     return (
         <div className="space-y-8">
             <div className="space-y-6">
-                <div className="space-y-1">
-                    <Heading as="h1" variant="page">
-                        Conversations
-                    </Heading>
-                    <Text variant="muted">Live and historical chats across all channels.</Text>
+                {/* The period governs the whole view (the stat cards and the conversations
+                    table below), so its picker rides in the page header. */}
+                <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                        <Heading as="h1" variant="page">
+                            Conversations
+                        </Heading>
+                        <Text variant="muted">Live and historical chats across all channels.</Text>
+                    </div>
+                    <DatePeriodPicker value={period} earliest={appStartDate} onChange={setPeriod} />
                 </div>
-                <ConversationStatsCards
-                    slug={slug}
-                    period={period}
-                    earliest={appStartDate}
-                    onPeriodChange={setPeriod}
-                />
+                <ConversationStatsCards slug={slug} period={period} />
             </div>
             <ConversationsSection slug={slug} period={period} />
         </div>

--- a/src/Raven.Quill.Web/src/pages/apps/conversations-section.tsx
+++ b/src/Raven.Quill.Web/src/pages/apps/conversations-section.tsx
@@ -3,7 +3,6 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { api } from "@/api/api";
 import type { ConversationDto } from "@/api/generated/server-api";
 import { ApiState } from "@/components/data/api-state";
-import { DatePeriodPicker } from "@/components/data/date-period-picker";
 import { TablePagination } from "@/components/table/table-pagination";
 import type { DatePeriod } from "@/lib/date-period";
 import { StatCardsSection, type DashboardStatCard } from "@/pages/dashboard/dashboard-stat-cards";
@@ -20,12 +19,7 @@ interface ConversationsSectionProps {
     period: DatePeriod;
 }
 
-export function ConversationStatsCards({
-    slug,
-    period,
-    earliest,
-    onPeriodChange,
-}: ConversationsSectionProps & { earliest: Date | undefined; onPeriodChange: (value: DatePeriod) => void }) {
+export function ConversationStatsCards({ slug, period }: ConversationsSectionProps) {
     const conversationStatsQuery = useQuery(api.queries.stats.conversationStats(slug, period));
     const stats = conversationStatsQuery.data;
 
@@ -35,12 +29,7 @@ export function ConversationStatsCards({
         { label: "Tokens", value: stats?.tokens, isLoading: conversationStatsQuery.isPending },
     ];
 
-    return (
-        <StatCardsSection
-            cards={cards}
-            action={<DatePeriodPicker value={period} earliest={earliest} onChange={onPeriodChange} />}
-        />
-    );
+    return <StatCardsSection cards={cards} />;
 }
 
 const EMPTY_CONVERSATIONS: ConversationDto[] = [];

--- a/src/Raven.Quill.Web/src/pages/dashboard/dashboard-home.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/dashboard-home.tsx
@@ -25,16 +25,14 @@ export function DashboardHome() {
                 <Heading as="h1" variant="page">
                     My apps
                 </Heading>
+                {/* The period governs the whole view (the stat cards and the apps table below),
+                    so its picker rides in the page header rather than in a section header. */}
+                {appsQuery.data && appsQuery.data.length > 0 && (
+                    <DatePeriodPicker value={period} earliest={setupStartDate} onChange={setPeriod} />
+                )}
             </header>
 
-            {appsQuery.data && appsQuery.data.length > 0 && (
-                // The period lives here because it also drives the apps table below, but the
-                // picker itself renders inline with the "Activity" header via the action slot.
-                <StatCardsSection
-                    cards={cards}
-                    action={<DatePeriodPicker value={period} earliest={setupStartDate} onChange={setPeriod} />}
-                />
-            )}
+            {appsQuery.data && appsQuery.data.length > 0 && <StatCardsSection cards={cards} />}
 
             <ApiState
                 isLoading={appsQuery.isPending}

--- a/src/Raven.Quill.Web/src/pages/dashboard/dashboard-home.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/dashboard-home.tsx
@@ -18,6 +18,7 @@ export function DashboardHome() {
     const appsQuery = useQuery(api.queries.stats.dashboardApps());
 
     const cards = buildUsageStatCards(usageQuery.data, usageQuery.isPending);
+    const hasApps = Boolean(appsQuery.data && appsQuery.data.length > 0);
 
     return (
         <div className="space-y-6">
@@ -25,14 +26,10 @@ export function DashboardHome() {
                 <Heading as="h1" variant="page">
                     My apps
                 </Heading>
-                {/* The period governs the whole view (the stat cards and the apps table below),
-                    so its picker rides in the page header rather than in a section header. */}
-                {appsQuery.data && appsQuery.data.length > 0 && (
-                    <DatePeriodPicker value={period} earliest={setupStartDate} onChange={setPeriod} />
-                )}
+                {hasApps && <DatePeriodPicker value={period} earliest={setupStartDate} onChange={setPeriod} />}
             </header>
 
-            {appsQuery.data && appsQuery.data.length > 0 && <StatCardsSection cards={cards} />}
+            {hasApps && <StatCardsSection cards={cards} />}
 
             <ApiState
                 isLoading={appsQuery.isPending}

--- a/src/Raven.Quill.Web/src/routes.tsx
+++ b/src/Raven.Quill.Web/src/routes.tsx
@@ -269,7 +269,6 @@ const appPages: AppRouteDefinition[] = [
             icon: LineChart,
             section: "settings",
         },
-        // The page renders its own header so the period picker can sit beside the title.
         isPageTitleHidden: true,
         element: <AppAnalytics />,
     },

--- a/src/Raven.Quill.Web/src/routes.tsx
+++ b/src/Raven.Quill.Web/src/routes.tsx
@@ -269,6 +269,8 @@ const appPages: AppRouteDefinition[] = [
             icon: LineChart,
             section: "settings",
         },
+        // The page renders its own header so the period picker can sit beside the title.
+        isPageTitleHidden: true,
         element: <AppAnalytics />,
     },
 ];


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-312

### Additional description

The Year/Month/Day period picker was rendered inside the "Activity" section header on several pages, even where it actually governs the entire view (stat cards and the table/charts below). This moves it up to the main page header on the three affected views so its scope reads correctly.

**Changed views**

- **My apps** (Dashboard home) — picker moved beside the "My apps" title; it drives the stat cards and the apps table.
- **Conversations** — picker moved beside the "Conversations" title; it drives the stat cards and the conversations table
- **Analytics** — page now renders its own header with the picker beside the "Analytics" title (route sets isPageTitleHidden, matching how Conversations/Usage already work).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
