### PR TITLE
RavenDB-27443 Restore sparse holes at 1 MB punch granularity

### DIFF
--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -36,7 +36,7 @@ namespace Voron.Impl.Backup
         /// <summary>
         /// Copies from source to destination while detecting contiguous zero-page regions and skipping them to create a sparse file.
         /// The destination file must already be marked as sparse on Windows (via <see cref="SparseFileHelper.TryMarkFileAsSparse"/>).
-        /// Zero runs shorter than <see cref="FreeSpaceHandling.NumberOfFreePagesForSparseConsideration"/> pages are written normally.
+        /// Zero runs shorter than <see cref="FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion"/> pages (the live hole-punch granularity) are written normally.
         /// </summary>
         public static void CopyToPreservingSparseRegions(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
         {
@@ -49,8 +49,8 @@ namespace Voron.Impl.Backup
             try
             {
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                Debug.Assert(bufferSize / pageSize < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration,
-                    $"Below code assumes buffer holds fewer pages ({bufferSize / pageSize}) than the sparse threshold ({FreeSpaceHandling.NumberOfFreePagesForSparseConsideration})");
+                Debug.Assert(bufferSize / pageSize < FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion,
+                    $"Below code assumes buffer holds fewer pages ({bufferSize / pageSize}) than the sparse threshold ({FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion})");
 
                 Array.Clear(zeroBuffer, 0, DefaultBufferSize);
 
@@ -164,7 +164,7 @@ namespace Voron.Impl.Backup
             long zeroRegionLength = (long)zeroPageCount * pageSize;
             long zeroStart = logicalPosition - zeroRegionLength;
 
-            if (zeroPageCount < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration)
+            if (zeroPageCount < FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion)
             {
                 // write zeros
 

--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -18,7 +18,8 @@ namespace Voron.Impl.FreeSpace
         private readonly FreeSpaceHandlingDisabler _disableStatus = new FreeSpaceHandlingDisabler();
 
         private readonly FreeSpaceRecursiveCallGuard _guard;
-        internal const int NumberOfFreePagesForSparseConsideration = NumberOfPagesInSection/4;
+        internal const int MinNumberOfFreePagesInSectionForSparseConsideration = NumberOfPagesInSection / 4; // 512
+        internal const int MinNumberOfContiguousFreePagesForSparseRegion = Constants.Size.Megabyte / Constants.Storage.PageSize; // 128
 
         private readonly Dictionary<long, SectionMetadata> _maxConsecutiveRangePerSection = new();
 
@@ -413,7 +414,7 @@ namespace Voron.Impl.FreeSpace
                 json["FreePagesCount"] = totalNumberFreePages;
                 json["FreeSpaceSizeHumane"] = new Size(totalNumberFreePages * Constants.Storage.PageSize, SizeUnit.Bytes).ToString();
                 json["FreeSpaceSize"] = totalNumberFreePages * Constants.Storage.PageSize;
-                long sparseSize = load.Where(x => x.Key >= NumberOfFreePagesForSparseConsideration)
+                long sparseSize = load.Where(x => x.Key >= MinNumberOfFreePagesInSectionForSparseConsideration)
                     .Sum(x => x.Value * x.Key) * Constants.Storage.PageSize;
                 json["ExpectedSparseSizeHumane"] = new Size(sparseSize, SizeUnit.Bytes).ToString();
                 json["ExpectedSparseSize"] = sparseSize;
@@ -464,7 +465,7 @@ namespace Voron.Impl.FreeSpace
                 do
                 {
                     int freePagesInSegment = it.CreateReaderForCurrent().Read<int>();
-                    if (freePagesInSegment >= NumberOfFreePagesForSparseConsideration)
+                    if (freePagesInSegment >= MinNumberOfFreePagesInSectionForSparseConsideration)
                     {
                         yield return it.CurrentKey;
                     }
@@ -495,7 +496,7 @@ namespace Voron.Impl.FreeSpace
                 var index = (int)(pageNumber % NumberOfPagesInSection);
                 sba.Set(index, true);
                 
-                if (_disableSparseRegions == false && sba.SetCount > NumberOfFreePagesForSparseConsideration)
+                if (_disableSparseRegions == false && sba.SetCount > MinNumberOfFreePagesInSectionForSparseConsideration)
                 {
                     tx.RecordSparseRangeCandidate(section);
                 }
@@ -550,7 +551,7 @@ namespace Voron.Impl.FreeSpace
                         continue;
 
                     var section = new StreamBitArray(result.CreateReader().Base);
-                    if(section .SetCount < NumberOfFreePagesForSparseConsideration)
+                    if(section .SetCount < MinNumberOfFreePagesInSectionForSparseConsideration)
                         continue;
 
                     var start = -1;
@@ -566,7 +567,7 @@ namespace Voron.Impl.FreeSpace
 
                         var freeRange = nextUnsetBit  - start;
 
-                        if (freeRange >= 128)
+                        if (freeRange >= MinNumberOfContiguousFreePagesForSparseRegion)
                         {
                             results.Add(((sectionId * NumberOfPagesInSection) + start, freeRange));
                         }

--- a/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
+++ b/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
@@ -181,7 +181,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
         Options.ManualFlushing = true;
         Options.ManualSyncing = true;
 
-        // the flushed free must push the section's free count above NumberOfFreePagesForSparseConsideration (512)
+        // the flushed free must push the section's free count above MinNumberOfFreePagesInSectionForSparseConsideration (512)
         // to register a sparse candidate; the reader's run only needs to be a punchable >= 128 pages
         const int sectionMatePages = 600;
         const int readerPages = 256;
@@ -254,7 +254,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
         Options.ManualFlushing = true;
         Options.ManualSyncing = true;
 
-        const int pages = 600; // > NumberOfFreePagesForSparseConsideration (512), so freeing the run yields a punchable region
+        const int pages = 600; // > MinNumberOfFreePagesInSectionForSparseConsideration (512), so freeing the run yields a punchable region
         const int overflowSize = pages * Constants.Storage.PageSize - PageHeader.SizeOf;
 
         long p;

--- a/test/SlowTests/Voron/Issues/RavenDB_24327.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_24327.cs
@@ -39,7 +39,7 @@ public class RavenDB_24327 : StorageTest
 
         using (var tx = Env.WriteTransaction())
         {
-            for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 200; i++)
+            for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 200; i++)
             {
                 var p = tx.LowLevelTransaction.AllocatePage(1, zeroPage: true);
 
@@ -69,7 +69,7 @@ public class RavenDB_24327 : StorageTest
 
         using (var tx = Env.WriteTransaction())
         {
-            for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 200; i++)
+            for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 200; i++)
             {
                 long pageNumber = startPageNumber + i;
                 var p = tx.LowLevelTransaction.ModifyPage(pageNumber);
@@ -84,7 +84,7 @@ public class RavenDB_24327 : StorageTest
 
         using (var tx = Env.WriteTransaction())
         {
-            for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 100; i++)
+            for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 100; i++)
             {
                 tx.LowLevelTransaction.FreePage(startPageNumber + i + 10);
             }
@@ -125,7 +125,7 @@ public class RavenDB_24327 : StorageTest
         {
             using (var tx = Env.WriteTransaction())
             {
-                for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 200; i++)
+                for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 200; i++)
                 {
                     var p = tx.LowLevelTransaction.AllocatePage(1, zeroPage: true);
 
@@ -158,7 +158,7 @@ public class RavenDB_24327 : StorageTest
         {
             using (var tx = Env.WriteTransaction())
             {
-                for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 200; i++)
+                for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 200; i++)
                 {
                     long pageNumber = startPageNumber[repeatTx] + i;
                     var p = tx.LowLevelTransaction.ModifyPage(pageNumber);
@@ -173,7 +173,7 @@ public class RavenDB_24327 : StorageTest
 
             using (var tx = Env.WriteTransaction())
             {
-                for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 100; i++)
+                for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 100; i++)
                 {
                     tx.LowLevelTransaction.FreePage(startPageNumber[repeatTx] + i + 10);
                 }
@@ -206,7 +206,7 @@ public class RavenDB_24327 : StorageTest
 
         using (var tx = Env.WriteTransaction())
         {
-            for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 200; i++)
+            for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 200; i++)
             {
                 var p = tx.LowLevelTransaction.AllocatePage(1, zeroPage: true);
 
@@ -236,7 +236,7 @@ public class RavenDB_24327 : StorageTest
 
         using (var tx = Env.WriteTransaction())
         {
-            for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 200; i++)
+            for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 200; i++)
             {
                 long pageNumber = startPageNumber + i;
                 var p = tx.LowLevelTransaction.ModifyPage(pageNumber);
@@ -253,7 +253,7 @@ public class RavenDB_24327 : StorageTest
         
         using (var tx = Env.WriteTransaction())
         {
-            for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 100; i++)
+            for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 100; i++)
             {
                 var pageNumber = startPageNumber + i + 10;
 
@@ -331,7 +331,7 @@ public class RavenDB_24327 : StorageTest
 
         using (var tx = Env.WriteTransaction())
         {
-            for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 200; i++)
+            for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 200; i++)
             {
                 var p = tx.LowLevelTransaction.AllocatePage(1, zeroPage: true);
 
@@ -361,7 +361,7 @@ public class RavenDB_24327 : StorageTest
 
         using (var tx = Env.WriteTransaction())
         {
-            for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 200; i++)
+            for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 200; i++)
             {
                 long pageNumber = startPageNumber + i;
                 var p = tx.LowLevelTransaction.ModifyPage(pageNumber);
@@ -376,7 +376,7 @@ public class RavenDB_24327 : StorageTest
 
         using (var tx = Env.WriteTransaction())
         {
-            for (int i = 0; i < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 100; i++)
+            for (int i = 0; i < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration + 100; i++)
             {
                 tx.LowLevelTransaction.FreePage(startPageNumber + i + 10);
             }

--- a/test/SlowTests/Voron/Issues/RavenDB_26344.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344.cs
@@ -166,6 +166,7 @@ public class RavenDB_26344 : StorageTest
         // 6. Open restored database and verify sizes
         var sparseOptions = StorageEnvironmentOptions.ForPathForTests(sparseRestoreDir.FullPath);
         sparseOptions.MaxLogFileSize = Env.Options.MaxLogFileSize;
+        sparseOptions.DisableSparseRegions = true; // the load-time re-punch must not mask what the restore itself produced
 
         using (var restoredEnv = new StorageEnvironment(sparseOptions))
         {
@@ -176,13 +177,17 @@ public class RavenDB_26344 : StorageTest
 
             if (PlatformDetails.RunningOnMacOsx == false)
             {
-                Assert.True(originalPhysical < originalAllocated - (40L * 1024 * 1024),
-                    $"Expected source database to be sparse before backup, but allocated={new Size(originalAllocated, SizeUnit.Bytes)}, physical={new Size(originalPhysical, SizeUnit.Bytes)}");
+                const long freedBytes = 28L * 256 * Constants.Storage.PageSize; // pages[2..29]
+                const long liveDataBytes = 4L * 256 * Constants.Storage.PageSize; // pages[0], pages[1], pages[30], pages[31]
+                const long tolerance = 2L * Constants.Size.Megabyte;
 
-                const long allowedRestoreOverhead = 16L * 1024 * 1024;
-                Assert.True(restoredPhysical <= originalPhysical + allowedRestoreOverhead,
-                    $"Expected restored physical size to stay close to the source sparse file after restore, " +
-                    $"but source physical={new Size(originalPhysical, SizeUnit.Bytes)}, restored physical={new Size(restoredPhysical, SizeUnit.Bytes)}, allocated={new Size(restoredAllocated, SizeUnit.Bytes)}");
+                Assert.True(originalPhysical <= originalAllocated - freedBytes + tolerance,
+                    $"Expected source database to have {new Size(freedBytes, SizeUnit.Bytes)} punched before backup, but allocated={new Size(originalAllocated, SizeUnit.Bytes)}, physical={new Size(originalPhysical, SizeUnit.Bytes)}");
+
+                // the file grows past the 32 overflows; that zero tail is physically allocated in the source but a hole after restore, so bound by the live data rather than by the source
+                Assert.True(restoredPhysical >= liveDataBytes && restoredPhysical <= liveDataBytes + tolerance,
+                    $"Expected the restored data file to physically hold only the {new Size(liveDataBytes, SizeUnit.Bytes)} of live pages, " +
+                    $"but physical={new Size(restoredPhysical, SizeUnit.Bytes)}, allocated={new Size(restoredAllocated, SizeUnit.Bytes)}, source physical={new Size(originalPhysical, SizeUnit.Bytes)}");
             }
         }
     }

--- a/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
@@ -17,7 +17,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldCreateHoleForZeroRunSpanningMultipleReadBuffers()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 17;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion + 17;
         var source = new byte[(2 + sparsePages) * pageSize];
 
         Fill(source, 0, pageSize, 1);
@@ -38,7 +38,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldCreateHoleForZeroRunSpanningNonPageAlignedReads()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 17;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion + 17;
         var source = new byte[(2 + sparsePages) * pageSize];
 
         Fill(source, 0, pageSize, 11);
@@ -59,7 +59,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldPreserveTrailingSparseHoleAtEndOfStream()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 9;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion + 9;
         var source = new byte[(1 + sparsePages) * pageSize];
 
         Fill(source, 0, pageSize, 3);
@@ -79,7 +79,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldPreserveTrailingSparseHoleAtEndOfStreamWithNonPageAlignedReads()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 9;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion + 9;
         var source = new byte[(1 + sparsePages) * pageSize];
 
         Fill(source, 0, pageSize, 13);
@@ -99,7 +99,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldWriteZeroRunBelowSparseThreshold()
     {
         int pageSize = Constants.Storage.PageSize;
-        int zeroPages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration - 1;
+        int zeroPages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion - 1;
         var source = new byte[(2 + zeroPages) * pageSize];
 
         Fill(source, 0, pageSize, 4);
@@ -120,7 +120,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldWriteZeroRunBelowSparseThresholdWithNonPageAlignedReads()
     {
         int pageSize = Constants.Storage.PageSize;
-        int zeroPages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration - 1;
+        int zeroPages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion - 1;
         var source = new byte[(2 + zeroPages) * pageSize];
 
         Fill(source, 0, pageSize, 14);
@@ -141,7 +141,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldCreateHoleForZeroRunAtSparseThreshold()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion;
         var source = new byte[(2 + sparsePages) * pageSize];
 
         Fill(source, 0, pageSize, 16);
@@ -162,7 +162,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldWritePartialPageTailAfterSparseHole()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 5;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion + 5;
         int tailLength = pageSize / 2;
         var source = new byte[((1 + sparsePages) * pageSize) + tailLength];
 
@@ -184,7 +184,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldWritePartialPageTailAfterSparseHoleWithNonPageAlignedReads()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 5;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion + 5;
         int tailLength = pageSize / 2;
         var source = new byte[((1 + sparsePages) * pageSize) + tailLength];
 
@@ -254,7 +254,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldHandleMultipleSparseRegions()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 11;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion + 11;
         int totalPages = 1 + sparsePages + 1 + sparsePages + 1;
         var source = new byte[totalPages * pageSize];
 
@@ -278,7 +278,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldHandleAllZeroStreamWithPartialPageTail()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 1;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion + 1;
         int tailLength = 100;
         var source = new byte[(sparsePages * pageSize) + tailLength];
 
@@ -346,7 +346,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldHandleEntirelyZeroPageAlignedStream()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 20;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion + 20;
         var source = new byte[sparsePages * pageSize];
 
         using var input = new MemoryStream(source);
@@ -364,7 +364,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     public void CopyToPreservingSparseRegions_ShouldCreateHoleForExactThresholdZeroRunFollowedByPartialTail()
     {
         int pageSize = Constants.Storage.PageSize;
-        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration;
+        int sparsePages = FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion;
         int tailLength = 137;
         var source = new byte[(sparsePages * pageSize) + tailLength];
 

--- a/test/SlowTests/Voron/Issues/RavenDB_27443.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_27443.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests.Voron;
+using Sparrow;
+using Sparrow.Backups;
+using Sparrow.Platform;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Global;
+using Voron.Impl.Backup;
+using Voron.Impl.FreeSpace;
+using Voron.Impl.Journal;
+using Voron.Util.Settings;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_27443 : StorageTest
+{
+    public RavenDB_27443(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.BackupExportImport)]
+    public unsafe void SnapshotRestoreShouldPreserveHolesSmallerThanSectionCandidacyThreshold()
+    {
+        RequireFileBasedPager();
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+
+        // each freed run is above the punch granularity but below the section candidacy gate that the restore used to reuse as its threshold
+        const int overflowPages = 256;
+        Assert.True(overflowPages >= FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion);
+        Assert.True(overflowPages < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration);
+
+        const int numberOfOverflows = 32; // 64 MB, 4 free-space sections
+
+        var pages = new List<long>();
+
+        using (var txw = Env.WriteTransaction())
+        {
+            for (int i = 0; i < numberOfOverflows; i++)
+            {
+                Page page = txw.LowLevelTransaction.AllocatePage(overflowPages);
+                page.Flags = PageFlags.Overflow | PageFlags.Single;
+                page.OverflowSize = (overflowPages * Constants.Storage.PageSize) - PageHeader.SizeOf;
+
+                Memory.Set(page.DataPointer, (byte)(i + 1), page.OverflowSize);
+                pages.Add(page.PageNumber);
+            }
+
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        // free every other overflow: 16 separate 2 MB runs, every section ends up with 1024 free pages so it passes the candidacy gate and gets punched
+        using (var txw = Env.WriteTransaction())
+        {
+            for (int i = 0; i < numberOfOverflows; i += 2)
+            {
+                for (int j = 0; j < overflowPages; j++)
+                {
+                    txw.LowLevelTransaction.FreePage(pages[i] + j);
+                }
+            }
+
+            txw.Commit();
+        }
+
+        List<(long Start, long Count)> punchedRegions = Env.CurrentStateRecord.SparseRegions;
+        Assert.NotNull(punchedRegions);
+        Assert.True(punchedRegions.Sum(r => r.Count) >= (numberOfOverflows / 2) * overflowPages);
+        Assert.All(punchedRegions, r => Assert.True(r.Count < FreeSpaceHandling.MinNumberOfFreePagesInSectionForSparseConsideration));
+
+        Env.FlushLogToDataFile();
+
+        using (var syncOperation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
+        {
+            Assert.True(syncOperation.SyncDataFile());
+        }
+
+        (long originalAllocated, long originalPhysical) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);
+
+        var voronDataDir = new VoronPathSetting(DataDir);
+        var backupPath = voronDataDir.Combine("voron-test.backup");
+
+        BackupMethods.Full.ToFile(Env, backupPath, SnapshotBackupCompressionAlgorithm.Zstd);
+
+        var restoreDir = voronDataDir.Combine("restored");
+        BackupMethods.Full.Restore(backupPath, restoreDir);
+
+        var options = StorageEnvironmentOptions.ForPathForTests(restoreDir.FullPath);
+        options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+        options.DisableSparseRegions = true; // the load-time re-punch must not mask what the restore itself produced
+
+        using (var restoredEnv = new StorageEnvironment(options))
+        {
+            (long restoredAllocated, long restoredPhysical) = restoredEnv.DataPager.GetFileSize(restoredEnv.CurrentStateRecord.DataPagerState);
+
+            Assert.Equal(originalAllocated, restoredAllocated);
+
+            if (PlatformDetails.RunningOnMacOsx)
+                return;
+
+            // the file may have grown past the 32 overflows; that zero tail is a hole either way, so bound the physical size by the live data instead of comparing to the source
+            const long liveDataBytes = (numberOfOverflows / 2) * overflowPages * (long)Constants.Storage.PageSize;
+            const long tolerance = 2L * Constants.Size.Megabyte;
+
+            Assert.True(restoredPhysical >= liveDataBytes && restoredPhysical <= liveDataBytes + tolerance,
+                $"Expected the restored data file to physically hold only the {new Size(liveDataBytes, SizeUnit.Bytes)} of live pages, " +
+                $"but physical={new Size(restoredPhysical, SizeUnit.Bytes)}, allocated={new Size(restoredAllocated, SizeUnit.Bytes)}, " +
+                $"source physical={new Size(originalPhysical, SizeUnit.Bytes)}, source allocated={new Size(originalAllocated, SizeUnit.Bytes)}");
+        }
+    }
+}


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27443

### Additional description

- `CopyToPreservingSparseRegions` (RavenDB-26344, #22670) reused `NumberOfFreePagesForSparseConsideration` (512 pages, 4 MB) as its hole threshold. That constant is the free-space section candidacy gate; the actual punch granularity in `GetSparseRegions` was an unnamed `128` (1 MB, RavenDB-23266). Zero runs of 128-511 pages were restored as physical zeros and re-punched on first boot only when the enclosing 16 MB section still had >= 512 free pages.
- Extracted `FreeSpaceHandling.MinNumberOfContiguousFreePagesForSparseRegion` (1 MB / PageSize) and use it on both sides. Restore now keeps a hole for every run the live engine would punch.
- Renamed `NumberOfFreePagesForSparseConsideration` to `MinNumberOfFreePagesInSectionForSparseConsideration` so the section gate and the run threshold are not confused again.
- New test restores a file with 16 x 2 MB holes: before the fix the restored data file held 64 MB physically for 32 MB of live pages. The existing `SnapshotRestoreShouldPreserveSparsity` now bounds the restored file by its live data instead of by the source physical size, which the allocated zero tail made too permissive.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
