### PR TITLE
RavenDB-27482 Fix the in-memory term sort above 32 768 entries, its top-N cut and its tie order

### DIFF
--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
@@ -2,6 +2,7 @@
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax.Mappings;
@@ -201,15 +202,13 @@ unsafe sealed partial class SortingMatch<TInner>
             _lookup.GetFor(batchResults, batchTermIds, SortingHelpers.MissingTermId);
             SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, NonExistingTermContainerId, NullTermContainerId, SortingHelpers.MissingTermId);
 
-            // Sort by term id (≈ page order, since term ids are container ids) to optimize GetAll access patterns
-            batchTermIds.Sort(batchResults);
+            // Page-ordered fetch that leaves batchResults in entry-id order; the tie-break below depends on it.
+            Container.GetAllSortedByPage(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), pageLocator);
 
-            var terms = new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length);
-            Container.GetAll(llt, batchTermIds, terms, pageLocator);
-
-            
-            var indirectComparer = new IndirectComparer<CompactKeyComparer>(batchTerms, new CompactKeyComparer(), descending);
-            var indexes = SortByTerms(match, batchTermIds, batchTerms, descending, indirectComparer);
+            // The batch index packed into the sort key must address the whole batch; SortInMemory passes it all at once.
+            var indexBits = IndexBitsFor(batchResults.Length);
+            var indirectComparer = new IndirectComparer<CompactKeyComparer>(batchTerms, new CompactKeyComparer(), descending, indexBits);
+            var indexes = SortByTerms(match, batchTermIds, batchTerms, descending, indirectComparer, indexBits);
             
             for (int i = 0; i < indexes.Length; i++)
             {
@@ -218,46 +217,58 @@ unsafe sealed partial class SortingMatch<TInner>
             }
         }
 
-        private static void MaybeBreakTies<TComparer>(Span<long> buffer, TComparer tieBreaker, bool isDescending) where TComparer : struct, IComparer<long>
+        /// <summary>Width of the batch index packed into the sort key. 15 bits are free by construction; a larger batch
+        /// takes one more per doubling from the term prefix, which only costs pre-sort precision - ties are resolved by the
+        /// full comparer. Capped at 31 so the key stays non-negative.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int IndexBitsFor(int length) => Math.Clamp(32 - BitOperations.LeadingZeroCount((uint)(length - 1)), 15, 31);
+
+        /// <summary>The part of the key at <paramref name="i"/> that the pre-sort actually ordered, i.e. without the packed batch index.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long KeyPrefixAt(Span<long> buffer, int i, bool isDescending, int indexBits)
+        {
+            var key = buffer[i];
+            if (isDescending)
+                key = -key;
+            return key >> indexBits;
+        }
+
+        /// <summary>First position at or after <paramref name="from"/> whose key prefix differs from <paramref name="prefix"/>.</summary>
+        private static int TieRunEnd(Span<long> buffer, long prefix, int from, bool isDescending, int indexBits)
+        {
+            int end = from;
+            for (; end < buffer.Length; end++)
+            {
+                if (KeyPrefixAt(buffer, end, isDescending, indexBits) != prefix)
+                    break;
+            }
+
+            return end;
+        }
+
+        private static void MaybeBreakTies<TComparer>(Span<long> buffer, TComparer tieBreaker, bool isDescending, int indexBits)
+            where TComparer : struct, IComparer<long>
         {
             // We may have ties, have to resolve that before we can continue
             for (int i = 1; i < buffer.Length; i++)
             {
-                var x = buffer[i - 1];
-                var y = buffer[i];
-                if (isDescending)
-                {
-                    x = -x;
-                    y = -y;
-                }
-
-                x >>= 15;
-                y >>= 15;
-                if (x != y)
+                var x = KeyPrefixAt(buffer, i - 1, isDescending, indexBits);
+                if (x != KeyPrefixAt(buffer, i, isDescending, indexBits))
                     continue;
 
                 // we have a match on the prefix, need to figure out where it ends hopefully this is rare
-                int end = i;
-                for (; end < buffer.Length; end++)
-                {
-                    y = buffer[end];
-                    if (isDescending)
-                        y = -y;
-                    y >>= 15;
-                    if (x != y)
-                        break;
-                }
-
+                int end = TieRunEnd(buffer, x, i, isDescending, indexBits);
                 buffer[(i - 1)..end].Sort(tieBreaker);
                 i = end;
             }
         }
 
         private static Span<int> SortByTerms<TComparer>(SortingMatch<TInner> match, Span<long> buffer, UnmanagedSpan* batchTerms, bool isDescending,
-            TComparer tieBreaker)
+            TComparer tieBreaker, int indexBits)
             where TComparer : struct, IComparer<long>
         {
-            Debug.Assert(buffer.Length < (1 << 15), "buffer.Length < (1<<15)");
+            long indexMask = (1L << indexBits) - 1;
+            Debug.Assert(buffer.Length <= indexMask + 1, "the packed index field has to address every entry of the batch");
             var nullValue = match._nullFirst
                 ? 0
                 : -1 >>> 16;
@@ -274,7 +285,7 @@ unsafe sealed partial class SortingMatch<TInner>
                     l = nullValue;
                 }
 
-                l = BinaryPrimitives.ReverseEndianness(l) >>> 1;
+                l = (BinaryPrimitives.ReverseEndianness(l) >>> 1) & ~indexMask;
                 long sortKey = l | (uint)i;
                 if (isDescending)
                     sortKey = -sortKey;
@@ -284,16 +295,19 @@ unsafe sealed partial class SortingMatch<TInner>
 
             Sort.Run(buffer);
 
-            if (match._take >= 0 &&
-                buffer.Length > match._take)
-                buffer = buffer[..match._take];
+            var take = match._take >= 0 && match._take < buffer.Length ? match._take : buffer.Length;
+            if (take > 0)
+            {
+                // Resolve the tie run straddling the cut before cutting, or the top N is chosen by batch index, not by term.
+                // That run can be the whole buffer; nth-element selection is the upgrade if it shows in a profile.
+                var end = TieRunEnd(buffer, KeyPrefixAt(buffer, take - 1, isDescending, indexBits), take, isDescending, indexBits);
+                MaybeBreakTies(buffer[..end], tieBreaker, isDescending, indexBits);
+            }
 
-            MaybeBreakTies(buffer, tieBreaker, isDescending);
-
-            return ExtractIndexes(buffer, isDescending);
+            return ExtractIndexes(buffer[..take], isDescending, indexMask);
         }
 
-        private static Span<int> ExtractIndexes(Span<long> buffer, bool isDescending)
+        private static Span<int> ExtractIndexes(Span<long> buffer, bool isDescending, long indexMask)
         {
             // note - we reuse the memory
             var indexes = MemoryMarshal.Cast<long, int>(buffer)[..(buffer.Length)];
@@ -302,7 +316,7 @@ unsafe sealed partial class SortingMatch<TInner>
                 var sortKey = buffer[i];
                 if (isDescending)
                     sortKey = -sortKey;
-                var idx = (ushort)sortKey & 0x7FFF;
+                var idx = (int)(sortKey & indexMask);
                 indexes[i] = idx;
             }
 
@@ -315,37 +329,6 @@ unsafe sealed partial class SortingMatch<TInner>
         }
     }
 
-
-    private struct EntryComparerHelper
-    {
-        public static Span<int> NumericSortBatch<TCmp>(Span<long> batchTermIds, UnmanagedSpan* batchTerms, bool descending = false)
-            where TCmp : struct, IComparer<UnmanagedSpan>, IEntryComparer
-        {
-            var indexes = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
-            for (int i = 0; i < batchTermIds.Length; i++)
-            {
-                batchTerms[i] = new UnmanagedSpan(batchTermIds[i]);
-                indexes[i] = i;
-            }
-
-            IndirectSort<TCmp>(indexes, batchTerms, descending);
-
-            return indexes;
-        }
-
-        public static void IndirectSort<TCmp>(Span<int> indexes, UnmanagedSpan* batchTerms, bool descending, TCmp cmp = default)
-            where TCmp : struct, IComparer<UnmanagedSpan>, IEntryComparer
-        {
-            if (descending)
-            {
-                indexes.Sort(new IndirectComparer<Descending<TCmp>>(batchTerms, new(cmp), true));
-            }
-            else
-            {
-                indexes.Sort(new IndirectComparer<TCmp>(batchTerms, cmp, false));
-            }
-        }
-    }
 
     private struct EntryComparerByLong : IEntryComparer, IComparer<UnmanagedSpan>
     {
@@ -581,18 +564,20 @@ unsafe sealed partial class SortingMatch<TInner>
     }
 
 
-    private readonly struct IndirectComparer<TComparer> : IComparer<long>, IComparer<int>
+    private readonly struct IndirectComparer<TComparer> : IComparer<long>
         where TComparer : struct, IComparer<UnmanagedSpan>
     {
         private readonly UnmanagedSpan* _terms;
         private readonly TComparer _inner;
         private readonly bool _isDescending;
+        private readonly long _indexMask;
 
-        public IndirectComparer(UnmanagedSpan* terms, TComparer entryComparer, bool isDescending)
+        public IndirectComparer(UnmanagedSpan* terms, TComparer entryComparer, bool isDescending, int indexBits)
         {
             _terms = terms;
             _inner = entryComparer;
             _isDescending = isDescending;
+            _indexMask = (1L << indexBits) - 1;
         }
 
         public int Compare(long x, long y)
@@ -603,24 +588,20 @@ unsafe sealed partial class SortingMatch<TInner>
                 y = -y;
             }
 
-            var xIdx = (ushort)x & 0X7FFF;
-            var yIdx = (ushort)y & 0X7FFF;
-            Debug.Assert(yIdx < SortingMatch.SortBatchSize && xIdx < SortingMatch.SortBatchSize);
+            // Same width SortByTerms packed for this batch; a fixed 15-bit mask folded larger batches onto 0..32767.
+            var xIdx = (int)(x & _indexMask);
+            var yIdx = (int)(y & _indexMask);
             var cmp = _isDescending
                 ? -_inner.Compare(_terms[xIdx], _terms[yIdx])
                 : _inner.Compare(_terms[xIdx], _terms[yIdx]);
             if (cmp != 0)
                 return cmp;
-            // Equal sort terms: break the tie by ascending batch index. bitmap Fill yields entry IDs in
-            // ascending order, so this reproduces the streaming strategy's tie order (forward posting-list
-            // walk = ascending entry id) — keeping result order identical across sort strategies, including
-            // for descending sorts where the negation above would otherwise reverse the tie order.
+            // Equal sort terms: break the tie by ascending batch index. batchResults holds entry IDs in ascending
+            // order (bitmap Fill yields them that way, and SortBatch no longer permutes it), so this reproduces the
+            // streaming strategy's tie order (forward posting-list walk = ascending entry id) — keeping result order
+            // identical across sort strategies, including for descending sorts where the negation above would
+            // otherwise reverse the tie order.
             return xIdx - yIdx;
-        }
-
-        public int Compare(int x, int y)
-        {
-            return _inner.Compare(_terms[x], _terms[y]);
         }
     }
 }

--- a/test/SlowTests.Issues/Issues/RavenDB_27482.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27482.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27482(ITestOutputHelper output) : RavenTestBase(output)
+{
+    // SortByTerms packs the batch index into the low 15 bits of the sort key; all three tests exercise that key.
+    private const int PackedIndexLimit = 32_768;
+
+    // Defect 1: past 32_768 the packed index wraps, documents repeat and the order is perturbed.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void SortMustNotLoseEntriesPastThePackedIndexLimit(Options options)
+    {
+        // both sides of the boundary in one run, so a failure names which side broke
+        var problems = new List<string>();
+
+        problems.AddRange(CheckBoundary(options, PackedIndexLimit));     // largest batch the packing can address
+        problems.AddRange(CheckBoundary(options, PackedIndexLimit + 1)); // one past it
+
+        Assert.True(problems.Count == 0, string.Join(Environment.NewLine, problems));
+    }
+
+    private IEnumerable<string> CheckBoundary(Options options, int documents)
+    {
+        using var store = GetDocumentStore(options);
+
+        // every key is distinct, so a lost or duplicated entry shows up directly in the counts
+        Fill(store, documents, i => $"k-{i:D6}");
+
+        using var session = store.OpenSession();
+
+        // no limit, so the server asks for every entry, which is what selects the in-memory sort
+        var rows = Query(session, options, "where true order by Key as string", pin: null);
+
+        if (rows.Count != documents)
+            yield return $"{documents} documents: got {rows.Count} rows";
+
+        var distinctIds = rows.Select(x => x.Id).Distinct().Count();
+        if (distinctIds != documents)
+            yield return $"{documents} documents: only {distinctIds} of them are distinct, the rest are duplicates";
+
+        var keys = rows.Select(x => x.Key).ToList();
+        var unsorted = Enumerable.Range(1, Math.Max(0, keys.Count - 1))
+            .FirstOrDefault(i => string.CompareOrdinal(keys[i - 1], keys[i]) > 0, -1);
+
+        if (unsorted >= 0)
+            yield return $"{documents} documents: not sorted at position {unsorted} ({keys[unsorted - 1]} then {keys[unsorted]})";
+    }
+
+    // Defect 2: the cut to _take happened before MaybeBreakTies, so the top N was picked by batch index, not by term.
+    // Needs terms equal in the 6 encoded bytes the key keeps (a 160-byte shared prefix guarantees that whatever the
+    // dictionary) and container ids out of term order: one indexing run inserts its terms sorted, so the group is
+    // split across two runs by parity - either way the lowest ids are never {0,1,2,3,4}.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void LimitMustNotPickTheTopNByTheTruncatedTermKey(Options options)
+    {
+        const int groupSize = 10, anchors = 5;
+        const int limit = anchors + groupSize / 2; // the cut lands in the middle of the tie group
+
+        using var store = GetDocumentStore(options);
+
+        new Items_ByKey().Execute(store); // index first, so each SaveChanges below is its own indexing run
+
+        using (var session = store.OpenSession())
+        {
+            for (int i = 0; i < anchors; i++)
+                session.Store(new Item { Key = AnchorTerm(i) }, $"items/anchor/{i}");
+
+            for (int i = 1; i < groupSize; i += 2) // odd half
+                session.Store(new Item { Key = GroupTerm(i) }, $"items/group/{i}");
+
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store); // must complete first, or the two halves become one indexing run
+
+        using (var session = store.OpenSession())
+        {
+            for (int i = 0; i < groupSize; i += 2) // even half
+                session.Store(new Item { Key = GroupTerm(i) }, $"items/group/{i}");
+
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        var expected = Enumerable.Range(0, anchors).Select(AnchorTerm)
+            .Concat(Enumerable.Range(0, groupSize).Select(GroupTerm))
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .Take(limit)
+            .ToArray();
+
+        using var read = store.OpenSession();
+
+        // keep documents > limit, otherwise take widens to TakeAll and nothing is cut
+        var rows = Query(read, options, "where true order by Key as string", pin: "InMemorySort", limit: limit);
+
+        // the set, not the order: the returned page is ordered correctly either way
+        Assert.Equal(expected, rows.Select(x => x.Key).OrderBy(x => x, StringComparer.Ordinal).ToArray());
+    }
+
+    // 160 shared bytes then a 4-digit discriminator, every term the same length
+    private static string GroupTerm(int i) => new string('a', 160) + i.ToString("D4");
+
+    // sort before every group term and differ in byte 0, so they are in the top N on term grounds alone
+    private static string AnchorTerm(int i) => $"{i}-anchor";
+
+    // Defect 3: batchTermIds.Sort(batchResults) reordered the batch by term id, so ties came out in container-page order.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void EqualTermsMustBeOrderedByAscendingId(Options options)
+    {
+        const int documents = 500;
+
+        using var store = GetDocumentStore(options);
+
+        // one tie group: the whole result is decided by the tie-break
+        Fill(store, documents, _ => "same-term-for-everyone");
+
+        using var session = store.OpenSession();
+
+        var rows = Query(session, options, "where true order by Key as string", pin: "InMemorySort");
+
+        var expected = Enumerable.Range(0, documents).Select(i => $"items/{i:D4}").ToArray();
+
+        Assert.Equal(expected, rows.Select(x => x.Id).ToArray());
+    }
+
+    private void Fill(IDocumentStore store, int documents, Func<int, string> key)
+    {
+        using (var bulk = store.BulkInsert())
+        {
+            // explicit padded ids so that lexicographic order == insertion order == entry id order
+            for (int i = 0; i < documents; i++)
+                bulk.Store(new Item { Key = key(i) }, $"items/{i:D4}");
+        }
+
+        new Items_ByKey().Execute(store);
+        Indexes.WaitForIndexing(store);
+    }
+
+    // 'where true' keeps the sort in the plan (an Equals on the sort field would elide it); 'as string' reaches the term
+    // comparer rather than the immune numeric one.
+    private static List<Item> Query(IDocumentSession session, Options options, string rql, string pin, int? limit = null)
+    {
+        // RQL puts LIMIT last, after SELECT and INCLUDE
+        var tail = limit is { } n ? $" limit {n}" : string.Empty;
+        var query = session.Advanced.RawQuery<Item>($"from index 'Items/ByKey' {rql} select id() as Id, Key include timings(){tail}");
+
+        if (pin != null)
+            query = query.AddParameter("rvn_corax_sort", pin);
+
+        var rows = query.Timings(out QueryTimings timings).ToList();
+
+        // guards against a vacuous pass: an elided sort, a numeric field or a dropped pin never touch the packed key
+        if (options.SearchEngineMode == RavenSearchEngineMode.Corax)
+        {
+            var sorting = Find(timings.QueryPlan as QueryInspectionNode, "SortingMatch");
+            Assert.True(sorting != null, "no SortingMatch in the plan, the query never reached the batch sort");
+
+            sorting.Parameters.TryGetValue("FieldType", out var fieldType);
+            Assert.Equal("Sequence", fieldType);
+
+            if (pin != null)
+            {
+                sorting.Parameters.TryGetValue("Strategy", out var strategy);
+                Assert.Equal(pin, strategy);
+            }
+        }
+
+        return rows;
+    }
+
+    private static QueryInspectionNode Find(QueryInspectionNode node, string operation)
+    {
+        if (node == null)
+            return null;
+        if (node.Operation == operation)
+            return node;
+
+        foreach (var child in node.Children ?? [])
+        {
+            var found = Find(child, operation);
+            if (found != null)
+                return found;
+        }
+
+        return null;
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+
+        public string Key { get; set; }
+    }
+
+    private class Items_ByKey : AbstractIndexCreationTask<Item>
+    {
+        public Items_ByKey()
+        {
+            Map = items => from item in items
+                           select new { item.Key };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27482

### Additional description

`SortByTerms` packs the entry's index within the batch into the low bits of the sort key and recovered it with a fixed 15-bit mask, while `SortInMemory` passes the whole candidate set as one batch. Three defects in that function:

1. Above 32 768 entries the index wrapped: documents were returned several times, never more than 32 768 distinct, and the order was perturbed. The field is now as wide as the batch needs; the pre-sort loses one term-prefix bit per doubling and `MaybeBreakTies` resolves equal prefixes with the full comparer. Below 32 768 the keys are bit-identical to before.
2. The cut to `_take` happened before `MaybeBreakTies`, so a tie run straddling the cut was truncated by batch index, not by term - wrong top-N. The straddling run is resolved first, then cut.
3. `batchTermIds.Sort(batchResults)` reordered the candidates by term container id, so equal terms came out in container-page order instead of entry-id order, unlike IndexOrderStreaming, Corax 1.0 and Lucene. Terms are now fetched with `Container.GetAllSortedByPage`, leaving `batchResults` untouched.

Dead `EntryComparerHelper` and unreachable `IndirectComparer.Compare(int, int)` removed; the stale `Debug.Assert`s replaced, so the path runs in Debug.

Reached by any `where` + `order by` on a string field with no effective limit (`select distinct` always removes it), and with `take >= 0` via `SortCheaper` and the streaming over-scan bailout.
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Tie order now follows the documented contract (ascending entry id, identical across strategies) and top-N under a limit follows term order. Snapshots of the previous arbitrary tie order will differ.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
