### PR TITLE
RavenDB-27348 Throw NotSupportedInCoraxException for methods Corax does not support

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1018,7 +1018,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             Reference<long> skippedResults, Reference<long> scannedDocuments, IQueryResultRetriever retriever,
             DocumentsOperationContext documentsContext, Func<string, SpatialField> getSpatialField, CancellationToken token)
         {
-            throw new NotImplementedException($"{nameof(Corax)} does not support intersect queries.");
+            throw new NotSupportedInCoraxException($"{nameof(Corax)} does not support intersect queries.");
         }
 
         public override SortedSet<string> Terms(string field, string fromValue, long pageSize, CancellationToken token)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -341,7 +341,7 @@ public static class CoraxQueryBuilder
         IQueryMatch Build<TInner>() where TInner : IQueryMatch => parameters.IndexSearcher.DeduplicationMatch((TInner)match);
     }
 
-    private static IQueryMatch ToCoraxQuery(Parameters builderParameters, QueryExpression expression, ref StreamingOptimization leftOnlyOptimization, bool exact = false, int? proximity = null)
+    private static IQueryMatch ToCoraxQuery(Parameters builderParameters, QueryExpression expression, ref StreamingOptimization leftOnlyOptimization, bool exact = false)
     {
         var indexSearcher = builderParameters.IndexSearcher;
         var metadata = builderParameters.Metadata;
@@ -590,7 +590,13 @@ public static class CoraxQueryBuilder
             switch (methodType)
             {
                 case MethodType.Search:
-                    return HandleSearch(builderParameters, me, proximity);
+                    return HandleSearch(builderParameters, me);
+                case MethodType.Proximity:
+                    throw new NotSupportedInCoraxException($"{nameof(Corax)} doesn't support proximity over search() method");
+                case MethodType.Fuzzy:
+                    throw new NotSupportedInCoraxException($"{nameof(Corax)} doesn't support fuzzy() method");
+                case MethodType.Lucene:
+                    throw new NotSupportedInCoraxException($"{nameof(Corax)} doesn't support lucene() method");
                 case MethodType.Boost:
                     return HandleBoost(builderParameters, me, exact);
                 case MethodType.StartsWith:
@@ -600,7 +606,7 @@ public static class CoraxQueryBuilder
                 case MethodType.Exists:
                     return HandleExists(builderParameters, me, ref leftOnlyOptimization);
                 case MethodType.Exact:
-                    return HandleExact(builderParameters, me, ref leftOnlyOptimization, proximity);
+                    return HandleExact(builderParameters, me, ref leftOnlyOptimization);
                 case MethodType.Spatial_Within:
                 case MethodType.Spatial_Contains:
                 case MethodType.Spatial_Disjoint:
@@ -793,9 +799,9 @@ public static class CoraxQueryBuilder
         }
     }
 
-    private static IQueryMatch HandleExact(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingConfiguration, int? proximity = null)
+    private static IQueryMatch HandleExact(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingConfiguration)
     {
-        return ToCoraxQuery(builderParameters, expression.Arguments[0], ref streamingConfiguration, exact: true, proximity);
+        return ToCoraxQuery(builderParameters, expression.Arguments[0], ref streamingConfiguration, exact: true);
     }
 
     private static IQueryMatch TranslateBetweenQuery(Parameters builderParameters, BetweenExpression be, bool exact)
@@ -993,7 +999,7 @@ public static class CoraxQueryBuilder
     }
     }
 
-    private static IQueryMatch HandleSearch(Parameters builderParameters, MethodExpression expression, int? proximity)
+    private static IQueryMatch HandleSearch(Parameters builderParameters, MethodExpression expression)
     {
         var metadata = builderParameters.Metadata;
         var highlightingTerms = builderParameters.HighlightingTerms;
@@ -1065,12 +1071,6 @@ public static class CoraxQueryBuilder
         // Wildcard queries:
         if (searchQueryOptions is IndexSearcher.SearchQueryOptions.PhraseQueryWithWildcardAdjustments && valueAsString.Length >= 1 && (valueAsString[0] == '*' || (valueAsString.Length >= 2 && valueAsString[^1] == '*')))
             fieldMetadata = ReplaceAnalyzerForWildcardQueries(fieldMetadata);
-        
-        
-        if (proximity.HasValue)
-        {
-            throw new NotSupportedInCoraxException($"{nameof(Corax)} doesn't support proximity over search() method");
-        }
 
         CoraxConstants.Search.Operator @operator = CoraxConstants.Search.Operator.Or;
         if (expression.Arguments.Count == 3)

--- a/test/SlowTests/Issues/RavenDB_27348.cs
+++ b/test/SlowTests/Issues/RavenDB_27348.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Corax;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27348 : RavenTestBase
+    {
+        public RavenDB_27348(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void MethodsCoraxDoesNotSupportMustThrowNotSupportedInCoraxException(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { Notes = "fluent french speaker", Age = 30 });
+                session.SaveChanges();
+            }
+
+            new Employees_ByNotesAndAge().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            var cases = new[]
+            {
+                ("proximity(search(Notes, 'fluent french'), 0)", "proximity over search() method"),
+                ("fuzzy(Notes = 'french', 0.5)", "fuzzy() method"),
+                ("lucene(Notes, 'french')", "lucene() method"),
+                ("intersect(Notes = 'french', Age = 30)", "intersect queries"),
+            };
+
+            foreach (var (where, expected) in cases)
+            {
+                using var session = store.OpenSession();
+                var query = () => session.Advanced.RawQuery<Employee>($"from index 'Employees/ByNotesAndAge' where {where}").ToList();
+
+                if (options.SearchEngineMode == RavenSearchEngineMode.Corax)
+                {
+                    var e = Assert.Throws<NotSupportedInCoraxException>(query);
+                    Assert.Contains(expected, e.Message);
+                }
+                else
+                {
+                    Assert.Equal(1, query().Count);
+                }
+            }
+        }
+
+        private class Employee
+        {
+            public string Notes { get; set; }
+
+            public int Age { get; set; }
+        }
+
+        private class Employees_ByNotesAndAge : AbstractIndexCreationTask<Employee>
+        {
+            public Employees_ByNotesAndAge()
+            {
+                Map = employees => from employee in employees
+                                   select new { employee.Notes, employee.Age };
+
+                Index(x => x.Notes, FieldIndexing.Search);
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-27348

### Additional description

Corax reported unsupported query methods with the wrong exception type, so the client could not tell "this engine cannot do it" from "your query is wrong".

`proximity()`, `fuzzy()` and `lucene()` had no `case` in the method switch of `CoraxQueryBuilder.ToCoraxQuery`, so they fell through to `QueryMethod.ThrowMethodNotSupported` and surfaced as `InvalidQueryException: Method '...' is not supported.` `intersect()` was worse: `CoraxIndexReadOperation.IntersectQuery` threw `NotImplementedException`, which reached the client wrapped in a generic `RavenException`, hiding the type. All four now throw `NotSupportedInCoraxException`.

Also removed the dead `int? proximity` parameter threaded through `ToCoraxQuery` -> `HandleExact` -> `HandleSearch` to an unreachable `if (proximity.HasValue) throw new NotSupportedInCoraxException(...)`. No caller ever supplied a value, because the `case` that would have produced one did not exist - which is why that guard never fired and the query fell through to the generic path instead. Keeping it next to the new `throw` would leave two copies of the same message, one unreachable.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
