### PR TITLE
RavenDB-26741 Update configuration scope for `Storage.DisableSparseRegions` to exclude per-index settings

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -173,7 +173,7 @@ namespace Raven.Server.Config.Categories
 
         [Description("Disable further usage of sparse regions for the FS to reclaim free pages. In order to clear existing sparse regions you need to do that manually.")]
         [DefaultValue(false)]
-        [ConfigurationEntry("Storage.DisableSparseRegions", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        [ConfigurationEntry("Storage.DisableSparseRegions", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public bool DisableSparseRegions { get; set; }
 
         [Description("EXPERT: I/O for flush and sync operation is issued for a low priority thread, giving transaction commits higher priority")]

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -54,7 +54,6 @@ class configurationItem {
         "Indexing.Corax.VectorSearch.OrderByScoreAutomatically",
         "Indexing.Corax.VectorSearch.MaximumConcurrentBatchesForHnswAcceleration",
         "Indexing.Corax.VectorSearch.OrderByScoreAutomatically",
-        "Storage.DisableSparseRegions",
         "Storage.JournalsCompressionAcceleration",
         "Indexing.Storage.DisableSharedJournals",
         "Indexing.Corax.UnmanagedAllocationsBatchSizeLimitInMb",

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -88,7 +88,6 @@ namespace FastTests.Issues
                 "Indexing.Querying.Corax.NullsSortMode",
                 
                 
-                "Storage.DisableSparseRegions",
                 "Storage.JournalsCompressionAcceleration",
 
                 "Indexing.Corax.VectorSearch.CacheSizeInMb",

--- a/test/SlowTests.Issues/Issues/RavenDB_26741.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26741.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26741 : RavenTestBase
+{
+    public RavenDB_26741(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void DisableSparseRegionsCannotBeSetPerIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var index = new IndexWithDisabledSparseRegions();
+
+            var exception = Assert.Throws<IndexCreationException>(() => index.Execute(store));
+
+            Assert.Contains($"Could not create index '{index.IndexName}' because the configuration option key 'Storage.DisableSparseRegions' is not recognized", exception.Message);
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+    }
+
+    private class IndexWithDisabledSparseRegions : AbstractIndexCreationTask<Dto>
+    {
+        public IndexWithDisabledSparseRegions()
+        {
+            Map = dtos => from dto in dtos
+                select new { dto.Id };
+
+            Configuration = new IndexConfiguration { { "Storage.DisableSparseRegions", "true" } };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26741

### Additional description

Update configuration scope for `Storage.DisableSparseRegions` to exclude per-index settings

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
