### PR TITLE
Quill-308 Drop IsSystem from usage

### DIFF
--- a/src/Raven.Quill.Web/src/api/generated/server-api.ts
+++ b/src/Raven.Quill.Web/src/api/generated/server-api.ts
@@ -1728,8 +1728,6 @@ export interface components {
             to: string;
             /** Format: int64 */
             usage: number;
-            /** @default false */
-            isSystem: boolean;
         };
         QuillPeriodUsage: {
             /** Format: date-time */

--- a/src/Raven.Quill.Web/src/mocks/settings-mocks.ts
+++ b/src/Raven.Quill.Web/src/mocks/settings-mocks.ts
@@ -109,9 +109,6 @@ export const sampleCertificates: CertificateItem[] = [
 // always ending in one of the four the final two bits allow. A couple carry a + or a /, because ids
 // that awkward to read are exactly why the table groups by name and only falls back to them.
 export const sampleTopologyIds = {
-    systemBusiest: "j9T7K/m7IZsA7MorB0UVmw",
-    system: "dFGqCGUYc8DUeweTsCxudA",
-    systemQuietest: "26jT6mFmbaClQn7J0vE1Yg",
     huetopiaBusiest: "NA+WUHfUc3cvjURuPbGDFQ",
     huetopia: "C3i3GQcS1dgeNvaAYmIHDQ",
     supportCopilot: "Y44Uy3cyOPO0UdiBXNPCeg",
@@ -119,19 +116,13 @@ export const sampleTopologyIds = {
     bookshopHelper: "2ODd5OiMFOwoH1TF1cOhJQ",
 };
 
-function usageRow(
-    topologyId: string,
-    applicationName: string,
-    usage: number,
-    { isSystem = false }: { isSystem?: boolean } = {},
-): QuillApplicationUsage {
+function usageRow(topologyId: string, applicationName: string, usage: number): QuillApplicationUsage {
     return {
         topologyId,
         applicationName,
         from: "2026-06-01T00:00:00Z",
         to: "2026-06-30T23:59:59Z",
         usage,
-        isSystem,
     };
 }
 
@@ -146,16 +137,13 @@ export const sampleQuillUsage: QuillUsageResponse = {
             usage: Math.round(280000 + wave * 130000),
         };
     }),
-    // Mirrors what a real licence covering several appliances reports: many system rows sharing the
-    // config database's name, a repeated app name, and unique apps - each distinguished only by
-    // topology id, and deliberately out of order so the grouping is doing the work.
+    // Mirrors what a real licence covering several appliances reports: a repeated app name and
+    // unique apps - each distinguished only by topology id, and deliberately out of order so the
+    // grouping is doing the work.
     perApplication: [
-        usageRow(sampleTopologyIds.system, "quill-config", 2600, { isSystem: true }),
         usageRow(sampleTopologyIds.supportCopilot, "support-copilot", 5200000),
         usageRow(sampleTopologyIds.huetopiaBusiest, "huetopia", 1300000),
-        usageRow(sampleTopologyIds.systemQuietest, "quill-config", 900, { isSystem: true }),
         usageRow(sampleTopologyIds.ordersSync, "orders-sync", 2400000),
-        usageRow(sampleTopologyIds.systemBusiest, "quill-config", 4100, { isSystem: true }),
         usageRow(sampleTopologyIds.huetopia, "huetopia", 640000),
         usageRow(sampleTopologyIds.bookshopHelper, "bookshop-helper", 88000),
     ],

--- a/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
@@ -13,12 +13,11 @@ import {
 } from "@tanstack/react-table";
 import { ChevronRight } from "lucide-react";
 import type { QuillApplicationUsage } from "@/api/generated/server-api";
-import { InfoHint } from "@/components/data/info-hint";
 import { WruLabel } from "@/components/data/wru-label";
 import { CountBadge } from "@/components/data/count-badge";
 import { VirtualDataTable, VirtualDataTableSkeleton } from "@/components/table/virtual-data-table";
 import { cn } from "@/lib/utils";
-import { rowKey, SYSTEM_GROUP_DESCRIPTION, toUsageGroups, type UsageGroup } from "@/pages/dashboard/usage-groups";
+import { rowKey, toUsageGroups, type UsageGroup } from "@/pages/dashboard/usage-groups";
 
 // Groups are the top-level rows; the databases behind them are the sub-rows.
 type UsageRow = UsageGroup | QuillApplicationUsage;
@@ -107,13 +106,6 @@ function GroupName({
                 />
                 {group.label}
             </button>
-            {group.isSystem && (
-                // The hint explains the group; it doesn't toggle it. `flex` keeps the icon off the
-                // text baseline an inline wrapper would put it on, which rides a couple of px high.
-                <span className="flex" onClick={(event) => event.stopPropagation()}>
-                    <InfoHint content={SYSTEM_GROUP_DESCRIPTION} />
-                </span>
-            )}
             <CountBadge>{group.rows.length}</CountBadge>
         </span>
     );

--- a/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/per-app-usage-table.tsx
@@ -139,7 +139,7 @@ function getSubRows(row: UsageRow) {
 }
 
 function getRowId(row: UsageRow, _index: number, parent?: Row<UsageRow>) {
-    return isGroup(row) ? row.key : `${parent?.id}/${rowKey(row)}`;
+    return isGroup(row) ? row.label : `${parent?.id}/${rowKey(row)}`;
 }
 
 export function PerAppUsageTable({ apps }: { apps: QuillApplicationUsage[] }) {

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.test.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { QuillApplicationUsage } from "@/api/generated/server-api";
-import { SYSTEM_GROUP_KEY, SYSTEM_GROUP_LABEL, toUsageGroups } from "@/pages/dashboard/usage-groups";
+import { toUsageGroups } from "@/pages/dashboard/usage-groups";
 
-function row(topologyId: string, applicationName: string, usage: number, isSystem = false): QuillApplicationUsage {
+function row(topologyId: string, applicationName: string, usage: number): QuillApplicationUsage {
     return {
         topologyId,
         applicationName,
         from: "2026-06-01T00:00:00Z",
         to: "2026-06-30T23:59:59Z",
         usage,
-        isSystem,
     };
 }
 
@@ -32,52 +31,16 @@ describe("toUsageGroups", () => {
         expect(group.rows.map((r) => r.topologyId)).toEqual(["t2", "t1"]); // heaviest first
     });
 
-    it("collapses every system row into one group, whatever the config database is called", () => {
-        const groups = toUsageGroups([
-            row("t1", "quill-config", 40, true),
-            row("t2", "quill-config", 12, true),
-            row("t3", "acme-config", 900, true),
-        ]);
+    it("sorts apps by usage descending", () => {
+        const groups = toUsageGroups([row("t1", "zeta", 1), row("t2", "alpha", 2), row("t3", "omega", 3)]);
 
-        const group = groups.find((g) => g.key === SYSTEM_GROUP_KEY)!;
-        expect(group.label).toBe(SYSTEM_GROUP_LABEL);
-        expect(group.rows).toHaveLength(3);
-        expect(group.usage).toBe(952);
-    });
-
-    it("expands a lone system row, unlike a lone app", () => {
-        // The system label hides which database it is, so expanding has to stay the way back to that
-        // even for the single-appliance case.
-        const [group] = toUsageGroups([row("t1", "quill-config", 40, true)]);
-
-        expect(group!.isExpandable).toBe(true);
-    });
-
-    it("sorts apps by usage descending and keeps the system group last", () => {
-        const groups = toUsageGroups([
-            row("t9", "quill-config", 5000, true),
-            row("t1", "zeta", 1),
-            row("t2", "alpha", 2),
-        ]);
-
-        // System stays last despite its far larger usage; apps above it order by usage descending.
-        expect(groups.map((g) => g.label)).toEqual(["alpha", "zeta", SYSTEM_GROUP_LABEL]);
+        expect(groups.map((g) => g.label)).toEqual(["omega", "alpha", "zeta"]);
     });
 
     it("breaks a usage tie between apps by label", () => {
         const groups = toUsageGroups([row("t1", "beta", 10), row("t2", "alpha", 10)]);
 
         expect(groups.map((g) => g.label)).toEqual(["alpha", "beta"]);
-    });
-
-    it("never groups an app with a system row that shares its name", () => {
-        // "quill-config" is only the default; an app can legitimately be called that on an appliance
-        // configured with a different config database, and must not be folded into System.
-        const groups = toUsageGroups([row("t1", "quill-config", 500), row("t2", "quill-config", 40, true)]);
-
-        expect(groups).toHaveLength(2);
-        expect(groups.find((g) => g.key === SYSTEM_GROUP_KEY)!.usage).toBe(40);
-        expect(groups.find((g) => g.label === "quill-config" && !g.isSystem)!.usage).toBe(500);
     });
 
     it("has no groups at all when nothing is reported", () => {

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.ts
@@ -4,7 +4,6 @@ import type { QuillApplicationUsage } from "@/api/generated/server-api";
 // id, so the same name arrives many times over. Same-named rows collapse into a group; the topology
 // ids behind it are what tell them apart.
 export type UsageGroup = {
-    key: string;
     label: string;
     isExpandable: boolean;
     rows: QuillApplicationUsage[];
@@ -22,7 +21,6 @@ function byUsageDescending(a: QuillApplicationUsage, b: QuillApplicationUsage) {
 
 function toGroup(name: string, rows: QuillApplicationUsage[]): UsageGroup {
     return {
-        key: `app/${name}`,
         label: name,
         isExpandable: rows.length > 1,
         rows: rows.toSorted(byUsageDescending),
@@ -30,7 +28,6 @@ function toGroup(name: string, rows: QuillApplicationUsage[]): UsageGroup {
     };
 }
 
-// Ordered by usage descending.
 export function toUsageGroups(apps: QuillApplicationUsage[]): UsageGroup[] {
     const byName = new Map<string, QuillApplicationUsage[]>();
 

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.ts
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage-groups.ts
@@ -6,21 +6,10 @@ import type { QuillApplicationUsage } from "@/api/generated/server-api";
 export type UsageGroup = {
     key: string;
     label: string;
-    isSystem: boolean;
-    // The system group expands even at a count of one: its label hides which database it is, and
-    // expanding is the only way back to that.
     isExpandable: boolean;
     rows: QuillApplicationUsage[];
     usage: number;
 };
-
-export const SYSTEM_GROUP_KEY = "system";
-
-export const SYSTEM_GROUP_LABEL = "@system";
-
-export const SYSTEM_GROUP_DESCRIPTION =
-    "Quill's own storage for your apps, channels and API keys. It is written to when you change " +
-    "configuration, and those writes count toward your total.";
 
 export function rowKey(row: QuillApplicationUsage) {
     return `${row.topologyId}/${row.applicationName}`;
@@ -31,38 +20,27 @@ function byUsageDescending(a: QuillApplicationUsage, b: QuillApplicationUsage) {
     return b.usage - a.usage || a.topologyId.localeCompare(b.topologyId);
 }
 
-function toGroup(key: string, label: string, isSystem: boolean, rows: QuillApplicationUsage[]): UsageGroup {
+function toGroup(name: string, rows: QuillApplicationUsage[]): UsageGroup {
     return {
-        key,
-        label,
-        isSystem,
-        isExpandable: isSystem || rows.length > 1,
+        key: `app/${name}`,
+        label: name,
+        isExpandable: rows.length > 1,
         rows: rows.toSorted(byUsageDescending),
         usage: rows.reduce((total, row) => total + row.usage, 0),
     };
 }
 
-// Apps first, ordered by usage descending, then the system group last.
+// Ordered by usage descending.
 export function toUsageGroups(apps: QuillApplicationUsage[]): UsageGroup[] {
     const byName = new Map<string, QuillApplicationUsage[]>();
-    const system: QuillApplicationUsage[] = [];
 
     for (const app of apps) {
-        if (app.isSystem) {
-            system.push(app);
-            continue;
-        }
-
         const existing = byName.get(app.applicationName);
         if (existing) existing.push(app);
         else byName.set(app.applicationName, [app]);
     }
 
-    const groups = Array.from(byName, ([name, rows]) => toGroup(`app/${name}`, name, false, rows)).sort(
+    return Array.from(byName, ([name, rows]) => toGroup(name, rows)).sort(
         (a, b) => b.usage - a.usage || a.label.localeCompare(b.label),
     );
-
-    if (system.length > 0) groups.push(toGroup(SYSTEM_GROUP_KEY, SYSTEM_GROUP_LABEL, true, system));
-
-    return groups;
 }

--- a/src/Raven.Quill.Web/src/pages/dashboard/usage.stories.tsx
+++ b/src/Raven.Quill.Web/src/pages/dashboard/usage.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 import { sampleTopologyIds, settingsMocks } from "@/mocks/settings-mocks";
-import { SYSTEM_GROUP_LABEL } from "@/pages/dashboard/usage-groups";
 import { DashboardUsage } from "./usage";
 
 const meta = {
@@ -46,56 +45,31 @@ export const Empty: Story = {
     },
 };
 
-// The config database is reported once per appliance, so a licence covering several of them reports
-// many rows sharing its name. They collapse into one labelled, counted group at the bottom, and
-// expanding identifies each by topology id - the only thing that tells them apart.
-export const SystemRowsCollapseIntoOneCountedGroup: Story = {
-    tags: ["!dev"],
-    play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
-
-        const system = await waitFor(() => canvas.getByRole("button", { name: SYSTEM_GROUP_LABEL }));
-
-        // Collapsed: the group carries the combined usage of its three rows and none of their ids.
-        expect(system).toHaveAttribute("aria-expanded", "false");
-        expect(rowFor(system)).toHaveTextContent("7,600");
-        expect(canvas.queryByText(TOPOLOGY_ID)).not.toBeInTheDocument();
-
-        // Sorted last, behind every app.
-        const names = canvas.getAllByRole("row").map((row) => row.textContent);
-        expect(names.at(-1)).toContain(SYSTEM_GROUP_LABEL);
-
-        await userEvent.click(system);
-        expect(system).toHaveAttribute("aria-expanded", "true");
-
-        // Expanded: one row per database, heaviest first, each named by its id rather than by the
-        // name all three share.
-        const ids = canvas.getAllByText(TOPOLOGY_ID).map((cell) => cell.textContent);
-        expect(ids).toEqual([
-            sampleTopologyIds.systemBusiest,
-            sampleTopologyIds.system,
-            sampleTopologyIds.systemQuietest,
-        ]);
-        expect(canvas.queryByText("quill-config")).not.toBeInTheDocument();
-
-        await userEvent.click(system);
-        expect(canvas.queryByText(TOPOLOGY_ID)).not.toBeInTheDocument();
-    },
-};
-
-// Same treatment for apps: two appliances can both run an app called "huetopia", and as bare rows
-// they are indistinguishable.
-export const SameNamedAppsCollapseToo: Story = {
+// Two appliances under one licence can both run an app called "huetopia", and as bare rows they
+// are indistinguishable. They collapse into one counted group, and expanding identifies each by
+// topology id - the only thing that tells them apart.
+export const SameNamedAppsCollapseIntoOneCountedGroup: Story = {
     tags: ["!dev"],
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
         const huetopia = await waitFor(() => canvas.getByRole("button", { name: "huetopia" }));
+
+        // Collapsed: the group carries the combined usage of its two rows and none of their ids.
+        expect(huetopia).toHaveAttribute("aria-expanded", "false");
         expect(rowFor(huetopia)).toHaveTextContent("1,940,000");
+        expect(canvas.queryByText(TOPOLOGY_ID)).not.toBeInTheDocument();
 
         await userEvent.click(huetopia);
-        expect(canvas.getByText(sampleTopologyIds.huetopiaBusiest)).toBeInTheDocument();
-        expect(canvas.getByText(sampleTopologyIds.huetopia)).toBeInTheDocument();
+        expect(huetopia).toHaveAttribute("aria-expanded", "true");
+
+        // Expanded: one row per database, heaviest first, each named by its id rather than by the
+        // name both share.
+        const ids = canvas.getAllByText(TOPOLOGY_ID).map((cell) => cell.textContent);
+        expect(ids).toEqual([sampleTopologyIds.huetopiaBusiest, sampleTopologyIds.huetopia]);
+
+        await userEvent.click(huetopia);
+        expect(canvas.queryByText(TOPOLOGY_ID)).not.toBeInTheDocument();
     },
 };
 
@@ -110,22 +84,18 @@ export const UniquelyNamedAppStaysAPlainRow: Story = {
     },
 };
 
-// The label is a small target in a wide row, so the whole row toggles - while the hint inside it
-// explains the group without collapsing it again.
+// The label is a small target in a wide row, so the whole row toggles.
 export const ClickingAnywhereInTheRowToggles: Story = {
     tags: ["!dev"],
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        const trigger = await waitFor(() => canvas.getByRole("button", { name: SYSTEM_GROUP_LABEL }));
+        const trigger = await waitFor(() => canvas.getByRole("button", { name: "huetopia" }));
         const row = rowFor(trigger);
 
         await userEvent.click(lastCell(row)); // the usage figure, well away from the label
         expect(trigger).toHaveAttribute("aria-expanded", "true");
-        expect(canvas.getByText(sampleTopologyIds.systemBusiest)).toBeInTheDocument();
-
-        await userEvent.click(within(row).getByText(/count toward your total/i));
-        expect(trigger).toHaveAttribute("aria-expanded", "true");
+        expect(canvas.getByText(sampleTopologyIds.huetopiaBusiest)).toBeInTheDocument();
     },
 };
 
@@ -136,7 +106,7 @@ export const UsageFiguresAreEndAligned: Story = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        await userEvent.click(await waitFor(() => canvas.getByRole("button", { name: SYSTEM_GROUP_LABEL })));
+        await userEvent.click(await waitFor(() => canvas.getByRole("button", { name: "huetopia" })));
 
         // Measured rather than asserted against a CSS property: the column has been laid out with
         // text-align and with flex, and what the eye checks is where the digits end.

--- a/src/Raven.Quill/Contracts/UsageResponse.cs
+++ b/src/Raven.Quill/Contracts/UsageResponse.cs
@@ -9,14 +9,9 @@ public record QuillPeriodUsage(
     DateTime To,
     long Usage);
 
-/// <param name="IsSystem">True for the appliance's own configuration database rather than a user-created
-/// app. The license server reports every database in the cluster, so this row is charged like any other and
-/// is kept in the list — the UI labels it instead of dropping it, so the per-app rows still sum to the total.
-/// Defaulted so a license-server payload that predates the flag still deserializes.</param>
 public record QuillApplicationUsage(
     string TopologyId,
     string ApplicationName,
     DateTime From,
     DateTime To,
-    long Usage,
-    bool IsSystem = false);
+    long Usage);

--- a/src/Raven.Quill/Licensing/LicenseStatsProvider.cs
+++ b/src/Raven.Quill/Licensing/LicenseStatsProvider.cs
@@ -1,9 +1,7 @@
 using System.Text.Json;
-using Microsoft.Extensions.Options;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Quill.AiHelper;
 using Raven.Quill.Contracts;
-using Raven.Quill.Hosting;
 using Raven.Quill.Metrics;
 
 namespace Raven.Quill.Licensing;
@@ -11,14 +9,10 @@ namespace Raven.Quill.Licensing;
 internal sealed class LicenseStatsProvider : ILicenseStatsProvider
 {
     private readonly IAiHelperClient _ravendb;
-    private readonly string _configDatabase;
 
-    public LicenseStatsProvider(IAiHelperClient ravendb, IOptions<ApplianceOptions> options)
+    public LicenseStatsProvider(IAiHelperClient ravendb)
     {
         _ravendb = ravendb;
-        // The config database name is configurable (RAVEN_QUILL_CONFIG_DB), so the appliance's own
-        // usage row can only be recognized by comparing against the configured value - never a literal.
-        _configDatabase = options.Value.ConfigDatabase;
     }
 
     private static readonly LicensePlan[] Plans =
@@ -49,6 +43,7 @@ internal sealed class LicenseStatsProvider : ILicenseStatsProvider
 
         var usage = await _ravendb.DeserializeAsync<QuillUsageResponse>(r.Content, token);
 
+        // The license server reports one row per period; the UI wants one row per database.
         var perApplicationUsages = (usage.PerApplication ?? [])
             .GroupBy(p => (p.TopologyId, p.ApplicationName))
             .Select(g => new QuillApplicationUsage(
@@ -56,8 +51,7 @@ internal sealed class LicenseStatsProvider : ILicenseStatsProvider
                 g.Key.ApplicationName,
                 g.Min(x => x.From),
                 g.Max(x => x.To),
-                g.Sum(x => x.Usage),
-                IsSystem: string.Equals(g.Key.ApplicationName, _configDatabase, StringComparison.OrdinalIgnoreCase)))
+                g.Sum(x => x.Usage)))
             .ToList();
 
         return new QuillUsageResponse(perApplicationUsages, usage.ByPeriod);

--- a/test/QuillTests/LicenseStatsProviderTests.cs
+++ b/test/QuillTests/LicenseStatsProviderTests.cs
@@ -1,10 +1,8 @@
 using System.Text.Json;
 using FastTests;
-using Microsoft.Extensions.Options;
 using Raven.Client.Documents.Operations.CdcSink;
 using Raven.Quill.AiHelper;
 using Raven.Quill.Contracts;
-using Raven.Quill.Hosting;
 using Raven.Quill.Licensing;
 using Tests.Infrastructure;
 using Xunit;
@@ -14,80 +12,38 @@ namespace QuillTests;
 public class LicenseStatsProviderTests(ITestOutputHelper output) : NoDisposalNeeded(output)
 {
     [RavenFact(RavenTestCategory.Quill)]
-    public async Task Config_database_row_is_flagged_as_system_by_the_configured_name()
+    public async Task Rows_for_one_database_are_merged_into_one()
     {
-        // The config database name is configurable, so the flag must follow ApplianceOptions - not the
-        // "quill-config" default. Here that default belongs to a *user* app and must stay unflagged.
-        var usage = await GetUsageAsync("acme-config",
-            Row("t1", "support-copilot", 5200),
-            Row("t2", "acme-config", 41),
-            Row("t3", "quill-config", 900));
+        // The license server reports one row per period; they collapse into a single row per database.
+        var usage = await GetUsageAsync(
+            Row("t2", "quill-config", 20),
+            Row("t2", "quill-config", 21));
 
-        Assert.False(Row(usage, "support-copilot").IsSystem);
-        Assert.True(Row(usage, "acme-config").IsSystem);
-        Assert.False(Row(usage, "quill-config").IsSystem);
+        var merged = Assert.Single(usage.PerApplication);
+        Assert.Equal(41, merged.Usage);
     }
 
     [RavenFact(RavenTestCategory.Quill)]
-    public async Task System_row_keeps_its_usage_and_stays_in_the_list()
-    {
-        // The license server charges the config database like any other, so dropping the row would leave
-        // the per-app rows short of the total shown beside them. It is labelled, never removed.
-        var usage = await GetUsageAsync("quill-config",
-            Row("t1", "support-copilot", 5200),
-            Row("t2", "quill-config", 41));
-
-        Assert.Equal(2, usage.PerApplication.Count);
-        Assert.Equal(41, Row(usage, "quill-config").Usage);
-        Assert.Equal(5241, usage.PerApplication.Sum(a => a.Usage));
-    }
-
-    [RavenFact(RavenTestCategory.Quill)]
-    public async Task System_row_is_matched_regardless_of_case()
-    {
-        // Database names are case-insensitive in RavenDB, so a differently-cased report still matches.
-        var usage = await GetUsageAsync("Quill-Config", Row("t1", "quill-config", 41));
-
-        Assert.True(Row(usage, "quill-config").IsSystem);
-    }
-
-    [RavenFact(RavenTestCategory.Quill)]
-    public async Task Every_appliance_reporting_under_one_license_is_flagged()
+    public async Task Same_named_databases_on_different_appliances_stay_separate()
     {
         // One license can cover several appliances, and re-provisioning one reports under a fresh
-        // topology id - so the config database's name arrives many times over, and every one of them
-        // has to be flagged. Only the topology id tells them apart.
-        var usage = await GetUsageAsync("quill-config",
-            Row("t1", "quill-config", 40),
-            Row("t2", "quill-config", 12),
+        // topology id - so the same name arrives many times over. Only the topology id tells them apart.
+        var usage = await GetUsageAsync(
+            Row("t1", "huetopia", 40),
+            Row("t2", "huetopia", 12),
             Row("t3", "support-copilot", 5200));
 
         Assert.Equal(3, usage.PerApplication.Count);
         Assert.Equal(
             ["t1", "t2"],
-            usage.PerApplication.Where(a => a.IsSystem).Select(a => a.TopologyId).Order());
+            usage.PerApplication.Where(a => a.ApplicationName == "huetopia").Select(a => a.TopologyId).Order());
+        Assert.Equal(5252, usage.PerApplication.Sum(a => a.Usage));
     }
 
-    [RavenFact(RavenTestCategory.Quill)]
-    public async Task Rows_for_one_database_are_merged_before_being_flagged()
-    {
-        // The license server reports one row per period; they collapse into a single row per database,
-        // and the merged row is still recognized as the config database.
-        var usage = await GetUsageAsync("quill-config",
-            Row("t2", "quill-config", 20),
-            Row("t2", "quill-config", 21));
-
-        var system = Assert.Single(usage.PerApplication);
-        Assert.True(system.IsSystem);
-        Assert.Equal(41, system.Usage);
-    }
-
-    private static async Task<QuillUsageResponse> GetUsageAsync(string configDatabase, params object[] perApplication)
+    private static async Task<QuillUsageResponse> GetUsageAsync(params object[] perApplication)
     {
         var payload = JsonSerializer.Serialize(new { PerApplication = perApplication, ByPeriod = Array.Empty<object>() });
-        var provider = new LicenseStatsProvider(
-            new StubAiHelperClient(payload),
-            Options.Create(new ApplianceOptions { ConfigDatabase = configDatabase }));
+        var provider = new LicenseStatsProvider(new StubAiHelperClient(payload));
 
         return await provider.GetUsageAsync(2026, month: 6, day: null, CancellationToken.None);
     }
@@ -100,9 +56,6 @@ public class LicenseStatsProviderTests(ITestOutputHelper output) : NoDisposalNee
         To = "2026-06-30T23:59:59Z",
         Usage = usage,
     };
-
-    private static QuillApplicationUsage Row(QuillUsageResponse usage, string applicationName) =>
-        Assert.Single(usage.PerApplication, a => a.ApplicationName == applicationName);
 
     /// Answers every upstream call with one canned body, so the test drives only the projection.
     private sealed class StubAiHelperClient(string content) : IAiHelperClient


### PR DESCRIPTION
### Issue link

https://issues.ravendb.net/issue/Quill-308

### Additional description

We do not account the quill-config usage any longer

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
