### PR TITLE
RavenDB-22670 Open the search subclause after the operator that joins it

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1828,10 +1828,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
             VisitExpression(target);
             _insideWhereOrSearchCounter--;
 
-            if (expressions.Count > 1)
-            {
-                DocumentQuery.OpenSubclause();
-            }
+            var subclauseToOpen = expressions.Count > 1;
 
             foreach (var expression in Enumerable.Reverse(expressions))
             {
@@ -1863,7 +1860,13 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 {
                     DocumentQuery.AndAlso();
                 }
-                
+
+                if (subclauseToOpen)
+                {
+                    DocumentQuery.OpenSubclause();
+                    subclauseToOpen = false;
+                }
+
                 if (options.HasFlag(SearchOptions.Not))
                 {
                     if (options.HasFlag(SearchOptions.And) && IsPreviousSearchOnSameField(target, expression))

--- a/test/SlowTests.Issues/Issues/RavenDB_22670.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22670.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22670 : RavenTestBase
+    {
+        public RavenDB_22670(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void SearchOptionsMustNotEmitTheGroupOperatorInsideTheSubclause()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Dto { Name = "test", Description = "the vision point" }, "dtos/1");
+                session.Store(new Dto { Name = "test", Description = "the vision" }, "dtos/2");
+                session.Store(new Dto { Name = "test", Description = "point sunset" }, "dtos/3");
+                session.SaveChanges();
+            }
+
+            using var s = store.OpenSession();
+
+            var cases = new (string Name, Func<IRavenQueryable<Dto>> Query, string Where)[]
+            {
+                ("ticket repro",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "*ion")
+                        .Search(i => i.Description, "point", options: SearchOptions.And | SearchOptions.Not)
+                        .Search(i => i.Description, "*ion"),
+                    "(Name = $p0) and search(Description, $p1) and (exists(Description) and not search(Description, $p2) or search(Description, $p3))"),
+
+                ("And|Not then Guess",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "point", options: SearchOptions.And | SearchOptions.Not)
+                        .Search(i => i.Description, "sunset"),
+                    "(Name = $p0) and ((exists(Description) and not search(Description, $p1)) or search(Description, $p2))"),
+
+                ("And|Not on another field then Guess",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "point", options: SearchOptions.And | SearchOptions.Not)
+                        .Search(i => i.Name, "test"),
+                    "(Name = $p0) and ((exists(Description) and not search(Description, $p1)) or search(Name, $p2))"),
+
+                ("no where, Guess then And|Not then Guess",
+                    () => s.Query<Dto>()
+                        .Search(i => i.Description, "vision")
+                        .Search(i => i.Description, "point", options: SearchOptions.And | SearchOptions.Not)
+                        .Search(i => i.Description, "sunset"),
+                    "search(Description, $p0) and (exists(Description) and not search(Description, $p1) or search(Description, $p2))"),
+
+                ("And then Guess",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "vision", options: SearchOptions.And)
+                        .Search(i => i.Description, "sunset"),
+                    "(Name = $p0) and (search(Description, $p1) or search(Description, $p2))"),
+
+                ("And then Guess then Guess",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "vision", options: SearchOptions.And)
+                        .Search(i => i.Description, "sunset")
+                        .Search(i => i.Description, "point"),
+                    "(Name = $p0) and (search(Description, $p1) or search(Description, $p2) or search(Description, $p3))"),
+
+                ("where and one Guess search",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "vision"),
+                    "(Name = $p0) and search(Description, $p1)"),
+
+                ("where and two Guess searches",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "vision")
+                        .Search(i => i.Description, "sunset"),
+                    "(Name = $p0) and (search(Description, $p1) or search(Description, $p2))"),
+
+                ("where and And",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "vision", options: SearchOptions.And),
+                    "(Name = $p0) and search(Description, $p1)"),
+
+                ("where and And|Not",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "point", options: SearchOptions.And | SearchOptions.Not),
+                    "(Name = $p0) and (exists(Description) and not search(Description, $p1))"),
+
+                ("where and Not",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "point", options: SearchOptions.Not),
+                    "(Name = $p0) and (exists(Description) and not search(Description, $p1))"),
+
+                ("Guess then And|Not",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "vision")
+                        .Search(i => i.Description, "point", options: SearchOptions.And | SearchOptions.Not),
+                    "(Name = $p0) and search(Description, $p1) and not search(Description, $p2)"),
+
+                ("where and Or",
+                    () => s.Query<Dto>().Where(x => x.Name == "test")
+                        .Search(i => i.Description, "vision", options: SearchOptions.Or),
+                    "(Name = $p0) and search(Description, $p1)"),
+
+                ("search then where",
+                    () => s.Query<Dto>()
+                        .Search(i => i.Description, "vision")
+                        .Where(x => x.Name == "test"),
+                    "search(Description, $p0) and (Name = $p1)")
+            };
+
+            foreach (var (name, query, where) in cases)
+            {
+                var q = query();
+                var expected = $"from 'Dtos' where {where}";
+                var actual = q.ToString();
+
+                Assert.True(expected == actual, $"{name}{Environment.NewLine}expected: {expected}{Environment.NewLine}actual:   {actual}");
+
+                // the malformed RQL did not execute, so the shapes must also be executable
+                q.ToList();
+            }
+
+            var results = s.Query<Dto>().Customize(x => x.WaitForNonStaleResults()).Where(x => x.Name == "test")
+                .Search(i => i.Description, "point", options: SearchOptions.And | SearchOptions.Not)
+                .Search(i => i.Description, "sunset")
+                .Select(x => x.Id)
+                .ToList();
+
+            Assert.Equal(new[] { "dtos/2", "dtos/3" }, results.OrderBy(x => x).ToArray());
+        }
+
+        private class Dto
+        {
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+
+            public string Description { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22670

### Additional description

A LINQ `Search` carrying `SearchOptions.And` followed by `Guess`-chained searches opened the group's subclause before the operator joining that group to the preceding clauses was written, so the operator ended up inside the parentheses:

`from 'Dtos' where (Name = $p0) and search(Description, $p1) or (and not search(Description, $p2) or search(Description, $p3))`

Such a query never worked. `QueryParser` rejects most of these shapes outright; it accepts the rest only by reading the stray `and` as a call to a non-existent `and()` method, which then fails during execution.

The subclause is now opened on the first loop iteration, after the operator. Only the parenthesis position moves - the loop already computed the correct operator.

The `exists(Description) and` that now appears inline is injected by `NegateIfNeeded`, which fires when a negation lands directly after an opening parenthesis. A bare `not` in that position is itself a parse error, so it cannot be suppressed.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed