### PR TITLE
RavenDB-27457 Do not report < and <= as greater-than operators

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/BinaryExpression.cs
+++ b/src/Raven.Server/Documents/Queries/AST/BinaryExpression.cs
@@ -21,8 +21,6 @@ namespace Raven.Server.Documents.Queries.AST
         {
             OperatorType.GreaterThan => true,
             OperatorType.GreaterThanEqual => true,
-            OperatorType.LessThan => true,
-            OperatorType.LessThanEqual => true,
             _ => false,
         };
 

--- a/test/FastTests/Issues/RavenDB_27457.cs
+++ b/test/FastTests/Issues/RavenDB_27457.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_27457 : RavenTestBase
+    {
+        public RavenDB_27457(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void TwoUpperBoundsOnTheSameFieldMustNotBeMergedIntoBetween(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                new Items_ByN().Execute(store);
+
+                using (var session = store.OpenSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                        session.Store(new Item { N = i }, "items/" + i);
+
+                    session.SaveChanges();
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    Assert.Equal(3, Count(session, "N < 3"));
+                    Assert.Equal(3, Count(session, "N < 3 and N < 5"));
+                    Assert.Equal(3, Count(session, "N < 5 and N < 3"));
+                    Assert.Equal(4, Count(session, "N <= 3 and N <= 5"));
+
+                    // two lower bounds were never merged - they must stay that way
+                    Assert.Equal(1, Count(session, "N > 6 and N > 8"));
+
+                    // an actual range is still merged into a between query
+                    Assert.Equal(2, Count(session, "N > 3 and N < 6"));
+                }
+            }
+
+            static int Count(IDocumentSession session, string where)
+            {
+                return session.Advanced.RawQuery<Item>($"from index 'Items/ByN' where {where}").ToList().Count;
+            }
+        }
+
+        private class Item
+        {
+            public int N { get; set; }
+        }
+
+        private class Items_ByN : AbstractIndexCreationTask<Item>
+        {
+            public Items_ByN()
+            {
+                Map = items => from item in items
+                               select new { item.N };
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27457

### Additional description

`BinaryExpression.IsGreaterThan` returned `true` for `LessThan` and `LessThanEqual` as well — its body was a copy of `IsRangeOperation` declared right above it. Two upper bounds on the same field (`Foo < a and Foo < b`) therefore satisfied the "left is greater-than, right is less-than" check in `CoraxQueryBuilder` and `LuceneQueryBuilder`; both merge branches then ran and the second overwrote the first, producing a `between` query with reversed bounds.

The fix removes `LessThan` / `LessThanEqual` from the property, which covers both query builders at once. `Foo > a and Foo < b` is still merged into a `between` query.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed