### PR TITLE
RavenDB-27347 Fixing that deleting large map results corrupts compressed map-reduce results trees

### DIFF
--- a/src/Voron/Data/BTrees/Tree.Compressed.cs
+++ b/src/Voron/Data/BTrees/Tree.Compressed.cs
@@ -17,15 +17,17 @@ namespace Voron.Data.BTrees
             _llt.RegisterDisposable(DecompressionsCache);
         }
 
-        private bool TryCompressPageNodes(Slice key, int len, TreePage page)
+        private bool TryCompressPageNodes(Slice key, int len, TreePage page, out DecompressedLeafPage decompressedPageToSplit)
         {
+            decompressedPageToSplit = null;
+
             var alreadyCompressed = page.IsCompressed;
             if (alreadyCompressed && page.NumberOfEntries == 0) // there isn't any entry what we could compress
                 return false;
 
             var pageToCompress = page;
 
-            if (alreadyCompressed) 
+            if (alreadyCompressed)
                 pageToCompress = DecompressPage(page, usage: DecompressionUsage.Write, skipCache: false); // no need to dispose, it's going to be cached anyway
 
             using (LeafPageCompressor.TryGetCompressedTempPage(_llt, pageToCompress, out CompressionResult result, defrag: alreadyCompressed == false))
@@ -40,9 +42,8 @@ namespace Voron.Data.BTrees
 
                     if (alreadyCompressed)
                     {
-                        // we've just put a decompressed page to the cache however we aren't going to compress it
-                        // need to invalidate it from the cache
-                        DecompressionsCache.Invalidate(page.PageNumber, DecompressionUsage.Write);
+                        // the caller must split the page using this decompressed version, see DecompressPage (RavenDB-27347)
+                        decompressedPageToSplit = (DecompressedLeafPage)pageToCompress;
                     }
 
                     return false;
@@ -57,6 +58,9 @@ namespace Voron.Data.BTrees
             }
         }
 
+        // Write usage applies the compression tombstones and updates to the tree state (NumberOfEntries, freed overflow pages). The caller
+        // must rewrite the original page from the result, otherwise the next Write decompression applies them again (RavenDB-27347).
+        // A cached Write decompression is reusable only while the uncompressed section of the original page stayed empty since caching.
         public DecompressedLeafPage DecompressPage(TreePage p, DecompressionUsage usage, bool skipCache)
         {
             var input = new DecompressionInput(p.CompressionHeader, p);

--- a/src/Voron/Data/BTrees/Tree.Compressed.cs
+++ b/src/Voron/Data/BTrees/Tree.Compressed.cs
@@ -205,6 +205,8 @@ namespace Voron.Data.BTrees
                                         {
                                             ref var state = ref State.Modify();
                                             state.NumberOfEntries--;
+
+                                            decompressedPage.MustBeWrittenBack = true;
                                         }
                                     }
 
@@ -252,6 +254,8 @@ namespace Voron.Data.BTrees
             {
                 ref var state = ref State.Modify();
                 state.NumberOfEntries--;
+
+                decompressedPage.MustBeWrittenBack = true;
 
                 if (node->Flags == TreeNodeFlags.PageRef)
                 {

--- a/src/Voron/Data/BTrees/Tree.Compressed.cs
+++ b/src/Voron/Data/BTrees/Tree.Compressed.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Sparrow;
 using Voron.Global;
 using Sparrow.Binary;
@@ -26,9 +27,10 @@ namespace Voron.Data.BTrees
                 return false;
 
             var pageToCompress = page;
+            DecompressedLeafPage decompressedPage = null;
 
             if (alreadyCompressed)
-                pageToCompress = DecompressPage(page, usage: DecompressionUsage.Write, skipCache: false); // no need to dispose, it's going to be cached anyway
+                pageToCompress = decompressedPage = DecompressPage(page, usage: DecompressionUsage.Write, skipCache: false); // no need to dispose, it's going to be cached anyway
 
             using (LeafPageCompressor.TryGetCompressedTempPage(_llt, pageToCompress, out CompressionResult result, defrag: alreadyCompressed == false))
             {
@@ -40,16 +42,16 @@ namespace Voron.Data.BTrees
                     // return incorrect values and AccessViolationException could be thrown
                     // instead we can explicitly check SizeLeft because the page isn't fragmented
 
-                    if (alreadyCompressed)
-                    {
-                        // the caller must split the page using this decompressed version, see DecompressPage (RavenDB-27347)
-                        decompressedPageToSplit = (DecompressedLeafPage)pageToCompress;
-                    }
+                    // the caller must split the page using this decompressed version, see DecompressPage (RavenDB-27347)
+                    decompressedPageToSplit = decompressedPage;
 
                     return false;
                 }
 
                 LeafPageCompressor.CopyToPage(result, page);
+
+                if (decompressedPage != null)
+                    decompressedPage.MustBeWrittenBack = false; // the original page has just been rewritten from it
 
                 if (result.InvalidateFromCache)
                     DecompressionsCache.Invalidate(page.PageNumber, DecompressionUsage.Write);
@@ -60,7 +62,8 @@ namespace Voron.Data.BTrees
 
         // Write usage applies the compression tombstones and updates to the tree state (NumberOfEntries, freed overflow pages). The caller
         // must rewrite the original page from the result, otherwise the next Write decompression applies them again (RavenDB-27347).
-        // A cached Write decompression is reusable only while the uncompressed section of the original page stayed empty since caching.
+        // The same rule keeps a cached Write decompression valid: after the rewrite it equals the compressed section of the original page,
+        // so the uncompressed nodes found on a cache hit were all added after it and HandleUncompressedNodes applies them for the first time.
         public DecompressedLeafPage DecompressPage(TreePage p, DecompressionUsage usage, bool skipCache)
         {
             var input = new DecompressionInput(p.CompressionHeader, p);
@@ -70,6 +73,8 @@ namespace Voron.Data.BTrees
 
             if (skipCache == false && DecompressionsCache.TryGet(p.PageNumber, usage, out cached))
             {
+                Debug.Assert(cached.MustBeWrittenBack == false, $"The original page #{p.PageNumber} was not rewritten from its cached decompressed version");
+
                 decompressedPage = ReuseCachedPage(cached, usage, ref input);
 
                 if (usage == DecompressionUsage.Read)

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -460,13 +460,15 @@ namespace Voron.Data.BTrees
             byte* dataPos;
             if (page.HasSpaceFor(_llt, key, len) == false)
             {
-                if (IsLeafCompressionSupported == false || TryCompressPageNodes(key, len, page) == false)
+                DecompressedLeafPage decompressedPageToSplit = null;
+
+                if (IsLeafCompressionSupported == false || TryCompressPageNodes(key, len, page, out decompressedPageToSplit) == false)
                 {
                     using (var cursor = cursorConstructor.Build(key))
                     {
                         cursor.Update(cursor.Pages, page);
 
-                        var pageSplitter = new TreePageSplitter(_llt, this, key, len, pageNumber, nodeType, cursor);
+                        var pageSplitter = new TreePageSplitter(_llt, this, key, len, pageNumber, nodeType, cursor, pageDecompressed: decompressedPageToSplit);
                         dataPos = pageSplitter.Execute();
                     }
 

--- a/src/Voron/Data/BTrees/TreePageSplitter.cs
+++ b/src/Voron/Data/BTrees/TreePageSplitter.cs
@@ -32,7 +32,8 @@ namespace Voron.Data.BTrees
             long pageNumber,
             TreeNodeFlags nodeType,
             TreeCursor cursor,
-            bool splittingOnDecompressed = false)
+            bool splittingOnDecompressed = false,
+            DecompressedLeafPage pageDecompressed = null)
         {
             _tx = tx;
             _tree = tree;
@@ -53,6 +54,13 @@ namespace Voron.Data.BTrees
             }
 
             _cursor.Pop();
+
+            // pageDecompressed: the page on top of the cursor decompressed with Write usage by Tree.TryCompressPageNodes. It has
+            // already applied the compression tombstones to the tree state, so it must be reused, not decompressed again (RavenDB-27347)
+            Debug.Assert(splittingOnDecompressed == false || pageDecompressed == null);
+            Debug.Assert(pageDecompressed == null || (_page.IsCompressed && pageDecompressed.PageNumber == _page.PageNumber && pageDecompressed.Usage == WriteDecompressionUsage));
+
+            _pageDecompressed = pageDecompressed;
         }
 
         private FreeSpaceHandlingDisabler DisableFreeSpaceUsageIfSplittingRootTree()
@@ -75,7 +83,7 @@ namespace Voron.Data.BTrees
 
                 if (_page.IsCompressed)
                 {
-                    _pageDecompressed = _tree.DecompressPage(_page, WriteDecompressionUsage, skipCache: false);
+                    _pageDecompressed ??= _tree.DecompressPage(_page, WriteDecompressionUsage, skipCache: false);
                     _pageDecompressed.Search(_tx, _newKey);
 
                     if (_pageDecompressed.LastMatch == 0)

--- a/src/Voron/Data/Compression/DecompressedLeafPage.cs
+++ b/src/Voron/Data/Compression/DecompressedLeafPage.cs
@@ -29,7 +29,8 @@ namespace Voron.Data.Compression
 
         public DecompressionUsage Usage;
 
-        // the Write decompression applied deferred work (tombstones, updates) to the tree state, the original page must be rewritten from this one
+        // the Write decompression applied deferred work (tombstones, updates) to the tree state, the original page must be rewritten from this one.
+        // Reset once that happened, a cached copy must not force another write-back later
         public bool MustBeWrittenBack;
 
         public void Dispose()
@@ -93,6 +94,8 @@ namespace Voron.Data.Compression
                     LeafPageCompressor.CopyToPage(compressed, Original);
                 }
             }
+
+            MustBeWrittenBack = false; // the original page has just been rewritten from this one
         }
 
         private void SplitPage(LowLevelTransaction tx, Tree tree)

--- a/src/Voron/Data/Compression/DecompressedLeafPage.cs
+++ b/src/Voron/Data/Compression/DecompressedLeafPage.cs
@@ -29,6 +29,9 @@ namespace Voron.Data.Compression
 
         public DecompressionUsage Usage;
 
+        // the Write decompression applied deferred work (tombstones, updates) to the tree state, the original page must be rewritten from this one
+        public bool MustBeWrittenBack;
+
         public void Dispose()
         {
             // RavenDB-22090: We must not dispose leaf pages more than once.
@@ -67,8 +70,8 @@ namespace Voron.Data.Compression
                 {
                     if (compressed == null)
                     {
-                        if (wasModified == false)
-                            return;
+                        if (wasModified == false && MustBeWrittenBack == false)
+                            return; // the original page is still a valid representation of this one
 
                         if (NumberOfEntries > 0)
                         {

--- a/src/Voron/Data/Compression/DecompressedLeafPage.cs
+++ b/src/Voron/Data/Compression/DecompressedLeafPage.cs
@@ -110,11 +110,17 @@ namespace Voron.Data.Compression
                 var node = GetNode(middleNodeIndex);
 
                 var flags = node->Flags;
-                var valueReader = tree.GetValueReaderFromHeader(node);
 
-                using (tx.Allocator.Allocate(valueReader.Length, out var tempValueOutput))
+                // the value of an overflow entry stays on its overflow page, only the reference moves
+                var isPageRef = flags == TreeNodeFlags.PageRef;
+                var valueReader = isPageRef ? default : tree.GetValueReaderFromHeader(node);
+                var len = isPageRef ? -1 : valueReader.Length;
+                var pageNumber = isPageRef ? node->PageNumber : PageNumber;
+
+                using (tx.Allocator.Allocate(isPageRef ? 0 : len, out var tempValueOutput))
                 {
-                    Memory.Copy(tempValueOutput.Ptr, valueReader.Base, valueReader.Length);
+                    if (isPageRef == false)
+                        Memory.Copy(tempValueOutput.Ptr, valueReader.Base, len);
 
                     RemoveNode(middleNodeIndex);
 
@@ -124,12 +130,13 @@ namespace Voron.Data.Compression
                     {
                         cursor.Update(cursor.Pages, this); // we need to use uncompressed page here because it might have some modifications (e.g. deleted node)
 
-                        var pageSplitter = new TreePageSplitter(tx, tree, key, valueReader.Length, PageNumber, flags, cursor,
+                        var pageSplitter = new TreePageSplitter(tx, tree, key, len, pageNumber, flags, cursor,
                             splittingOnDecompressed: true);
 
                         var pos = pageSplitter.Execute();
 
-                        tempValueOutput.CopyTo(pos);
+                        if (isPageRef == false)
+                            tempValueOutput.CopyTo(pos);
                     }
                 }
             }

--- a/test/SlowTests/Issues/RavenDB_27347.cs
+++ b/test/SlowTests/Issues/RavenDB_27347.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Documents.Indexes.Debugging;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27347 : RavenTestBase
+{
+    public RavenDB_27347(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    // Constants.Tree.NodeMaxSize == (8192 - 64) / 2 - 1 == 4063 and Constants.Tree.NodeHeaderSize == 11,
+    // so Tree.ShouldGoToOverflowPage is true for any map result of 4053 bytes or more. Such a map
+    // result is stored as an overflow value in the map-reduce results tree.
+    private const int LargePayloadSize = 6000;
+
+    private const int SmallPayloadSize = 1500;
+
+    // random content is incompressible, which makes the recompression attempted when the leaf gets
+    // full fail to make room for the incoming entry. The thrown away attempt is what consumes the
+    // deletion tombstone for the first time.
+    private const int ChurnPayloadSize = 3000;
+
+    private const int NumberOfSmallItems = 6;
+
+    private const int NumberOfRounds = 6;
+
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(30);
+
+    private sealed class Item
+    {
+        public string Group { get; set; }
+        public string Payload { get; set; }
+    }
+
+    private sealed class Items_ByGroup : AbstractIndexCreationTask<Item, Items_ByGroup.Result>
+    {
+        public sealed class Result
+        {
+            public string Group { get; set; }
+            public int Count { get; set; }
+            public string Payload { get; set; }
+        }
+
+        public Items_ByGroup()
+        {
+            Map = items => from item in items
+                           select new { Group = item.Group, Count = 1, Payload = item.Payload };
+
+            Reduce = results => from result in results
+                                group result by result.Group
+                                into g
+                                select new { Group = g.Key, Count = g.Sum(x => x.Count), Payload = g.First().Payload };
+        }
+    }
+
+    private static string RandomPayload(Random random)
+    {
+        var chars = new char[ChurnPayloadSize];
+        for (int i = 0; i < chars.Length; i++)
+            chars[i] = (char)('a' + random.Next(26));
+        return new string(chars);
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task IndexingDocumentsWithLargeMapResultsMustKeepWorkingWhenSomeOfThemAreDeleted()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var index = new Items_ByGroup();
+            await index.ExecuteAsync(store);
+
+            // every document maps to the same reduce key, so all of the map results live in one
+            // map-reduce results tree. The large map result is stored as an overflow value.
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Item { Group = "all", Payload = new string('L', LargePayloadSize) }, "large/0");
+
+                await session.SaveChangesAsync();
+            }
+
+            await Indexes.WaitForIndexingAsync(store, allowErrors: true, timeout: WaitTimeout);
+
+            // ordinary sized documents - their map results are stored inline and are what actually
+            // fills the leaf, which makes the leaf compress and take the overflow node with it
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < NumberOfSmallItems; i++)
+                    await session.StoreAsync(new Item { Group = "all", Payload = new string('s', SmallPayloadSize) }, $"small/{i}");
+
+                await session.SaveChangesAsync();
+            }
+
+            await Indexes.WaitForIndexingAsync(store, allowErrors: true);
+
+            // the large document goes away - its map result entry gets a compression tombstone
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete("large/0");
+
+                await session.SaveChangesAsync();
+            }
+
+            await Indexes.WaitForIndexingAsync(store, allowErrors: true);
+
+            // day to day churn - new documents keep arriving and filling the leaf
+            var random = new Random(27347);
+
+            for (int round = 0; round < NumberOfRounds; round++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Item { Group = "all", Payload = RandomPayload(random) }, $"churn/{round}");
+
+                    await session.SaveChangesAsync();
+                }
+
+                await Indexes.WaitForIndexingAsync(store, allowErrors: true);
+            }
+
+            var errors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { index.IndexName }));
+            var first = errors.SelectMany(x => x.Errors).FirstOrDefault();
+
+            Assert.True(first == null, $"The index failed while indexing ordinary documents: {first?.Error}");
+
+            var expected = NumberOfSmallItems + NumberOfRounds;
+
+            using (var session = store.OpenSession())
+            {
+                var results = session.Query<Items_ByGroup.Result, Items_ByGroup>().ToList();
+
+                Assert.Equal(1, results.Count);
+                Assert.Equal(expected, results[0].Count);
+            }
+
+            // in Release builds nothing throws at the fault point - the double consumption of the
+            // deletion tombstone silently corrupts the map results tree header (the entry and page
+            // accounting the map-reduce visualizer displays)
+            var database = await GetDatabase(store.Database);
+            var serverSideIndex = database.IndexStore.GetIndex(index.IndexName);
+
+            using (serverSideIndex.GetReduceTree(new[] { "small/0" }, out IEnumerable<ReduceTree> trees))
+            {
+                var tree = trees.Single();
+
+                Assert.Equal(expected, tree.NumberOfEntries);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task IndexingManyDocumentsWithLargeMapResultsMustKeepWorkingWhenTheyAreDeletedOneByOne()
+    {
+        // issue description variant (v8.0 repro); on 6.2 the recompression succeeds, so it only guards the query count
+        const int numberOfLargeItems = 60;
+        const int numberOfRounds = 50;
+
+        using (var store = GetDocumentStore())
+        {
+            var index = new Items_ByGroup();
+            await index.ExecuteAsync(store);
+
+            // every document maps to the same reduce key, so all of the map results live in one
+            // map-reduce results tree. These map results are over Constants.Tree.NodeMaxSize, so the
+            // tree stores each of them as an overflow value.
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < numberOfLargeItems; i++)
+                    await session.StoreAsync(new Item { Group = "all", Payload = new string('L', LargePayloadSize) }, $"large/{i}");
+
+                await session.SaveChangesAsync();
+            }
+
+            await Indexes.WaitForIndexingAsync(store, allowErrors: true, timeout: WaitTimeout);
+
+            // ordinary sized documents - their map results are stored inline and are what actually
+            // fills the leaf, which makes the leaf compress and take the overflow nodes with it
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < NumberOfSmallItems; i++)
+                    await session.StoreAsync(new Item { Group = "all", Payload = new string('s', SmallPayloadSize) }, $"small/{i}");
+
+                await session.SaveChangesAsync();
+            }
+
+            await Indexes.WaitForIndexingAsync(store, allowErrors: true);
+
+            // day to day churn: an old document goes away and a new one arrives
+            for (int round = 0; round < numberOfRounds; round++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete($"large/{round}");
+
+                    await session.StoreAsync(new Item { Group = "all", Payload = new string('s', SmallPayloadSize) }, $"small/{NumberOfSmallItems + round}");
+
+                    await session.SaveChangesAsync();
+                }
+
+                await Indexes.WaitForIndexingAsync(store, allowErrors: true);
+            }
+
+            var errors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { index.IndexName }));
+            var first = errors.SelectMany(x => x.Errors).FirstOrDefault();
+
+            Assert.True(first == null, $"The index failed while indexing ordinary documents: {first?.Error}");
+
+            var expected = numberOfLargeItems - numberOfRounds + NumberOfSmallItems + numberOfRounds;
+
+            using (var session = store.OpenSession())
+            {
+                var results = session.Query<Items_ByGroup.Result, Items_ByGroup>().ToList();
+
+                Assert.Equal(1, results.Count);
+                Assert.Equal(expected, results[0].Count);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Voron/LeafsCompression/RavenDB_27347.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RavenDB_27347.cs
@@ -3,6 +3,7 @@ using FastTests.Voron;
 using Tests.Infrastructure;
 using Voron;
 using Voron.Data.BTrees;
+using Voron.Data.Compression;
 using Voron.Global;
 using Voron.Impl;
 using Xunit;
@@ -32,8 +33,8 @@ namespace SlowTests.Voron.LeafsCompression
             {
                 var tree = tx.CreateTree("tree", flags: TreeFlags.LeafsCompressed);
 
-                // two overflow entries, so the double free of the buggy path lands on OverflowPages == 0 instead of tripping
-                // Debug.Assert(OverflowPages >= 0) in Tree.RecordFreedPage (which would fail-fast the test host)
+                // two overflow entries, so the double free of the buggy path lands on OverflowPages == 0 and is caught by the
+                // assertions below instead of tripping Debug.Assert(OverflowPages >= 0) in Tree.RecordFreedPage
                 Add(tx, tree, "00000", new byte[OverflowValueSize]);
                 Add(tx, tree, "00001", new byte[OverflowValueSize]);
 
@@ -97,9 +98,119 @@ namespace SlowTests.Voron.LeafsCompression
             }
         }
 
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Compression)]
+        public void SplittingDecompressedPageMustKeepOverflowEntryInTheMiddle()
+        {
+            // DecompressedLeafPage.SplitPage runs when a decompressed page can neither fit into 8 KB nor be compressed back into
+            // it (CopyToOriginal with wasModified: true, reached from the slow path of Tree.Delete on a compressed page and from
+            // TreePageSplitter). The content that gets there is decided by LZ4 on the byte level, so the failing recompression is
+            // forced here directly on the decompressed page.
+            var random = new Random(27347);
+
+            var overflowValue = new byte[OverflowValueSize];
+            Array.Fill(overflowValue, (byte)0x2A);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("tree", flags: TreeFlags.LeafsCompressed);
+
+                // 15 entries, the overflow entry is the 8th one, so it is the middle node (NumberOfEntries / 2) that
+                // SplitPage takes out and adds back when it needs to split the decompressed page
+                for (int i = 0; i <= 6; i++)
+                    Add(tx, tree, Key(i), new byte[InlineValueSize]);
+
+                Add(tx, tree, Key(7), overflowValue);
+
+                // 7 x 1018 + 18 + 1018 > 8128, "00008" compresses the page, the rest fills the uncompressed section
+                for (int i = 8; i <= 14; i++)
+                    Add(tx, tree, Key(i), new byte[InlineValueSize]);
+
+                var root = GetPage(tx, tree.State.Header.RootPageNumber);
+
+                Assert.True(root.IsCompressed);
+                Assert.Equal(1, tree.State.Header.Depth);
+                Assert.Equal(15, tree.State.Header.NumberOfEntries);
+                Assert.Equal(1, tree.State.Header.OverflowPages);
+                Assert.Equal(2, tree.State.Header.PageCount);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("tree");
+
+                var page = tree.ModifyPage(tree.State.Header.RootPageNumber);
+
+                Assert.True(page.IsCompressed);
+
+                using (var decompressed = tree.DecompressPage(page, DecompressionUsage.Write, skipCache: true))
+                {
+                    Assert.Equal(15, decompressed.NumberOfEntries);
+                    Assert.Equal(TreeNodeFlags.PageRef, NodeFlags(decompressed, decompressed.NumberOfEntries / 2));
+
+                    // the decompressed page does not fit into 8 KB and after this it does not compress either, so writing it back
+                    // to the original page has to split it
+                    MakeValuesIncompressible(decompressed, random);
+
+                    decompressed.CopyToOriginal(tx.LowLevelTransaction, defragRequired: false, wasModified: true, tree);
+                }
+
+                Assert.Equal(2, tree.State.Header.Depth);
+                Assert.Equal(15, tree.State.Header.NumberOfEntries);
+                Assert.Equal(1, tree.State.Header.OverflowPages);
+
+                tree.ValidateTree_Forced(tree.State.Header.RootPageNumber);
+
+                Assert.Equal(overflowValue, ReadValue(tx, tree, Key(7)));
+                Assert.Equal(15, CountEntries(tree));
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("tree");
+
+                tree.ValidateTree_Forced(tree.State.Header.RootPageNumber);
+
+                Assert.Equal(overflowValue, ReadValue(tx, tree, Key(7)));
+                Assert.Equal(15, CountEntries(tree));
+            }
+        }
+
         private static string Key(int i)
         {
             return i.ToString("D5");
+        }
+
+        private static unsafe TreeNodeFlags NodeFlags(TreePage page, int index)
+        {
+            return page.GetNode(index)->Flags;
+        }
+
+        private static unsafe void MakeValuesIncompressible(TreePage page, Random random)
+        {
+            for (int i = 0; i < page.NumberOfEntries; i++)
+            {
+                var node = page.GetNode(i);
+
+                if (node->Flags != TreeNodeFlags.Data)
+                    continue;
+
+                random.NextBytes(new Span<byte>((byte*)node + Constants.Tree.NodeHeaderSize + node->KeySize, node->DataSize));
+            }
+        }
+
+        private static unsafe byte[] ReadValue(Transaction tx, Tree tree, string key)
+        {
+            using (Slice.From(tx.Allocator, key, out Slice keySlice))
+            using (var result = tree.ReadDecompressed(keySlice))
+            {
+                Assert.NotNull(result);
+
+                return new ReadOnlySpan<byte>(result.Reader.Base, result.Reader.Length).ToArray();
+            }
         }
 
         private static byte[] RandomBytes(Random random, int size)

--- a/test/SlowTests/Voron/LeafsCompression/RavenDB_27347.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RavenDB_27347.cs
@@ -223,10 +223,13 @@ namespace SlowTests.Voron.LeafsCompression
                     Assert.Equal(15, decompressed.NumberOfEntries);
                     Assert.Equal(15, tree.State.Header.NumberOfEntries);
                     Assert.Equal(1, tree.State.Header.OverflowPages);
+                    Assert.True(decompressed.MustBeWrittenBack);
 
                     MakeValuesIncompressible(decompressed, random);
 
                     decompressed.CopyToOriginal(tx.LowLevelTransaction, defragRequired: false, wasModified: false, tree);
+
+                    Assert.False(decompressed.MustBeWrittenBack); // the original page got rewritten
                 }
 
                 // the page must have been rewritten (split): no compression tombstone may survive in the tree and decompressing the
@@ -252,6 +255,60 @@ namespace SlowTests.Voron.LeafsCompression
                 Assert.Null(ReadLength(tx, tree, "00000"));
                 Assert.Equal(OverflowValueSize, ReadLength(tx, tree, "00001"));
                 Assert.Equal(15, CountEntries(tree));
+
+                tx.Commit();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Compression)]
+        public void SuccessfulRecompressionMustResetMustBeWrittenBackOfTheCachedDecompressedPage()
+        {
+            // TryCompressPageNodes rewrites the original page from the Write-decompressed copy and leaves the copy in the decompressions
+            // cache. If the copy kept claiming it must be written back, a later CopyToOriginal(wasModified: false) on a cache hit would
+            // split the page instead of leaving the still valid original alone
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("tree", flags: TreeFlags.LeafsCompressed);
+
+                Add(tx, tree, "00000", new byte[OverflowValueSize]);
+                Add(tx, tree, "00001", new byte[OverflowValueSize]);
+
+                // compressible values only, so every recompression succeeds. "00009" compresses the page for the first time, the values
+                // added afterwards fill the uncompressed section
+                for (int i = 2; i <= 15; i++)
+                    Add(tx, tree, Key(i), new byte[InlineValueSize]);
+
+                Assert.True(GetPage(tx, tree.State.Header.RootPageNumber).IsCompressed);
+                Assert.Equal(1, tree.State.Header.Depth);
+                Assert.Equal(16, tree.State.Header.NumberOfEntries);
+                Assert.Equal(2, tree.State.Header.OverflowPages);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("tree");
+                var rootPageNumber = tree.State.Header.RootPageNumber;
+
+                Delete(tx, tree, "00000"); // compression tombstone
+
+                Assert.True(HasCompressionTombstone(GetPage(tx, rootPageNumber)));
+
+                // does not fit into the uncompressed section: TryCompressPageNodes decompresses the page for writing (the tombstone gets
+                // consumed, the copy is marked to be written back) and recompresses it, which rewrites the page from the copy
+                Add(tx, tree, Key(16), new byte[InlineValueSize]);
+
+                var root = GetPage(tx, rootPageNumber);
+
+                Assert.Equal(1, tree.State.Header.Depth);
+                Assert.True(root.IsCompressed);
+                Assert.False(HasCompressionTombstone(root));
+                Assert.Equal(16, tree.State.Header.NumberOfEntries);
+                Assert.Equal(1, tree.State.Header.OverflowPages);
+
+                Assert.True(tree.DecompressionsCache.TryGet(rootPageNumber, DecompressionUsage.Write, out var cached));
+                Assert.False(cached.MustBeWrittenBack);
 
                 tx.Commit();
             }

