### PR TITLE
Quill-315 Serve the conversations-by-channel chart from the conversation preview index

### DIFF
--- a/src/Raven.Quill/Metrics/ConversationPreviewIndex.cs
+++ b/src/Raven.Quill/Metrics/ConversationPreviewIndex.cs
@@ -16,10 +16,11 @@ internal sealed class ConversationPreviewIndex : AbstractIndexCreationTask
             Maps =
             {
                 """
-                from p in docs.@ConversationPreviews 
-                select new { 
+                from p in docs.@ConversationPreviews
+                select new {
                     p.LastMessageAt,
                     p.Agent,
+                    p.CreatedAt,
                 }
                 """
             }

--- a/src/Raven.Quill/Metrics/MetricsReadService.cs
+++ b/src/Raven.Quill/Metrics/MetricsReadService.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.ServerWide.Operations;
 using Raven.Quill.Agents;
@@ -271,14 +272,14 @@ internal static class MetricsReadService
         for (var b = 0; b < buckets.Count; b++)
             points[b] = NewBucketPoint(keys, period.Label(buckets[b]));
 
-        var previews = await session.LoadAllStartingWithAsync<ConversationPreview>(ConversationPreview.IdPrefix, ct);
-        foreach (var preview in previews)
+        var rows = await QueryConversationChannelRowsAsync(session, period.Start, period.End, ct);
+        foreach (var row in rows)
         {
-            if (preview.ChannelId.StartsWith(Channel.IdPrefix, StringComparison.Ordinal) == false) continue;
-            var channelId = preview.ChannelId[Channel.IdPrefix.Length..];
+            if (row.ChannelId.StartsWith(Channel.IdPrefix, StringComparison.Ordinal) == false) continue;
+            var channelId = row.ChannelId[Channel.IdPrefix.Length..];
             if (nameByChannel.ContainsKey(channelId) == false) continue;
             if (channelId == TimeAxisKey) continue;   // dropped from keys above
-            var i = period.IndexOf(preview.CreatedAt);
+            var i = period.IndexOf(row.CreatedAt);
             if (i < 0) continue;
             points[i][channelId] = (long)points[i][channelId] + 1L;
         }
@@ -685,6 +686,28 @@ internal static class MetricsReadService
                 .ToListAsync(ct);
         }
         catch (IndexDoesNotExistException) { return []; }
+    }
+
+    private sealed class ConversationChannelRow
+    {
+        public string ChannelId { get; set; } = "";
+        public DateTime CreatedAt { get; set; }
+    }
+
+    private static async Task<List<ConversationChannelRow>> QueryConversationChannelRowsAsync(
+        IAsyncDocumentSession session, DateTime start, DateTime end, CancellationToken ct)
+    {
+        try
+        {
+            return await session.Advanced
+                .AsyncDocumentQuery<ConversationPreview, ConversationPreviewIndex>()
+                .WhereGreaterThanOrEqual(p => p.CreatedAt, start)
+                .AndAlso()
+                .WhereLessThan(p => p.CreatedAt, end)
+                .SelectFields<ConversationChannelRow>()
+                .ToListAsync(ct);
+        }
+        catch (Exception e) when (e is IndexDoesNotExistException or InvalidQueryException) { return []; }
     }
 
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-315/Conversations-by-channel-chart-showcases-the-links-created-via-web-widget-channel-not-the-conversations

### Additional description


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
