### PR TITLE
Quill-315 Count conversations, not embed links, in the conversations-by-channel chart

### DIFF
--- a/src/Raven.Quill/Metrics/MetricsReadService.cs
+++ b/src/Raven.Quill/Metrics/MetricsReadService.cs
@@ -19,13 +19,9 @@ namespace Raven.Quill.Metrics;
 
 internal static class MetricsReadService
 {
-    private const int ChannelPageSize = 1024;
-
     private const string AppIdPrefix = "apps/";
 
     private const string ConversationIdPrefix = "chats/";
-
-    private const int EmbedLinkPageSize = 1024;
 
     private const string UnknownModel = "unknown";
 
@@ -256,14 +252,7 @@ internal static class MetricsReadService
     private static async Task<SeriesData> BuildConversationsByChannelAsync(
         IAsyncDocumentSession session, List<DateTime> buckets, UsagePeriod period, CancellationToken ct)
     {
-        // one round-trip: channels + embed-links batched as lazy loads
-        var lazyChannels = session.Advanced.Lazily.LoadStartingWithAsync<Channel>(
-            Channel.IdPrefix, pageSize: ChannelPageSize, token: ct);
-        var lazyLinks = session.Advanced.Lazily.LoadStartingWithAsync<EmbedLink>(
-            EmbedLink.IdPrefix, pageSize: EmbedLinkPageSize, token: ct);
-        await session.Advanced.Eagerly.ExecuteAllPendingLazyOperationsAsync(ct);
-
-        var channels = (await lazyChannels.Value).Values;
+        var channels = await session.LoadAllStartingWithAsync<Channel>(Channel.IdPrefix, ct);
         var nameByChannel = channels
             .Where(c => c.Id is not null)
             .ToDictionary(c => c.Id![Channel.IdPrefix.Length..],
@@ -281,14 +270,16 @@ internal static class MetricsReadService
         for (var b = 0; b < buckets.Count; b++)
             points[b] = NewBucketPoint(keys, period.Label(buckets[b]));
 
-        foreach (var link in (await lazyLinks.Value).Values)
+        var previews = await session.LoadAllStartingWithAsync<ConversationPreview>(ConversationPreview.IdPrefix, ct);
+        foreach (var preview in previews)
         {
-            if (link.CreatedAt < period.Start || link.CreatedAt >= period.End) continue;
-            if (link.ChannelId is null || nameByChannel.ContainsKey(link.ChannelId) == false) continue;
-            if (link.ChannelId == TimeAxisKey) continue;   // dropped from keys above
-            var i = period.IndexOf(link.CreatedAt);
+            if (preview.ChannelId.StartsWith(Channel.IdPrefix, StringComparison.Ordinal) == false) continue;
+            var channelId = preview.ChannelId[Channel.IdPrefix.Length..];
+            if (nameByChannel.ContainsKey(channelId) == false) continue;
+            if (channelId == TimeAxisKey) continue;   // dropped from keys above
+            var i = period.IndexOf(preview.CreatedAt);
             if (i < 0) continue;
-            points[i][link.ChannelId] = (long)points[i][link.ChannelId] + 1L;
+            points[i][channelId] = (long)points[i][channelId] + 1L;
         }
 
         return new SeriesData(points, seriesKeys);

--- a/test/QuillTests/AppUsageEndpointTests.cs
+++ b/test/QuillTests/AppUsageEndpointTests.cs
@@ -53,14 +53,15 @@ public class AppUsageEndpointTests(ITestOutputHelper output) : QuillTestBase(out
         })).AgentId;
 
         var now = DateTime.UtcNow;
-        await SeedConversationAsync(app.Store, app.Slug, "chats/a", agentId, now, tokens: 100_000);
-        await SeedConversationAsync(app.Store, app.Slug, "chats/b", agentId, now, tokens: 200_000);
-
         var channel = await app.ProvisionChannelAsync(
             new ProvisionChannelRequest(ChannelType.IFrame, agentId, Array.Empty<string>(), "Support Widget"));
+
+        await SeedConversationAsync(app.Store, app.Slug, "chats/a", agentId, now, tokens: 100_000, channelId: channel.ChannelId);
+        await SeedConversationAsync(app.Store, app.Slug, "chats/b", agentId, now, tokens: 200_000, channelId: channel.ChannelId);
+
         using (var session = app.Store.OpenAsyncSession(app.Slug))
         {
-            for (var i = 0; i < 2; i++)
+            for (var i = 0; i < 3; i++)
             {
                 await session.StoreAsync(new EmbedLink
                 {
@@ -159,10 +160,10 @@ public class AppUsageEndpointTests(ITestOutputHelper output) : QuillTestBase(out
                 await session.StoreAsync(
                     new Channel { Type = ChannelType.IFrame, DisplayName = id, AgentId = "demo", Enabled = true, CreatedAt = now },
                     $"{Channel.IdPrefix}{id}");
-            await session.StoreAsync(new EmbedLink { ChannelId = "t", AgentId = "demo", ExpiresAt = now.AddHours(1), MaxInvocations = 5, ConversationId = "chats/x", CreatedAt = now }, $"{EmbedLink.IdPrefix}{Guid.NewGuid():N}");
-            await session.StoreAsync(new EmbedLink { ChannelId = "alpha", AgentId = "demo", ExpiresAt = now.AddHours(1), MaxInvocations = 5, ConversationId = "chats/y", CreatedAt = now }, $"{EmbedLink.IdPrefix}{Guid.NewGuid():N}");
             await session.SaveChangesAsync();
         }
+        await SeedConversationAsync(app.Store, app.Slug, "chats/x", "demo", now, channelId: "t");
+        await SeedConversationAsync(app.Store, app.Slug, "chats/y", "demo", now, channelId: "alpha");
 
         // GetUsageAsync asserts 2xx → a 500 from the "t" collision fails here
         var byChannel = (await app.GetUsageAsync(now.Year, now.Month)).ConversationsByChannel;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-315/Conversations-by-channel-chart-showcases-the-links-created-via-web-widget-channel-not-the-conversations

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
