### PR TITLE
Quill-329 Use a clearer placeholder for the client certificate name

### DIFF
--- a/src/Raven.Quill.Web/src/pages/dashboard/certificates/generate-certificate-dialog.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/certificates/generate-certificate-dialog.tsx
@@ -129,7 +129,7 @@ function GenerateCertificateForm({ apps, onGenerated }: { apps: AppResponse[]; o
 
     return (
         <form className="grid gap-4" onSubmit={submit}>
-            <FormInput control={form.control} name="name" label="Certificate name" placeholder="e.g. backups" />
+            <FormInput control={form.control} name="name" label="Certificate name" placeholder="e.g. acme-shop-api" />
             <FormInput control={form.control} name="password" type="password" label="Certificate password (optional)" />
             <FormSelect
                 control={form.control}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/Quill-329/Use-a-clearer-placeholder-for-the-client-certificate-name

### Additional description
Replaced `backups` with `acme-shop-api` to better illustrate naming a certificate after the client that uses it.

### Type of change
- [x] Bug fix => usability/cosmetics
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
