### PR TITLE
RavenDB-27473 Do not carry a skipped document's missing fields into the next one

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -74,8 +74,11 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
         using var _ = Scope; // ensure that we release all the resources generated in SetDocumentFields
         var currentIndexingScope = CurrentIndexingScope.Current;
 
-        return SetDocumentFields(key, sourceDocumentId, doc, indexContext, builder, currentIndexingScope?.Source);
+        // The previous document may have bailed out before its 'non existing' markers were written (no indexed field
+        // at all, or an exception) - the fields it registered as missing must not leak into this one.
+        _nonExistingFieldsOfDocument.Clear();
 
+        return SetDocumentFields(key, sourceDocumentId, doc, indexContext, builder, currentIndexingScope?.Source);
     }
     
     protected CoraxDocumentConverterBase(Index index, bool storeValue, bool indexImplicitNull, bool indexEmptyEntries, int numberOfBaseFields, string keyFieldName, string storeValueFieldName, bool canContainSourceDocumentId, ICollection<IndexField> fields = null) : base(index, storeValue, indexImplicitNull, indexEmptyEntries, numberOfBaseFields,

--- a/test/FastTests/Issues/RavenDB_27473.cs
+++ b/test/FastTests/Issues/RavenDB_27473.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_27473 : RavenTestBase
+    {
+        public RavenDB_27473(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void DocumentWithoutAnyIndexedFieldMustNotMarkTheNextDocumentsFieldsAsNonExisting(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var commands = store.Commands())
+            {
+                var metadata = new Dictionary<string, object> { [Raven.Client.Constants.Documents.Metadata.Collection] = "Items" };
+
+                // items/2 has none of the indexed fields, so the converter skips it. Its "missing" fields used to leak
+                // into items/3, which then got the 'non existing' marker for N on top of its real value and was sorted
+                // among the documents that have no N.
+                commands.Put("items/1", null, new { S = "a", N = 1 }, metadata);
+                commands.Put("items/2", null, new { }, metadata);
+                commands.Put("items/3", null, new { S = "a", N = 3 }, metadata);
+                commands.Put("items/4", null, new { S = "a", N = 4 }, metadata);
+                commands.Put("items/5", null, new { S = "a" }, metadata);
+                commands.Put("items/6", null, new { S = "a", N = 6 }, metadata);
+            }
+
+            new Items_BySAndN().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var rows = session.Advanced
+                    .RawQuery<Row>("from index 'Items/BySAndN' order by N select id() as Id, N")
+                    .ToList();
+
+                Assert.Equal(new[] { "items/1", "items/3", "items/4", "items/5", "items/6" }, rows.Select(x => x.Id).OrderBy(x => x));
+
+                Assert.Equal(new[] { "items/1", "items/3", "items/4", "items/6" }, rows.Where(x => x.N != null).Select(x => x.Id));
+
+                // the only document without N goes first or last - never among the documents that have a value
+                var missingAt = rows.FindIndex(x => x.N == null);
+                Assert.True(missingAt == 0 || missingAt == rows.Count - 1,
+                    $"items/5 (no N) landed at position {missingAt} of {rows.Count}: {string.Join(", ", rows.Select(x => $"{x.Id}({x.N})"))}");
+            }
+        }
+
+        private class Row
+        {
+            public string Id { get; set; }
+
+            public long? N { get; set; }
+        }
+
+        private class Items_BySAndN : AbstractIndexCreationTask
+        {
+            public override IndexDefinition CreateIndexDefinition()
+            {
+                return new IndexDefinition
+                {
+                    Name = "Items/BySAndN",
+                    Maps = { "from d in docs.Items select new { d.S, d.N }" }
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27473

### Additional description

`order by <field>` in Corax sorted a few documents that **have** a value among the documents that lack it. `as long` / `as double`, filtering and Lucene were all correct.

**Cause.** The Corax document converter collects the fields a document lacks in `_nonExistingFieldsOfDocument` and writes their `non existing` markers at the end of `SetDocumentFields`, clearing the set right after. A document with **no indexed field at all** (`hasFields == false`, `Indexing.IndexEmptyEntries` off) returns before that point, so the set was never cleared and leaked into the **next** document: on top of its real term it received a `non existing` marker for a field it actually has. The entries-to-terms tracker keeps the first term recorded for an entry, and special terms are processed first, so that document got bound to the `non existing` term and compared equal to the documents without a value.

**Fix.** Clear the set when a document starts, in `CoraxDocumentConverterBase.SetDocument` - the single entry point of all three converters - so nothing carries over from an early return or from an exception.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed