### PR TITLE
RavenDB-27425 - custom 7.2 build with indexing batch limits fix

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexingOperation.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexingOperation.cs
@@ -41,6 +41,12 @@
             public const string DictionaryTraining = "Corax/DictionaryTraining";
         }
 
+        internal static class Cleanup
+        {
+            public const string Documents = "DocumentsCleanup";
+            public const string TimeSeries = "TimeSeriesCleanup";
+        }
+
         internal static class Storage
         {
             public const string Commit = "Storage/Commit";

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4712,11 +4712,10 @@ namespace Raven.Server.Documents.Indexes
                 return CanContinueBatchResult.False;
             }
 
-            var cpuCreditsAlertFlag = DocumentDatabase.ServerStore.Server.CpuCreditsBalance.BackgroundTasksAlertRaised;
-            if (cpuCreditsAlertFlag.IsRaised())
+            if (DocumentDatabase.ServerStore.Server.CpuCreditsBalance.BackgroundTasksAlertRaised.IsRaised())
             {
                 HandleStoppedBatchesConcurrently(parameters.Stats, parameters.Count,
-                   canContinue: () => cpuCreditsAlertFlag.IsRaised() == false,
+                   canContinue: () => DocumentDatabase.ServerStore.Server.CpuCreditsBalance.BackgroundTasksAlertRaised.IsRaised() == false,
                    reason: "CPU credits balance is low", parameters.WorkType);
 
                 parameters.Stats.RecordBatchCompletedReason(parameters.WorkType, $"The batch was stopped after processing {parameters.Count:#,#;;0} documents because the CPU credits balance is almost completely used");

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4549,6 +4549,8 @@ namespace Raven.Server.Documents.Indexes
         private int? _minBatchSize;
 
         private const int MinMapBatchSize = 128;
+
+        public const int CanContinueBatchCheckInterval = 128;
         internal const int MinMapReduceBatchSize = 64;
 
         private int MinBatchSize
@@ -4666,9 +4668,9 @@ namespace Raven.Server.Documents.Indexes
                 return CanContinueBatchResult.False;
             }
 
-            if (parameters.SeenCount - lastCheckedSeenItemsCount < 128)
+            if (lastCheckedSeenItemsCount > 0 && parameters.SeenCount - lastCheckedSeenItemsCount < CanContinueBatchCheckInterval)
             {
-                // the counter advances in jumps (fanout results, loaded items) - do the actual check once per at least 128 seen items
+                // the counter advances in jumps (fanout results, loaded items) - do the actual check on the first call and then once per at least CanContinueBatchCheckInterval seen items
                 return CanContinueBatchResult.True;
             }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4652,7 +4652,7 @@ namespace Raven.Server.Documents.Indexes
             RenewTransaction
         }
 
-        public CanContinueBatchResult CanContinueBatch(in CanContinueBatchParameters parameters, ref TimeSpan maxTimeForDocumentTransactionToRemainOpen)
+        public CanContinueBatchResult CanContinueBatch(in CanContinueBatchParameters parameters, ref TimeSpan maxTimeForDocumentTransactionToRemainOpen, ref long lastCheckedSeenItemsCount)
         {
             if (Configuration.MapBatchSize.HasValue && parameters.Count >= Configuration.MapBatchSize.Value)
             {
@@ -4666,11 +4666,13 @@ namespace Raven.Server.Documents.Indexes
                 return CanContinueBatchResult.False;
             }
 
-            if (parameters.Count % 128 != 0)
+            if (parameters.SeenCount - lastCheckedSeenItemsCount < 128)
             {
-                // do the actual check only every N ops
+                // the counter advances in jumps (fanout results, loaded items) - do the actual check once per at least 128 seen items
                 return CanContinueBatchResult.True;
             }
+
+            lastCheckedSeenItemsCount = parameters.SeenCount;
 
             if (parameters.Sw.Elapsed > maxTimeForDocumentTransactionToRemainOpen)
             {

--- a/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
@@ -366,7 +366,7 @@ namespace Raven.Server.Documents.Indexes
             if (_stats.MapDetails != null && name == "Map")
                 operation.MapDetails = _stats.MapDetails;
 
-            if (_stats.CleanupDetails != null && name == "Cleanup")
+            if (_stats.CleanupDetails != null && name is "DocumentsCleanup" or "TimeSeriesCleanup")
                 operation.CleanupDetails = _stats.CleanupDetails;
 
             if (_stats.LuceneMergeDetails != null && name == IndexingOperation.Lucene.Merge)

--- a/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexingStatsAggregator.cs
@@ -366,7 +366,7 @@ namespace Raven.Server.Documents.Indexes
             if (_stats.MapDetails != null && name == "Map")
                 operation.MapDetails = _stats.MapDetails;
 
-            if (_stats.CleanupDetails != null && name is "DocumentsCleanup" or "TimeSeriesCleanup")
+            if (_stats.CleanupDetails != null && name is IndexingOperation.Cleanup.Documents or IndexingOperation.Cleanup.TimeSeries)
                 operation.CleanupDetails = _stats.CleanupDetails;
 
             if (_stats.LuceneMergeDetails != null && name == IndexingOperation.Lucene.Merge)

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -80,6 +80,8 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public string SourceCollection;
 
+        public int LoadedItemsCount;
+
         public readonly TransactionOperationContext IndexContext;
 
         public readonly IndexDefinitionBaseServerSide IndexDefinition;
@@ -248,6 +250,8 @@ namespace Raven.Server.Documents.Indexes.Static
 
                 references.Add(keySlice);
 
+                LoadedItemsCount++;
+
                 // when there is conflict, we need to apply same behavior as if the document would not exist
                 var document = _documentsStorage.Get(QueryContext.Documents, keySlice, throwOnConflict: false);
 
@@ -351,6 +355,8 @@ namespace Raven.Server.Documents.Indexes.Static
                 var references = GetCompareExchangeReferencesForItem(idSlice);
 
                 references.Add(keySlice);
+
+                LoadedItemsCount++;
 
                 var value = _documentsStorage.DocumentDatabase.ServerStore.Cluster.GetCompareExchangeValue(QueryContext.Server, keySlice);
 

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -124,6 +124,8 @@ namespace Raven.Server.Documents.Indexes.Static
                 var results = new List<DynamicAttachment>();
                 foreach (var attachmentName in attachmentNames)
                 {
+                    LoadedItemsCount++;
+
                     var attachment = _documentsStorage.AttachmentsStorage.GetAttachment(QueryContext.Documents, documentId, attachmentName, AttachmentType.Document, null);
                     if (attachment == null)
                         continue;
@@ -201,6 +203,8 @@ namespace Raven.Server.Documents.Indexes.Static
             {
                 if (attachmentName == null)
                     return DynamicNullObject.Null;
+
+                LoadedItemsCount++;
 
                 var attachment = _documentsStorage.AttachmentsStorage.GetAttachment(QueryContext.Documents, documentId, attachmentName, AttachmentType.Document, null);
                 if (attachment == null)

--- a/src/Raven.Server/Documents/Indexes/Workers/CanContinueBatchParameters.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/CanContinueBatchParameters.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.Documents.Indexes.Workers
     public readonly struct CanContinueBatchParameters
     {
         public CanContinueBatchParameters(IndexingStatsScope stats, IndexingWorkType workType, QueryOperationContext queryContext, TransactionOperationContext indexingContext,
-            Lazy<IndexWriteOperationBase> indexWriteOperation, long currentEtag, long maxEtag, long count,
+            Lazy<IndexWriteOperationBase> indexWriteOperation, long currentEtag, long maxEtag, long count, long seenCount,
             Stopwatch sw)
         {
             Stats = stats;
@@ -19,6 +19,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             CurrentEtag = currentEtag;
             MaxEtag = maxEtag;
             Count = count;
+            SeenCount = seenCount;
             Sw = sw;
         }
 
@@ -37,6 +38,8 @@ namespace Raven.Server.Documents.Indexes.Workers
         public long MaxEtag { get; }
 
         public long Count { get; }
+
+        public long SeenCount { get; }
 
         public Stopwatch Sw { get; }
 

--- a/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupDocuments.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupDocuments.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
             _documentsStorage = documentsStorage;
         }
 
-        public override string Name => "DocumentsCleanup";
+        public override string Name => IndexingOperation.Cleanup.Documents;
 
         protected override long ReadLastProcessedTombstoneEtag(RavenTransaction transaction, string collection) =>
             IndexStorage.ReadLastProcessedTombstoneEtag(transaction, collection);

--- a/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupItemsBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupItemsBase.cs
@@ -62,6 +62,7 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
             var moreWorkFound = false;
             var batchContinuationResult = Index.CanContinueBatchResult.None;
             var totalProcessedCount = 0;
+            var lastCheckedSeenItemsCount = 0L;
 
             foreach (var collection in _index.Collections)
             {
@@ -111,26 +112,37 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
                                     _logger.Debug($"Executing cleanup for '{_index.Name}'. Processed count: {totalProcessedCount:#,#;;0} etag: {lastEtag}.");
 
                                 if (IsValidTombstoneType(tombstone) == false)
-                                    continue; // this can happen when we have '@all_docs'
+                                {
+                                    // this can happen when we have '@all_docs'
+                                    if (CanContinueCleanupBatch() == false)
+                                        break;
+
+                                    continue;
+                                }
 
                                 HandleDelete(tombstone, collection, writeOperation, queryContext, indexContext, collectionStats);
                                 stats.RecordTombstoneDeleteSuccess();
 
-                                var parameters = new CanContinueBatchParameters(stats, IndexingWorkType.Cleanup, queryContext, indexContext, writeOperation, lastEtag,
-                                    lastCollectionEtag,
-                                    totalProcessedCount, sw);
-
-                                batchContinuationResult = _index.CanContinueBatch(in parameters, ref maxTimeForDocumentTransactionToRemainOpen);
-
-                                if (batchContinuationResult != Index.CanContinueBatchResult.True)
-                                {
-                                    keepRunning = batchContinuationResult == Index.CanContinueBatchResult.RenewTransaction;
+                                if (CanContinueCleanupBatch() == false)
                                     break;
-                                }
                             }
 
                             if (hasChanges == false)
                                 break;
+
+                            bool CanContinueCleanupBatch()
+                            {
+                                var parameters = new CanContinueBatchParameters(stats, IndexingWorkType.Cleanup, queryContext, indexContext, writeOperation, lastEtag, lastCollectionEtag, totalProcessedCount, totalProcessedCount, sw);
+
+                                batchContinuationResult = _index.CanContinueBatch(in parameters, ref maxTimeForDocumentTransactionToRemainOpen, ref lastCheckedSeenItemsCount);
+                                if (batchContinuationResult != Index.CanContinueBatchResult.True)
+                                {
+                                    keepRunning = batchContinuationResult == Index.CanContinueBatchResult.RenewTransaction;
+                                    return false;
+                                }
+
+                                return true;
+                            }
                         }
                     }
 

--- a/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupTimeSeries.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupTimeSeries.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
             _tsStorage = documentsStorage.TimeSeriesStorage;
         }
 
-        public override string Name => "TimeSeriesCleanup";
+        public override string Name => IndexingOperation.Cleanup.TimeSeries;
 
         protected override long ReadLastProcessedTombstoneEtag(RavenTransaction transaction, string collection) =>
             IndexStorage.ReadLastProcessedTimeSeriesDeletedRangeEtag(transaction, collection);

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -134,6 +134,8 @@ namespace Raven.Server.Documents.Indexes.Workers
             Dictionary<string, long> lastIndexedEtagsByCollection = null;
 
             var totalProcessedCount = 0;
+            var totalSeenItemsCount = 0;
+            var lastCheckedSeenItemsCount = 0L;
             foreach (var collection in _index.Collections)
             {
                 if (TryGetReferencedCollectionsFor(collection, out var referencedCollections) == false)
@@ -220,6 +222,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                 foreach (var referencedItem in references)
                                 {
                                     hasChanges = true;
+                                    totalSeenItemsCount++;
 
                                     using (referencedItem)
                                     {
@@ -268,6 +271,7 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                                                 lastIndexedParentEtag = current.Etag;
                                                 totalProcessedCount++;
+                                                totalSeenItemsCount++;
                                                 collectionStats.RecordMapReferenceAttempt();
                                                 stats.RecordDocumentSize(current.Size);
 
@@ -293,6 +297,9 @@ namespace Raven.Server.Documents.Indexes.Workers
                                                     collectionStats.AddMapReferenceError(current.Id,
                                                         $"Failed to execute mapping function on {current.Id}. Exception: {e}");
                                                 }
+
+                                                totalSeenItemsCount += CurrentIndexingScope.Current.LoadedItemsCount;
+                                                CurrentIndexingScope.Current.LoadedItemsCount = 0;
 
                                                 _index.UpdateThreadAllocations(indexContext, writeOperation, stats, IndexingWorkType.References);
                                             }
@@ -320,9 +327,9 @@ namespace Raven.Server.Documents.Indexes.Workers
                                 bool CanContinueReferenceBatch()
                                 {
                                     var parameters = new CanContinueBatchParameters(stats, IndexingWorkType.References, queryContext, indexContext, writeOperation,
-                                        lastEtag, lastCollectionEtag, totalProcessedCount, sw);
+                                        lastEtag, lastCollectionEtag, totalProcessedCount, totalSeenItemsCount, sw);
 
-                                    batchContinuationResult = _index.CanContinueBatch(in parameters, ref maxTimeForDocumentTransactionToRemainOpen);
+                                    batchContinuationResult = _index.CanContinueBatch(in parameters, ref maxTimeForDocumentTransactionToRemainOpen, ref lastCheckedSeenItemsCount);
                                     if (batchContinuationResult != Index.CanContinueBatchResult.True)
                                     {
                                         keepRunning = batchContinuationResult == Index.CanContinueBatchResult.RenewTransaction;

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -12,6 +12,7 @@ using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server.Logging;
@@ -277,9 +278,10 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                                                 numberOfReferencedItemLoad++;
 
+                                                var numberOfResults = 0;
                                                 try
                                                 {
-                                                    var numberOfResults = _index.HandleMap(current, mapResults, writeOperation, indexContext, collectionStats);
+                                                    numberOfResults = _index.HandleMap(current, mapResults, writeOperation, indexContext, collectionStats);
 
                                                     resultsCount += numberOfResults;
                                                     collectionStats.RecordMapReferenceSuccess();
@@ -298,6 +300,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                                         $"Failed to execute mapping function on {current.Id}. Exception: {e}");
                                                 }
 
+                                                totalSeenItemsCount += numberOfResults - (numberOfResults > 0).ToInt32();
                                                 totalSeenItemsCount += CurrentIndexingScope.Current.LoadedItemsCount;
                                                 CurrentIndexingScope.Current.LoadedItemsCount = 0;
 

--- a/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
@@ -176,7 +176,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                     // Include the processed fanout results as well. We might not have seen more documents
                                     // on disk, but we certainly processed more than usual. Since fanouts might be big,
                                     // it's better to account for them too.
-                                    totalSeenItemsCount += numberOfResults - (numberOfResults > 1).ToInt32();
+                                    totalSeenItemsCount += numberOfResults - (numberOfResults > 0).ToInt32();
 
                                     totalSeenItemsCount += currentIndexingScope.LoadedItemsCount;
                                     currentIndexingScope.LoadedItemsCount = 0;

--- a/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/MapItems.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,9 +7,11 @@ using Raven.Client.Documents.Indexes;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Indexes.MapReduce;
 using Raven.Server.Documents.Indexes.Persistence;
+using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Logging;
 using Sparrow.Server.Logging;
 
@@ -41,9 +43,12 @@ namespace Raven.Server.Documents.Indexes.Workers
                 ? _configuration.MaxTimeForDocumentTransactionToRemainOpen.AsTimeSpan
                 : TimeSpan.FromMinutes(15);
 
+            var currentIndexingScope = CurrentIndexingScope.Current;
             var moreWorkFound = false;
             var batchContinuationResult = Index.CanContinueBatchResult.None;
             var totalProcessedCount = 0;
+            var totalSeenItemsCount = 0;
+            var lastCheckedSeenItemsCount = 0L;
 
             foreach (var collection in _index.Collections)
             {
@@ -127,6 +132,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                     }
 
                                     totalProcessedCount++;
+                                    totalSeenItemsCount++;
                                     collectionStats.RecordMapAttempt();
                                     stats.RecordDocumentSize(current.Size);
                                     if (_logger.IsDebugEnabled && totalProcessedCount % 8192 == 0)
@@ -135,17 +141,18 @@ namespace Raven.Server.Documents.Indexes.Workers
                                     lastEtag = current.Etag;
                                     inMemoryStats.UpdateLastEtag(lastEtag, isTombstone: false);
 
+                                    var numberOfResults = 0;
                                     try
                                     {
                                         current.KnownToBeNew = _indexStorage.LowerThanLastDatabaseEtagOnIndexCreation(current.Etag);
 
                                         if (itemEnumerator.Current.ShouldBeProcessedAsArchived(_index.ArchivedDataProcessingBehavior) == false)
                                         {
-                                            var numberOfResults = _index.HandleMap(current, mapResults,
+                                            numberOfResults = _index.HandleMap(current, mapResults,
                                                 writeOperation, indexContext, collectionStats);
-                                            
+
                                             resultsCount += numberOfResults;
-                                            
+
                                             collectionStats.RecordMapSuccess();
                                             _index.MapsPerSec?.MarkSingleThreaded(numberOfResults);
                                         }
@@ -163,14 +170,21 @@ namespace Raven.Server.Documents.Indexes.Workers
                                         if (_logger.IsWarnEnabled)
                                             _logger.Warn($"Failed to execute mapping function on '{current.Id}' for '{_index.Name}'.", e);
 
-                                        collectionStats.AddMapError(current.Id, $"Failed to execute mapping function on {current.Id}. " +
-                                                                                $"Exception: {e}");
+                                        collectionStats.AddMapError(current.Id, $"Failed to execute mapping function on {current.Id}. Exception: {e}");
                                     }
 
-                                    var parameters = new CanContinueBatchParameters(collectionStats, IndexingWorkType.Map, queryContext, indexContext, writeOperation,
-                                        lastEtag, lastCollectionEtag, totalProcessedCount, sw);
+                                    // Include the processed fanout results as well. We might not have seen more documents
+                                    // on disk, but we certainly processed more than usual. Since fanouts might be big,
+                                    // it's better to account for them too.
+                                    totalSeenItemsCount += numberOfResults - (numberOfResults > 1).ToInt32();
 
-                                    batchContinuationResult = _index.CanContinueBatch(in parameters, ref maxTimeForDocumentTransactionToRemainOpen);
+                                    totalSeenItemsCount += currentIndexingScope.LoadedItemsCount;
+                                    currentIndexingScope.LoadedItemsCount = 0;
+
+                                    var parameters = new CanContinueBatchParameters(collectionStats, IndexingWorkType.Map, queryContext, indexContext, writeOperation,
+                                        lastEtag, lastCollectionEtag, totalProcessedCount, totalSeenItemsCount, sw);
+
+                                    batchContinuationResult = _index.CanContinueBatch(in parameters, ref maxTimeForDocumentTransactionToRemainOpen, ref lastCheckedSeenItemsCount);
                                 }
                             }
                         }

--- a/test/SlowTests/Issues/RavenDB_27425.cs
+++ b/test/SlowTests/Issues/RavenDB_27425.cs
@@ -182,6 +182,63 @@ public class RavenDB_27425 : RavenTestBase
         }
     }
 
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task FanoutReferenceHandlingShouldRespectManagedAllocationsBatchLimitWhenBatchHasFewerThan128Documents()
+    {
+        using (var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = r =>
+            {
+                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = "1";
+            }
+        }))
+        {
+            await using (var bulk = store.BulkInsert())
+            {
+                for (var i = 0; i < FanoutDocsCount; i++)
+                {
+                    var items = Enumerable.Range(0, FanoutPerDocument)
+                        .Select(j => $"{i:D4}-{j:D6}-" + new string('x', 100))
+                        .ToList();
+
+                    await bulk.StoreAsync(new FanoutEntity { RefDocId = $"RefDocs/ref-{i}", Items = items }, $"fanouts/{i}");
+                    await bulk.StoreAsync(new RefDoc { NestedId = "nested/" + i }, $"RefDocs/ref-{i}");
+                }
+            }
+
+            var index = new FanoutEntities_ByItemAndRefDoc();
+            await index.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
+
+            await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                for (var i = 0; i < FanoutDocsCount; i++)
+                    await session.StoreAsync(new RefDoc { NestedId = "nested-updated/" + i }, $"RefDocs/ref-{i}");
+
+                await session.SaveChangesAsync();
+            }
+
+            await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Query<FanoutEntities_ByItemAndRefDoc.Result, FanoutEntities_ByItemAndRefDoc>()
+                    .Where(x => x.RefNestedId.StartsWith("nested-updated/"))
+                    .CountAsync();
+
+                Assert.Equal(FanoutDocsCount * FanoutPerDocument, count);
+            }
+
+            var referenceDetails = await GetReferenceRunDetails(store, index.IndexName);
+
+            Assert.NotEmpty(referenceDetails);
+            Assert.Contains(referenceDetails, x => x.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+        }
+    }
+
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.CompareExchange)]
     public async Task CompareExchangeReferenceHandlingShouldRespectManagedAllocationsBatchLimit()
     {
@@ -437,6 +494,7 @@ public class RavenDB_27425 : RavenTestBase
     private class FanoutEntity
     {
         public string Id { get; set; }
+        public string RefDocId { get; set; }
         public List<string> Items { get; set; }
     }
 
@@ -500,6 +558,27 @@ public class RavenDB_27425 : RavenTestBase
                               select new
                               {
                                   Item = item
+                              };
+        }
+    }
+
+    private class FanoutEntities_ByItemAndRefDoc : AbstractIndexCreationTask<FanoutEntity>
+    {
+        public class Result
+        {
+            public string Item { get; set; }
+            public string RefNestedId { get; set; }
+        }
+
+        public FanoutEntities_ByItemAndRefDoc()
+        {
+            Map = entities => from entity in entities
+                              let refDoc = LoadDocument<RefDoc>(entity.RefDocId, "RefDocs")
+                              from item in entity.Items
+                              select new
+                              {
+                                  Item = item,
+                                  RefNestedId = refDoc == null ? null : refDoc.NestedId
                               };
         }
     }

--- a/test/SlowTests/Issues/RavenDB_27425.cs
+++ b/test/SlowTests/Issues/RavenDB_27425.cs
@@ -1,0 +1,525 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27425 : RavenTestBase
+{
+    public RavenDB_27425(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    // must be >= 1 and not a multiple of 128, otherwise the reference batch counter cannot freeze between the checks
+    private const int MappedCount = 5;
+    private const int TailCount = 16_000;
+    private const int RefDocBodyBytes = 8 * 1024;
+    private const int FilteredOutCount = 10_000;
+
+    // fewer than 128 documents, so the per-document counter alone never opens the check gate
+    private const int FanoutDocsCount = 30;
+    private const int FanoutPerDocument = 2_000;
+
+    private const int SkippedItemsCount = 20_000;
+
+    // MapBatchSize is checked on every CanContinueBatch call, so anything above 128 tombstones works
+    private const int CleanupTombstonesCount = 2_048;
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Encryption)]
+    public async Task ReferenceHandlingShouldRespectTransactionSizeLimit()
+    {
+        var dbName = Encryption.SetupEncryptedDatabase(out var certificates, out _);
+
+        using (var store = GetDocumentStore(new Options
+        {
+            AdminCertificate = certificates.ServerCertificateForCommunication.Value,
+            ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+            ModifyDatabaseName = _ => dbName,
+            Path = NewDataPath(),
+            ModifyDatabaseRecord = r =>
+            {
+                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.EncryptedTransactionSizeLimit)] = "1";
+                r.Encrypted = true;
+            }
+        }))
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                for (var i = 0; i < MappedCount; i++)
+                    await session.StoreAsync(new Entity { RefDocId = $"RefDocs/ref-{i}", Field1 = "v" + i }, $"entities/{i}");
+
+                await session.SaveChangesAsync();
+            }
+
+            var index = new Entities_ByRefDoc();
+            await index.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
+
+            await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+
+            var filler = new string('x', RefDocBodyBytes);
+            await using (var bulk = store.BulkInsert())
+            {
+                for (var i = 0; i < MappedCount; i++)
+                    await bulk.StoreAsync(new RefDoc { NestedId = "nested/" + i, Filler = filler }, $"RefDocs/ref-{i}");
+
+                for (var i = 0; i < TailCount; i++)
+                    await bulk.StoreAsync(new RefDoc { Filler = filler }, $"RefDocs/tail-{i}");
+            }
+
+            await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Query<Entities_ByRefDoc.Result, Entities_ByRefDoc>()
+                    .Where(x => x.RefNestedId != null)
+                    .CountAsync();
+
+                Assert.Equal(MappedCount, count);
+            }
+
+            var referenceDetails = await GetReferenceRunDetails(store, index.IndexName);
+
+            Assert.NotEmpty(referenceDetails);
+            Assert.Contains(referenceDetails, x => x.BatchCompleteReason?.Contains("Reached transaction size limit") == true);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task MapShouldRespectManagedAllocationsBatchLimitWhenMostDocumentsAreFilteredOut()
+    {
+        using (var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = r =>
+            {
+                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = "1";
+            }
+        }))
+        {
+            var index = new FilteredEntities_ByField1();
+            await index.ExecuteAsync(store);
+
+            var filler = new string('x', RefDocBodyBytes);
+            await using (var bulk = store.BulkInsert())
+            {
+                await bulk.StoreAsync(new FilteredEntity { ShouldIndex = true, Field1 = "first", Filler = filler }, "filtered/first");
+
+                for (var i = 0; i < FilteredOutCount; i++)
+                    await bulk.StoreAsync(new FilteredEntity { ShouldIndex = false, Filler = filler }, $"filtered/skip-{i}");
+
+                await bulk.StoreAsync(new FilteredEntity { ShouldIndex = true, Field1 = "last", Filler = filler }, "filtered/last");
+            }
+
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Query<FilteredEntity, FilteredEntities_ByField1>().CountAsync();
+
+                Assert.Equal(2, count);
+            }
+
+            var mapDetails = await GetMapRunDetails(store, index.IndexName);
+
+            Assert.NotEmpty(mapDetails);
+            Assert.Contains(mapDetails, x => x.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task FanoutMapShouldRespectManagedAllocationsBatchLimitWhenBatchHasFewerThan128Documents()
+    {
+        using (var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = r =>
+            {
+                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = "1";
+            }
+        }))
+        {
+            var index = new FanoutEntities_ByItem();
+            await index.ExecuteAsync(store);
+
+            await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+
+            await using (var bulk = store.BulkInsert())
+            {
+                for (var i = 0; i < FanoutDocsCount; i++)
+                {
+                    var items = Enumerable.Range(0, FanoutPerDocument)
+                        .Select(j => $"{i:D4}-{j:D6}-" + new string('x', 100))
+                        .ToList();
+
+                    await bulk.StoreAsync(new FanoutEntity { Items = items }, $"fanouts/{i}");
+                }
+            }
+
+            await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Query<FanoutEntities_ByItem.Result, FanoutEntities_ByItem>().CountAsync();
+
+                Assert.Equal(FanoutDocsCount * FanoutPerDocument, count);
+            }
+
+            var mapDetails = await GetMapRunDetails(store, index.IndexName);
+
+            Assert.NotEmpty(mapDetails);
+            Assert.Contains(mapDetails, x => x.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.CompareExchange)]
+    public async Task CompareExchangeReferenceHandlingShouldRespectManagedAllocationsBatchLimit()
+    {
+        using (var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = r =>
+            {
+                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = "2";
+            }
+        }))
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                for (var i = 0; i < MappedCount; i++)
+                    await session.StoreAsync(new CmpEntity { CmpKey = $"refs/{i}", Field1 = "v" + i }, $"cmpEntities/{i}");
+
+                await session.SaveChangesAsync();
+            }
+
+            var index = new CmpEntities_ByRefValue();
+            await index.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
+
+            await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                for (var i = 0; i < MappedCount; i++)
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue($"refs/{i}", "nested/" + i);
+
+                await session.SaveChangesAsync();
+            }
+
+            for (var i = 0; i < SkippedItemsCount; i += 1000)
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    for (var j = i; j < i + 1000; j++)
+                        session.Advanced.ClusterTransaction.CreateCompareExchangeValue($"tail/{j}", "x");
+
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Query<CmpEntities_ByRefValue.Result, CmpEntities_ByRefValue>()
+                    .Where(x => x.RefValue != null)
+                    .CountAsync();
+
+                Assert.Equal(MappedCount, count);
+            }
+
+            var referenceDetails = await GetReferenceRunDetails(store, index.IndexName);
+
+            Assert.NotEmpty(referenceDetails);
+            Assert.Contains(referenceDetails, x => x.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task ReferenceTombstoneHandlingShouldRespectManagedAllocationsBatchLimit()
+    {
+        using (var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = r =>
+            {
+                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = "2";
+            }
+        }))
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                for (var i = 0; i < MappedCount; i++)
+                    await session.StoreAsync(new Entity { RefDocId = $"RefDocs/ref-{i}", Field1 = "v" + i }, $"entities/{i}");
+
+                await session.SaveChangesAsync();
+            }
+
+            var index = new Entities_ByRefDoc();
+            await index.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
+
+            await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+
+            await using (var bulk = store.BulkInsert())
+            {
+                for (var i = 0; i < MappedCount; i++)
+                    await bulk.StoreAsync(new RefDoc { NestedId = "nested/" + i }, $"RefDocs/ref-{i}");
+
+                for (var i = 0; i < SkippedItemsCount; i++)
+                    await bulk.StoreAsync(new RefDoc(), $"RefDocs/tail-{i}");
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                for (var i = 0; i < MappedCount; i++)
+                    session.Delete($"RefDocs/ref-{i}");
+
+                await session.SaveChangesAsync();
+            }
+
+            for (var i = 0; i < SkippedItemsCount; i += 1000)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (var j = i; j < i + 1000; j++)
+                        session.Delete($"RefDocs/tail-{j}");
+
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
+
+            var referenceDetails = await GetReferenceRunDetails(store, index.IndexName);
+
+            Assert.NotEmpty(referenceDetails);
+            Assert.Contains(referenceDetails, x => x.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Attachments)]
+    public async Task TombstoneCleanupShouldRespectMapBatchSizeWhenTombstonesAreSkippedByType()
+    {
+        const string indexName = "AllDocs/ByField1";
+
+        using (var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = r =>
+            {
+                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.MapBatchSize)] = "128";
+            }
+        }))
+        {
+            await using (var bulk = store.BulkInsert())
+            {
+                for (var i = 0; i < CleanupTombstonesCount; i++)
+                    await bulk.StoreAsync(new CounterEntity { Field1 = "v" + i }, $"counterEntities/{i}");
+            }
+
+            for (var i = 0; i < CleanupTombstonesCount; i += 1024)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (var j = i; j < i + 1024; j++)
+                        session.Advanced.Attachments.Store($"counterEntities/{j}", "a", new System.IO.MemoryStream(new byte[] { 1 }));
+
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            await store.Maintenance.SendAsync(new PutIndexesOperation(new IndexDefinition
+            {
+                Name = indexName,
+                Maps = { "from doc in docs select new { doc.Field1 }" }
+            }));
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
+
+            await store.Maintenance.SendAsync(new StopIndexOperation(indexName));
+
+            for (var i = 0; i < CleanupTombstonesCount; i += 1024)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (var j = i; j < i + 1024; j++)
+                        session.Advanced.Attachments.Delete($"counterEntities/{j}", "a");
+
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            await store.Maintenance.SendAsync(new StartIndexOperation(indexName));
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
+
+            var indexInstance = (await GetDatabase(store.Database)).IndexStore.GetIndex(indexName);
+
+            var cleanupDetails = indexInstance.GetIndexingPerformance()
+                .Where(x => x.Details != null)
+                .SelectMany(x => Flatten(x.Details))
+                .Where(x => x.CleanupDetails != null)
+                .Select(x => x.CleanupDetails)
+                .ToList();
+
+            Assert.Contains(cleanupDetails, x => x.BatchCompleteReason?.Contains("Reached maximum configured map batch size") == true);
+        }
+    }
+
+    private async Task<List<ReferenceRunDetails>> GetReferenceRunDetails(IDocumentStore store, string indexName)
+    {
+        var indexInstance = (await GetDatabase(store.Database)).IndexStore.GetIndex(indexName);
+
+        return indexInstance.GetIndexingPerformance()
+            .Where(x => x.Details?.Operations != null)
+            .SelectMany(x => x.Details.Operations)
+            .Where(x => x.ReferenceDetails != null)
+            .Select(x => x.ReferenceDetails)
+            .ToList();
+    }
+
+    private async Task<List<MapRunDetails>> GetMapRunDetails(IDocumentStore store, string indexName)
+    {
+        var indexInstance = (await GetDatabase(store.Database)).IndexStore.GetIndex(indexName);
+
+        return indexInstance.GetIndexingPerformance()
+            .Where(x => x.Details?.Operations != null)
+            .SelectMany(x => x.Details.Operations)
+            .Where(x => x.MapDetails != null)
+            .Select(x => x.MapDetails)
+            .ToList();
+    }
+
+    private static IEnumerable<IndexingPerformanceOperation> Flatten(IndexingPerformanceOperation operation)
+    {
+        yield return operation;
+
+        if (operation.Operations == null)
+            yield break;
+
+        foreach (var child in operation.Operations)
+        {
+            foreach (var descendant in Flatten(child))
+                yield return descendant;
+        }
+    }
+
+    private class Entity
+    {
+        public string Id { get; set; }
+        public string RefDocId { get; set; }
+        public string Field1 { get; set; }
+    }
+
+    private class RefDoc
+    {
+        public string Id { get; set; }
+        public string NestedId { get; set; }
+        public string Filler { get; set; }
+    }
+
+    private class FilteredEntity
+    {
+        public string Id { get; set; }
+        public bool ShouldIndex { get; set; }
+        public string Field1 { get; set; }
+        public string Filler { get; set; }
+    }
+
+    private class FanoutEntity
+    {
+        public string Id { get; set; }
+        public List<string> Items { get; set; }
+    }
+
+    private class CmpEntity
+    {
+        public string Id { get; set; }
+        public string CmpKey { get; set; }
+        public string Field1 { get; set; }
+    }
+
+    private class CounterEntity
+    {
+        public string Id { get; set; }
+        public string Field1 { get; set; }
+    }
+
+    private class Entities_ByRefDoc : AbstractIndexCreationTask<Entity>
+    {
+        public class Result
+        {
+            public string RefNestedId { get; set; }
+        }
+
+        public Entities_ByRefDoc()
+        {
+            Map = entities => from entity in entities
+                              let refDoc = LoadDocument<RefDoc>(entity.RefDocId, "RefDocs")
+                              select new
+                              {
+                                  entity.Field1,
+                                  entity.RefDocId,
+                                  RefNestedId = refDoc == null ? null : refDoc.NestedId
+                              };
+        }
+    }
+
+    private class FilteredEntities_ByField1 : AbstractIndexCreationTask<FilteredEntity>
+    {
+        public FilteredEntities_ByField1()
+        {
+            Map = entities => from entity in entities
+                              where entity.ShouldIndex
+                              select new
+                              {
+                                  entity.Field1
+                              };
+        }
+    }
+
+    private class FanoutEntities_ByItem : AbstractIndexCreationTask<FanoutEntity>
+    {
+        public class Result
+        {
+            public string Item { get; set; }
+        }
+
+        public FanoutEntities_ByItem()
+        {
+            Map = entities => from entity in entities
+                              from item in entity.Items
+                              select new
+                              {
+                                  Item = item
+                              };
+        }
+    }
+
+    private class CmpEntities_ByRefValue : AbstractIndexCreationTask<CmpEntity>
+    {
+        public class Result
+        {
+            public string RefValue { get; set; }
+        }
+
+        public CmpEntities_ByRefValue()
+        {
+            Map = entities => from entity in entities
+                              let refValue = LoadCompareExchangeValue<string>(entity.CmpKey)
+                              select new
+                              {
+                                  entity.Field1,
+                                  RefValue = refValue
+                              };
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_27425.cs
+++ b/test/SlowTests/Issues/RavenDB_27425.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
@@ -24,13 +26,17 @@ public class RavenDB_27425 : RavenTestBase
     private const int MappedCount = 5;
     private const int TailCount = 16_000;
     private const int RefDocBodyBytes = 8 * 1024;
-    private const int FilteredOutCount = 10_000;
 
     // fewer than 128 documents, so the per-document counter alone never opens the check gate
     private const int FanoutDocsCount = 30;
+    private const string ManagedAllocationsBatchLimitInMb = "8";
     private const int FanoutPerDocument = 2_000;
 
     private const int SkippedItemsCount = 20_000;
+
+    private const int AttachmentDocsCount = 30;
+    private const int AttachmentsPerDocument = 100;
+    private const int AttachmentSizeBytes = 1024;
 
     // MapBatchSize is checked on every CanContinueBatch call, so anything above 128 tombstones works
     private const int CleanupTombstonesCount = 2_048;
@@ -92,48 +98,7 @@ public class RavenDB_27425 : RavenTestBase
             var referenceDetails = await GetReferenceRunDetails(store, index.IndexName);
 
             Assert.NotEmpty(referenceDetails);
-            Assert.Contains(referenceDetails, x => x.BatchCompleteReason?.Contains("Reached transaction size limit") == true);
-        }
-    }
-
-    [RavenFact(RavenTestCategory.Indexes)]
-    public async Task MapShouldRespectManagedAllocationsBatchLimitWhenMostDocumentsAreFilteredOut()
-    {
-        using (var store = GetDocumentStore(new Options
-        {
-            ModifyDatabaseRecord = r =>
-            {
-                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = "1";
-            }
-        }))
-        {
-            var index = new FilteredEntities_ByField1();
-            await index.ExecuteAsync(store);
-
-            var filler = new string('x', RefDocBodyBytes);
-            await using (var bulk = store.BulkInsert())
-            {
-                await bulk.StoreAsync(new FilteredEntity { ShouldIndex = true, Field1 = "first", Filler = filler }, "filtered/first");
-
-                for (var i = 0; i < FilteredOutCount; i++)
-                    await bulk.StoreAsync(new FilteredEntity { ShouldIndex = false, Filler = filler }, $"filtered/skip-{i}");
-
-                await bulk.StoreAsync(new FilteredEntity { ShouldIndex = true, Field1 = "last", Filler = filler }, "filtered/last");
-            }
-
-            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
-
-            using (var session = store.OpenAsyncSession())
-            {
-                var count = await session.Query<FilteredEntity, FilteredEntities_ByField1>().CountAsync();
-
-                Assert.Equal(2, count);
-            }
-
-            var mapDetails = await GetMapRunDetails(store, index.IndexName);
-
-            Assert.NotEmpty(mapDetails);
-            Assert.Contains(mapDetails, x => x.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+            Assert.Contains(referenceDetails, x => x.Details.BatchCompleteReason?.Contains("Reached transaction size limit") == true);
         }
     }
 
@@ -144,7 +109,7 @@ public class RavenDB_27425 : RavenTestBase
         {
             ModifyDatabaseRecord = r =>
             {
-                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = "1";
+                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = ManagedAllocationsBatchLimitInMb;
             }
         }))
         {
@@ -178,7 +143,7 @@ public class RavenDB_27425 : RavenTestBase
             var mapDetails = await GetMapRunDetails(store, index.IndexName);
 
             Assert.NotEmpty(mapDetails);
-            Assert.Contains(mapDetails, x => x.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+            Assert.Contains(mapDetails, x => x.InputCount > 1 && x.Details.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
         }
     }
 
@@ -189,7 +154,7 @@ public class RavenDB_27425 : RavenTestBase
         {
             ModifyDatabaseRecord = r =>
             {
-                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = "1";
+                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = ManagedAllocationsBatchLimitInMb;
             }
         }))
         {
@@ -235,7 +200,56 @@ public class RavenDB_27425 : RavenTestBase
             var referenceDetails = await GetReferenceRunDetails(store, index.IndexName);
 
             Assert.NotEmpty(referenceDetails);
-            Assert.Contains(referenceDetails, x => x.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+            Assert.Contains(referenceDetails, x => x.InputCount > 1 && x.Details.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Attachments)]
+    public async Task AttachmentLoadingShouldRespectManagedAllocationsBatchLimitWhenBatchHasFewerThan128Documents()
+    {
+        using (var store = GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = r =>
+            {
+                r.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = ManagedAllocationsBatchLimitInMb;
+            }
+        }))
+        {
+            var index = new AttachmentEntities_ByContentLength();
+            await index.ExecuteAsync(store);
+
+            await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+
+            var content = Encoding.UTF8.GetBytes(new string('x', AttachmentSizeBytes));
+            await using (var bulk = store.BulkInsert())
+            {
+                for (var i = 0; i < AttachmentDocsCount; i++)
+                {
+                    var id = $"attachmentEntities/{i}";
+                    await bulk.StoreAsync(new AttachmentEntity(), id);
+
+                    var attachments = bulk.AttachmentsFor(id);
+                    for (var j = 0; j < AttachmentsPerDocument; j++)
+                        await attachments.StoreAsync($"attachment-{j}", new MemoryStream(content));
+                }
+            }
+
+            await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Query<AttachmentEntities_ByContentLength.Result, AttachmentEntities_ByContentLength>()
+                    .Where(x => x.ContentLength == AttachmentsPerDocument * AttachmentSizeBytes)
+                    .CountAsync();
+
+                Assert.Equal(AttachmentDocsCount, count);
+            }
+
+            var mapDetails = await GetMapRunDetails(store, index.IndexName);
+
+            Assert.NotEmpty(mapDetails);
+            Assert.Contains(mapDetails, x => x.InputCount > 1 && x.Details.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
         }
     }
 
@@ -298,7 +312,7 @@ public class RavenDB_27425 : RavenTestBase
             var referenceDetails = await GetReferenceRunDetails(store, index.IndexName);
 
             Assert.NotEmpty(referenceDetails);
-            Assert.Contains(referenceDetails, x => x.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+            Assert.Contains(referenceDetails, x => x.Details.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
         }
     }
 
@@ -361,7 +375,7 @@ public class RavenDB_27425 : RavenTestBase
             var referenceDetails = await GetReferenceRunDetails(store, index.IndexName);
 
             Assert.NotEmpty(referenceDetails);
-            Assert.Contains(referenceDetails, x => x.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
+            Assert.Contains(referenceDetails, x => x.Details.BatchCompleteReason?.Contains("Reached managed allocations limit") == true);
         }
     }
 
@@ -431,27 +445,23 @@ public class RavenDB_27425 : RavenTestBase
         }
     }
 
-    private async Task<List<ReferenceRunDetails>> GetReferenceRunDetails(IDocumentStore store, string indexName)
+    private async Task<List<(long InputCount, ReferenceRunDetails Details)>> GetReferenceRunDetails(IDocumentStore store, string indexName)
     {
         var indexInstance = (await GetDatabase(store.Database)).IndexStore.GetIndex(indexName);
 
         return indexInstance.GetIndexingPerformance()
             .Where(x => x.Details?.Operations != null)
-            .SelectMany(x => x.Details.Operations)
-            .Where(x => x.ReferenceDetails != null)
-            .Select(x => x.ReferenceDetails)
+            .SelectMany(x => x.Details.Operations.Where(o => o.ReferenceDetails != null).Select(o => (x.InputCount, o.ReferenceDetails)))
             .ToList();
     }
 
-    private async Task<List<MapRunDetails>> GetMapRunDetails(IDocumentStore store, string indexName)
+    private async Task<List<(long InputCount, MapRunDetails Details)>> GetMapRunDetails(IDocumentStore store, string indexName)
     {
         var indexInstance = (await GetDatabase(store.Database)).IndexStore.GetIndex(indexName);
 
         return indexInstance.GetIndexingPerformance()
             .Where(x => x.Details?.Operations != null)
-            .SelectMany(x => x.Details.Operations)
-            .Where(x => x.MapDetails != null)
-            .Select(x => x.MapDetails)
+            .SelectMany(x => x.Details.Operations.Where(o => o.MapDetails != null).Select(o => (x.InputCount, o.MapDetails)))
             .ToList();
     }
 
@@ -483,19 +493,16 @@ public class RavenDB_27425 : RavenTestBase
         public string Filler { get; set; }
     }
 
-    private class FilteredEntity
-    {
-        public string Id { get; set; }
-        public bool ShouldIndex { get; set; }
-        public string Field1 { get; set; }
-        public string Filler { get; set; }
-    }
-
     private class FanoutEntity
     {
         public string Id { get; set; }
         public string RefDocId { get; set; }
         public List<string> Items { get; set; }
+    }
+
+    private class AttachmentEntity
+    {
+        public string Id { get; set; }
     }
 
     private class CmpEntity
@@ -527,19 +534,6 @@ public class RavenDB_27425 : RavenTestBase
                                   entity.Field1,
                                   entity.RefDocId,
                                   RefNestedId = refDoc == null ? null : refDoc.NestedId
-                              };
-        }
-    }
-
-    private class FilteredEntities_ByField1 : AbstractIndexCreationTask<FilteredEntity>
-    {
-        public FilteredEntities_ByField1()
-        {
-            Map = entities => from entity in entities
-                              where entity.ShouldIndex
-                              select new
-                              {
-                                  entity.Field1
                               };
         }
     }
@@ -579,6 +573,24 @@ public class RavenDB_27425 : RavenTestBase
                               {
                                   Item = item,
                                   RefNestedId = refDoc == null ? null : refDoc.NestedId
+                              };
+        }
+    }
+
+    private class AttachmentEntities_ByContentLength : AbstractIndexCreationTask<AttachmentEntity>
+    {
+        public class Result
+        {
+            public int ContentLength { get; set; }
+        }
+
+        public AttachmentEntities_ByContentLength()
+        {
+            Map = entities => from entity in entities
+                              let attachments = LoadAttachments(entity).Select(x => x.GetContentAsString())
+                              select new
+                              {
+                                  ContentLength = attachments.Sum(x => x.Length)
                               };
         }
     }

--- a/test/SlowTests/Issues/RavenDB_27425.cs
+++ b/test/SlowTests/Issues/RavenDB_27425.cs
@@ -12,7 +12,6 @@ using Raven.Client.Documents.Session;
 using Raven.Server.Config;
 using Tests.Infrastructure;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SlowTests.Issues;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27425

### Custom build

Based on the reset `release/custom/v7.2` at `ea1b627ee3672094494a75d2ab7e1ce7c5a2f27b` (`7.2.6-custom-72`), with all six commits from #23488 cherry-picked, plus the xUnit import compatibility fix from #23560.