### PR TITLE
RavenDB-26005 Setup Wizard: Confusing content in the “Complete cluster setup” tab on the "All Set" view

### DIFF
--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardFinishStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardFinishStep.tsx
@@ -440,7 +440,7 @@ function CompletedSummary() {
                 <Nav className="mb-2">
                     <Nav.Item className="flex-grow">
                         <Nav.Link eventKey="cluster" className="cluster-tab">
-                            Setting up a cluster
+                            Complete cluster setup
                         </Nav.Link>
                     </Nav.Item>
                 </Nav>
@@ -467,33 +467,7 @@ function CompletedSummary() {
                         </Col>
                     </Row>
                     <hr />
-                    <h5>How to set up the cluster nodes?</h5>
-                    <NumberedList>
-                        <NumberedListItem stepKey={1}>
-                            The next step is to download a new RavenDB server for each of the cluster nodes.
-                        </NumberedListItem>
-                        <NumberedListItem stepKey={2}>
-                            When you enter the Setup Wizard on a new node, choose &apos;
-                            <b>Use Setup Package</b>&apos;.
-                            <br />
-                            Do not start a setup process on a node that has already been configured; this is not
-                            supported.
-                        </NumberedListItem>
-                        <NumberedListItem stepKey={3}>
-                            You will be asked to upload the zip file that was just downloaded.
-                        </NumberedListItem>
-                        <NumberedListItem stepKey={4}>
-                            The new server node will join the existing cluster.
-                        </NumberedListItem>
-                    </NumberedList>
-                    <RichAlert variant="info" className="mt-3">
-                        When the Setup Wizard is done and the new node restarts, the cluster will automatically detect
-                        it.
-                        <br />
-                        There is no need to add it manually from Studio.
-                        <br />
-                        Simply access the &apos;Cluster&apos; view and observe the topology update.
-                    </RichAlert>
+                    <ClusterNodesInstructions heading="How to set up the cluster nodes?" />
                 </div>
             </div>
         );
@@ -558,53 +532,41 @@ function CompletedSummary() {
                         </RichAlert>
                     </Tab.Pane>
                     <Tab.Pane eventKey="cluster">
-                        <Row>
-                            <Col md={6} className="vstack gap-2 text-center justify-content-center">
-                                <div>
-                                    <Icon icon="folder" addon="attachment" color="primary" size="lg" />
-                                </div>
-                                <span>The new server will be available at: {studioUrl}</span>
-                            </Col>
-                            <Col md={6} className="vstack gap-2 text-center justify-content-center">
-                                <Icon icon="cluster" color="node" size="lg" />
-                                <span>
-                                    The current <span className="text-node fw-bold">Node {nodeTag}</span> has already
-                                    been configured and requires no further action on your part.
-                                </span>
-                            </Col>
-                        </Row>
-                        <hr />
-                        <h5>How to set up the other nodes?</h5>
-                        <NumberedList>
-                            <NumberedListItem stepKey={1}>
-                                The next step is to download a new RavenDB server for each of the cluster nodes.
-                            </NumberedListItem>
-                            <NumberedListItem stepKey={2}>
-                                When you enter the Setup Wizard on a new node, choose &apos;
-                                <b>Use Setup Package</b>&apos;.
-                                <br />
-                                Do not start a setup process on a node that has already been configured; this is not
-                                supported.
-                            </NumberedListItem>
-                            <NumberedListItem stepKey={3}>
-                                You will be asked to upload the zip file that was just downloaded.
-                            </NumberedListItem>
-                            <NumberedListItem stepKey={4}>
-                                The new server node will join the existing cluster.
-                            </NumberedListItem>
-                        </NumberedList>
-                        <RichAlert variant="info" className="mt-2">
-                            When the Setup Wizard is done and the new node restarts, the cluster will automatically
-                            detect it.
-                            <br />
-                            There is no need to add it manually from Studio.
-                            <br />
-                            Simply access the &apos;Cluster&apos; view and observe the topology update.
-                        </RichAlert>
+                        <ClusterNodesInstructions heading="How to set up the other nodes?" />
                     </Tab.Pane>
                 </Tab.Content>
             </Tab.Container>
         </div>
+    );
+}
+
+function ClusterNodesInstructions({ heading }: { heading: string }) {
+    return (
+        <>
+            <h5>{heading}</h5>
+            <NumberedList>
+                <NumberedListItem stepKey={1}>
+                    The next step is to download a new RavenDB server for each of the cluster nodes.
+                </NumberedListItem>
+                <NumberedListItem stepKey={2}>
+                    When you enter the Setup Wizard on a new node, choose &apos;
+                    <b>Use Setup Package</b>&apos;.
+                    <br />
+                    Do not start a setup process on a node that has already been configured; this is not supported.
+                </NumberedListItem>
+                <NumberedListItem stepKey={3}>
+                    You will be asked to upload the zip file that was just downloaded.
+                </NumberedListItem>
+                <NumberedListItem stepKey={4}>The new server node will join the existing cluster.</NumberedListItem>
+            </NumberedList>
+            <RichAlert variant="info" className="mt-3">
+                When the Setup Wizard is done and the new node restarts, the cluster will automatically detect it.
+                <br />
+                There is no need to add it manually from Studio.
+                <br />
+                Simply access the &apos;Cluster&apos; view and observe the topology update.
+            </RichAlert>
+        </>
     );
 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26005

### Additional description

Removed the duplicated server-access block from the **Complete cluster setup** tab, so it now shows only the "How to set up the other nodes?" instructions. Each tab has a distinct purpose.
Renamed the **Create Setup Package** tab label from "Setting up a cluster" → "Complete cluster setup" for consistency.
Extracted the shared node-setup instructions into a `ClusterNodesInstructions` component to remove near-duplicate markup.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
