### PR TITLE
RavenDB-27458 Do not let a null satisfy < and <= in MultiUnaryMatch

### DIFF
--- a/src/Corax/Querying/Matches/MultiUnaryMatch.cs
+++ b/src/Corax/Querying/Matches/MultiUnaryMatch.cs
@@ -122,14 +122,14 @@ public unsafe struct MultiUnaryItem
                     byteComparer = &LessThanMatchComparer.Compare;
                     longComparer = &LessThanMatchComparer.Compare;
                     doubleComparer = &LessThanMatchComparer.Compare;
-                    compareNull = &TrueUnlessNull;
+                    compareNull = &AlwaysFalse;
                     compareNotExisting = &AlwaysFalse;
                     break;
                 case UnaryMatchOperation.LessThanOrEqual:
                     byteComparer = &LessThanOrEqualMatchComparer.Compare;
                     longComparer = &LessThanOrEqualMatchComparer.Compare;
                     doubleComparer = &LessThanOrEqualMatchComparer.Compare;
-                    compareNull = &AlwaysTrue;
+                    compareNull = &FalseUnlessNull;
                     compareNotExisting = &AlwaysFalse;
                     break;
                 case UnaryMatchOperation.GreaterThan:

--- a/test/FastTests/Issues/RavenDB_27458.cs
+++ b/test/FastTests/Issues/RavenDB_27458.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_27458 : RavenTestBase
+    {
+        public RavenDB_27458(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void NullMustNotSatisfyLessThanWhenTheComparisonIsAPostFilter(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                new Items_ByTAndN().Execute(store);
+
+                using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < 100; i++)
+                        bulk.Store(new Item { T = "x", N = i % 10 });
+
+                    for (int i = 0; i < 30; i++)
+                        bulk.Store(new Item { T = "x", N = null });
+
+                    for (int i = 0; i < 10; i++)
+                        bulk.Store(new Item { T = "y", N = 1 });
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    // the clause on T makes the comparison run as a post-filter over the entries
+                    Assert.Equal(30, Count(session, "T = 'x' and N < 3"));
+                    Assert.Equal(40, Count(session, "T = 'x' and N <= 3"));
+
+                    // a null keeps failing > and keeps being found by equality
+                    Assert.Equal(20, Count(session, "T = 'x' and N > 7"));
+                    Assert.Equal(30, Count(session, "T = 'x' and N = null"));
+
+                    // between and the standalone range were correct before the fix as well
+                    Assert.Equal(30, Count(session, "T = 'x' and N between 2 and 4"));
+                    Assert.Equal(40, Count(session, "N < 3"));
+                }
+            }
+
+            static int Count(IDocumentSession session, string where)
+            {
+                return session.Advanced.RawQuery<Item>($"from index 'Items/ByTAndN' where {where}").ToList().Count;
+            }
+        }
+
+        private class Item
+        {
+            public string T { get; set; }
+
+            public int? N { get; set; }
+        }
+
+        private class Items_ByTAndN : AbstractIndexCreationTask<Item>
+        {
+            public Items_ByTAndN()
+            {
+                Map = items => from item in items
+                               select new { item.T, item.N };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_27458.cs
+++ b/test/SlowTests/Issues/RavenDB_27458.cs
@@ -1,11 +1,12 @@
 using System.Linq;
+using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace FastTests.Issues
+namespace SlowTests.Issues
 {
     public class RavenDB_27458 : RavenTestBase
     {

--- a/test/SlowTests/Issues/RavenDB_27458_LowLevel.cs
+++ b/test/SlowTests/Issues/RavenDB_27458_LowLevel.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Corax;
+using Corax.Mappings;
+using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
+using FastTests.Voron;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+using IndexSearcher = Corax.Querying.IndexSearcher;
+using IndexWriter = Corax.Indexing.IndexWriter;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27458_LowLevel : StorageTest
+{
+    private const int IdIndex = 0, TextIndex = 1, NumberIndex = 2;
+
+    private const string TextValue = "x";
+
+    // Number is 0..9 for the first entries and null for the rest.
+    private const int EntriesWithValue = 10, EntriesWithNull = 5;
+
+    private IndexFieldsMapping _knownFields;
+
+    public RavenDB_27458_LowLevel(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [InlineData(UnaryMatchOperation.LessThan, 3L)]
+    [InlineData(UnaryMatchOperation.LessThanOrEqual, 3L)]
+    [InlineData(UnaryMatchOperation.GreaterThan, 7L)]
+    [InlineData(UnaryMatchOperation.GreaterThanOrEqual, 7L)]
+    public void MultiUnaryMatchMustAgreeWithRangeQueryOnNull(UnaryMatchOperation operation, long value)
+    {
+        IndexEntries();
+
+        using var searcher = new IndexSearcher(Env, _knownFields);
+
+        var numberField = FieldMetadataFor(NumberIndex);
+        var textField = FieldMetadataFor(TextIndex);
+
+        // The same predicate in its two representations: the range query walks the field's term tree and never sees
+        // the null posting list, while MultiUnaryMatch scans the entries of another clause and compares in place.
+        // Both must agree, and neither may accept an entry whose Number is null.
+        var rangeQuery = RangeQueryFor(searcher, numberField, operation, value);
+        var multiUnaryMatch = searcher.CreateMultiUnaryMatch(searcher.TermQuery(textField, TextValue),
+            [new MultiUnaryItem(numberField, value, operation)]);
+
+        var expected = Expected(operation, value);
+
+        Assert.Equal(expected, Fetch(searcher, ref rangeQuery));
+        Assert.Equal(expected, Fetch(searcher, ref multiUnaryMatch));
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void NullEntriesAreIndexedAsNull()
+    {
+        // Guards the theory above: if the null entries were not indexed as null at all, no comparison could accept
+        // them and the theory would pass for the wrong reason.
+        IndexEntries();
+
+        using var searcher = new IndexSearcher(Env, _knownFields);
+
+        Assert.True(searcher.TryGetPostingListForNull(FieldMetadataFor(NumberIndex), out long nullPostingListId));
+        Assert.Equal(EntriesWithNull, searcher.GetPostingList(nullPostingListId).State.NumberOfEntries);
+    }
+
+    private static List<string> Expected(UnaryMatchOperation operation, long value)
+    {
+        var ids = new List<string>();
+
+        // deliberately over the entries that have a value only - a null belongs to no range
+        for (int i = 0; i < EntriesWithValue; i++)
+        {
+            var matches = operation switch
+            {
+                UnaryMatchOperation.LessThan => i < value,
+                UnaryMatchOperation.LessThanOrEqual => i <= value,
+                UnaryMatchOperation.GreaterThan => i > value,
+                UnaryMatchOperation.GreaterThanOrEqual => i >= value,
+                _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null)
+            };
+
+            if (matches)
+                ids.Add(IdOf(i));
+        }
+
+        return ids;
+    }
+
+    private static MultiTermMatch RangeQueryFor(IndexSearcher searcher, in FieldMetadata field, UnaryMatchOperation operation, long value)
+    {
+        return operation switch
+        {
+            UnaryMatchOperation.LessThan => searcher.LessThanQuery<long>(field, value),
+            UnaryMatchOperation.LessThanOrEqual => searcher.LessThanOrEqualsQuery<long>(field, value),
+            UnaryMatchOperation.GreaterThan => searcher.GreaterThanQuery<long>(field, value),
+            UnaryMatchOperation.GreaterThanOrEqual => searcher.GreatThanOrEqualsQuery<long>(field, value),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null)
+        };
+    }
+
+    private static List<string> Fetch<TMatch>(IndexSearcher searcher, ref TMatch match)
+        where TMatch : IQueryMatch
+    {
+        var reader = searcher.TermsReaderFor(searcher.GetFirstIndexedFiledName());
+        var ids = new List<string>();
+
+        Span<long> buffer = stackalloc long[64];
+        int read;
+        while ((read = match.Fill(buffer)) > 0)
+        {
+            for (int i = 0; i < read; i++)
+                ids.Add(reader.GetTermFor(buffer[i]));
+        }
+
+        ids.Sort(StringComparer.Ordinal);
+        return ids;
+    }
+
+    private FieldMetadata FieldMetadataFor(int fieldId)
+    {
+        return FieldMetadata.Build(_knownFields.GetByFieldId(fieldId).FieldName, default, fieldId, default, default);
+    }
+
+    private static string IdOf(int index) => $"items/{index:00}";
+
+    private void IndexEntries()
+    {
+        _knownFields = CreateKnownFields(Allocator);
+
+        using var indexWriter = new IndexWriter(Env, _knownFields, SupportedFeatures.All);
+
+        for (int i = 0; i < EntriesWithValue + EntriesWithNull; i++)
+        {
+            var id = IdOf(i);
+
+            using var builder = indexWriter.Index(id);
+            builder.Write(IdIndex, Encoding.UTF8.GetBytes(id));
+            builder.Write(TextIndex, Encoding.UTF8.GetBytes(TextValue));
+
+            if (i < EntriesWithValue)
+                builder.Write(NumberIndex, Encoding.UTF8.GetBytes(i.ToString(CultureInfo.InvariantCulture)), i, i);
+            else
+                builder.WriteNull(NumberIndex, path: null);
+
+            builder.EndWriting();
+        }
+
+        indexWriter.Commit();
+    }
+
+    private static IndexFieldsMapping CreateKnownFields(ByteStringContext ctx)
+    {
+        Slice.From(ctx, "Id", ByteStringType.Immutable, out Slice idSlice);
+        Slice.From(ctx, "Text", ByteStringType.Immutable, out Slice textSlice);
+        Slice.From(ctx, "Number", ByteStringType.Immutable, out Slice numberSlice);
+
+        using var builder = IndexFieldsMappingBuilder.CreateForWriter(false)
+            .AddBinding(IdIndex, idSlice)
+            .AddBinding(TextIndex, textSlice)
+            .AddBinding(NumberIndex, numberSlice);
+
+        return builder.Build();
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27458

### Additional description

`MultiUnaryItem.SelectComparers` mapped the null case asymmetrically: `<` got `TrueUnlessNull` and `<=` got `AlwaysTrue`, while `>` got `AlwaysFalse` and `>=` got `FalseUnlessNull`. The delegate is called with "is the queried value null", so for an ordinary value `TrueUnlessNull` returned `true` and an entry whose field is null was accepted by `<` and `<=`.

It only shows up when the comparison is evaluated by `MultiUnaryMatch` - that is, when it is paired with a clause on another field. A standalone `Bar < 59` goes through the range provider and was always correct, which is why the bug is easy to miss. 

The fix aligns `<` with `>` (`AlwaysFalse`) and `<=` with `>=` (`FalseUnlessNull`). `NotEquals` keeps `TrueUnlessNull`, which is correct - an entry whose field is null is not equal to a value. `between` is unaffected: it runs as a `>=` / `<=` pair combined with `AND`, and the left side already returned `false` for a null entry.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed