### PR TITLE
RavenDB-27348 Throw NotSupportedInCoraxException for methods Corax does not support

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1083,7 +1083,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             Reference<long> skippedResults, Reference<long> scannedDocuments, IQueryResultRetriever retriever,
             DocumentsOperationContext documentsContext, Func<string, SpatialField> getSpatialField, QueryTimeScope queryTime, CancellationToken token)
         {
-            throw new NotSupportedException($"{nameof(Corax)} does not support intersect queries.");
+            throw new NotSupportedInCoraxException($"{nameof(Corax)} does not support intersect queries.");
         }
 
         public override List<string> Terms(string field, string fromValue, long pageSize, CancellationToken token)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Corax.Querying.Planning;
 using Corax.Utils.Spatial;
+using Raven.Client.Exceptions.Corax;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
 using Sparrow.Json;
@@ -638,6 +639,9 @@ internal static partial class QueryPlanBuilder
         [MethodType.Spatial_Disjoint] = ParseSpatial,
         [MethodType.Spatial_Intersects] = ParseSpatial,
         [MethodType.Vector_Search] = ParseVectorSearch,
+        [MethodType.Proximity] = static (_, _) => throw new NotSupportedInCoraxException($"{nameof(Corax)} doesn't support proximity over search() method"),
+        [MethodType.Fuzzy] = static (_, _) => throw new NotSupportedInCoraxException($"{nameof(Corax)} doesn't support fuzzy() method"),
+        [MethodType.Lucene] = static (_, _) => throw new NotSupportedInCoraxException($"{nameof(Corax)} doesn't support lucene() method"),
         // MoreLikeThis in a WHERE clause acts as "all entries" — the actual MLT logic runs in the
         // separate reader.MoreLikeThis() path, so here it is a no-op that matches everything.
         [MethodType.MoreLikeThis] = static (_, _) => BooleanOp.Leaf,

--- a/test/SlowTests.Issues/Issues/RavenDB_27348.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27348.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Corax;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27348(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void MethodsCoraxDoesNotSupportMustThrowNotSupportedInCoraxException(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Employee { Notes = "fluent french speaker", Age = 30 });
+            session.SaveChanges();
+        }
+
+        new Employees_ByNotesAndAge().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        var cases = new[]
+        {
+            ("proximity(search(Notes, 'fluent french'), 0)", "proximity over search() method"),
+            ("fuzzy(Notes = 'french', 0.5)", "fuzzy() method"),
+            ("lucene(Notes, 'french')", "lucene() method"),
+            ("intersect(Notes = 'french', Age = 30)", "intersect queries"),
+        };
+
+        foreach (var (where, expected) in cases)
+        {
+            using var session = store.OpenSession();
+            var query = () => session.Advanced.RawQuery<Employee>($"from index 'Employees/ByNotesAndAge' where {where}").ToList();
+
+            if (options.SearchEngineMode == RavenSearchEngineMode.Corax)
+            {
+                var e = Assert.Throws<NotSupportedInCoraxException>(query);
+                Assert.Contains(expected, e.Message);
+            }
+            else
+            {
+                Assert.Equal(1, query().Count);
+            }
+        }
+    }
+
+    private class Employee
+    {
+        public string Notes { get; set; }
+
+        public int Age { get; set; }
+    }
+
+    private class Employees_ByNotesAndAge : AbstractIndexCreationTask<Employee>
+    {
+        public Employees_ByNotesAndAge()
+        {
+            Map = employees => from employee in employees
+                               select new { employee.Notes, employee.Age };
+
+            Index(x => x.Notes, FieldIndexing.Search);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27348

### Additional description

Corax reported unsupported query methods with the wrong exception type, so the client could not tell "this engine cannot do it" from "your query is wrong".

`proximity()`, `fuzzy()` and `lucene()` were not registered in `QueryPlanBuilder.MethodHandlers`, so `ParseMethod` rejected them with `InvalidOperationException`, which reached the client wrapped in a generic `RavenException` - the type was invisible. `intersect()` threw `NotSupportedException` from `CoraxIndexReadOperation.IntersectQuery`. All four now throw `NotSupportedInCoraxException`.
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
