### PR TITLE
Quill-276: exclude everything on dockerignore, allow only what is copied

### DIFF
--- a/docker/quill/Dockerfile.dockerignore
+++ b/docker/quill/Dockerfile.dockerignore
@@ -1,2 +1,3 @@
+*
 !docker
 !artifacts/Quill-*.tar.bz2


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-276/source-build-through-build.ps1-so-the-image-carries-build-version

### Additional description

the two negation lines had no leading '*', so BuildKit sent the whole repo (including .git) as the build context. add '*' to exclude everything, thenre-include the docker/ tree and the pre-built Quill payload tarball. the shipped image is unchanged (the Dockerfile has no COPY . .); this only trims the build context.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
