### PR TITLE
Quill 325 Add app wizard: set port default value

### DIFF
--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/add-app-wizard.stories.tsx
@@ -190,13 +190,13 @@ export const ChooseDataSource: Story = {
 
 export const ConnectSource: Story = {
     render: () => <AppWizardAtStep initialStep="externalConnection" />,
-    // Switching the database type leaves the connection details untouched.
+    // Switching the database type applies its default port and leaves the other details untouched.
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
         await userEvent.click(canvas.getByRole("button", { name: /sql server/i }));
 
-        expect(canvas.getByLabelText(/port/i)).toHaveValue(5432);
+        expect(canvas.getByLabelText(/port/i)).toHaveValue(1433);
         expect(canvas.getByLabelText(/host/i)).toHaveValue("localhost");
     },
 };

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connect-source-step.tsx
@@ -9,6 +9,7 @@ import { type AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-valida
 import { PROVIDER_OPTIONS } from "@/pages/setup/add-app-wizard/steps/connect/connect-source-options";
 import { ConnectionEditor } from "@/pages/setup/add-app-wizard/steps/connect/connection-editor";
 import { TestConnectionButton } from "@/pages/setup/add-app-wizard/steps/connect/test-connection-button";
+import { useConnectionSync } from "@/pages/setup/add-app-wizard/steps/connect/use-connection-sync";
 import { toSlug } from "@/pages/setup/add-app-wizard/slugify";
 import { InputGroupAddon } from "@/components/shadcn/ui/input-group";
 import { Button } from "@/components/shadcn/ui/button";
@@ -19,6 +20,7 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
     const { control, setValue, getValues } = useFormContext<AppFormData>();
     const { touchedFields } = useFormState({ control });
     const isEditingApp = useSetupWizardStore((state) => state.editedAppSlug !== null);
+    const { changeProvider } = useConnectionSync();
 
     // The slug follows the app name until the operator touches it, and never on an existing app,
     // where it is already the app's database name.
@@ -87,12 +89,7 @@ export function ConnectSourceStep({ isBusy }: WizardBodyComponentProps) {
                                 key={option.value}
                                 type="button"
                                 aria-pressed={isSelected}
-                                onClick={() =>
-                                    setValue("externalConnection.provider", option.value, {
-                                        shouldDirty: true,
-                                        shouldValidate: true,
-                                    })
-                                }
+                                onClick={() => changeProvider(option.value)}
                                 disabled={isBusy}
                                 className={cn(
                                     "flex items-center gap-3 rounded-lg border bg-background px-4 py-3 transition-colors",

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connection-editor.tsx
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/connection-editor.tsx
@@ -73,13 +73,6 @@ function ConnectionFieldsEditor({ isDisabled }: { isDisabled: boolean }) {
                     disabled={isDisabled}
                 />
             </div>
-            <FormInput
-                control={control}
-                name="externalConnection.fields.database"
-                label="Database"
-                placeholder="e.g. acme_shop"
-                disabled={isDisabled}
-            />
             <div className="grid gap-5 sm:grid-cols-2">
                 <FormInput
                     control={control}
@@ -96,6 +89,13 @@ function ConnectionFieldsEditor({ isDisabled }: { isDisabled: boolean }) {
                     disabled={isDisabled}
                 />
             </div>
+            <FormInput
+                control={control}
+                name="externalConnection.fields.database"
+                label="Database"
+                placeholder="e.g. acme_shop"
+                disabled={isDisabled}
+            />
             <FormToggleGroup
                 control={control}
                 name="externalConnection.fields.ssl"

--- a/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connection-sync.ts
+++ b/src/Raven.Quill.Web/src/pages/setup/add-app-wizard/steps/connect/use-connection-sync.ts
@@ -1,12 +1,25 @@
 import { useFormContext } from "react-hook-form";
 import { toast } from "sonner";
 import type { AppFormData } from "@/pages/setup/add-app-wizard/app-wizard-validation";
-import { buildConnectionString, parseConnectionString } from "@/pages/setup/add-app-wizard/connection-string";
+import {
+    buildConnectionString,
+    DEFAULT_PORT_BY_PROVIDER,
+    parseConnectionString,
+    type Provider,
+} from "@/pages/setup/add-app-wizard/connection-string";
 
 type ExternalConnection = AppFormData["externalConnection"];
 
 export function useConnectionSync() {
     const { getValues, setValue } = useFormContext<AppFormData>();
+
+    const changeProvider = (provider: Provider) => {
+        setValue("externalConnection.provider", provider, { shouldDirty: true, shouldValidate: true });
+        setValue("externalConnection.fields.port", DEFAULT_PORT_BY_PROVIDER[provider], {
+            shouldDirty: true,
+            shouldValidate: true,
+        });
+    };
 
     const changeMode = (mode: ExternalConnection["mode"]) => {
         const connection = getValues("externalConnection");
@@ -18,6 +31,7 @@ export function useConnectionSync() {
                 setValue(
                     "externalConnection.connectionString",
                     buildConnectionString(connection.provider, connection.fields),
+                    { shouldDirty: true, shouldValidate: true },
                 );
             }
         } else if (connection.connectionString.trim() !== "") {
@@ -30,15 +44,15 @@ export function useConnectionSync() {
             // Same protection when nothing in the string maps to a detail field: the details
             // keep what was typed, and the warning names what could not be carried over.
             if (hasRecognizedKeywords) {
-                setValue("externalConnection.fields", values);
+                setValue("externalConnection.fields", values, { shouldDirty: true, shouldValidate: true });
             }
             warnAboutDroppedKeywords(droppedKeywords);
         }
 
-        setValue("externalConnection.mode", mode, { shouldValidate: true });
+        setValue("externalConnection.mode", mode, { shouldDirty: true, shouldValidate: true });
     };
 
-    return { changeMode };
+    return { changeProvider, changeMode };
 }
 
 function hasCompleteFields(fields: ExternalConnection["fields"]): boolean {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-325/Add-app-wizard-set-port-default-value

### Additional description

- Set port by default
- Validate inputs after switching tabs
- Move database input below credentials (picking db from list will be handled later here [Quill-324](https://issues.hibernatingrhinos.com/issue/Quill-324))

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
