### PR TITLE
RavenDB-22083 Report a proper IndexCompilationException for a C# index whose outer from clause does not enumerate the documents source

### DIFF
--- a/src/Raven.Client/Documents/Indexes/AbstractMultiMapIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractMultiMapIndexCreationTask.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Raven.Client.Documents.Conventions;
-using Raven.Client.Exceptions.Documents.Compilation;
 
 namespace Raven.Client.Documents.Indexes
 {
@@ -109,18 +108,7 @@ namespace Raven.Client.Documents.Indexes
 
             var indexDefinition = builder.ToIndexDefinition(Conventions, validateMap: false);
 
-            try
-            {
-                foreach (var map in _maps.Select(generateMap => generateMap()))
-                {
-                    string formattedMap = map;
-                    indexDefinition.Maps.Add(formattedMap);
-                }
-            }
-            catch (Exception e)
-            {
-                throw new IndexCompilationException("Failed to create index " + IndexName, e);
-            }
+            IndexDefinitionHelper.AddMaps(indexDefinition.Maps, _maps, IndexName);
 
             return indexDefinition;
         }

--- a/src/Raven.Client/Documents/Indexes/AbstractMultiMapIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractMultiMapIndexCreationTask.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Exceptions.Documents.Compilation;
 
 namespace Raven.Client.Documents.Indexes
 {
@@ -108,10 +109,17 @@ namespace Raven.Client.Documents.Indexes
 
             var indexDefinition = builder.ToIndexDefinition(Conventions, validateMap: false);
 
-            foreach (var map in _maps.Select(generateMap => generateMap()))
+            try
             {
-                string formattedMap = map;
-                indexDefinition.Maps.Add(formattedMap);
+                foreach (var map in _maps.Select(generateMap => generateMap()))
+                {
+                    string formattedMap = map;
+                    indexDefinition.Maps.Add(formattedMap);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new IndexCompilationException("Failed to create index " + IndexName, e);
             }
 
             return indexDefinition;

--- a/src/Raven.Client/Documents/Indexes/Counters/AbstractMultiMapCountersIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/Counters/AbstractMultiMapCountersIndexCreationTask.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Raven.Client.Documents.Conventions;
-using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Indexes.Counters
@@ -111,18 +110,7 @@ namespace Raven.Client.Documents.Indexes.Counters
 
             var indexDefinition = builder.ToIndexDefinition(Conventions, validateMap: false);
 
-            try
-            {
-                foreach (var map in _maps.Select(generateMap => generateMap()))
-                {
-                    string formattedMap = map;
-                    indexDefinition.Maps.Add(formattedMap);
-                }
-            }
-            catch (Exception e)
-            {
-                throw new IndexCompilationException("Failed to create index " + IndexName, e);
-            }
+            IndexDefinitionHelper.AddMaps(indexDefinition.Maps, _maps, IndexName);
 
             return indexDefinition;
         }

--- a/src/Raven.Client/Documents/Indexes/Counters/AbstractMultiMapCountersIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/Counters/AbstractMultiMapCountersIndexCreationTask.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Indexes.Counters
@@ -110,10 +111,17 @@ namespace Raven.Client.Documents.Indexes.Counters
 
             var indexDefinition = builder.ToIndexDefinition(Conventions, validateMap: false);
 
-            foreach (var map in _maps.Select(generateMap => generateMap()))
+            try
             {
-                string formattedMap = map;
-                indexDefinition.Maps.Add(formattedMap);
+                foreach (var map in _maps.Select(generateMap => generateMap()))
+                {
+                    string formattedMap = map;
+                    indexDefinition.Maps.Add(formattedMap);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new IndexCompilationException("Failed to create index " + IndexName, e);
             }
 
             return indexDefinition;

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
@@ -100,7 +100,7 @@ namespace Raven.Client.Documents.Indexes
 
         private static void ThrowIfEnumerationDoesNotStartFromQuerySource(LambdaExpression expr, ParameterExpression querySourceParameter, string linqQuery)
         {
-            var body = StripConvert(expr.Body);
+            var body = expr.Body.SkipConvertExpressions();
             if (body is MethodCallExpression == false)
                 return;
 
@@ -111,7 +111,7 @@ namespace Raven.Client.Documents.Indexes
                 if (source == null)
                     break;
 
-                root = StripConvert(source);
+                root = source.SkipConvertExpressions();
             }
 
             if (root is ParameterExpression parameter && parameter.Name == querySourceParameter.Name)
@@ -121,14 +121,6 @@ namespace Raven.Client.Documents.Indexes
                 $"An index function must start its enumeration from the '{querySourceParameter.Name}' parameter, e.g. 'from item in {querySourceParameter.Name}'. " +
                 $"The outer-most clause of the given expression enumerates over a different source, which cannot be compiled into an index. " +
                 $"Generated code: {linqQuery}");
-        }
-
-        private static Expression StripConvert(Expression expression)
-        {
-            while (expression.NodeType == ExpressionType.Convert || expression.NodeType == ExpressionType.ConvertChecked)
-                expression = ((UnaryExpression)expression).Operand;
-
-            return expression;
         }
 
         private static MethodCallExpression GetFirstMethodCallExpression(Expression expression)

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
@@ -66,6 +66,12 @@ namespace Raven.Client.Documents.Indexes
             if (indexOfQuerySource == -1)
                 throw new InvalidOperationException("Cannot understand how to parse the query");
 
+            if (indexOfQuerySource != 0)
+                throw new IndexCompilationException(
+                    $"An index function must start its enumeration from the '{querySourceName}' parameter, e.g. 'from item in {querySourceName}'. " +
+                    $"The outer-most clause of the given expression enumerates over a different source, which cannot be compiled into an index. " +
+                    $"Generated code: {linqQuery}");
+
             linqQuery = linqQuery.Substring(0, indexOfQuerySource) + querySource +
                         linqQuery.Substring(indexOfQuerySource + querySourceName.Length);
 

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
@@ -100,7 +100,7 @@ namespace Raven.Client.Documents.Indexes
                 root = StripConvert(source);
             }
 
-            if (root is ParameterExpression parameter && ReferenceEquals(parameter, querySourceParameter))
+            if (root is ParameterExpression parameter && parameter.Name == querySourceParameter.Name)
                 return;
 
             throw new IndexCompilationException(

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
@@ -62,9 +62,11 @@ namespace Raven.Client.Documents.Indexes
         {
             var querySourceName = expr.Parameters.First().Name;
 
-            var indexOfQuerySource = linqQuery.IndexOf(querySourceName, StringComparison.Ordinal);
-            if (indexOfQuerySource == -1)
+            var querySourceMatch = Regex.Match(linqQuery, $@"\b{Regex.Escape(querySourceName)}\b");
+            if (querySourceMatch.Success == false)
                 throw new InvalidOperationException("Cannot understand how to parse the query");
+
+            var indexOfQuerySource = querySourceMatch.Index;
 
             if (indexOfQuerySource != 0)
                 throw new IndexCompilationException(

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
@@ -56,6 +57,19 @@ namespace Raven.Client.Documents.Indexes
             var linqQuery = ExpressionStringBuilder.ExpressionToString(conventions, translateIdentityProperty, typeof(TQueryRoot), queryRootName, expression, isReduce);
 
             return FormatLinqQuery(expr, querySource, linqQuery);
+        }
+
+        internal static void AddMaps(ISet<string> maps, IEnumerable<Func<string>> generateMaps, string indexName)
+        {
+            try
+            {
+                foreach (var generateMap in generateMaps)
+                    maps.Add(generateMap());
+            }
+            catch (Exception e)
+            {
+                throw new IndexCompilationException("Failed to create index " + indexName, e);
+            }
         }
 
         private static string FormatLinqQuery(LambdaExpression expr, string querySource, string linqQuery)

--- a/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinitionHelper.cs
@@ -60,19 +60,16 @@ namespace Raven.Client.Documents.Indexes
 
         private static string FormatLinqQuery(LambdaExpression expr, string querySource, string linqQuery)
         {
-            var querySourceName = expr.Parameters.First().Name;
+            var querySourceParameter = expr.Parameters.First();
+            var querySourceName = querySourceParameter.Name;
+
+            ThrowIfEnumerationDoesNotStartFromQuerySource(expr, querySourceParameter, linqQuery);
 
             var querySourceMatch = Regex.Match(linqQuery, $@"\b{Regex.Escape(querySourceName)}\b");
             if (querySourceMatch.Success == false)
                 throw new InvalidOperationException("Cannot understand how to parse the query");
 
             var indexOfQuerySource = querySourceMatch.Index;
-
-            if (indexOfQuerySource != 0)
-                throw new IndexCompilationException(
-                    $"An index function must start its enumeration from the '{querySourceName}' parameter, e.g. 'from item in {querySourceName}'. " +
-                    $"The outer-most clause of the given expression enumerates over a different source, which cannot be compiled into an index. " +
-                    $"Generated code: {linqQuery}");
 
             linqQuery = linqQuery.Substring(0, indexOfQuerySource) + querySource +
                         linqQuery.Substring(indexOfQuerySource + querySourceName.Length);
@@ -85,6 +82,39 @@ namespace Raven.Client.Documents.Indexes
 
             linqQuery = JSBeautify.Apply(linqQuery);
             return linqQuery;
+        }
+
+        private static void ThrowIfEnumerationDoesNotStartFromQuerySource(LambdaExpression expr, ParameterExpression querySourceParameter, string linqQuery)
+        {
+            var body = StripConvert(expr.Body);
+            if (body is MethodCallExpression == false)
+                return;
+
+            var root = body;
+            while (root is MethodCallExpression call)
+            {
+                var source = call.Object ?? call.Arguments.FirstOrDefault();
+                if (source == null)
+                    break;
+
+                root = StripConvert(source);
+            }
+
+            if (root is ParameterExpression parameter && ReferenceEquals(parameter, querySourceParameter))
+                return;
+
+            throw new IndexCompilationException(
+                $"An index function must start its enumeration from the '{querySourceParameter.Name}' parameter, e.g. 'from item in {querySourceParameter.Name}'. " +
+                $"The outer-most clause of the given expression enumerates over a different source, which cannot be compiled into an index. " +
+                $"Generated code: {linqQuery}");
+        }
+
+        private static Expression StripConvert(Expression expression)
+        {
+            while (expression.NodeType == ExpressionType.Convert || expression.NodeType == ExpressionType.ConvertChecked)
+                expression = ((UnaryExpression)expression).Operand;
+
+            return expression;
         }
 
         private static MethodCallExpression GetFirstMethodCallExpression(Expression expression)

--- a/src/Raven.Client/Documents/Indexes/TimeSeries/AbstractMultiMapTimeSeriesIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/TimeSeries/AbstractMultiMapTimeSeriesIndexCreationTask.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Raven.Client.Documents.Conventions;
-using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Indexes.TimeSeries
@@ -111,18 +110,7 @@ namespace Raven.Client.Documents.Indexes.TimeSeries
 
             var indexDefinition = builder.ToIndexDefinition(Conventions, validateMap: false);
 
-            try
-            {
-                foreach (var map in _maps.Select(generateMap => generateMap()))
-                {
-                    string formattedMap = map;
-                    indexDefinition.Maps.Add(formattedMap);
-                }
-            }
-            catch (Exception e)
-            {
-                throw new IndexCompilationException("Failed to create index " + IndexName, e);
-            }
+            IndexDefinitionHelper.AddMaps(indexDefinition.Maps, _maps, IndexName);
 
             return indexDefinition;
         }

--- a/src/Raven.Client/Documents/Indexes/TimeSeries/AbstractMultiMapTimeSeriesIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/TimeSeries/AbstractMultiMapTimeSeriesIndexCreationTask.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Indexes.TimeSeries
@@ -110,10 +111,17 @@ namespace Raven.Client.Documents.Indexes.TimeSeries
 
             var indexDefinition = builder.ToIndexDefinition(Conventions, validateMap: false);
 
-            foreach (var map in _maps.Select(generateMap => generateMap()))
+            try
             {
-                string formattedMap = map;
-                indexDefinition.Maps.Add(formattedMap);
+                foreach (var map in _maps.Select(generateMap => generateMap()))
+                {
+                    string formattedMap = map;
+                    indexDefinition.Maps.Add(formattedMap);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new IndexCompilationException("Failed to create index " + IndexName, e);
             }
 
             return indexDefinition;

--- a/src/Raven.Client/Extensions/ExpressionExtensions.cs
+++ b/src/Raven.Client/Extensions/ExpressionExtensions.cs
@@ -14,6 +14,14 @@ namespace Raven.Client.Extensions
     ///</summary>
     internal static class ExpressionExtensions
     {
+        public static Expression SkipConvertExpressions(this Expression expression)
+        {
+            while (expression.NodeType == ExpressionType.Convert || expression.NodeType == ExpressionType.ConvertChecked)
+                expression = ((UnaryExpression)expression).Operand;
+
+            return expression;
+        }
+
         public static MemberInfo ToProperty(this LambdaExpression expr)
         {
             var expression = expr.Body;

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -448,9 +448,9 @@ function map(name, lambda) {
                     var result = ExecuteCodeAndCollectReferencedCollections(map, additionalSources);
                     mapReferencedCollections.Add(result);
                 }
-                catch (Exception e) when (e is IndexCreationException == false && e is OperationCanceledException == false)
+                catch (Exception e)
                 {
-                    throw new IndexCompilationException($"Failed to compile the map of JavaScript index '{Definition.Name}', the map must be valid JavaScript. Map: {map}", e);
+                    throw new IndexCompilationException($"Failed to compile the map of JavaScript index '{Definition.Name}': {e.Message}", e);
                 }
             }
 
@@ -460,9 +460,9 @@ function map(name, lambda) {
                 {
                     _engine.ExecuteWithReset(definition.Reduce);
                 }
-                catch (Exception e) when (e is IndexCreationException == false && e is OperationCanceledException == false)
+                catch (Exception e)
                 {
-                    throw new IndexCompilationException($"Failed to compile the reduce of JavaScript index '{Definition.Name}', the reduce must be valid JavaScript. Reduce: {definition.Reduce}", e);
+                    throw new IndexCompilationException($"Failed to compile the reduce of JavaScript index '{Definition.Name}': {e.Message}", e);
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -308,16 +308,14 @@ function map(name, lambda) {
 
                     case IndexSourceType.Counters:
                         return new CountersJavaScriptIndex(definition, configuration, indexVersion);
-
-                    default:
-                        throw new NotSupportedException($"Not supported source type '{definition.SourceType}'.");
                 }
             }
             catch (Exception e) when (e is IndexCompilationException == false && e is IndexCreationException == false)
             {
                 IndexCompilationException.ThrowFor(definition.Name, e.Message, e);
-                return null;
             }
+
+            throw new NotSupportedException($"Not supported source type '{definition.SourceType}'.");
         }
 
         private void ProcessFields(IndexDefinition definition, Dictionary<string, Dictionary<string, List<JavaScriptMapOperation>>> collectionFunctions)

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -447,16 +447,16 @@ function map(name, lambda) {
 
             var mapReferencedCollections = new List<MapMetadata>();
             var additionalSources = sb.ToString();
-            foreach (var map in maps)
+            for (var i = 0; i < maps.Count; i++)
             {
                 try
                 {
-                    var result = ExecuteCodeAndCollectReferencedCollections(map, additionalSources);
+                    var result = ExecuteCodeAndCollectReferencedCollections(maps[i], additionalSources);
                     mapReferencedCollections.Add(result);
                 }
                 catch (Exception e)
                 {
-                    IndexCompilationException.ThrowFor(Definition.Name, e.Message, e, nameof(IndexDefinition.Maps), map);
+                    IndexCompilationException.ThrowFor(Definition.Name, e.Message, e, nameof(IndexDefinition.Maps), definition.Maps.ElementAt(i));
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -296,19 +296,27 @@ function map(name, lambda) {
 
         internal static AbstractJavaScriptIndex Create(IndexDefinition definition, RavenConfiguration configuration, long indexVersion)
         {
-            switch (definition.SourceType)
+            try
             {
-                case IndexSourceType.Documents:
-                    return new JavaScriptIndex(definition, configuration, indexVersion);
+                switch (definition.SourceType)
+                {
+                    case IndexSourceType.Documents:
+                        return new JavaScriptIndex(definition, configuration, indexVersion);
 
-                case IndexSourceType.TimeSeries:
-                    return new TimeSeriesJavaScriptIndex(definition, configuration, indexVersion);
+                    case IndexSourceType.TimeSeries:
+                        return new TimeSeriesJavaScriptIndex(definition, configuration, indexVersion);
 
-                case IndexSourceType.Counters:
-                    return new CountersJavaScriptIndex(definition, configuration, indexVersion);
+                    case IndexSourceType.Counters:
+                        return new CountersJavaScriptIndex(definition, configuration, indexVersion);
 
-                default:
-                    throw new NotSupportedException($"Not supported source type '{definition.SourceType}'.");
+                    default:
+                        throw new NotSupportedException($"Not supported source type '{definition.SourceType}'.");
+                }
+            }
+            catch (Exception e) when (e is IndexCompilationException == false && e is IndexCreationException == false)
+            {
+                IndexCompilationException.ThrowFor(definition.Name, e.Message, e);
+                return null;
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -450,7 +450,7 @@ function map(name, lambda) {
                 }
                 catch (Exception e)
                 {
-                    throw new IndexCompilationException($"Failed to compile the map of JavaScript index '{Definition.Name}': {e.Message}", e);
+                    IndexCompilationException.ThrowFor(Definition.Name, e.Message, e, nameof(IndexDefinition.Maps), map);
                 }
             }
 
@@ -462,7 +462,7 @@ function map(name, lambda) {
                 }
                 catch (Exception e)
                 {
-                    throw new IndexCompilationException($"Failed to compile the reduce of JavaScript index '{Definition.Name}': {e.Message}", e);
+                    IndexCompilationException.ThrowFor(Definition.Name, e.Message, e, nameof(IndexDefinition.Reduce), definition.Reduce);
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -13,6 +13,7 @@ using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Server.Config;
 using Raven.Server.Documents.AI.Embeddings;
@@ -442,13 +443,27 @@ function map(name, lambda) {
             var additionalSources = sb.ToString();
             foreach (var map in maps)
             {
-                var result = ExecuteCodeAndCollectReferencedCollections(map, additionalSources);
-                mapReferencedCollections.Add(result);
+                try
+                {
+                    var result = ExecuteCodeAndCollectReferencedCollections(map, additionalSources);
+                    mapReferencedCollections.Add(result);
+                }
+                catch (Exception e) when (e is IndexCreationException == false && e is OperationCanceledException == false)
+                {
+                    throw new IndexCompilationException($"Failed to compile the map of JavaScript index '{Definition.Name}', the map must be valid JavaScript. Map: {map}", e);
+                }
             }
 
             if (definition.Reduce != null)
             {
-                _engine.ExecuteWithReset(definition.Reduce);
+                try
+                {
+                    _engine.ExecuteWithReset(definition.Reduce);
+                }
+                catch (Exception e) when (e is IndexCreationException == false && e is OperationCanceledException == false)
+                {
+                    throw new IndexCompilationException($"Failed to compile the reduce of JavaScript index '{Definition.Name}', the reduce must be valid JavaScript. Reduce: {definition.Reduce}", e);
+                }
             }
 
             return mapReferencedCollections;

--- a/test/FastTests/Issues/RavenDB_22083.cs
+++ b/test/FastTests/Issues/RavenDB_22083.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_22083 : RavenTestBase
+    {
+        public RavenDB_22083(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Animal
+        {
+            public string Name { get; set; }
+        }
+
+        private class Dog : Animal
+        {
+        }
+
+        private class Cat : Animal
+        {
+        }
+
+        private class MultiMapIndexWithAddMapForAll : AbstractMultiMapIndexCreationTask
+        {
+            public MultiMapIndexWithAddMapForAll()
+            {
+                AddMapForAll<Animal>(animals => from animal in animals select new { animal.Name });
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void MultiMap_Index_With_AddMapForAll_Creates_Definition()
+        {
+            var definition = new MultiMapIndexWithAddMapForAll().CreateIndexDefinition();
+
+            Assert.Equal(3, definition.Maps.Count);
+        }
+    }
+}

--- a/test/FastTests/Issues/RavenDB_22083.cs
+++ b/test/FastTests/Issues/RavenDB_22083.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Linq;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Documents.Compilation;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -9,6 +11,84 @@ namespace FastTests.Issues
     {
         public RavenDB_22083(ITestOutputHelper output) : base(output)
         {
+        }
+
+        private class Candle
+        {
+            public string Id { get; set; }
+            public float[] Ohlc { get; set; }
+            public float Volume { get; set; }
+            public long Time { get; set; }
+        }
+
+        private class AggregateCandle
+        {
+            public string Ref { get; set; }
+            public float Volume { get; set; }
+            public string Timeframe { get; set; }
+        }
+
+        private class IndexWithConstantArrayAsOuterSource : AbstractIndexCreationTask<Candle, AggregateCandle>
+        {
+            public IndexWithConstantArrayAsOuterSource()
+            {
+                Map = candles => from x in new[]
+                    {
+                        new Tuple<long, string>(60000, "1m"),
+                        new Tuple<long, string>(60000 * 5, "5m")
+                    }
+                    from candle in candles
+                    select new AggregateCandle
+                    {
+                        Ref = $"{candle.Time / x.Item1}",
+                        Volume = candle.Volume,
+                        Timeframe = x.Item2
+                    };
+
+                Reduce = results => from result in results
+                    group result by new { result.Timeframe, result.Ref }
+                    into g
+                    select new AggregateCandle
+                    {
+                        Ref = g.Key.Ref,
+                        Volume = g.Sum(x => x.Volume),
+                        Timeframe = g.Key.Timeframe
+                    };
+            }
+        }
+
+        private class IndexWithParameterNamePrefixingOuterSource : AbstractIndexCreationTask<Candle, AggregateCandle>
+        {
+            public IndexWithParameterNamePrefixingOuterSource()
+            {
+                Map = n => from t in new[] { 60000L, 300000L }
+                    from candle in n
+                    select new AggregateCandle
+                    {
+                        Ref = $"{candle.Time / t}",
+                        Volume = candle.Volume,
+                        Timeframe = "1m"
+                    };
+            }
+        }
+
+        private class MultiMapIndexWithConstantArrayAsOuterSource : AbstractMultiMapIndexCreationTask<AggregateCandle>
+        {
+            public MultiMapIndexWithConstantArrayAsOuterSource()
+            {
+                AddMap<Candle>(candles => from x in new[]
+                    {
+                        new Tuple<long, string>(60000, "1m"),
+                        new Tuple<long, string>(60000 * 5, "5m")
+                    }
+                    from candle in candles
+                    select new AggregateCandle
+                    {
+                        Ref = $"{candle.Time / x.Item1}",
+                        Volume = candle.Volume,
+                        Timeframe = x.Item2
+                    });
+            }
         }
 
         private class Animal
@@ -30,6 +110,31 @@ namespace FastTests.Issues
             {
                 AddMapForAll<Animal>(animals => from animal in animals select new { animal.Name });
             }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void Index_With_Constant_Array_As_Outer_Source_Throws_Descriptive_Exception()
+        {
+            var e = Assert.Throws<IndexCompilationException>(() => new IndexWithConstantArrayAsOuterSource().CreateIndexDefinition());
+
+            Assert.Contains("must start its enumeration from the 'candles' parameter", e.InnerException.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void Index_With_Parameter_Name_Prefixing_Outer_Source_Throws_Descriptive_Exception()
+        {
+            var e = Assert.Throws<IndexCompilationException>(() => new IndexWithParameterNamePrefixingOuterSource().CreateIndexDefinition());
+
+            Assert.Contains("must start its enumeration from the 'n' parameter", e.InnerException.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void MultiMap_Index_With_Constant_Array_As_Outer_Source_Throws_Descriptive_Exception()
+        {
+            var e = Assert.Throws<IndexCompilationException>(() => new MultiMapIndexWithConstantArrayAsOuterSource().CreateIndexDefinition());
+
+            Assert.Contains("Failed to create index", e.Message);
+            Assert.Contains("must start its enumeration from the 'candles' parameter", e.InnerException.Message);
         }
 
         [RavenFact(RavenTestCategory.Indexes)]

--- a/test/FastTests/Issues/RavenDB_22083.cs
+++ b/test/FastTests/Issues/RavenDB_22083.cs
@@ -44,16 +44,6 @@ namespace FastTests.Issues
                         Volume = candle.Volume,
                         Timeframe = x.Item2
                     };
-
-                Reduce = results => from result in results
-                    group result by new { result.Timeframe, result.Ref }
-                    into g
-                    select new AggregateCandle
-                    {
-                        Ref = g.Key.Ref,
-                        Volume = g.Sum(x => x.Volume),
-                        Timeframe = g.Key.Timeframe
-                    };
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_22083.cs
+++ b/test/SlowTests/Issues/RavenDB_22083.cs
@@ -145,5 +145,55 @@ namespace SlowTests.Issues
 
             Assert.Contains("must start its enumeration from the 'n' parameter", e.InnerException.Message);
         }
+
+        private class IndexWithOrderedReduce : AbstractIndexCreationTask<Candle, AggregateCandle>
+        {
+            public IndexWithOrderedReduce()
+            {
+                Map = candles => from candle in candles
+                    select new AggregateCandle
+                    {
+                        Ref = $"{candle.Time / 60000}",
+                        Volume = candle.Volume,
+                        Timeframe = "1m"
+                    };
+
+                Reduce = results => results
+                    .GroupBy(x => new { x.Timeframe, x.Ref })
+                    .Select(g => new AggregateCandle
+                    {
+                        Ref = g.Key.Ref,
+                        Volume = g.Sum(x => x.Volume),
+                        Timeframe = g.Key.Timeframe
+                    })
+                    .OrderBy(x => x.Ref);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void Index_With_Ordered_Reduce_Deploys_And_Indexes()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new IndexWithOrderedReduce());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Candle { Volume = 1, Time = 60000 });
+                    session.Store(new Candle { Volume = 2, Time = 60000 });
+                    session.SaveChanges();
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var results = session.Query<AggregateCandle, IndexWithOrderedReduce>().ToList();
+
+                    Assert.Equal(1, results.Count);
+                    Assert.Equal(3, results[0].Volume);
+                }
+            }
+        }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_22083.cs
+++ b/test/SlowTests/Issues/RavenDB_22083.cs
@@ -146,6 +146,34 @@ namespace SlowTests.Issues
             Assert.Contains("must start its enumeration from the 'n' parameter", e.InnerException.Message);
         }
 
+        private class MultiMapIndexWithConstantArrayAsOuterSource : AbstractMultiMapIndexCreationTask<AggregateCandle>
+        {
+            public MultiMapIndexWithConstantArrayAsOuterSource()
+            {
+                AddMap<Candle>(candles => from x in new[]
+                    {
+                        new Tuple<long, string>(60000, "1m"),
+                        new Tuple<long, string>(60000 * 5, "5m")
+                    }
+                    from candle in candles
+                    select new AggregateCandle
+                    {
+                        Ref = $"{candle.Time / x.Item1}",
+                        Volume = candle.Volume,
+                        Timeframe = x.Item2
+                    });
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void MultiMap_Index_With_Constant_Array_As_Outer_Source_Throws_Descriptive_Exception()
+        {
+            var e = Assert.Throws<IndexCompilationException>(() => new MultiMapIndexWithConstantArrayAsOuterSource().CreateIndexDefinition());
+
+            Assert.Contains("Failed to create index", e.Message);
+            Assert.Contains("must start its enumeration from the 'candles' parameter", e.InnerException.Message);
+        }
+
         private class IndexWithOrderedReduce : AbstractIndexCreationTask<Candle, AggregateCandle>
         {
             public IndexWithOrderedReduce()

--- a/test/SlowTests/Issues/RavenDB_22083.cs
+++ b/test/SlowTests/Issues/RavenDB_22083.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Documents.Compilation;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22083 : RavenTestBase
+    {
+        public RavenDB_22083(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Candle
+        {
+            public string Id { get; set; }
+            public float[] Ohlc { get; set; }
+            public float Volume { get; set; }
+            public long Time { get; set; }
+        }
+
+        private class AggregateCandle
+        {
+            public string Ref { get; set; }
+            public float Volume { get; set; }
+            public string Timeframe { get; set; }
+        }
+
+        private class IndexWithConstantArrayAsOuterSource : AbstractIndexCreationTask<Candle, AggregateCandle>
+        {
+            public IndexWithConstantArrayAsOuterSource()
+            {
+                Map = candles => from x in new[]
+                    {
+                        new Tuple<long, string>(60000, "1m"),
+                        new Tuple<long, string>(60000 * 5, "5m")
+                    }
+                    from candle in candles
+                    select new AggregateCandle
+                    {
+                        Ref = $"{candle.Time / x.Item1}",
+                        Volume = candle.Volume,
+                        Timeframe = x.Item2
+                    };
+
+                Reduce = results => from result in results
+                    group result by new { result.Timeframe, result.Ref }
+                    into g
+                    select new AggregateCandle
+                    {
+                        Ref = g.Key.Ref,
+                        Volume = g.Sum(x => x.Volume),
+                        Timeframe = g.Key.Timeframe
+                    };
+            }
+        }
+
+        private class IndexWithConstantArrayAsInnerSource : AbstractIndexCreationTask<Candle, AggregateCandle>
+        {
+            public IndexWithConstantArrayAsInnerSource()
+            {
+                Map = candles => from candle in candles
+                    from x in new[]
+                    {
+                        new Tuple<long, string>(60000, "1m"),
+                        new Tuple<long, string>(60000 * 5, "5m")
+                    }
+                    select new AggregateCandle
+                    {
+                        Ref = $"{candle.Time / x.Item1}",
+                        Volume = candle.Volume,
+                        Timeframe = x.Item2
+                    };
+
+                Reduce = results => from result in results
+                    group result by new { result.Timeframe, result.Ref }
+                    into g
+                    select new AggregateCandle
+                    {
+                        Ref = g.Key.Ref,
+                        Volume = g.Sum(x => x.Volume),
+                        Timeframe = g.Key.Timeframe
+                    };
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void Index_With_Constant_Array_As_Outer_Source_Throws_Descriptive_Exception()
+        {
+            var e = Assert.Throws<IndexCompilationException>(() => new IndexWithConstantArrayAsOuterSource().CreateIndexDefinition());
+
+            Assert.Contains("must start its enumeration from the 'candles' parameter", e.InnerException.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void Index_With_Constant_Array_As_Inner_Source_Deploys_And_Indexes()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.ExecuteIndex(new IndexWithConstantArrayAsInnerSource());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Candle { Volume = 1, Time = 60000 });
+                    session.Store(new Candle { Volume = 2, Time = 60000 });
+                    session.SaveChanges();
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var results = session.Query<AggregateCandle, IndexWithConstantArrayAsInnerSource>()
+                        .Where(x => x.Timeframe == "1m")
+                        .ToList();
+
+                    Assert.Equal(1, results.Count);
+                    Assert.Equal(3, results[0].Volume);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_22083.cs
+++ b/test/SlowTests/Issues/RavenDB_22083.cs
@@ -30,35 +30,6 @@ namespace SlowTests.Issues
             public string Timeframe { get; set; }
         }
 
-        private class IndexWithConstantArrayAsOuterSource : AbstractIndexCreationTask<Candle, AggregateCandle>
-        {
-            public IndexWithConstantArrayAsOuterSource()
-            {
-                Map = candles => from x in new[]
-                    {
-                        new Tuple<long, string>(60000, "1m"),
-                        new Tuple<long, string>(60000 * 5, "5m")
-                    }
-                    from candle in candles
-                    select new AggregateCandle
-                    {
-                        Ref = $"{candle.Time / x.Item1}",
-                        Volume = candle.Volume,
-                        Timeframe = x.Item2
-                    };
-
-                Reduce = results => from result in results
-                    group result by new { result.Timeframe, result.Ref }
-                    into g
-                    select new AggregateCandle
-                    {
-                        Ref = g.Key.Ref,
-                        Volume = g.Sum(x => x.Volume),
-                        Timeframe = g.Key.Timeframe
-                    };
-            }
-        }
-
         private class IndexWithConstantArrayAsInnerSource : AbstractIndexCreationTask<Candle, AggregateCandle>
         {
             public IndexWithConstantArrayAsInnerSource()
@@ -88,29 +59,6 @@ namespace SlowTests.Issues
             }
         }
 
-        private class IndexWithParameterNamePrefixingOuterSource : AbstractIndexCreationTask<Candle, AggregateCandle>
-        {
-            public IndexWithParameterNamePrefixingOuterSource()
-            {
-                Map = n => from t in new[] { 60000L, 300000L }
-                    from candle in n
-                    select new AggregateCandle
-                    {
-                        Ref = $"{candle.Time / t}",
-                        Volume = candle.Volume,
-                        Timeframe = "1m"
-                    };
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Indexes)]
-        public void Index_With_Constant_Array_As_Outer_Source_Throws_Descriptive_Exception()
-        {
-            var e = Assert.Throws<IndexCompilationException>(() => new IndexWithConstantArrayAsOuterSource().CreateIndexDefinition());
-
-            Assert.Contains("must start its enumeration from the 'candles' parameter", e.InnerException.Message);
-        }
-
         [RavenFact(RavenTestCategory.Indexes)]
         public void Index_With_Constant_Array_As_Inner_Source_Deploys_And_Indexes()
         {
@@ -137,42 +85,6 @@ namespace SlowTests.Issues
                     Assert.Equal(3, results[0].Volume);
                 }
             }
-        }
-
-        [RavenFact(RavenTestCategory.Indexes)]
-        public void Index_With_Parameter_Name_Prefixing_Outer_Source_Throws_Descriptive_Exception()
-        {
-            var e = Assert.Throws<IndexCompilationException>(() => new IndexWithParameterNamePrefixingOuterSource().CreateIndexDefinition());
-
-            Assert.Contains("must start its enumeration from the 'n' parameter", e.InnerException.Message);
-        }
-
-        private class MultiMapIndexWithConstantArrayAsOuterSource : AbstractMultiMapIndexCreationTask<AggregateCandle>
-        {
-            public MultiMapIndexWithConstantArrayAsOuterSource()
-            {
-                AddMap<Candle>(candles => from x in new[]
-                    {
-                        new Tuple<long, string>(60000, "1m"),
-                        new Tuple<long, string>(60000 * 5, "5m")
-                    }
-                    from candle in candles
-                    select new AggregateCandle
-                    {
-                        Ref = $"{candle.Time / x.Item1}",
-                        Volume = candle.Volume,
-                        Timeframe = x.Item2
-                    });
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Indexes)]
-        public void MultiMap_Index_With_Constant_Array_As_Outer_Source_Throws_Descriptive_Exception()
-        {
-            var e = Assert.Throws<IndexCompilationException>(() => new MultiMapIndexWithConstantArrayAsOuterSource().CreateIndexDefinition());
-
-            Assert.Contains("Failed to create index", e.Message);
-            Assert.Contains("must start its enumeration from the 'candles' parameter", e.InnerException.Message);
         }
 
         private class IndexWithOrderedReduce : AbstractIndexCreationTask<Candle, AggregateCandle>

--- a/test/SlowTests/Issues/RavenDB_22083.cs
+++ b/test/SlowTests/Issues/RavenDB_22083.cs
@@ -87,6 +87,21 @@ namespace SlowTests.Issues
             }
         }
 
+        private class IndexWithParameterNamePrefixingOuterSource : AbstractIndexCreationTask<Candle, AggregateCandle>
+        {
+            public IndexWithParameterNamePrefixingOuterSource()
+            {
+                Map = n => from t in new[] { 60000L, 300000L }
+                    from candle in n
+                    select new AggregateCandle
+                    {
+                        Ref = $"{candle.Time / t}",
+                        Volume = candle.Volume,
+                        Timeframe = "1m"
+                    };
+            }
+        }
+
         [RavenFact(RavenTestCategory.Indexes)]
         public void Index_With_Constant_Array_As_Outer_Source_Throws_Descriptive_Exception()
         {
@@ -121,6 +136,14 @@ namespace SlowTests.Issues
                     Assert.Equal(3, results[0].Volume);
                 }
             }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void Index_With_Parameter_Name_Prefixing_Outer_Source_Throws_Descriptive_Exception()
+        {
+            var e = Assert.Throws<IndexCompilationException>(() => new IndexWithParameterNamePrefixingOuterSource().CreateIndexDefinition());
+
+            Assert.Contains("must start its enumeration from the 'n' parameter", e.InnerException.Message);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_22083.cs
+++ b/test/SlowTests/Issues/RavenDB_22083.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions.Documents.Compilation;
 using Tests.Infrastructure;
 using Xunit;
@@ -221,6 +222,37 @@ namespace SlowTests.Issues
                     Assert.Equal(1, results.Count);
                     Assert.Equal(3, results[0].Volume);
                 }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.JavaScript)]
+        public void JavaScript_Index_With_Invalid_Map_Throws_IndexCompilationException()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var e = Assert.Throws<IndexCompilationException>(() => store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Name = "BrokenJsMap",
+                    Maps = { "map('Candles', function (c) { return { Volume: c.Volume }; )" }
+                })));
+
+                Assert.Equal(nameof(IndexDefinition.Maps), e.IndexDefinitionProperty);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.JavaScript)]
+        public void JavaScript_Index_With_Invalid_Reduce_Throws_IndexCompilationException()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var e = Assert.Throws<IndexCompilationException>(() => store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Name = "BrokenJsReduce",
+                    Maps = { "map('Candles', function (c) { return { Volume: c.Volume }; })" },
+                    Reduce = "groupBy(x => x.Volume).aggregate(g => { return { Volume: g.values.reduce((a, b) => a + b.Volume, 0) }; )"
+                })));
+
+                Assert.Equal(nameof(IndexDefinition.Reduce), e.IndexDefinitionProperty);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22083/C-defined-index-fails-to-deploy-with-Unexpected-token

### Additional description


### Type of change

More meaningful exception

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