--- a/test/SlowTests/Voron/LeafsCompression/RavenDB_27347.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RavenDB_27347.cs
@@ -179,6 +179,84 @@ namespace SlowTests.Voron.LeafsCompression
             }
         }
 
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Compression)]
+        public void DecompressedPageThatConsumedTombstonesMustBeWrittenBackEvenIfItCannotBeCompressed()
+        {
+            // RecompressPageIfNeeded(wasModified: false) used to leave the original page untouched when the copy could not be compressed
+            // back. If the decompression consumed tombstones (work already applied to the tree state), they survive in the page and the
+            // next Write decompression applies them again (double free of the overflow page).
+            var random = new Random(27347);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("tree", flags: TreeFlags.LeafsCompressed);
+
+                Add(tx, tree, "00000", new byte[OverflowValueSize]);
+                Add(tx, tree, "00001", new byte[OverflowValueSize]);
+
+                for (int i = 2; i <= 8; i++)
+                    Add(tx, tree, Key(i), new byte[InlineValueSize]);
+
+                for (int i = 9; i <= 15; i++)
+                    Add(tx, tree, Key(i), RandomBytes(random, InlineValueSize));
+
+                Assert.True(GetPage(tx, tree.State.Header.RootPageNumber).IsCompressed);
+                Assert.Equal(16, tree.State.Header.NumberOfEntries);
+                Assert.Equal(2, tree.State.Header.OverflowPages);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("tree");
+
+                Delete(tx, tree, "00000"); // compression tombstone, the overflow page is still allocated
+
+                var page = tree.ModifyPage(tree.State.Header.RootPageNumber);
+
+                Assert.True(HasCompressionTombstone(page));
+
+                using (var decompressed = tree.DecompressPage(page, DecompressionUsage.Write, skipCache: true))
+                {
+                    // the tombstone got consumed: the entry is gone from the tree state and its overflow page is freed
+                    Assert.Equal(15, decompressed.NumberOfEntries);
+                    Assert.Equal(15, tree.State.Header.NumberOfEntries);
+                    Assert.Equal(1, tree.State.Header.OverflowPages);
+
+                    MakeValuesIncompressible(decompressed, random);
+
+                    decompressed.CopyToOriginal(tx.LowLevelTransaction, defragRequired: false, wasModified: false, tree);
+                }
+
+                // the page must have been rewritten (split): no compression tombstone may survive in the tree and decompressing the
+                // leaves for writing once more must not apply anything
+                foreach (var pageNumber in tree.AllPages())
+                {
+                    var leaf = GetPage(tx, pageNumber);
+
+                    if (leaf.IsLeaf == false)
+                        continue;
+
+                    Assert.False(HasCompressionTombstone(leaf), $"page {pageNumber} still holds a compression tombstone");
+
+                    if (leaf.IsCompressed)
+                        tree.DecompressPage(tree.ModifyPage(pageNumber), DecompressionUsage.Write, skipCache: true).Dispose();
+                }
+
+                Assert.Equal(15, tree.State.Header.NumberOfEntries);
+                Assert.Equal(1, tree.State.Header.OverflowPages);
+
+                tree.ValidateTree_Forced(tree.State.Header.RootPageNumber);
+
+                Assert.Null(ReadLength(tx, tree, "00000"));
+                Assert.Equal(OverflowValueSize, ReadLength(tx, tree, "00001"));
+                Assert.Equal(15, CountEntries(tree));
+
+                tx.Commit();
+            }
+        }
+
         private static string Key(int i)
         {
             return i.ToString("D5");

--- a/test/SlowTests/Voron/LeafsCompression/RavenDB_27347.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RavenDB_27347.cs
@@ -1,0 +1,165 @@
+using System;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.BTrees;
+using Voron.Global;
+using Voron.Impl;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.LeafsCompression
+{
+    public class RavenDB_27347 : StorageTest
+    {
+        public RavenDB_27347(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // a leaf page has 8192 - 64 = 8128 bytes for nodes. A node takes 11 bytes of header + key + value (padded to an even
+        // size) plus a 2 bytes offset. With a 5 bytes key an inline 1000 bytes value takes 1018 bytes, an overflow entry
+        // (value of 4053 bytes or more, NodeMaxSize == 4063) is a 18 bytes PageRef node pointing to a separate overflow page.
+        private const int OverflowValueSize = 5000;
+
+        private const int InlineValueSize = 1000;
+
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Compression)]
+        public void FailedRecompressionMustNotConsumeCompressionTombstoneTwice()
+        {
+            var random = new Random(27347);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("tree", flags: TreeFlags.LeafsCompressed);
+
+                // two overflow entries, so the double free of the buggy path lands on OverflowPages == 0 instead of tripping
+                // Debug.Assert(OverflowPages >= 0) in Tree.RecordFreedPage (which would fail-fast the test host)
+                Add(tx, tree, "00000", new byte[OverflowValueSize]);
+                Add(tx, tree, "00001", new byte[OverflowValueSize]);
+
+                // 2 x 18 + 7 x 1018 = 7162 bytes, the next 1018 bytes node does not fit anymore
+                for (int i = 2; i <= 8; i++)
+                    Add(tx, tree, Key(i), new byte[InlineValueSize]);
+
+                // "00009" makes TryCompressPageNodes compress the page for the first time: the zero-filled values compress to
+                // almost nothing and the overflow entries land in the compressed section together with them. The incompressible
+                // values added afterwards fill the uncompressed section of the compressed leaf.
+                for (int i = 9; i <= 15; i++)
+                    Add(tx, tree, Key(i), RandomBytes(random, InlineValueSize));
+
+                var root = GetPage(tx, tree.State.Header.RootPageNumber);
+
+                Assert.True(root.IsCompressed);
+                Assert.Equal(1, tree.State.Header.Depth);
+                Assert.Equal(16, tree.State.Header.NumberOfEntries);
+                Assert.Equal(2, tree.State.Header.OverflowPages);
+                Assert.Equal(3, tree.State.Header.PageCount);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("tree");
+
+                // the key lives in the compressed section, so the delete just appends a compression tombstone to the uncompressed
+                // section. Decrementing NumberOfEntries and freeing the overflow page is deferred until the page gets decompressed
+                // with DecompressionUsage.Write
+                Delete(tx, tree, "00000");
+
+                var root = GetPage(tx, tree.State.Header.RootPageNumber);
+
+                Assert.True(root.IsCompressed);
+                Assert.True(HasCompressionTombstone(root));
+                Assert.Equal(16, tree.State.Header.NumberOfEntries);
+                Assert.Equal(2, tree.State.Header.OverflowPages);
+
+                // does not fit into the uncompressed section. TryCompressPageNodes decompresses the page with Write usage, which
+                // consumes the tombstone (NumberOfEntries--, overflow page freed), but the incompressible values leave no room for
+                // the new entry after the recompression, so the attempt is abandoned and the page gets split instead. The split
+                // must not decompress the page again - that would consume the tombstone a second time.
+                Add(tx, tree, "000041", RandomBytes(random, 1500));
+
+                Assert.Equal(16, tree.State.Header.NumberOfEntries);
+                Assert.Equal(1, tree.State.Header.OverflowPages);
+                Assert.Equal(2, tree.State.Header.Depth);
+                Assert.Equal(tree.AllPages().Count, tree.State.Header.PageCount);
+
+                tree.ValidateTree_Forced(tree.State.Header.RootPageNumber);
+
+                Assert.Null(ReadLength(tx, tree, "00000"));
+                Assert.Equal(OverflowValueSize, ReadLength(tx, tree, "00001"));
+                Assert.Equal(1500, ReadLength(tx, tree, "000041"));
+
+                Assert.Equal(16, CountEntries(tree));
+
+                tx.Commit();
+            }
+        }
+
+        private static string Key(int i)
+        {
+            return i.ToString("D5");
+        }
+
+        private static byte[] RandomBytes(Random random, int size)
+        {
+            var bytes = new byte[size];
+            random.NextBytes(bytes);
+            return bytes;
+        }
+
+        private static unsafe TreePage GetPage(Transaction tx, long pageNumber)
+        {
+            return new TreePage(tx.LowLevelTransaction.GetPage(pageNumber).Pointer, Constants.Storage.PageSize);
+        }
+
+        private static void Add(Transaction tx, Tree tree, string key, byte[] value)
+        {
+            using (Slice.From(tx.Allocator, key, out Slice keySlice))
+                tree.Add(keySlice, value);
+        }
+
+        private static void Delete(Transaction tx, Tree tree, string key)
+        {
+            using (Slice.From(tx.Allocator, key, out Slice keySlice))
+                tree.Delete(keySlice);
+        }
+
+        private static int? ReadLength(Transaction tx, Tree tree, string key)
+        {
+            using (Slice.From(tx.Allocator, key, out Slice keySlice))
+            using (var result = tree.ReadDecompressed(keySlice))
+                return result?.Reader.Length;
+        }
+
+        private static int CountEntries(Tree tree)
+        {
+            var count = 0;
+
+            using (var it = tree.Iterate(prefetch: false))
+            {
+                if (it.Seek(Slices.BeforeAllKeys) == false)
+                    return 0;
+
+                do
+                {
+                    count++;
+                } while (it.MoveNext());
+            }
+
+            return count;
+        }
+
+        private static unsafe bool HasCompressionTombstone(TreePage page)
+        {
+            for (int i = 0; i < page.NumberOfEntries; i++)
+            {
+                if (page.GetNode(i)->Flags == TreeNodeFlags.CompressionTombstone)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/StressTests/Voron/Issues/RavenDB_27347.cs
+++ b/test/StressTests/Voron/Issues/RavenDB_27347.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using FastTests.Voron;
+using Sparrow.Binary;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.BTrees;
+using Voron.Data.Compression;
+using Voron.Global;
+using Voron.Impl;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Voron.Issues
+{
+    public class RavenDB_27347 : StorageTest
+    {
+        public RavenDB_27347(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // the access pattern of a map-reduce results tree: 8 bytes big endian ids (a new entry is always the greatest key), deletes
+        // and in-place updates of recent entries (compression tombstones in the leaf that keeps receiving entries), values of mixed
+        // compressibility with a large share of overflow values. The compressed leaves keep getting decompressed for writing,
+        // recompressed, split or written back, which is where RavenDB-27347 lived: a failed recompression must not apply the
+        // compression tombstones twice, a decompressed page that consumed tombstones must be written back even if it cannot be
+        // compressed, and splitting such a page must handle an overflow entry in the middle. The seeds are fixed, the runs are deterministic.
+        [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.Compression)]
+        [InlineData(27347)]
+        [InlineData(27348)]
+        [InlineData(27349)]
+        public void CompressedLeavesSurviveSequentialChurnWithDeletesAndOverflowValues(int seed)
+        {
+            const int numberOfBatches = 3000;
+            const int operationsPerBatch = 50;
+
+            var random = new Random(seed);
+            var live = new List<long>();
+            var expected = new Dictionary<long, byte[]>();
+            var recentlyDeleted = new Queue<long>();
+            long nextId = 1;
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("tree", flags: TreeFlags.LeafsCompressed);
+                tx.Commit();
+            }
+
+            for (int batch = 0; batch < numberOfBatches; batch++)
+            {
+                using (var tx = Env.WriteTransaction())
+                {
+                    var tree = tx.ReadTree("tree");
+
+                    for (int i = 0; i < operationsPerBatch; i++)
+                    {
+                        var operation = random.Next(100);
+
+                        if (operation < 60 || live.Count < 200)
+                        {
+                            var value = RandomValue(random);
+                            Add(tx, tree, nextId, value);
+                            expected[nextId] = value;
+                            live.Add(nextId++);
+                        }
+                        else if (operation < 70)
+                        {
+                            // a recent entry, most likely already in the compressed section of the hot leaf
+                            var id = live[live.Count - 1 - random.Next(5, Math.Min(80, live.Count))];
+                            var value = RandomValue(random);
+                            Add(tx, tree, id, value);
+                            expected[id] = value;
+                        }
+                        else
+                        {
+                            // mostly recent entries, sometimes the oldest ones
+                            var index = random.Next(10) < 7
+                                ? live.Count - 1 - random.Next(5, Math.Min(80, live.Count))
+                                : random.Next(Math.Min(100, live.Count));
+
+                            var id = live[index];
+                            Delete(tx, tree, id);
+                            expected.Remove(id);
+                            live.RemoveAt(index);
+
+                            recentlyDeleted.Enqueue(id);
+
+                            if (recentlyDeleted.Count > 200)
+                                recentlyDeleted.Dequeue();
+                        }
+                    }
+
+                    tx.Commit();
+                }
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("tree");
+
+                // ValidateTree_Forced is not used on purpose: a compressed leaf whose entries all got deleted stays in the tree with
+                // its tombstones until something decompresses it for writing, and the validator reports it as an empty page
+                long entries = 0;
+
+                foreach (var pageNumber in tree.AllPages())
+                {
+                    var page = GetPage(tx, pageNumber);
+
+                    if (page.IsLeaf == false)
+                        continue;
+
+                    if (page.IsCompressed)
+                    {
+                        using (var decompressed = tree.DecompressPage(page, DecompressionUsage.Read, skipCache: true))
+                            entries += decompressed.NumberOfEntries;
+                    }
+                    else
+                    {
+                        entries += page.NumberOfEntries;
+                    }
+                }
+
+                Assert.Equal(expected.Count, entries);
+
+                foreach (var (id, value) in expected)
+                    Assert.Equal(value, Read(tx, tree, id));
+
+                foreach (var id in recentlyDeleted)
+                    Assert.Null(Read(tx, tree, id));
+            }
+        }
+
+        private static byte[] RandomValue(Random random)
+        {
+            var kind = random.Next(100);
+
+            if (kind < 30)
+            {
+                // overflow value
+                var overflow = new byte[random.Next(4200, 6000)];
+
+                if (random.Next(2) == 0)
+                    random.NextBytes(overflow);
+                else
+                    Array.Fill(overflow, (byte)'L');
+
+                return overflow;
+            }
+
+            var value = new byte[random.Next(200, 3000)];
+
+            if (kind < 60)
+                random.NextBytes(value); // incompressible
+            else
+                Array.Fill(value, (byte)('a' + random.Next(26))); // compressible
+
+            return value;
+        }
+
+        private static unsafe TreePage GetPage(Transaction tx, long pageNumber)
+        {
+            return new TreePage(tx.LowLevelTransaction.GetPage(pageNumber).Pointer, Constants.Storage.PageSize);
+        }
+
+        private static unsafe void Add(Transaction tx, Tree tree, long id, byte[] value)
+        {
+            id = Bits.SwapBytes(id);
+
+            using (Slice.External(tx.Allocator, (byte*)&id, sizeof(long), out Slice key))
+                tree.Add(key, value);
+        }
+
+        private static unsafe void Delete(Transaction tx, Tree tree, long id)
+        {
+            id = Bits.SwapBytes(id);
+
+            using (Slice.External(tx.Allocator, (byte*)&id, sizeof(long), out Slice key))
+                tree.Delete(key);
+        }
+
+        private static unsafe byte[] Read(Transaction tx, Tree tree, long id)
+        {
+            id = Bits.SwapBytes(id);
+
+            using (Slice.External(tx.Allocator, (byte*)&id, sizeof(long), out Slice key))
+            using (var result = tree.ReadDecompressed(key))
+            {
+                if (result == null)
+                    return null;
+
+                return new ReadOnlySpan<byte>(result.Reader.Base, result.Reader.Length).ToArray();
+            }
+        }
+    }
+}

--- a/test/StressTests/Voron/Issues/RavenDB_27347.cs
+++ b/test/StressTests/Voron/Issues/RavenDB_27347.cs
@@ -8,6 +8,7 @@ using Voron.Data.BTrees;
 using Voron.Data.Compression;
 using Voron.Global;
 using Voron.Impl;
+using Voron.Impl.Paging;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -94,33 +95,84 @@ namespace StressTests.Voron.Issues
                 }
             }
 
