### PR TITLE
RavenDB-27467 Turn a date-shaped value into ticks only when the field holds time values

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.ResolveInFromBindings.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.ResolveInFromBindings.cs
@@ -48,6 +48,8 @@ internal static partial class QueryPlanBuilder
                 return;
             }
 
+            (val, type) = ToTicksIfFieldHasTimeValues(exec, val, type, builderParameters);
+
             resolvedValues.Add(val);
             termTypes.Add(type);
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
@@ -166,6 +166,8 @@ internal static partial class QueryPlanBuilder
             {
                 var (low, lowType) = ResolveBindingScalar(bindings[BindingIndex.BetweenLow], slotBindings, queryParameters, builderParameters);
                 var (high, highType) = ResolveBindingScalar(bindings[BindingIndex.BetweenHigh], slotBindings, queryParameters, builderParameters);
+                (low, lowType) = ToTicksIfFieldHasTimeValues(exec, low, lowType, builderParameters);
+                (high, highType) = ToTicksIfFieldHasTimeValues(exec, high, highType, builderParameters);
                 bool lowIsSentinel = low is RavenConstants.Documents.Querying.Terms.LeftNullValueOfBetweenQuery;
                 bool highIsSentinel = high is RavenConstants.Documents.Querying.Terms.RightNullValueOfBetweenQuery;
                 switch (lowIsSentinel, highIsSentinel)
@@ -203,6 +205,7 @@ internal static partial class QueryPlanBuilder
                 break;
             default: // Simple clause (Equals, Range, Search, Regex, etc.): single value at Bindings[0]
                 var (value, valueType) = ResolveBindingScalar(bindings[BindingIndex.Value], slotBindings, queryParameters, builderParameters);
+                (value, valueType) = ToTicksIfFieldHasTimeValues(exec, value, valueType, builderParameters);
                 if (value == null && exec.Clause.ClauseType is ClauseType.StartsWith or ClauseType.EndsWith or ClauseType.Search or ClauseType.Regex)
                 {
                     throw new InvalidQueryException(  // reject null (matches Lucene behavior).
@@ -232,6 +235,29 @@ internal static partial class QueryPlanBuilder
         exec.PackedParamValue = new PackedParam(packedType, startIdx);
         exec.InTermCount = written;
         exec.HasNullTerm = hasNullTerm;
+    }
+
+    // A date-shaped value becomes ticks only when the field actually holds time values - the same check Corax 1.0
+    // does before converting. Without it a string field is searched with a long term and matches nothing.
+    private static (object Value, ParamValueType Type) ToTicksIfFieldHasTimeValues(ClauseExecution exec, object value, ParamValueType type,
+        QueryBuilderParameters builderParameters)
+    {
+        if (type != ParamValueType.String || value == null || builderParameters == null)
+            return (value, type);
+
+        if (exec.Clause.ClauseType is not (ClauseType.Equals or ClauseType.NotEquals
+            or ClauseType.GreaterThan or ClauseType.GreaterThanOrEqual
+            or ClauseType.LessThan or ClauseType.LessThanOrEqual
+            or ClauseType.Between or ClauseType.In or ClauseType.AllIn))
+            return (value, type);
+
+        if (exec.Clause.FieldName is not { } fieldName
+            || builderParameters.Index is not { } index
+            || index.IndexFieldsPersistence.HasTimeValues(fieldName) == false
+            || QueryBuilderHelper.TryGetTime(index, value, out long ticks) == false)
+            return (value, type);
+
+        return (ticks, ParamValueType.Long);
     }
 
     private static (object Value, ParamValueType Type) ResolveBindingScalar(ParameterBinding binding, ParameterBinding[] slotBindings, BlittableJsonReaderObject queryParameters, QueryBuilderParameters builderParameters)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
@@ -1008,13 +1008,8 @@ internal static partial class QueryPlanBuilder
             default:
             {
                 string str = value.ToString();
-                if (str is { Length: > 18 and < 35 } && str.Contains('T')
-                                                     && DateTime.TryParse(str, CultureInfo.InvariantCulture,
-                                                         DateTimeStyles.RoundtripKind, out DateTime parsed))
-                {
-                    return (parsed.Ticks, ValueTokenType.Long);
-                }
-
+                // A date-shaped string stays a string here: whether it becomes ticks depends on the field, which is
+                // only known when the clause value is resolved - see ToTicksIfFieldHasTimeValues.
                 return (str, ValueTokenType.String);
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB_27467.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27467.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27467 : RavenTestBase
+{
+    public RavenDB_27467(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void ADateShapedStringParameterMustNotBecomeTicks(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            for (int i = 0; i < 100; i++)
+                session.Store(new Movie { ReleaseDate = new DateTime(2019, 1, 1).AddDays(i * 10).ToString("yyyy-MM-dd") });
+
+            session.SaveChanges();
+        }
+
+        new Movies_ByDate().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            foreach (var where in new[] { "ReleaseDate > $d", "ReleaseDate >= $d", "ReleaseDate < $d", "ReleaseDate between $d and $to" })
+            {
+                int plain = Count(where, "2020-01-01");
+
+                Assert.True(plain > 0, $"{where}: the plain form returned nothing, the data is wrong");
+
+                foreach (var withTime in new[] { "2020-01-01T00:00:00", "2020-01-01T00:00:00.0000000", "2020-01-01T00:00:00.0000000Z" })
+                    Assert.Equal(plain, Count(where, withTime));
+            }
+
+            int Count(string where, string d) => session.Advanced
+                .RawQuery<Movie>($"from index 'Movies/ByDate' where {where}")
+                .AddParameter("d", d)
+                .AddParameter("to", "2021-01-01")
+                .ToList()
+                .Count;
+        }
+    }
+
+    private class Movie
+    {
+        public string ReleaseDate { get; set; }
+    }
+
+    private class Movies_ByDate : AbstractIndexCreationTask<Movie>
+    {
+        public Movies_ByDate()
+        {
+            Map = movies => from m in movies
+                            select new { m.ReleaseDate };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27467

### Additional description

`ResolveParameterValue` turned any value whose string form is 19–34 characters long, contains `T` and parses as `DateTime` into ticks. It sees the value alone - the field is not in scope - so a field indexed with string terms received a long term, the plan scanned that field's long tree (`Estimate: 0`) and the query silently returned nothing. `between` with two parameters failed harder: once the first value had become a number, the second was parsed as one (`FormatException`).

The conversion now happens where the clause value meets its field, in `PopulateClauseValues`, under the same `IndexFieldsPersistence.HasTimeValues` check Corax 1.0 performs, reusing `QueryBuilderHelper.TryGetTime`. It covers all value paths (parameter, literal, deferred `now()`/`today()`, `in` terms, both `between` bounds) and is decided per query rather than baked into the cached plan template, so a field that starts holding dates later is handled. Fields with time values behave exactly as before.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed