### PR TITLE
RavenDB-27503 Fix the in-memory term sort's top-N cut and tie order

### DIFF
--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax.Mappings;
@@ -188,8 +189,10 @@ unsafe partial struct SortingMatch<TInner>
             match._cancellationToken.ThrowIfCancellationRequested();
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
             Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
-            var indirectComparer = new IndirectComparer<CompactKeyComparer>(batchTerms, new CompactKeyComparer(), descending);
-            var indexes = SortByTerms(ref match, batchTermIds, batchTerms, descending, indirectComparer);
+            // The batch index packed into the sort key must address the whole batch; SortResults passes it all at once.
+            var indexBits = IndexBitsFor(batchResults.Length);
+            var indirectComparer = new IndirectComparer<CompactKeyComparer>(batchTerms, new CompactKeyComparer(), descending, indexBits);
+            var indexes = SortByTerms(ref match, batchTermIds, batchTerms, descending, indirectComparer, indexBits);
             for (int i = 0; i < indexes.Length; i++)
             {
                 int bIdx = indexes[i];
@@ -197,46 +200,58 @@ unsafe partial struct SortingMatch<TInner>
             }
         }
 
-        private static void MaybeBreakTies<TComparer>(Span<long> buffer, TComparer tieBreaker, bool isDescending) where TComparer : struct, IComparer<long>
+        /// <summary>Width of the batch index packed into the sort key. 15 bits are free by construction; a larger batch
+        /// takes one more per doubling from the term prefix, which only costs pre-sort precision - ties are resolved by the
+        /// full comparer. Capped at 31 so the key stays non-negative.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int IndexBitsFor(int length) => Math.Clamp(32 - BitOperations.LeadingZeroCount((uint)(length - 1)), 15, 31);
+
+        /// <summary>The part of the key at <paramref name="i"/> that the pre-sort actually ordered, i.e. without the packed batch index.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long KeyPrefixAt(Span<long> buffer, int i, bool isDescending, int indexBits)
+        {
+            var key = buffer[i];
+            if (isDescending)
+                key = -key;
+            return key >> indexBits;
+        }
+
+        /// <summary>First position at or after <paramref name="from"/> whose key prefix differs from <paramref name="prefix"/>.</summary>
+        private static int TieRunEnd(Span<long> buffer, long prefix, int from, bool isDescending, int indexBits)
+        {
+            int end = from;
+            for (; end < buffer.Length; end++)
+            {
+                if (KeyPrefixAt(buffer, end, isDescending, indexBits) != prefix)
+                    break;
+            }
+
+            return end;
+        }
+
+        private static void MaybeBreakTies<TComparer>(Span<long> buffer, TComparer tieBreaker, bool isDescending, int indexBits)
+            where TComparer : struct, IComparer<long>
         {
             // We may have ties, have to resolve that before we can continue
             for (int i = 1; i < buffer.Length; i++)
             {
-                var x = buffer[i - 1];
-                var y = buffer[i];
-                if (isDescending)
-                {
-                    x = -x;
-                    y = -y;
-                }
-
-                x >>= 15;
-                y >>= 15;
-                if (x != y)
+                var x = KeyPrefixAt(buffer, i - 1, isDescending, indexBits);
+                if (x != KeyPrefixAt(buffer, i, isDescending, indexBits))
                     continue;
 
                 // we have a match on the prefix, need to figure out where it ends hopefully this is rare
-                int end = i;
-                for (; end < buffer.Length; end++)
-                {
-                    y = buffer[end];
-                    if (isDescending)
-                        y = -y;
-                    y >>= 15;
-                    if (x != y)
-                        break;
-                }
-
+                int end = TieRunEnd(buffer, x, i, isDescending, indexBits);
                 buffer[(i - 1)..end].Sort(tieBreaker);
                 i = end;
             }
         }
 
         private static Span<int> SortByTerms<TComparer>(ref SortingMatch<TInner> match, Span<long> buffer, UnmanagedSpan* batchTerms, bool isDescending,
-            TComparer tieBreaker)
+            TComparer tieBreaker, int indexBits)
             where TComparer : struct, IComparer<long>
         {
-            Debug.Assert(buffer.Length < (1 << 15), "buffer.Length < (1<<15)");
+            long indexMask = (1L << indexBits) - 1;
+            Debug.Assert(buffer.Length <= indexMask + 1, "the packed index field has to address every entry of the batch");
             for (int i = 0; i < buffer.Length; i++)
             {
                 long l = 0;
@@ -250,7 +265,7 @@ unsafe partial struct SortingMatch<TInner>
                     l = -1 >>> 16; // effectively move to the end
                 }
 
-                l = BinaryPrimitives.ReverseEndianness(l) >>> 1;
+                l = (BinaryPrimitives.ReverseEndianness(l) >>> 1) & ~indexMask;
                 long sortKey = l | (uint)i;
                 if (isDescending)
                     sortKey = -sortKey;
@@ -260,16 +275,19 @@ unsafe partial struct SortingMatch<TInner>
 
             Sort.Run(buffer);
 
-            if (match._take >= 0 &&
-                buffer.Length > match._take)
-                buffer = buffer[..match._take];
+            var take = match._take >= 0 && match._take < buffer.Length ? match._take : buffer.Length;
+            if (take > 0)
+            {
+                // Resolve the tie run straddling the cut before cutting, or the top N is chosen by batch index, not by term.
+                // That run can be the whole buffer; nth-element selection is the upgrade if it shows in a profile.
+                var end = TieRunEnd(buffer, KeyPrefixAt(buffer, take - 1, isDescending, indexBits), take, isDescending, indexBits);
+                MaybeBreakTies(buffer[..end], tieBreaker, isDescending, indexBits);
+            }
 
-            MaybeBreakTies(buffer, tieBreaker, isDescending);
-
-            return ExtractIndexes(buffer, isDescending);
+            return ExtractIndexes(buffer[..take], isDescending, indexMask);
         }
 
-        private static Span<int> ExtractIndexes(Span<long> buffer, bool isDescending)
+        private static Span<int> ExtractIndexes(Span<long> buffer, bool isDescending, long indexMask)
         {
             // note - we reuse the memory
             var indexes = MemoryMarshal.Cast<long, int>(buffer)[..(buffer.Length)];
@@ -278,7 +296,7 @@ unsafe partial struct SortingMatch<TInner>
                 var sortKey = buffer[i];
                 if (isDescending)
                     sortKey = -sortKey;
-                var idx = (ushort)sortKey & 0x7FFF;
+                var idx = (int)(sortKey & indexMask);
                 indexes[i] = idx;
             }
 
@@ -291,37 +309,6 @@ unsafe partial struct SortingMatch<TInner>
         }
     }
 
-
-    private struct EntryComparerHelper
-    {
-        public static Span<int> NumericSortBatch<TCmp>(Span<long> batchTermIds, UnmanagedSpan* batchTerms, bool descending = false)
-            where TCmp : struct, IComparer<UnmanagedSpan>, IEntryComparer
-        {
-            var indexes = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
-            for (int i = 0; i < batchTermIds.Length; i++)
-            {
-                batchTerms[i] = new UnmanagedSpan(batchTermIds[i]);
-                indexes[i] = i;
-            }
-
-            IndirectSort<TCmp>(indexes, batchTerms, descending);
-
-            return indexes;
-        }
-
-        public static void IndirectSort<TCmp>(Span<int> indexes, UnmanagedSpan* batchTerms, bool descending, TCmp cmp = default)
-            where TCmp : struct, IComparer<UnmanagedSpan>, IEntryComparer
-        {
-            if (descending)
-            {
-                indexes.Sort(new IndirectComparer<Descending<TCmp>>(batchTerms, new(cmp), true));
-            }
-            else
-            {
-                indexes.Sort(new IndirectComparer<TCmp>(batchTerms, cmp, false));
-            }
-        }
-    }
 
     private struct EntryComparerByLong : IEntryComparer, IComparer<UnmanagedSpan>
     {
@@ -531,18 +518,20 @@ unsafe partial struct SortingMatch<TInner>
     }
 
 
-    private readonly struct IndirectComparer<TComparer> : IComparer<long>, IComparer<int>
+    private readonly struct IndirectComparer<TComparer> : IComparer<long>
         where TComparer : struct, IComparer<UnmanagedSpan>
     {
         private readonly UnmanagedSpan* _terms;
         private readonly TComparer _inner;
         private readonly bool _isDescending;
+        private readonly long _indexMask;
 
-        public IndirectComparer(UnmanagedSpan* terms, TComparer entryComparer, bool isDescending)
+        public IndirectComparer(UnmanagedSpan* terms, TComparer entryComparer, bool isDescending, int indexBits)
         {
             _terms = terms;
             _inner = entryComparer;
             _isDescending = isDescending;
+            _indexMask = (1L << indexBits) - 1;
         }
 
         public int Compare(long x, long y)
@@ -553,17 +542,18 @@ unsafe partial struct SortingMatch<TInner>
                 y = -y;
             }
 
-            var xIdx = (ushort)x & 0X7FFF;
-            var yIdx = (ushort)y & 0X7FFF;
-            Debug.Assert(yIdx < SortingMatch.SortBatchSize && xIdx < SortingMatch.SortBatchSize);
-            return _isDescending
+            // Same width SortByTerms packed for this batch; a fixed 15-bit mask folded larger batches onto 0..32767.
+            var xIdx = (int)(x & _indexMask);
+            var yIdx = (int)(y & _indexMask);
+            var cmp = _isDescending
                 ? -_inner.Compare(_terms[xIdx], _terms[yIdx])
                 : _inner.Compare(_terms[xIdx], _terms[yIdx]);
-        }
+            if (cmp != 0)
+                return cmp;
 
-        public int Compare(int x, int y)
-        {
-            return _inner.Compare(_terms[x], _terms[y]);
+            // Equal sort terms: break the tie by ascending batch index. batchResults holds entry ids in ascending
+            // order, so ties come out in entry id order for both directions instead of whatever the sort left.
+            return xIdx - yIdx;
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_27503.cs
+++ b/test/SlowTests/Issues/RavenDB_27503.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27503 : RavenTestBase
+{
+    public RavenDB_27503(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    // SortByTerms packs the batch index into the low bits of the sort key; both tests exercise that key.
+    // Defect 2: the cut to _take happens before MaybeBreakTies, so the top N is picked by batch index, not by term.
+    // Needs terms equal in the 6 encoded bytes the key keeps - a 160-byte shared prefix guarantees that whatever the
+    // dictionary - and an insertion order that disagrees with the term order, hence the group is stored descending.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void LimitMustNotPickTheTopNByTheTruncatedTermKey(Options options)
+    {
+        const int groupSize = 10, anchors = 5;
+        const int limit = anchors + groupSize / 2; // the cut lands in the middle of the tie group
+
+        using var store = GetDocumentStore(options);
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < anchors; i++)
+                bulk.Store(new Item { Key = AnchorTerm(i) }, $"items/anchor/{i}");
+
+            for (int i = groupSize - 1; i >= 0; i--) // descending, so the batch index disagrees with the term order
+                bulk.Store(new Item { Key = GroupTerm(i) }, $"items/group/{i}");
+        }
+
+        new Items_ByKey().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        var expected = Enumerable.Range(0, anchors).Select(AnchorTerm)
+            .Concat(Enumerable.Range(0, groupSize).Select(GroupTerm))
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .Take(limit)
+            .ToArray();
+
+        using var session = store.OpenSession();
+
+        // keep documents > limit, otherwise take widens to TakeAll and nothing is cut
+        var rows = Query(session, options, "where true order by Key as string", limit);
+
+        // the set, not the order: the returned page is ordered correctly either way
+        Assert.Equal(expected, rows.Select(x => x.Key).OrderBy(x => x, StringComparer.Ordinal).ToArray());
+    }
+
+    // github.com/ravendb/ravendb/issues/23570 - the same cut, reached through a filter on another field
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void FilteredPageOverIsoDateStringsReturnsTheNewestFirst(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var bulk = store.BulkInsert())
+        {
+            bulk.Store(new Item { Key = "2026-09-01", Category = "News" }, "items/A");
+            bulk.Store(new Item { Key = "2026-08-01", Category = "News" }, "items/B");
+            bulk.Store(new Item { Key = "2026-07-01", Category = "News" }, "items/C");
+            bulk.Store(new Item { Key = "2026-06-01", Category = "News" }, "items/D");
+        }
+
+        new Items_ByKey().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using var session = store.OpenSession();
+
+        var rows = Query(session, options, "where Category = 'News' order by Key desc", limit: 2);
+
+        Assert.Equal(new[] { "items/A", "items/B" }, rows.Select(x => x.Id).ToArray());
+    }
+
+    // 160 shared bytes then a 4-digit discriminator, every term the same length
+    private static string GroupTerm(int i) => new string('a', 160) + i.ToString("D4");
+
+    // sort before every group term and differ in byte 0, so they are in the top N on term grounds alone
+    private static string AnchorTerm(int i) => $"{i}-anchor";
+
+    // Defect 3: with no secondary comparison, equal terms came out in whatever order the sort left them.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void EqualTermsMustBeOrderedByAscendingId(Options options)
+    {
+        const int documents = 500;
+
+        using var store = GetDocumentStore(options);
+
+        // one tie group: the whole result is decided by the tie-break
+        Fill(store, documents, _ => "same-term-for-everyone");
+
+        using var session = store.OpenSession();
+
+        var rows = Query(session, options, "where true order by Key as string");
+
+        var expected = Enumerable.Range(0, documents).Select(i => $"items/{i:D4}").ToArray();
+
+        Assert.Equal(expected, rows.Select(x => x.Id).ToArray());
+    }
+
+    private void Fill(IDocumentStore store, int documents, Func<int, string> key)
+    {
+        using (var bulk = store.BulkInsert())
+        {
+            // explicit padded ids so that lexicographic order == insertion order == entry id order
+            for (int i = 0; i < documents; i++)
+                bulk.Store(new Item { Key = key(i) }, $"items/{i:D4}");
+        }
+
+        new Items_ByKey().Execute(store);
+        Indexes.WaitForIndexing(store);
+    }
+
+    // 'where true' keeps the sort in the plan and forces the in-memory batch sort instead of the sort-field scan;
+    // 'as string' reaches the term comparer rather than the immune numeric one.
+    private static List<Item> Query(IDocumentSession session, Options options, string rql, int? limit = null)
+    {
+        // RQL puts LIMIT last, after SELECT and INCLUDE
+        var tail = limit is { } n ? $" limit {n}" : string.Empty;
+
+        var rows = session.Advanced
+            .RawQuery<Item>($"from index 'Items/ByKey' {rql} select id() as Id, Key include timings(){tail}")
+            .Timings(out QueryTimings timings)
+            .ToList();
+
+        // guards against a vacuous pass: an elided sort or a numeric field never touches the packed key
+        if (options.SearchEngineMode == RavenSearchEngineMode.Corax)
+        {
+            var sorting = Find(timings.QueryPlan as QueryInspectionNode, "SortingMatch");
+            Assert.True(sorting != null, "no SortingMatch in the plan, the query never reached the batch sort");
+
+            sorting.Parameters.TryGetValue("FieldType", out var fieldType);
+            Assert.Equal("Sequence", fieldType);
+        }
+
+        return rows;
+    }
+
+    private static QueryInspectionNode Find(QueryInspectionNode node, string operation)
+    {
+        if (node == null)
+            return null;
+        if (node.Operation == operation)
+            return node;
+
+        foreach (var child in node.Children ?? new List<QueryInspectionNode>())
+        {
+            var found = Find(child, operation);
+            if (found != null)
+                return found;
+        }
+
+        return null;
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+
+        public string Key { get; set; }
+
+        public string Category { get; set; }
+    }
+
+    private class Items_ByKey : AbstractIndexCreationTask<Item>
+    {
+        public Items_ByKey()
+        {
+            Map = items => from item in items
+                           select new { item.Key, item.Category };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27503

Corax 1.0 counterpart of RavenDB-27482 (`feature/corax-2.0`), fixes https://github.com/ravendb/ravendb/issues/23570.

### Additional description

`SortByTerms` sorts a batch by a key that keeps 6 encoded bytes of the term plus the entry's index within the batch, then resolves prefix ties with the full comparer. Two things were wrong on this branch:

- The cut to `_take` happened before `MaybeBreakTies`, so when the limit fell inside a group of terms equal in those 6 bytes, the surviving documents were picked by batch index, not by term. Now the tie run straddling the cut is resolved first, then the cut is made - the same narrow correction as on corax-2.0.
- `IndirectComparer` had no secondary comparison, so equal terms came out in whatever order the unstable sort left them. It now falls back to ascending batch index, which is ascending entry id here, matching Lucene and corax-2.0.

The packed index field is also widened by the batch size (`IndexBitsFor`) as on corax-2.0. It is hardening only: on this branch sets of 4096 and more take `SortUsingIndex`, and no shape reached `SortByTerms` with more than 32 768 entries, but that path's fallback hands over an unbounded span with only a Release-inert assert in the way. For batches up to 32 768 the key is bit-for-bit unchanged. The dead `EntryComparerHelper` goes with it, as on corax-2.0, keeping the file identical between the branches.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

A paged string `ORDER BY` whose limit cuts inside a group of terms sharing their first 6 encoded bytes now returns the correct set. Documents with equal sort terms now come back in ascending entry id instead of an arbitrary order. Worst case for the first change is a tie run spanning the whole buffer, in which case everything is resolved with the full comparer - the same cost the no-limit query already pays.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed