### PR TITLE
RavenDB-27046 Debug Package Analyzer: count nodes unreachable during package creation

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/DebugPackageAnalysisSummary.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/DebugPackageAnalysisSummary.cs
@@ -32,10 +32,12 @@ public class DebugPackageAnalysisSummary : IDynamicJson
             SummaryPerNode.Add(nodeTag, summary);
         }
 
+        UnreachableNodes = packageAnalysisReport.UnreachableNodes;
         ClusterWideIssues = packageAnalysisReport.ClusterWideIssues;
     }
     public string PackageId { get; set; }
     public Dictionary<string, DebugPackageNodeAnalysisSummary> SummaryPerNode { get; set; }
+    public Dictionary<string, string> UnreachableNodes { get; set; }
     public DebugPackageAnalysisIssues ClusterWideIssues { get; set; }
 
     private DebugPackageNodeAnalysisSummary GetNodeSummary(DebugPackageNodeReport nodeReport)
@@ -150,9 +152,8 @@ public class DebugPackageAnalysisSummary : IDynamicJson
         return new DynamicJsonValue
         {
             [nameof(PackageId)] = PackageId,
-            [nameof(SummaryPerNode)] = SummaryPerNode != null 
-                ? DynamicJsonValue.Convert(SummaryPerNode)
-                : null,
+            [nameof(SummaryPerNode)] = DynamicJsonValue.Convert(SummaryPerNode),
+            [nameof(UnreachableNodes)] = DynamicJsonValue.Convert(UnreachableNodes),
             [nameof(ClusterWideIssues)] = ClusterWideIssues?.ToJson()
         };
     }

--- a/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/DebugPackageAnalyzer.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/DebugPackageAnalyzer.cs
@@ -173,19 +173,53 @@ public class DebugPackageAnalyzer(Stream packageZipStream)
             }
         }
 
-        var clusterWideIssues = DetectClusterWideIssues(nodeReports);
+        var unreachableNodes = isClusterPackage ? GetUnreachableNodes(nodeReports) : new();
+
+        var clusterWideIssues = DetectClusterWideIssues(nodeReports, unreachableNodes);
         var databaseGroupsIssues = DetectDatabaseGroupsIssues(nodeReports);
 
-        return new DebugPackageReport(nodeReports.ToArray(), new DebugPackageAnalysisIssues
+        return new DebugPackageReport(nodeReports.ToArray(), unreachableNodes, new DebugPackageAnalysisIssues
         {
             ClusterIssues = clusterWideIssues,
             DatabaseIssues = databaseGroupsIssues
         });
     }
 
-    private List<DetectedIssue> DetectClusterWideIssues(List<DebugPackageNodeReport> reports)
+    // the collecting node writes one zip per node it could reach, so topology nodes without a report were unreachable
+    private static Dictionary<string, string> GetUnreachableNodes(List<DebugPackageNodeReport> reports)
+    {
+        var reportedNodes = reports.Select(x => x.NodeTag).ToHashSet();
+        var unreachableNodes = new Dictionary<string, string>();
+
+        foreach (var report in reports)
+        {
+            var allNodes = report.ClusterNode?.NodeStateInfo?.Topology?.Topology?.AllNodes;
+            if (allNodes == null)
+                continue;
+
+            foreach (var (nodeTag, url) in allNodes)
+            {
+                if (reportedNodes.Contains(nodeTag) == false)
+                    unreachableNodes[nodeTag] = url;
+            }
+        }
+
+        return unreachableNodes;
+    }
+
+    private List<DetectedIssue> DetectClusterWideIssues(List<DebugPackageNodeReport> reports, Dictionary<string, string> unreachableNodes)
     {
         var clusterWideIssues = new List<DetectedIssue>();
+
+        foreach (var (nodeTag, url) in unreachableNodes)
+        {
+            clusterWideIssues.Add(new DetectedIssue("Node was unreachable when the debug package was created",
+                $"Node {nodeTag} ({url}) could not be reached by the node that created the cluster-wide debug package. The analysis does not include it.",
+                IssueSeverity.Warning, IssueCategory.Cluster)
+            {
+                RecommendedAction = $"Please check that node {nodeTag} is running and reachable, then create the debug package again to include it"
+            });
+        }
 
         var customElectionTimeoutDetected = false;
         

--- a/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/DebugPackageReport.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/DebugPackageReport.cs
@@ -10,15 +10,17 @@ public class DebugPackageReport
     public readonly string PackageId = Guid.NewGuid().ToString("N").Substring(0, 10);
     private DebugPackageAnalysisSummary _summary;
 
-    public DebugPackageReport(DebugPackageNodeReport[] nodeReports, DebugPackageAnalysisIssues clusterWideIssues)
+    public DebugPackageReport(DebugPackageNodeReport[] nodeReports, Dictionary<string, string> unreachableNodes, DebugPackageAnalysisIssues clusterWideIssues)
     {
         Reports = nodeReports;
+        UnreachableNodes = unreachableNodes;
         ClusterWideIssues = clusterWideIssues;
     }
-    
+
     public DateTime LastAccessTime { get; set; }
     public DebugPackageAnalysisIssues ClusterWideIssues { get; set; }
     public DebugPackageNodeReport[] Reports { get; }
+    public Dictionary<string, string> UnreachableNodes { get; }
 
     public DebugPackageAnalysisSummary GetSummary()
     {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -145,7 +145,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                             }
                             catch (Exception e)
                             {
-                                await DebugInfoPackageUtils.WriteExceptionAsZipEntryAsync(e, archive, $"Node - [{ServerStore.NodeTag}]");
+                                await DebugInfoPackageUtils.WriteExceptionAsZipEntryAsync(e, archive, $"Node - [{tag}]");
                             }
                         }
                     }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/debugPackageAnalyzer/DebugPackageAnalyzer.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/debugPackageAnalyzer/DebugPackageAnalyzer.stories.tsx
@@ -109,6 +109,7 @@ interface SectionToggles {
     showOngoingTasks: boolean;
     showRaftDebug: boolean;
     showObserverDecisions: boolean;
+    nodeCUnreachable: boolean;
     // Node scope
     showNetworkInfo: boolean;
     showThreadsInfo: boolean;
@@ -132,6 +133,7 @@ const defaultSectionArgs: SectionToggles = {
     showOngoingTasks: true,
     showRaftDebug: true,
     showObserverDecisions: true,
+    nodeCUnreachable: false,
     showNetworkInfo: true,
     showThreadsInfo: true,
     showDatabaseStats: true,
@@ -169,6 +171,7 @@ const sectionArgTypes = {
     showOngoingTasks: { name: "Ongoing tasks (summary)", control: "boolean", table: { category: clusterSections } },
     showRaftDebug: { name: "Raft debug", control: "boolean", table: { category: clusterSections } },
     showObserverDecisions: { name: "Observer decisions", control: "boolean", table: { category: clusterSections } },
+    nodeCUnreachable: { name: "Node C unreachable", control: "boolean", table: { category: clusterSections } },
     showNetworkInfo: { name: "Network info", control: "boolean", table: { category: nodeSections } },
     showThreadsInfo: { name: "Threads info", control: "boolean", table: { category: nodeSections } },
     showDatabaseStats: { name: "Database stats", control: "boolean", table: { category: databaseSections } },
@@ -198,7 +201,7 @@ function renderAnalyzer(nodeTags: string[], args: SectionToggles) {
         indexingPerNode: !args.showIndexingPerNode,
         ongoingTasks: !args.showOngoingTasks,
     };
-    const summary = DebugPackageStubs.storySummary(nodeTags, omit);
+    const summary = DebugPackageStubs.storySummary(nodeTags, omit, args.nodeCUnreachable ? ["C"] : []);
 
     // The async sections fetch from manageServerService; configure each mock to resolve either a
     // filled stub or its empty value based on the matching control (off = empty).

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/debugPackageAnalyzer/partials/ClusterOverview.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/debugPackageAnalyzer/partials/ClusterOverview.tsx
@@ -19,6 +19,8 @@ import SizeGetter from "components/common/SizeGetter";
 type DebugPackageAnalysisSummary = Raven.Server.Documents.Handlers.Debugging.DebugPackage.DebugPackageAnalysisSummary;
 type NodeSummary = DebugPackageAnalysisSummary["SummaryPerNode"][string];
 type ClusterNodeInfo = NodeSummary["ClusterNodeInfo"];
+// unreachable nodes carry only NodeTag and NodeUrl (from the topology), so a missing NodeState marks an offline row
+type ClusterNodeRow = Partial<ClusterNodeInfo> & Pick<ClusterNodeInfo, "NodeTag" | "NodeUrl">;
 
 interface ClusterOverviewProps {
     summary: DebugPackageAnalysisSummary;
@@ -34,7 +36,7 @@ function useClusterOverviewColumns(availableWidth: number) {
     );
     const getSize = useMemo(() => virtualTableUtils.getCellSizeProvider(bodyWidth), [bodyWidth]);
 
-    const clusterColumns: ColumnDef<ClusterNodeInfo>[] = useMemo(
+    const clusterColumns: ColumnDef<ClusterNodeRow>[] = useMemo(
         () => [
             {
                 header: "Node tag",
@@ -97,6 +99,14 @@ export default function ClusterOverview({ summary }: ClusterOverviewProps) {
 function ClusterOverviewWithSize({ summary, width }: ClusterOverviewWithSizeProps) {
     const nodes = useMemo(() => Object.values(summary.SummaryPerNode ?? {}) as NodeSummary[], [summary]);
     const nodeInfos = useMemo(() => nodes.map((n) => n.ClusterNodeInfo).filter(Boolean), [nodes]);
+    const rows = useMemo<ClusterNodeRow[]>(
+        () =>
+            [
+                ...nodeInfos,
+                ...Object.entries(summary.UnreachableNodes ?? {}).map(([NodeTag, NodeUrl]) => ({ NodeTag, NodeUrl })),
+            ].sort((a, b) => a.NodeTag.localeCompare(b.NodeTag)),
+        [nodeInfos, summary]
+    );
 
     const leader = nodeInfos.find((n) => n.NodeState === "Leader");
 
@@ -106,9 +116,7 @@ function ClusterOverviewWithSize({ summary, width }: ClusterOverviewWithSizeProp
         return names.size;
     }, [nodes]);
 
-    // A node only carries ClusterNodeInfo if it was reachable when the package was captured, so the count of
-    // captured infos is our "online" count against the total set of nodes the package knows about.
-    const totalNodes = nodes.length;
+    const totalNodes = rows.length;
     const onlineNodes = nodeInfos.length;
     const allNodesOnline = onlineNodes === totalNodes;
 
@@ -128,10 +136,11 @@ function ClusterOverviewWithSize({ summary, width }: ClusterOverviewWithSizeProp
     const { clusterColumns } = useClusterOverviewColumns(width);
 
     const table = useReactTable({
-        data: nodeInfos,
+        data: rows,
         columns: clusterColumns,
-        enableSorting: nodeInfos.length > analyzerConstants.minRowsForControls,
-        enableColumnFilters: nodeInfos.length > analyzerConstants.minRowsForControls,
+        renderFallbackValue: "-",
+        enableSorting: rows.length > analyzerConstants.minRowsForControls,
+        enableColumnFilters: rows.length > analyzerConstants.minRowsForControls,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),
@@ -141,7 +150,7 @@ function ClusterOverviewWithSize({ summary, width }: ClusterOverviewWithSizeProp
         getRowId: (row) => row.NodeTag,
     });
 
-    const heightInPx = virtualTableUtils.getHeightInPx(nodeInfos.length, 300);
+    const heightInPx = virtualTableUtils.getHeightInPx(rows.length, 300);
 
     return (
         <div className="cluster-overview">
@@ -188,7 +197,11 @@ function ClusterOverviewWithSize({ summary, width }: ClusterOverviewWithSizeProp
 function ClusterRoleCell({ getValue }: { getValue: () => unknown }) {
     const state = getValue() as string;
     if (!state) {
-        return null;
+        return (
+            <span className="hstack gap-1 text-danger">
+                <Icon icon="disconnected" margin="m-0" /> Offline
+            </span>
+        );
     }
     switch (state) {
         case "Leader":
@@ -220,7 +233,10 @@ function ClusterRoleCell({ getValue }: { getValue: () => unknown }) {
     }
 }
 
-function ClusterOsCell({ row }: { row: { original: ClusterNodeInfo } }) {
+function ClusterOsCell({ row }: { row: { original: ClusterNodeRow } }) {
+    if (!row.original.OsName) {
+        return <>-</>;
+    }
     return (
         <>
             <Icon icon={osIcon(row.original.OsType)} /> {row.original.OsName}
@@ -230,6 +246,9 @@ function ClusterOsCell({ row }: { row: { original: ClusterNodeInfo } }) {
 
 function ClusterUrlCell({ getValue }: { getValue: () => unknown }) {
     const url = getValue() as string;
+    if (!url) {
+        return <>-</>;
+    }
     return (
         <a href={url} target="_blank" rel="noreferrer">
             {url}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/debugPackageAnalyzer/partials/ClusterOverview.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/debugPackageAnalyzer/partials/ClusterOverview.tsx
@@ -116,9 +116,10 @@ function ClusterOverviewWithSize({ summary, width }: ClusterOverviewWithSizeProp
         return names.size;
     }, [nodes]);
 
-    const totalNodes = rows.length;
-    const onlineNodes = nodeInfos.length;
-    const allNodesOnline = onlineNodes === totalNodes;
+    const offlineNodes = Object.keys(summary.UnreachableNodes ?? {}).length;
+    const onlineNodes = nodes.length;
+    const totalNodes = onlineNodes + offlineNodes;
+    const allNodesOnline = offlineNodes === 0;
 
     const clusterUpTime = useMemo(() => {
         let best: string | null = null;

--- a/src/Raven.Studio/typescript/test/stubs/DebugPackageStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DebugPackageStubs.ts
@@ -44,6 +44,7 @@ export class DebugPackageStubs {
     static analysisSummary(): DebugPackageAnalysisSummary {
         return {
             PackageId: "story-package",
+            UnreachableNodes: {},
             ClusterWideIssues: {
                 ServerIssues: [],
                 ClusterIssues: [
@@ -349,21 +350,27 @@ export class DebugPackageStubs {
 
     // Builds a comprehensive summary for `nodeTags.length` nodes with every synchronous section filled.
     // The first node is the leader. `omit` flags strip individual sections so the story controls can
-    // empty them one at a time.
-    static storySummary(nodeTags: string[], omit: StorySummaryOmit = {}): DebugPackageAnalysisSummary {
+    // empty them one at a time. `unreachableNodeTags` are reported as unreachable instead of getting a node summary.
+    static storySummary(
+        nodeTags: string[],
+        omit: StorySummaryOmit = {},
+        unreachableNodeTags: string[] = []
+    ): DebugPackageAnalysisSummary {
         const databases = ["Orders", "Products", "Customers"];
         const summaryPerNode: Record<string, any> = {};
+        const unreachableNodes: Record<string, string> = {};
 
         nodeTags.forEach((tag, index) => {
+            const url = `http://127.0.0.1:${8080 + index}`;
+            if (unreachableNodeTags.includes(tag)) {
+                unreachableNodes[tag] = url;
+                return;
+            }
             const isLeader = index === 0;
             summaryPerNode[tag] = {
                 ClusterNodeInfo: omit.clusterOverview
                     ? null
-                    : DebugPackageStubs.nodeInfo(
-                          tag,
-                          isLeader ? "Leader" : "Follower",
-                          `http://127.0.0.1:${8080 + index}`
-                      ),
+                    : DebugPackageStubs.nodeInfo(tag, isLeader ? "Leader" : "Follower", url),
                 CpuUsageInfo: omit.resourceUsage ? null : DebugPackageStubs.cpuInfo(12 - index, 34 - index * 6),
                 MemoryUsageInfo: omit.resourceUsage ? null : DebugPackageStubs.memoryInfo(),
                 GcInfo: omit.resourceUsage ? null : DebugPackageStubs.gcInfo(),
@@ -395,6 +402,7 @@ export class DebugPackageStubs {
 
         return {
             PackageId: "story-package",
+            UnreachableNodes: unreachableNodes,
             ClusterWideIssues: omit.issues
                 ? DebugPackageStubs.emptyIssues()
                 : {

--- a/test/SlowTests.Issues/Issues/RavenDB_14548.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14548.cs
@@ -42,6 +42,8 @@ public class RavenDB_14548 : RavenTestBase
 
             var packageReport = analyzer.Analyze();
 
+            Assert.Empty(packageReport.UnreachableNodes);
+
             var report = packageReport.ForNode("A");
 
             Assert.Equal(2, report.Machine.NumberOfCores);
@@ -255,10 +257,17 @@ public class RavenDB_14548 : RavenTestBase
                 Assert.True(summaryResult.SummaryPerNode.ContainsKey("A"));
 
                 // node C was down - intentionally
+                const string nodeCUrl = "https://c.rdb14548.arek-t3st.cloudtest.ravendb.org";
+
                 Assert.NotNull(summaryResult.SummaryPerNode["A"]);
                 Assert.NotNull(summaryResult.SummaryPerNode["B"]);
+                Assert.False(summaryResult.SummaryPerNode.ContainsKey("C"));
 
-                foreach (var item in summaryResult.SummaryPerNode.Where(x => x.Key != "C"))
+                var unreachableNode = Assert.Single(summaryResult.UnreachableNodes);
+                Assert.Equal("C", unreachableNode.Key);
+                Assert.Equal(nodeCUrl, unreachableNode.Value);
+
+                foreach (var item in summaryResult.SummaryPerNode)
                 {
                     var nodeSummary = item.Value;
                     var nodeTag = item.Key;
@@ -354,10 +363,11 @@ public class RavenDB_14548 : RavenTestBase
 
                 Assert.NotNull(summaryResult.ClusterWideIssues);
                 
-                Assert.Equal(1, summaryResult.ClusterWideIssues.ClusterIssues.Count);
+                Assert.Equal(2, summaryResult.ClusterWideIssues.ClusterIssues.Count);
 
-                Assert.Contains("Custom Election Timeout", summaryResult.ClusterWideIssues.ClusterIssues[0].Title);
-                
+                Assert.Contains(summaryResult.ClusterWideIssues.ClusterIssues, x => x.Title.Contains("Custom Election Timeout"));
+                Assert.Contains(summaryResult.ClusterWideIssues.ClusterIssues, x => x.Title.Contains("unreachable") && x.Description.Contains($"Node C ({nodeCUrl})"));
+
                 Assert.Equal(0, summaryResult.ClusterWideIssues.DatabaseIssues.Count);
                 Assert.Equal(0, summaryResult.ClusterWideIssues.ServerIssues.Count);
             }


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27046 

### Additional description

- report topology nodes without their own zip as UnreachableNodes and a cluster-wide warning
- Studio: nodes status counts them as offline and lists them in the Cluster Overview table
- name the cluster-wide package .error entry after the failed node, not the collecting one


<img width="391" height="401" alt="image" src="https://github.com/user-attachments/assets/3b47c6ec-8146-4483-b3c9-5c69c2c5a7d9" />


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