-            using (var tx = Env.ReadTransaction())
+            // the tree can be validated and its header compared with a structure walk only once every compressed leaf has consumed its
+            // deferred work: decompress each of them for writing and write it back, or take it out of the tree if all of its entries got
+            // deleted (what the map-reduce code does with such leaves)
+            using (var tx = Env.WriteTransaction())
             {
                 var tree = tx.ReadTree("tree");
 
-                // ValidateTree_Forced is not used on purpose: a compressed leaf whose entries all got deleted stays in the tree with
-                // its tombstones until something decompresses it for writing, and the validator reports it as an empty page
-                long entries = 0;
+                var compressedLeaves = new List<long>();
 
                 foreach (var pageNumber in tree.AllPages())
                 {
                     var page = GetPage(tx, pageNumber);
 
-                    if (page.IsLeaf == false)
+                    if (page.IsOverflow == false && page.IsLeaf && page.IsCompressed)
+                        compressedLeaves.Add(pageNumber);
+                }
+
+                foreach (var pageNumber in compressedLeaves)
+                {
+                    using (var decompressed = tree.DecompressPage(tree.ModifyPage(pageNumber), DecompressionUsage.Write, skipCache: true))
+                    {
+                        if (decompressed.NumberOfEntries == 0)
+                            tree.RemoveEmptyDecompressedPage(decompressed);
+                        else
+                            decompressed.CopyToOriginal(tx.LowLevelTransaction, defragRequired: true, wasModified: true, tree);
+                    }
+                }
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("tree");
+
+                tree.ValidateTree_Forced(tree.State.Header.RootPageNumber);
+
+                // AllPages does not see the overflow pages referenced from the compressed sections, the overflow pages are counted here
+                long entries = 0;
+                long branchPages = 0;
+                long leafPages = 0;
+                long overflowPages = 0;
+
+                foreach (var pageNumber in tree.AllPages())
+                {
+                    var page = GetPage(tx, pageNumber);
+
+                    if (page.IsOverflow)
                         continue;
 
-                    if (page.IsCompressed)
+                    if (page.IsBranch)
                     {
-                        using (var decompressed = tree.DecompressPage(page, DecompressionUsage.Read, skipCache: true))
-                            entries += decompressed.NumberOfEntries;
+                        branchPages++;
+                        continue;
                     }
-                    else
+
+                    leafPages++;
+
+                    if (page.IsCompressed)
+                        Assert.Equal(0, page.NumberOfEntries); // written back: nothing left in the uncompressed section, in particular no tombstone
+
+                    using (page.IsCompressed ? (DecompressedLeafPage)(page = tree.DecompressPage(page, DecompressionUsage.Read, skipCache: true)) : null)
                     {
                         entries += page.NumberOfEntries;
+                        overflowPages += CountOverflowPages(tx, page);
                     }
                 }
 
                 Assert.Equal(expected.Count, entries);
+                Assert.Equal(branchPages, tree.State.Header.BranchPages);
+                Assert.Equal(leafPages, tree.State.Header.LeafPages);
+
+                // not asserted yet: NumberOfEntries, OverflowPages and PageCount in the header drift because of pre-existing accounting gaps
+                // (a delete of an uncompressed key skips the decrement, an update of a compressed key leaks its old overflow page), to be
+                // fixed and asserted separately
+                // Assert.Equal(expected.Count, tree.State.Header.NumberOfEntries);
+                // Assert.Equal(overflowPages, tree.State.Header.OverflowPages);
+                // Assert.Equal(branchPages + leafPages + overflowPages, tree.State.Header.PageCount);
 
                 foreach (var (id, value) in expected)
                     Assert.Equal(value, Read(tx, tree, id));
@@ -128,6 +180,21 @@ namespace StressTests.Voron.Issues
                 foreach (var id in recentlyDeleted)
                     Assert.Null(Read(tx, tree, id));
             }
