### PR TITLE
RavenDB-27466 Fix flaky ETL errors endpoint tests

### DIFF
--- a/test/SlowTests.Issues/Issues/RavenDB-21192.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21192.cs
@@ -482,6 +482,7 @@ public class RavenDB_21192 : RavenTestBase
             }
 
             await WaitForEtlStatsAsync(src, EtlProcess.GetProcessName(etlName1, transformationName1), stats => stats.TransformationErrors == 5);
+            await WaitForPersistedItemErrorsAsync(src, EtlProcess.GetProcessName(etlName1, transformationName1), 5);
 
             AddEtlTask(src, dest, etlName2, connectionStringName2, [transformationName2, transformationName3], [script2, script3], collections2);
 
@@ -606,6 +607,7 @@ public class RavenDB_21192 : RavenTestBase
             }
 
             await WaitForEtlStatsAsync(src, EtlProcess.GetProcessName(etlName1, transformationName1), stats => stats.TransformationErrors == 5, shardNumber);
+            await WaitForPersistedItemErrorsAsync(src, EtlProcess.GetProcessName(etlName1, transformationName1), 5, shardNumber);
 
             AddEtlTask(src, dest, etlName2, connectionStringName2, [transformationName2, transformationName3], [script2, script3], collections2);
 
@@ -693,6 +695,9 @@ public class RavenDB_21192 : RavenTestBase
 
             await WaitForEtlStatsAsync(src, EtlProcess.GetProcessName(etlName1, transformationName1), stats => stats.TransformationErrors == 5);
             await WaitForEtlStatsAsync(src, EtlProcess.GetProcessName(etlName2, transformationName2), stats => stats.TransformationErrors == 5);
+
+            await WaitForPersistedItemErrorsAsync(src, EtlProcess.GetProcessName(etlName1, transformationName1), 5);
+            await WaitForPersistedItemErrorsAsync(src, EtlProcess.GetProcessName(etlName2, transformationName2), 5);
 
             using (var commands = src.Commands())
             {
@@ -1818,24 +1823,33 @@ public class RavenDB_21192 : RavenTestBase
         }
     }
 
-    private async Task<EtlProcessStatistics> GetEtlStatsAsync(DocumentStore store, string etlName, int shardNumber = 0)
+    private async Task<DocumentDatabase> GetEtlDatabaseAsync(DocumentStore store, int shardNumber)
     {
         var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
 
-        DocumentDatabase database;
         if (record.IsSharded)
         {
             var bucket = await Sharding.GetBucketAsync(store, shardNumber.ToString());
-            database = await Sharding.GetShardedDocumentDatabaseForBucketAsync(store.Database, bucket);
+            return await Sharding.GetShardedDocumentDatabaseForBucketAsync(store.Database, bucket);
         }
-        else
-        {
-            database = await GetDatabase(store.Database);
-        }
-        
+
+        return await GetDatabase(store.Database);
+    }
+
+    private async Task<EtlProcessStatistics> GetEtlStatsAsync(DocumentStore store, string etlName, int shardNumber = 0)
+    {
+        var database = await GetEtlDatabaseAsync(store, shardNumber);
         var etl = database.EtlLoader.Processes.Single(x => x.Name == etlName);
 
         return etl.Statistics;
+    }
+
+    private async Task WaitForPersistedItemErrorsAsync(DocumentStore store, string etlName, int expectedCount, int shardNumber = 0)
+    {
+        var database = await GetEtlDatabaseAsync(store, shardNumber);
+        var etl = database.EtlLoader.Processes.Single(x => x.Name == etlName);
+
+        await AssertWaitForValueAsync(() => Task.FromResult(database.TaskErrorsStorage.ReadItemErrorsOfTask(etl.TaskCategory, etlName).Count), expectedCount);
     }
 
     private async Task WaitForEtlStatsAsync(DocumentStore store, string etlName, Func<EtlProcessStatistics, bool> predicate = null, int shardNumber = 0, int timeout = 10_000, int interval = 500)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27466/SlowTests.Issues.RavenDB21192.TestDeleteEtlErrorsEndpoint

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
