### PR TITLE
RavenDB-27484 Improve TestDriver and Embedded process failure diagnostics

### DIFF
--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Concurrent;
@@ -257,79 +257,65 @@ namespace Raven.Embedded
 
             process.Exited += (sender, e) => ServerProcessExited?.Invoke(sender, new ServerProcessExitedEventArgs());
 
-            bool domainBind;
-
 #if NET462
             AppDomain.CurrentDomain.DomainUnload += (s, args) =>
             {
                 ShutdownServerProcess(process);
             };
-            domainBind = true;
 #else
             AssemblyLoadContext.Default.Unloading += c =>
             {
                 ShutdownServerProcess(process);
             };
-            domainBind = true;
 #endif
 
-            if (domainBind == false)
-                throw new InvalidOperationException("Should not happen!");
-
-            string? url = null;
-            var startupDuration = Stopwatch.StartNew();
-
-            var outputString = await ProcessHelper.ReadOutput(process.StandardOutput, startupDuration, _serverOptions, async (line, builder) =>
+            var serverUrlTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var outputString = process.ReadOutput(onOutputLine: line =>
             {
-                if (line == null)
-                {
-                    var errorString = await ProcessHelper.ReadOutput(process.StandardError, startupDuration, _serverOptions, null).ConfigureAwait(false);
-
-                    ShutdownServerProcess(process);
-
-                    throw new InvalidOperationException(BuildStartupExceptionMessage(builder.ToString(), errorString));
-                }
-
                 const string prefix = "Server available on: ";
                 if (line.StartsWith(prefix))
+                    serverUrlTcs.TrySetResult(line.Substring(prefix.Length));
+            });
+
+            try
+            {
+                var startupTask = Task.WhenAny(serverUrlTcs.Task, outputString.Completion);
+                var isCompleted = await startupTask.WaitWithTimeout(_serverOptions.MaxServerStartupTimeDuration).ConfigureAwait(false);
+                var exitCode = outputString.ExitCode;
+
+                if (isCompleted == false || serverUrlTcs.Task.IsCompleted == false || exitCode.HasValue)
                 {
-                    url = line.Substring(prefix.Length);
-                    return true;
+                    throw new InvalidOperationException(isCompleted == false
+                        ? $"Server startup did not complete within {_serverOptions.MaxServerStartupTimeDuration}."
+                        : "The server process exited before startup completed.");
                 }
 
-                return false;
-            }).ConfigureAwait(false);
+                var serverUrl = new Uri(await serverUrlTcs.Task.ConfigureAwait(false));
 
-            if (url == null)
-            {
-                var errorString = await ProcessHelper.ReadOutput(process.StandardError, startupDuration, _serverOptions, null).ConfigureAwait(false);
-
-                ShutdownServerProcess(process);
-
-                throw new InvalidOperationException(BuildStartupExceptionMessage(outputString, errorString));
+                return (serverUrl, process);
             }
-
-            return (new Uri(url), process);
-        }
-
-        private static string BuildStartupExceptionMessage(string? outputString, string? errorString)
-        {
-            var sb = new StringBuilder();
-            sb.AppendLine("Unable to start the RavenDB Server");
-
-            if (string.IsNullOrWhiteSpace(errorString) == false)
+            catch (Exception e)
             {
-                sb.AppendLine("Error:");
-                sb.AppendLine(errorString);
-            }
+                try
+                {
+                    // Capture the exit code before cleanup can terminate a still-running process.
+                    var exitCodeBeforeShutdown = outputString.ExitCode;
 
-            if (string.IsNullOrWhiteSpace(outputString) == false)
-            {
-                sb.AppendLine("Output:");
-                sb.AppendLine(outputString);
-            }
+                    ShutdownServerProcess(process);
+                    await outputString.DrainAsync(_serverOptions.ProcessKillTimeout).ConfigureAwait(false);
 
-            return sb.ToString();
+                    var message = new StringBuilder();
+                    message.AppendLine("Unable to start the RavenDB Server");
+                    message.AppendLine(e.Message);
+                    outputString.AppendDiagnostics(message, exitCodeBeforeShutdown);
+
+                    throw new InvalidOperationException(message.ToString(), e);
+                }
+                finally
+                {
+                    process.Dispose();
+                }
+            }
         }
 
         public void OpenStudioInBrowser()

--- a/src/Raven.Embedded/ProcessHelper.cs
+++ b/src/Raven.Embedded/ProcessHelper.cs
@@ -1,54 +1,142 @@
-﻿#nullable enable
+#nullable enable
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Raven.Client.Extensions;
+using Sparrow.Platform;
 
 namespace Raven.Embedded
 {
     internal static class ProcessHelper
     {
-        internal static async Task<string?> ReadOutput(StreamReader output, Stopwatch elapsed, ServerOptions options, Func<string, StringBuilder, Task<bool>>? onLine)
+        internal static ProcessOutput ReadOutput(this Process process, Action<string> onOutputLine) => new(process, onOutputLine);
+
+        internal sealed class ProcessOutput
         {
-            var sb = new StringBuilder();
+            private readonly Process _process;
+            private readonly string _executable;
+            private readonly string _workingDirectory;
+            private readonly string? _resolvedExecutable;
+            private readonly CapturedOutput _standardOutput = new();
+            private readonly CapturedOutput _standardError = new();
 
-            Task<string?>? readLineTask = null;
-            while (true)
+            internal Task Completion { get; }
+
+            internal int? ExitCode => _process.HasExited ? _process.ExitCode : null;
+
+            internal ProcessOutput(Process process, Action<string> onOutputLine)
             {
-                readLineTask ??= output.ReadLineAsync();
-
-                var hasResult = await readLineTask.WaitWithTimeout(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-
-                if (elapsed != null && elapsed.Elapsed > options.MaxServerStartupTimeDuration)
-                    return null;
-
-                if (hasResult == false)
-                    continue;
-
-                var line = readLineTask.Result;
-
-                readLineTask = null;
-
-                var shouldStop = false;
-                if (line != null)
+                _process = process;
+                _executable = process.StartInfo.FileName;
+                _workingDirectory = string.IsNullOrEmpty(process.StartInfo.WorkingDirectory) ? Directory.GetCurrentDirectory() : process.StartInfo.WorkingDirectory;
+                try
                 {
-                    sb.AppendLine(line);
-
-                    if (onLine != null)
-                        shouldStop = await onLine(line, sb).ConfigureAwait(false);
+                    _resolvedExecutable = process.MainModule?.FileName;
+                }
+                catch (Exception error) when (error is Win32Exception or InvalidOperationException or NotSupportedException or NullReferenceException)
+                {
+                    // An early exit can make the image unavailable.
+                    // .NET Framework can also throw NullReferenceException from ProcessModule.FileName while inspecting a child.
                 }
 
-                if (shouldStop)
-                    break;
+                var exited = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                process.Exited += OnExit;
+                process.EnableRaisingEvents = true;
+                if (process.HasExited)
+                    exited.TrySetResult(true);
 
-                if (line == null)
-                    break;
+                // Start both readers immediately.
+                // Keep draining after a server announces readiness - otherwise later console output can fill a pipe and block the running server.
+                var outputReadStreamTask = ReadStream(process.StandardOutput, _standardOutput, onOutputLine);
+                var errorOutputReadStreamTask = ReadStream(process.StandardError, _standardError, onLine: null);
+                Completion = CompleteAsync();
+                _ = Completion.IgnoreUnobservedExceptions();
+                return;
+
+                void OnExit(object? sender, EventArgs args) => exited.TrySetResult(true);
+
+                async Task CompleteAsync()
+                {
+                    try
+                    {
+                        await Task.WhenAll(outputReadStreamTask, errorOutputReadStreamTask, exited.Task).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        process.Exited -= OnExit;
+                    }
+                }
             }
 
-            return sb.ToString();
-        }
+            internal async Task DrainAsync(TimeSpan timeout)
+            {
+                try
+                {
+                    // Let the readers consume trailing output, including unterminated lines,
+                    // before the caller builds its diagnostic or disposes the process.
+                    if (await Completion.WaitWithTimeout(timeout).ConfigureAwait(false))
+                        await Completion.ConfigureAwait(false);
+                }
+                catch (Exception error) when (error is Win32Exception or InvalidOperationException or IOException)
+                {
+                    // Cleanup must not replace the original startup/discovery failure.
+                }
+            }
 
+            internal void AppendDiagnostics(StringBuilder message, int? exitCode)
+            {
+                // Server arguments can contain license keys and certificate passwords.
+                // Report the executable here; callers may add arguments only when they are known to be safe.
+                message.AppendLine($"Executable: '{_executable}'");
+                message.AppendLine($"Working directory: '{_workingDirectory}'");
+                message.AppendLine($"Resolved executable: {_resolvedExecutable ?? "unavailable (the process may have exited before it could be queried)"}");
+                if (exitCode.HasValue)
+                {
+                    message.AppendLine($"Exit code: {exitCode.Value} (0x{exitCode.Value:X8})");
+                    if (PlatformDetails.RunningOnPosix == false && exitCode.Value == unchecked((int)0xC0000135))
+                        message.AppendLine("Windows reported STATUS_DLL_NOT_FOUND: a DLL required by the process could not be found.");
+                }
+                message.AppendLine("Standard output:");
+                message.AppendLine(_standardOutput.ToString());
+                message.AppendLine("Standard error:");
+                message.AppendLine(_standardError.ToString());
+            }
+
+            private static async Task ReadStream(StreamReader stream, CapturedOutput output, Action<string>? onLine)
+            {
+                string? line;
+                while ((line = await stream.ReadLineAsync().ConfigureAwait(false)) != null)
+                {
+                    output.AppendLine(line);
+                    onLine?.Invoke(line);
+                }
+            }
+
+            private sealed class CapturedOutput
+            {
+                private readonly StringBuilder _text = new();
+
+                internal void AppendLine(string line)
+                {
+                    lock (_text)
+                    {
+                        _text.AppendLine(line);
+                    }
+                }
+
+                public override string ToString()
+                {
+                    lock (_text)
+                    {
+                        return _text.Length == 0
+                            ? "<empty>"
+                            : _text.ToString();
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Raven.Embedded/RuntimeFrameworkVersionMatcher.cs
+++ b/src/Raven.Embedded/RuntimeFrameworkVersionMatcher.cs
@@ -1,9 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Raven.Client.Extensions;
 
 namespace Raven.Embedded
 {
@@ -61,7 +64,7 @@ namespace Raven.Embedded
         private static async Task<List<RuntimeFrameworkVersion>> GetFrameworkVersionsAsync(ServerOptions options)
         {
             if (string.IsNullOrWhiteSpace(options.DotNetPath))
-                throw new InvalidOperationException();
+                throw new InvalidOperationException("'ServerOptions.DotNetPath' must specify the dotnet executable used to discover installed .NET runtimes.");
 
             var processStartInfo = new ProcessStartInfo
             {
@@ -74,49 +77,86 @@ namespace Raven.Embedded
                 UseShellExecute = false
             };
 
-            Process process = null;
+            using var process = new Process();
+            process.StartInfo = processStartInfo;
+            process.EnableRaisingEvents = true;
+
+            var workingDirectory = Directory.GetCurrentDirectory();
             try
             {
-                process = Process.Start(processStartInfo);
-                process.EnableRaisingEvents = true;
+                process.Start();
             }
             catch (Exception e)
             {
-                process?.Kill();
-                throw new InvalidOperationException($"Unable to execute dotnet to retrieve list of installed runtimes.{Environment.NewLine}Command was: {Environment.NewLine}{processStartInfo.WorkingDirectory}> {processStartInfo.FileName} {processStartInfo.Arguments}", e);
+                string message = $"Unable to execute dotnet to retrieve list of installed runtimes.{Environment.NewLine}" +
+                                 $"Command was: {Environment.NewLine}" +
+                                 $"{workingDirectory}> \"{processStartInfo.FileName}\" {processStartInfo.Arguments}";
+
+                throw new InvalidOperationException(message, e);
             }
 
-            var insideRuntimes = false;
+            var isInsideRuntimes = false;
             var runtimeLines = new List<string>();
-            await ProcessHelper.ReadOutput(process.StandardOutput, elapsed: null, options, (line, builder) =>
+            var output = process.ReadOutput(onOutputLine: line =>
             {
                 line = line.Trim();
-
                 if (line.StartsWith(".NET runtimes installed:") || line.StartsWith(".NET Core runtimes installed:"))
+                    isInsideRuntimes = true;
+                else if (isInsideRuntimes && line.StartsWith("Microsoft.NETCore.App"))
+                    runtimeLines.Add(line);
+            });
+
+            try
+            {
+                process.StandardInput.Close();
+
+                if (await output.Completion.WaitWithTimeout(options.MaxServerStartupTimeDuration).ConfigureAwait(false) == false)
+                    throw new InvalidOperationException($"The dotnet runtime discovery command did not complete within {options.MaxServerStartupTimeDuration}.");
+
+                await output.Completion.ConfigureAwait(false);
+                if (process.ExitCode != 0)
+                    throw new InvalidOperationException("The dotnet runtime discovery command failed.");
+
+                var runtimes = new List<RuntimeFrameworkVersion>();
+                foreach (string line in runtimeLines)
                 {
-                    insideRuntimes = true;
-                    return Task.FromResult(false);
+                    var values = line.Split(' ');
+                    if (values.Length < 2)
+                        throw new InvalidOperationException($"Invalid runtime line. Expected 'Microsoft.NETCore.App x.x.x', but was '{line}'.");
+
+                    runtimes.Add(new RuntimeFrameworkVersion(values[1]));
                 }
 
-                if (insideRuntimes && line.StartsWith("Microsoft.NETCore.App"))
-                    runtimeLines.Add(line);
-
-                return Task.FromResult(false);
-            }).ConfigureAwait(false);
-
-            var runtimes = new List<RuntimeFrameworkVersion>();
-            foreach (string runtimeLine in runtimeLines) // Microsoft.NETCore.App 5.0.2 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
-            {
-                var values = runtimeLine.Split(' ');
-                if (values.Length < 2)
-                    throw new InvalidOperationException($"Invalid runtime line. Expected 'Microsoft.NETCore.App x.x.x', but was '{runtimeLine}'.");
-
-                runtimes.Add(new RuntimeFrameworkVersion(values[1]));
+                return runtimes.Count != 0
+                    ? runtimes
+                    : throw new InvalidOperationException("The command completed successfully, but no Microsoft.NETCore.App runtimes were found in its output. " +
+                                                          "Check the .NET installation and the output below.");
             }
+            catch (Exception e)
+            {
+                var exitCodeBeforeTermination = output.ExitCode;
+                try
+                {
+                    if (process.HasExited == false)
+                        process.Kill();
+                }
+                catch (Exception cleanupError) when (cleanupError is Win32Exception or InvalidOperationException)
+                {
+                    // Cleanup must not replace the original discovery failure.
+                }
 
-            return runtimes;
+                await output.DrainAsync(options.ProcessKillTimeout).ConfigureAwait(false);
+
+                var message = new StringBuilder();
+                message.AppendLine("Unable to discover installed .NET runtimes.");
+                message.AppendLine(e.Message);
+                message.AppendLine($"Command: \"{processStartInfo.FileName}\" {processStartInfo.Arguments}");
+                message.AppendLine("Run the command above from the same working directory and under the same account/environment as the tests. Check ServerOptions.DotNetPath and the .NET installation.");
+
+                output.AppendDiagnostics(message, exitCodeBeforeTermination);
+                throw new InvalidOperationException(message.ToString(), e);
+            }
         }
-
         internal sealed class RuntimeFrameworkVersion
         {
             private static readonly char[] Separators = { '.' };

--- a/test/EmbeddedTests/RuntimeFrameworkVersionMatcherTests.cs
+++ b/test/EmbeddedTests/RuntimeFrameworkVersionMatcherTests.cs
@@ -1,5 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.IO;
 using System.Threading.Tasks;
 using Raven.Embedded;
@@ -120,6 +123,128 @@ namespace EmbeddedTests
             Assert.Equal("Cannot set 'Minor' with value '1+' because '+' is not allowed.", e.Message);
         }
 
+#if NETCOREAPP
+        [Theory]
+        [InlineData("diagnosis")]
+        [InlineData("command")]
+        [InlineData("exit code")]
+        [InlineData("stderr")]
+        public async Task Should_report_runtime_discovery_failure_when_dotnet_host_is_incomplete(string diagnostic)
+        {
+            ServerOptions options = CopyServerAndCreateOptions();
+            options.DotNetPath = CopyDotNetHost();
+
+            InvalidOperationException error = await GetStartupFailure(options);
+
+            // Each diagnostic is checked independently so the red run reaches every assertion.
+            switch (diagnostic)
+            {
+                case "diagnosis":
+                    Assert.DoesNotContain("Could not find a matching runtime", error.Message);
+                    Assert.Contains("Unable to discover installed .NET runtimes", error.Message);
+                    break;
+                case "command":
+                    Assert.Contains(options.DotNetPath, error.Message);
+                    Assert.Contains("--info", error.Message);
+                    break;
+                case "exit code":
+                    Assert.Contains(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "-2147450749 (0x80008083)" : "131 (0x00000083)", error.Message);
+                    break;
+                case "stderr":
+                    Assert.Contains("host", error.Message);
+                    Assert.Contains("fxr", error.Message);
+                    break;
+            }
+        }
+
+        [WindowsFact]
+        public async Task Should_report_windows_loader_failure_with_empty_output()
+        {
+            ServerOptions options = CopyServerAndCreateOptions();
+            options.DotNetPath = CopyDotNetHost();
+
+            // Change an import in a private copy, leaving the installed host untouched. Windows
+            // must fail in the real loader because the required DLL does not exist.
+            byte[] executable = File.ReadAllBytes(options.DotNetPath);
+            int importOffset = Encoding.ASCII.GetString(executable).IndexOf("KERNEL32.dll\0", StringComparison.OrdinalIgnoreCase);
+            Assert.True(importOffset >= 0, "The Windows dotnet host must import KERNEL32.dll.");
+            Encoding.ASCII.GetBytes("RDB27484.dll").CopyTo(executable, importOffset);
+            File.WriteAllBytes(options.DotNetPath, executable);
+
+            // Verify the native failure itself before exercising the public embedded lifecycle.
+            using (Process child = Process.Start(new ProcessStartInfo(options.DotNetPath, "--info")
+                   { UseShellExecute = false, CreateNoWindow = true, RedirectStandardOutput = true, RedirectStandardError = true }))
+            {
+                Task<string> output = child.StandardOutput.ReadToEndAsync();
+                Task<string> error = child.StandardError.ReadToEndAsync();
+                Assert.True(child.WaitForExit(30_000));
+                Assert.Equal(unchecked((int)0xC0000135), child.ExitCode);
+                Assert.Empty(await output);
+                Assert.Empty(await error);
+            }
+
+            InvalidOperationException failure = await GetStartupFailure(options);
+            Assert.Contains("-1073741515 (0xC0000135)", failure.Message);
+            Assert.Contains("STATUS_DLL_NOT_FOUND", failure.Message);
+            Assert.Contains(options.DotNetPath, failure.Message);
+        }
+
+        [Fact]
+        public async Task Should_preserve_a_genuine_runtime_version_mismatch()
+        {
+            ServerOptions options = CopyServerAndCreateOptions();
+            options.FrameworkVersion = "999.0.0+";
+
+            InvalidOperationException error = await GetStartupFailure(options);
+            Assert.Contains("Could not find a matching runtime for '999.0.0+'. Available runtimes:", error.Message);
+            Assert.Contains(Environment.NewLine + "- ", error.Message);
+        }
+
+        private static async Task<InvalidOperationException> GetStartupFailure(ServerOptions options)
+        {
+            var embedded = new EmbeddedServer();
+            InvalidOperationException startupError = null;
+            try
+            {
+                embedded.StartServer(options);
+                startupError = await Assert.ThrowsAsync<InvalidOperationException>(() => embedded.GetServerUriAsync());
+                return startupError;
+            }
+            finally
+            {
+                try
+                {
+                    embedded.Dispose();
+                }
+                catch (AggregateException error) when (startupError != null && error.InnerExceptions.Count == 1 && ReferenceEquals(error.InnerException, startupError))
+                {
+                    // Dispose also observes the faulted startup task.
+                    // Do not let the same exception hide the diagnostic assertion this regression is checking.
+                }
+            }
+        }
+
+        private string CopyDotNetHost()
+        {
+            string runtimeDirectory = RuntimeEnvironment.GetRuntimeDirectory();
+            string installation = Directory.GetParent(runtimeDirectory.TrimEnd(Path.DirectorySeparatorChar)).Parent.Parent.FullName;
+            string executable = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+            string directory = Path.Combine(NewDataPath(), "incomplete dotnet installation");
+            Directory.CreateDirectory(directory);
+            string copy = Path.Combine(directory, executable);
+            File.Copy(Path.Combine(installation, executable), copy);
+            return copy;
+        }
+
+        private sealed class WindowsFactAttribute : FactAttribute
+        {
+            public WindowsFactAttribute()
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == false)
+                    Skip = "This test exercises the Windows native DLL loader.";
+            }
+        }
+#endif
         private static List<RuntimeFrameworkVersionMatcher.RuntimeFrameworkVersion> GetRuntimes()
         {
             return new()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27484

### Additional description

A customer investigation found that `dotnet --info` exited with `0xC0000135` (`STATUS_DLL_NOT_FOUND`) and no output, while TestDriver reported `Could not find a matching runtime` with an empty runtime list. The message pointed troubleshooting toward runtime versions without exposing the child-process failure.

Runtime discovery now distinguishes command failures and timeouts from a genuine version mismatch, and includes the executable, exit code, stdout and stderr in its diagnostics. Normal runtime matching is preserved.

The output reader is also used by EmbeddedServer. Both streams are now drained concurrently, and reading continues after server readiness so a full pipe cannot block the server. Embedded startup failures retain diagnostic output and use the existing graceful shutdown policy.

Validation: red/green tests cover incomplete .NET installations, Windows loader failure with empty output, and genuine runtime mismatch through public startup APIs. Windows EmbeddedTests: 58 passed, 2 skipped. Linux matcher tests in Debug and Release: 9 passed, 1 Windows-only skip each. Full Windows Debug solution build passed.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No. Process diagnostics and stream handling apply across platforms; the DLL-loader explanation and regression are Windows-specific.

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. EmbeddedServer drains stdout and stderr throughout the server lifetime and retains startup failure diagnostics.
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
