### PR TITLE
RavenDB-27035 Don't drive an order by from a value tree that misses entries

### DIFF
--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -9,6 +9,7 @@ using Corax.Mappings;
 using Corax.Pipeline;
 using Corax.Querying.Matches;
 using Corax.Querying.Matches.Meta;
+using Corax.Querying.Matches.SortingMatches.Meta;
 using Corax.Querying.Matches.TermsProviders;
 using Corax.Utils;
 using Sparrow;
@@ -427,6 +428,35 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         }
 
         return termCount;
+    }
+
+    /// <summary>Whether the field's value tree for <paramref name="fieldType"/>, plus nulls, holds every entry that has
+    /// this field. False for a mixed-type field: a scan of one tree would skip the other types' entries (RavenDB-27035).</summary>
+    public bool SortFieldTreeCoversAllEntries(in FieldMetadata field, MatchCompareFieldType fieldType)
+    {
+        Slice treeName;
+        switch (fieldType)
+        {
+            case MatchCompareFieldType.Sequence:
+                treeName = field.FieldName;
+                break;
+            case MatchCompareFieldType.Integer:
+                IndexFieldsMappingBuilder.GetFieldNameForLongs(Allocator, field.FieldName, out treeName);
+                break;
+            case MatchCompareFieldType.Floating:
+                IndexFieldsMappingBuilder.GetFieldNameForDoubles(Allocator, field.FieldName, out treeName);
+                break;
+            default:
+                return false;
+        }
+
+        // entries -> terms is keyed by entry id, so its count is the number of entries with a value in that tree
+        long covered = EntriesToTermsReader(treeName)?.NumberOfEntries ?? 0;
+
+        if (TryGetPostingListForNull(field, out var nullPostingListId))
+            covered += NumberOfDocumentsUnderSpecificTerm(nullPostingListId);
+
+        return covered >= NumberOfEntriesForExists(field);
     }
 
     public bool TryGetTermsOfField(in FieldMetadata field, out ExistsTermsProvider<Lookup<CompactKeyLookup>.ForwardIterator> existsTermsProvider)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.cs
@@ -671,7 +671,7 @@ internal static partial class QueryPlanBuilder
             }
             if (ctx.OrderByFields[0].MayHaveMissingEntries)
             {
-                rejectReason = "some documents have no value for the sort field (a direct scan can't place them in order)";
+                rejectReason = "some documents have no value of the sort field's type (a direct scan can't place them in order)";
                 return false;
             }
             if (ctx.OrderByFields[0].FieldType is not (MatchCompareFieldType.Sequence or MatchCompareFieldType.Integer or MatchCompareFieldType.Floating))

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Sorting.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Sorting.cs
@@ -277,7 +277,9 @@ internal static partial class QueryPlanBuilder
                     var p = template.Prebuilt[i];
                     bool mayHaveMissingEntries = p.MayHaveMissingEntries
                         || indexSearcher.GetDistinctTermCountInField(fieldMeta) == 0 // no entries at all
-                        || indexSearcher.HasAnyNonExistingEntries(fieldMeta);         
+                        || indexSearcher.HasAnyNonExistingEntries(fieldMeta)
+                        // a mixed-type field has entries the tree we would scan never sees (RavenDB-27035)
+                        || indexSearcher.SortFieldTreeCoversAllEntries(fieldMeta, p.FieldType) == false;
                     result[i] = new OrderMetadata(fieldMeta, p.Ascending, p.FieldType, p.NullsSortMode, mayHaveMissingEntries);
                     break;
                 }

--- a/test/SlowTests.Issues/Issues/RavenDB_27035.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27035.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Raven.Client.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27035 : RavenTestBase
+{
+    public RavenDB_27035(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Movie
+    {
+        public string Id { get; set; }
+
+        public object Title { get; set; }
+
+        public int Year { get; set; }
+    }
+
+    private class Movies_ByTitle : AbstractIndexCreationTask<Movie>
+    {
+        public Movies_ByTitle()
+        {
+            Map = movies => from m in movies
+                            select new
+                            {
+                                m.Title
+                            };
+        }
+    }
+
+    // the second field keeps a document without Title in the index, so Title lands in the non-existing posting list
+    private class Movies_ByTitleAndYear : AbstractIndexCreationTask<Movie>
+    {
+        public Movies_ByTitleAndYear()
+        {
+            Map = movies => from m in movies
+                            select new
+                            {
+                                m.Title,
+                                m.Year
+                            };
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void OrderByShouldNotDropDocumentsWhenFieldHasTimeAndStringValues(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Movie { Id = "movies/1", Title = "Alpha" });
+                session.Store(new Movie { Id = "movies/2", Title = "Beta" });
+                session.Store(new Movie { Id = "movies/3", Title = "Gamma" });
+                session.Store(new Movie { Id = "movies/4", Title = "Zulu" });
+                session.Store(new Movie { Id = "movies/5", Title = "01:02:03" }); // indexed as a TimeSpan, marks Title as a time field
+                session.SaveChanges();
+            }
+
+            store.ExecuteIndex(new Movies_ByTitle());
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                Assert.Equal(5, session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitle'").ToList().Count);
+                Assert.Equal(5, session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitle' order by Title").ToList().Count);
+                Assert.Equal(5, session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitle' order by Title desc").ToList().Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void OrderByAsLongShouldNotDropDocumentsWhenFieldHasNumericAndStringValues(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Movie { Id = "movies/1", Title = "Alpha" });
+                session.Store(new Movie { Id = "movies/2", Title = "Beta" });
+                session.Store(new Movie { Id = "movies/3", Title = "Gamma" });
+                session.Store(new Movie { Id = "movies/4", Title = "Zulu" });
+                session.Store(new Movie { Id = "movies/5", Title = 300L });
+                session.SaveChanges();
+            }
+
+            store.ExecuteIndex(new Movies_ByTitle());
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                Assert.Equal(5, session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitle' order by Title as long").ToList().Count);
+                Assert.Equal(5, session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitle' order by Title as double").ToList().Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void DirectScanIsStillUsedWhenTheSortFieldIsHomogeneous(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                for (var i = 0; i < 10; i++)
+                    session.Store(new Movie { Id = $"movies/{i}", Title = (long)i });
+
+                session.SaveChanges();
+            }
+
+            store.ExecuteIndex(new Movies_ByTitle());
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                QueryTimings timings = null;
+
+                var results = session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitle' order by Title as long include timings()")
+                    .Timings(out timings)
+                    .ToList();
+
+                Assert.Equal(10, results.Count);
+
+                var plan = Assert.IsType<QueryInspectionNode>(timings.QueryPlan);
+
+                // the numeric tree covers every entry, so the scan drives the query and the sort is elided
+                Assert.True(PlanContains(plan, "DirectScan"), PlanOperations(plan));
+                Assert.False(PlanContains(plan, "SortingMatch"), PlanOperations(plan));
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void DirectScanIsStillUsedWhenTheSortFieldIsAllStrings(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                for (var i = 0; i < 10; i++)
+                    session.Store(new Movie { Id = $"movies/{i}", Title = $"movie-{i}" });
+
+                session.SaveChanges();
+            }
+
+            store.ExecuteIndex(new Movies_ByTitle());
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                QueryTimings timings = null;
+
+                var results = session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitle' order by Title include timings()")
+                    .Timings(out timings)
+                    .ToList();
+
+                Assert.Equal(10, results.Count);
+
+                var plan = Assert.IsType<QueryInspectionNode>(timings.QueryPlan);
+
+                Assert.True(PlanContains(plan, "DirectScan"), PlanOperations(plan));
+                Assert.False(PlanContains(plan, "SortingMatch"), PlanOperations(plan));
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void OneValueOfAnotherTypeIsEnoughToDisqualifyTheScan(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            SetupNullAndMissingValues(store, extraStringTitle: true);
+
+            using (var session = store.OpenSession())
+            {
+                QueryTimings timings = null;
+
+                var results = session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitleAndYear' order by Title as long include timings()")
+                    .Timings(out timings)
+                    .ToList();
+
+                Assert.Equal(5, results.Count);
+
+                var plan = Assert.IsType<QueryInspectionNode>(timings.QueryPlan);
+
+                Assert.True(PlanContains(plan, "SortingMatch"), PlanOperations(plan));
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void NullAndMissingValuesAloneDoNotChangeTheResultSet(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            SetupNullAndMissingValues(store, extraStringTitle: false);
+
+            using (var session = store.OpenSession())
+            {
+                var results = session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitleAndYear' order by Title as long").ToList();
+
+                Assert.Equal(4, results.Count);
+            }
+        }
+    }
+
+    private void SetupNullAndMissingValues(IDocumentStore store, bool extraStringTitle)
+    {
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Movie { Id = "movies/1", Title = 10L, Year = 2001 });
+            session.Store(new Movie { Id = "movies/2", Title = 20L, Year = 2002 });
+            session.Store(new Movie { Id = "movies/3", Title = null, Year = 2003 });
+
+            if (extraStringTitle)
+                session.Store(new Movie { Id = "movies/5", Title = "Alpha", Year = 2005 });
+
+            session.SaveChanges();
+        }
+
+        // no Title field at all - it lands in the field's non-existing posting list
+        using (var bulk = store.BulkInsert())
+            bulk.Store(new { Year = 2004 }, "movies/4", new MetadataAsDictionary { [Constants.Documents.Metadata.Collection] = "Movies" });
+
+        store.ExecuteIndex(new Movies_ByTitleAndYear());
+        Indexes.WaitForIndexing(store);
+    }
+
+    // after the fix a mixed-type field falls back to the bitmap pipeline, so a page has to come out of the sort, not the scan
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void PagingANumericOrderByOnAMixedTypeFieldReturnsTheCorrectPage(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Movie { Id = "movies/10", Title = 10L });
+                session.Store(new Movie { Id = "movies/20", Title = 20L });
+                session.Store(new Movie { Id = "movies/30", Title = 30L });
+                session.Store(new Movie { Id = "movies/40", Title = 40L });
+                session.Store(new Movie { Id = "movies/str", Title = "Alpha" });
+                session.SaveChanges();
+            }
+
+            store.ExecuteIndex(new Movies_ByTitle());
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var page = session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitle' order by Title as long desc limit 2")
+                    .ToList();
+
+                Assert.Equal(new[] { "movies/40", "movies/30" }, page.Select(x => x.Id).ToArray());
+            }
+        }
+    }
+
+    // terms sharing 160 bytes are equal in the bytes the textual sort key keeps, so a page must not be picked by them
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void PagingATextualOrderByOnCollidingTermsReturnsTheCorrectPage(Options options)
+    {
+        var prefix = new string('a', 160);
+
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                for (var i = 1; i <= 4; i++)
+                    session.Store(new Movie { Id = $"movies/{i}", Title = prefix + i.ToString("0000") });
+
+                session.Store(new Movie { Id = "movies/time", Title = "01:02:03" });
+                session.SaveChanges();
+            }
+
+            store.ExecuteIndex(new Movies_ByTitle());
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var page = session.Advanced.RawQuery<Movie>("from index 'Movies/ByTitle' order by Title as string desc limit 2")
+                    .ToList();
+
+                Assert.Equal(new[] { "movies/4", "movies/3" }, page.Select(x => x.Id).ToArray());
+            }
+        }
+    }
+
+    private static bool PlanContains(QueryInspectionNode node, string operation)
+    {
+        if (node.Operation != null && node.Operation.Contains(operation, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (node.Children == null)
+            return false;
+
+        foreach (var child in node.Children)
+        {
+            if (PlanContains(child, operation))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string PlanOperations(QueryInspectionNode node)
+    {
+        var operations = new List<string>();
+        Collect(node, operations);
+        return string.Join(" -> ", operations);
+
+        static void Collect(QueryInspectionNode current, List<string> into)
+        {
+            into.Add(current.Operation);
+
+            if (current.Children == null)
+                return;
+
+            foreach (var child in current.Children)
+                Collect(child, into);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27035

### Additional description

Port of the 6.2 fix. Corax 2.0 already rejects the direct scan when the sort field `MayHaveMissingEntries`, but that predicate is computed per field (`GetDistinctTermCountInField`, `HasAnyNonExistingEntries`) and cannot see that the tree the scan would walk holds only one of the field's types, so the 5-document reproduction drops 4 documents there as well. On a large index the predicate can trip for an unrelated reason and mask the defect.

`SortFieldTreeCoversAllEntries` is added to `IndexSearcher` as on 6.2, using this branch's own O(1) helpers (`NumberOfDocumentsUnderSpecificTerm` for the encoding-aware posting list count, `NumberOfEntriesForExists` for the target), and joins `mayHaveMissingEntries` as an extra disjunct - the existing checks are not relaxed, the plan only ever moves from the direct scan to the `BitmapPipeline` + `SortingMatch` path it already falls back to. The `DecisionTrail` reject reason is reworded, since the rejection is now also about the value's type and not only about missing values.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

A query with no WHERE clause ordering by a mixed-type field now returns every matching document instead of the sort type's subset, and runs `AllEntries` + `SortingMatch` instead of the sort-field scan. Homogeneous fields keep the scan, asserted by tests over the query plan.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