+        }
+
+        private static unsafe long CountOverflowPages(Transaction tx, TreePage page)
+        {
+            long count = 0;
+
+            for (int i = 0; i < page.NumberOfEntries; i++)
+            {
+                var node = page.GetNode(i);
+
+                if (node->Flags == TreeNodeFlags.PageRef)
+                    count += VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(GetPage(tx, node->PageNumber).OverflowSize);
+            }
+
+            return count;
         }
 
         private static byte[] RandomValue(Random random)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27347

### Additional description

Background:
- Map-reduce results trees are `LeafsCompressed`. Deleting a key from the compressed section of a leaf only appends a tombstone, the delete itself (`NumberOfEntries--`, freeing the overflow page) happens on the next Write decompression of that leaf.
- So a Write decompression must always end with the original page rewritten from the decompressed copy. If the copy is dropped, the next Write decompression applies the same tombstone again: a double decrement and a double free.
- Three places broke that rule, one reported, two found on the way.

Impact summary:

| # | Problem | 6.2 | v8.0 |
|---|---|---|---|
| 1 | Failed recompression applied the tombstones twice (reported) | header corruption of the results tree (`NumberOfEntries`, `OverflowPages`, `PageCount`), Release: no crash, entries and query results intact; Debug: `Debug.Assert(OverflowPages >= 0)` -> the indexing error from the issue | crash: the second free reads an already freed page, pager validation throws, the index ends in a catastrophic failure |
| 2 | Decompressed page that applied tombstones was not written back when it could not be recompressed | data corruption of the whole index environment: a live page gets freed, catastrophic failure | same |
| 3 | `DecompressedLeafPage.SplitPage` with an overflow entry in the middle | `NullReferenceException` in the write transaction, the indexing batch fails (and keeps failing on retry, derived) | same |

Problems and fixes:

1. Tombstones applied twice when the recompression fails (the reported bug, afdd790d265)
   - `Tree.TryCompressPageNodes` decompressed the leaf for writing (tombstones applied), the recompression left no room for the new entry, the copy was dropped and the original page left untouched. `TreePageSplitter.Execute` then decompressed the same page again and applied the same tombstones a second time.
   - Fix: the decompressed page is handed over to `TreePageSplitter` and reused, the leaf is decompressed once.

2. Decompressed page not written back when it cannot be recompressed (8e291d479b9, 06ea38d1051)
   - `DecompressedLeafPage.CopyToOriginal(wasModified: false)` returned early on a failed recompression, leaving the tombstone in the original page after the header and the free space already reflected the delete. In a later transaction the freed overflow page belongs to someone else, the next Write decompression applies the stale tombstone again and frees a live page.
   - Fix: `MustBeWrittenBack` flag, set when a Write decompression applies a tombstone or an update. `CopyToOriginal` skips the write-back only when the flag is not set, otherwise the page is split and written back. The flag is reset once the original page was rewritten.

3. `DecompressedLeafPage.SplitPage` with an overflow entry in the middle (pre-existing, 22ef0872d85)
   - The middle node moved to the new page was always treated as a Data node. For a `PageRef` this produced a reference to the leaf itself and a value copy into a null pointer. Reachable before this PR from the `DeleteOnCompressedPage` slow path and `SplitPageInHalf`, fix 2 adds another caller, so this went in first.
   - Fix: a `PageRef` middle node is moved as a reference, the way `Tree.DirectAdd` stores overflow values.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
