### PR TITLE
RavenDB-26604 Don't register the client certificate in the OS when only creating a setup package

### DIFF
--- a/src/Raven.Server/Commercial/SetupWizard/SetupWizardUtils.cs
+++ b/src/Raven.Server/Commercial/SetupWizard/SetupWizardUtils.cs
@@ -122,7 +122,7 @@ public static class SetupWizardUtils
                 throw new InvalidOperationException($"Failed to generate a client certificate for '{domain}'.", e);
             }
 
-            if (parameters.SetupInfo.RegisterClientCert)
+            if (parameters.SetupInfo.RegisterClientCert && parameters.SetupInfo.ZipOnly == false)
                 parameters.RegisterClientCertInOs?.Invoke(parameters.OnProgress, parameters.Progress, clientCert);
             
             parameters.Progress?.SetupActionSteps.StepsByConfigurationStepType[ConfigurationStepType.ClientCertificate].SetState(State.Completed);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26604/Creating-secure-setup-package-registers-certificate-in-the-OS

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
