### PR TITLE
RavenDB-27468 Port the byte-based alphanumeric comparer from Corax 1.0

### DIFF
--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.BasicsComparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.BasicsComparers.cs
@@ -19,20 +19,21 @@ internal sealed class AlphanumericalComparer
     private unsafe ref struct AlphanumericStringComparisonState
     {
         private readonly Span<char> _curCharacters;
-        public uint CurPositionInString = 0;
+        public uint CurrentBytePosition = 0;
         private readonly ReadOnlySpan<byte> _originalString;
-        public readonly uint StringLength;
+        public readonly uint StringLengthInBytes;
         private bool _curSequenceIsNumber = false;
         private uint _numberLength = 0;
+        private uint _numberLengthInBytes = 0;
         private uint _curSequenceStartPosition = 0;
-        private uint _stringBufferOffset = 0;
 
         public void ScanNextAlphabeticOrNumericSequence()
         {
-            _curSequenceStartPosition = _stringBufferOffset;
-            var (usedBytes, usedChars) = ReadCharacter(_originalString, _stringBufferOffset, _curCharacters);
+            _curSequenceStartPosition = CurrentBytePosition;
+            var (usedBytes, usedChars) = ReadCharacter(_originalString, CurrentBytePosition, _curCharacters);
             _curSequenceIsNumber = usedChars == 1 && char.IsDigit(_curCharacters[0]);
             _numberLength = 0;
+            _numberLengthInBytes = 0;
 
             var curCharacterIsDigit = _curSequenceIsNumber;
             var insideZeroPrefix = _curSequenceIsNumber && _curCharacters[0] == '0';
@@ -44,6 +45,7 @@ internal sealed class AlphanumericalComparer
             {
                 if (_curSequenceIsNumber)
                 {
+
                     if (_curCharacters[0] != '0')
                     {
                         insideZeroPrefix = false;
@@ -52,15 +54,15 @@ internal sealed class AlphanumericalComparer
                     if (insideZeroPrefix == false)
                     {
                         _numberLength++;
+                        _numberLengthInBytes += usedBytes;
                     }
                 }
 
-                CurPositionInString += usedChars;
-                _stringBufferOffset += usedBytes;
+                CurrentBytePosition += usedBytes;
 
-                if (CurPositionInString < StringLength)
+                if (CurrentBytePosition < StringLengthInBytes)
                 {
-                    (usedBytes, usedChars) = ReadCharacter(_originalString, _stringBufferOffset, _curCharacters);
+                    (usedBytes, usedChars) = ReadCharacter(_originalString, CurrentBytePosition, _curCharacters);
                     curCharacterIsDigit = usedChars == 1 && char.IsDigit(_curCharacters[0]);
                 }
                 else
@@ -77,35 +79,35 @@ internal sealed class AlphanumericalComparer
         {
             _curCharacters = curCharacters;
             _originalString = originalString;
-            StringLength = (uint)originalString.Length;
+            StringLengthInBytes = (uint)originalString.Length;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static (uint BytesUsed, uint CharUsed) ReadCharacter(ReadOnlySpan<byte> str, uint offset, Span<char> charactersBuffer)
         {
-            var currentCharacter = Unsafe.Add(ref MemoryMarshal.GetReference(str), offset);
-            if ((uint)currentCharacter <= 0b0111_1111)
+            var firstByte = Unsafe.Add(ref MemoryMarshal.GetReference(str), offset);
+            if ((uint)firstByte <= 0b0111_1111)
             {
-                charactersBuffer[0] = (char)currentCharacter;
+                charactersBuffer[0] = (char)firstByte;
                 return (1, 1);
             }
 
-            uint bytesUsed = ReadCharacterUtf8(str, offset, charactersBuffer, out uint charUsed);
+            uint bytesUsed = ReadCharacterUtf8(firstByte, str, offset, charactersBuffer, out uint charUsed);
             return (bytesUsed, charUsed);
         }
 
-        private static uint ReadCharacterUtf8(ReadOnlySpan<byte> str, uint offset, Span<char> charactersBuffer, out uint charUsed)
+        private static uint ReadCharacterUtf8(byte firstByte, ReadOnlySpan<byte> str, uint offset, Span<char> charactersBuffer, out uint charUsed)
         {
             var decoder = Decoder ??= Encoding.UTF8.GetDecoder();
 
             //Numbers and ASCII are always 1 so we will pay the price only in case of UTF-8 characters.
             //http://www.unicode.org/versions/Unicode9.0.0/ch03.pdf#page=54
-            var (byteLengthOfCharacter, charNeededToEncodeCharacters) = Unsafe.Add(ref MemoryMarshal.GetReference(str), offset) switch
+            var (byteLengthOfCharacter, charNeededToEncodeCharacters) = firstByte switch
             {
                 <= 0b0111_1111 => (1, 1), /* 1 byte sequence: 0b0xxxxxxxx */
-                <= 0b1101_1111 => (2, Encoding.UTF8.GetCharCount(str.Slice((int)offset, 2))), /* 2 byte sequence: 0b110xxxxxx */
-                <= 0b1110_1111 => (3, Encoding.UTF8.GetCharCount(str.Slice((int)offset, 3))), /* 0b1110xxxx: 3 bytes sequence */
-                <= 0b1111_0111 => (4, Encoding.UTF8.GetCharCount(str.Slice((int)offset, 4))), /* 0b11110xxx: 4 bytes sequence */
+                <= 0b1101_1111 => (2, 1), /* 2 byte sequence: 0b110xxxxxx */
+                <= 0b1110_1111 => (3, 1), /* 0b1110xxxx: 3 bytes sequence */
+                <= 0b1111_0111 => (4, 2), /* 0b11110xxx: 4 bytes sequence */
                 _ => throw new InvalidDataException($"Characters should be between 1 and 4 bytes long and cannot match the specified sequence. This is invalid code.")
             };
 
@@ -132,10 +134,10 @@ internal sealed class AlphanumericalComparer
                 }
 
                 // else, it means they should be compared by string, again, we compare only the effective numbers
-                // One digit is always one byte, so no need to care about chars vs bytes 
-                return string1State._originalString.Slice((int)(string1State._stringBufferOffset - string1State._numberLength), (int)string1State._numberLength)
-                    .SequenceCompareTo(string2State._originalString.Slice((int)(string2State._stringBufferOffset - string2State._numberLength),
-                        (int)string2State._numberLength));
+                // we compare the numbers as byte sequences, because both numbers are guaranteed to be of the same length
+                return string1State._originalString.Slice((int)(string1State.CurrentBytePosition - string1State._numberLengthInBytes), (int)string1State._numberLengthInBytes)
+                    .SequenceCompareTo(string2State._originalString.Slice((int)(string2State.CurrentBytePosition - string2State._numberLengthInBytes),
+                        (int)string2State._numberLengthInBytes));
             }
 
             // if one of the sequences is a number and the other is not, the number is always smaller
@@ -152,8 +154,8 @@ internal sealed class AlphanumericalComparer
             var offset1 = string1State._curSequenceStartPosition;
             var offset2 = string2State._curSequenceStartPosition;
 
-            var length1 = string1State._stringBufferOffset - string1State._curSequenceStartPosition;
-            var length2 = string2State._stringBufferOffset - string2State._curSequenceStartPosition;
+            var length1 = string1State.CurrentBytePosition - string1State._curSequenceStartPosition;
+            var length2 = string2State.CurrentBytePosition - string2State._curSequenceStartPosition;
 
             while (length1 > 0 && length2 > 0)
             {
@@ -193,8 +195,8 @@ internal sealed class AlphanumericalComparer
 
         
         // Walk through two the strings with two markers.
-        while (string1State.CurPositionInString < string1State.StringLength &&
-               string2State.CurPositionInString < string2State.StringLength)
+        while (string1State.CurrentBytePosition < string1State.StringLengthInBytes &&
+               string2State.CurrentBytePosition < string2State.StringLengthInBytes)
         {
             string1State.ScanNextAlphabeticOrNumericSequence();
             string2State.ScanNextAlphabeticOrNumericSequence();
@@ -206,9 +208,9 @@ internal sealed class AlphanumericalComparer
             }
         }
 
-        if (string1State.CurPositionInString < string1State.StringLength)
+        if (string1State.CurrentBytePosition < string1State.StringLengthInBytes)
             return 1;
-        if (string2State.CurPositionInString < string2State.StringLength)
+        if (string2State.CurrentBytePosition < string2State.StringLengthInBytes)
             return -1;
 
         return 0;

--- a/test/SlowTests.Issues/Issues/RavenDB_27468.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27468.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27468 : RavenTestBase
+{
+    public RavenDB_27468(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void OrderByAlphanumericMustHandleMultiByteTerms(Options options)
+    {
+        const int documents = 600;
+
+        using var store = GetDocumentStore(options);
+
+        using (var bulk = store.BulkInsert())
+        {
+            // identical titles force every comparison to walk to the end of the term
+            for (int i = 0; i < documents; i++)
+                bulk.Store(new Movie { Language = "he", Title = "סרט ההמשך הגדול" });
+        }
+
+        new Movies_ByTitle().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var titles = session.Advanced
+                .RawQuery<Movie>("from index 'Movies/ByTitle' where Language = 'he' order by Title as alphanumeric")
+                .ToList();
+
+            Assert.Equal(documents, titles.Count);
+        }
+    }
+
+    private class Movie
+    {
+        public string Language { get; set; }
+
+        public string Title { get; set; }
+    }
+
+    private class Movies_ByTitle : AbstractIndexCreationTask<Movie>
+    {
+        public Movies_ByTitle()
+        {
+            Map = movies => from m in movies
+                            select new { m.Language, m.Title };
+
+            Index(x => x.Title, FieldIndexing.Search);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27468

### Additional description

`AlphanumericalComparer` on this branch kept two counters while walking a term: `_stringBufferOffset` in bytes, used for the reads, and `CurPositionInString` in characters. The scan guard compared the character counter with `StringLength`, which is the term length **in bytes**. For ASCII both are the same number; for a multi-byte term the character counter lags, so a comparison that reaches the last character runs one more iteration and reads at `offset == length`. `Encoding.UTF8.GetCharCount(str.Slice(offset, 2..4))` then throws `ArgumentOutOfRangeException` when the byte that follows looks like a multi-byte lead byte, and silently compares a garbage character when it is ASCII - hence the data dependence.

The comparison only reaches the end of a term when both terms are equal up to that point, which is why the crash needs repeated titles and never shows on ASCII-only fields.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed