### PR TITLE
RavenDB-13497 Validate that Reduce function fields are a subset of Map functions fields of a JavaScript map-reduce index

### DIFF
--- a/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
@@ -55,7 +55,10 @@ public abstract class AbstractIndexCreateController
         var databaseConfiguration = GetDatabaseConfiguration();
         // pre-compile it and validate
         var instance = IndexCompilationCache.GetIndexInstance(definition, databaseConfiguration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
-        
+
+        if (instance is AbstractJavaScriptIndex javaScriptIndex)
+            javaScriptIndex.ValidateFieldsOfMapAndReduceFunctions();
+
         if (definition.Type == IndexType.MapReduce)
         {
             await MapReduceIndex.ValidateReduceResultsCollectionNameAsync(

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -213,11 +213,12 @@ namespace Raven.Server.Documents.Indexes
             public const long CoraxOrderPreservingCompoundNumericEncoding = Base72Version; // RavenDB-26831
             public const long CoraxNumericTreesWithoutFrequencies_72 = 72_002; // RavenDB-27171
             public const long LuceneExactDatesUseTimeTicks_72 = 72_003; // RavenDB-27052
+            public const long JavaScriptMapReduceFieldsValidation = 72_004; // RavenDB-13497
 
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = LuceneExactDatesUseTimeTicks_72;
+            public const long CurrentVersion = JavaScriptMapReduceFieldsValidation;
 
             public static bool IsLowerCasedReferencesSupported(long indexVersion)
             {

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -213,12 +213,11 @@ namespace Raven.Server.Documents.Indexes
             public const long CoraxOrderPreservingCompoundNumericEncoding = Base72Version; // RavenDB-26831
             public const long CoraxNumericTreesWithoutFrequencies_72 = 72_002; // RavenDB-27171
             public const long LuceneExactDatesUseTimeTicks_72 = 72_003; // RavenDB-27052
-            public const long JavaScriptMapReduceFieldsValidation = 72_004; // RavenDB-13497
 
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = JavaScriptMapReduceFieldsValidation;
+            public const long CurrentVersion = LuceneExactDatesUseTimeTicks_72;
 
             public static bool IsLowerCasedReferencesSupported(long indexVersion)
             {

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -263,10 +263,9 @@ function map(name, lambda) {
                 ProcessMaps(definitions, resolver, maps, mapReferencedCollections, out var collectionFunctions);
                 AssertVectorFieldForMapReduceIndexes(mapReferencedCollections);
 
+                _mapOperations = collectionFunctions.SelectMany(x => x.Value).SelectMany(x => x.Value).ToList();
 
                 ProcessReduce(definition, definitions, resolver, indexVersion);
-
-                ValidateFieldsOfMapAndReduceFunctions(collectionFunctions, indexVersion);
 
                 ProcessFields(definition, collectionFunctions);
             }
@@ -353,14 +352,14 @@ function map(name, lambda) {
             OutputFields = fields.ToArray();
         }
 
-        private void ValidateFieldsOfMapAndReduceFunctions(Dictionary<string, Dictionary<string, List<JavaScriptMapOperation>>> collectionFunctions, long indexVersion)
+        internal void ValidateFieldsOfMapAndReduceFunctions()
         {
-            if (ReduceOperation == null || indexVersion < IndexDefinitionBaseServerSide.IndexVersion.JavaScriptMapReduceFieldsValidation)
+            if (ReduceOperation == null)
                 return;
 
             JavaScriptMapOperation baseline = null;
 
-            foreach (var operation in collectionFunctions.SelectMany(x => x.Value).SelectMany(x => x.Value))
+            foreach (var operation in _mapOperations)
             {
                 if (operation.HasDynamicReturns || operation.Fields.Count == 0)
                     continue;
@@ -704,6 +703,7 @@ function loadVector(pathToEmbedding, aiTaskIdentifier, embeddingSourceDocumentId
         protected readonly IndexDefinition Definition;
         internal readonly Engine _engine;
         protected readonly JavaScriptUtils _javaScriptUtils;
+        private readonly List<JavaScriptMapOperation> _mapOperations;
 
         public JavaScriptReduceOperation ReduceOperation { get; private set; }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -380,8 +380,8 @@ function map(name, lambda) {
 
             foreach (var reduceFields in ReduceOperation.GetStaticallyKnownOutputFields())
             {
-                if (baseline.Fields.SetEquals(reduceFields) == false)
-                    ThrowFieldsMismatch(baseline.MapString, baseline.Fields, ReduceOperation.ReduceString, reduceFields);
+                if (baseline.Fields.IsSubsetOf(reduceFields) == false)
+                    ThrowReduceMissingFields(baseline.MapString, baseline.Fields, ReduceOperation.ReduceString, reduceFields);
             }
 
             foreach (var groupByField in GroupByFields)
@@ -395,13 +395,25 @@ function map(name, lambda) {
         private void ThrowFieldsMismatch(string baselineFunction, HashSet<string> baselineFields, string nonMatchingFunction, ICollection<string> nonMatchingFields)
         {
             ThrowIndexCreationException($"""
-                                         must return identical fields in its Map and Reduce functions.
+                                         must return identical fields in all its Map functions.
                                          Baseline function: {baselineFunction}
                                          Non matching function: {nonMatchingFunction}
 
                                          Common fields: {string.Join(", ", baselineFields.Intersect(nonMatchingFields))}
                                          Missing fields: {string.Join(", ", baselineFields.Except(nonMatchingFields))}
                                          Additional fields: {string.Join(", ", nonMatchingFields.Except(baselineFields))}
+                                         """);
+        }
+
+        [DoesNotReturn]
+        private void ThrowReduceMissingFields(string mapFunction, HashSet<string> mapFields, string reduceFunction, ICollection<string> reduceFields)
+        {
+            ThrowIndexCreationException($"""
+                                         must return all fields of its Map functions in the Reduce function.
+                                         Map function: {mapFunction}
+                                         Reduce function: {reduceFunction}
+
+                                         Missing fields: {string.Join(", ", mapFields.Except(reduceFields))}
                                          """);
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -263,8 +263,10 @@ function map(name, lambda) {
                 ProcessMaps(definitions, resolver, maps, mapReferencedCollections, out var collectionFunctions);
                 AssertVectorFieldForMapReduceIndexes(mapReferencedCollections);
 
-                
+
                 ProcessReduce(definition, definitions, resolver, indexVersion);
+
+                ValidateFieldsOfMapAndReduceFunctions(collectionFunctions, indexVersion);
 
                 ProcessFields(definition, collectionFunctions);
             }
@@ -349,6 +351,58 @@ function map(name, lambda) {
             }
 
             OutputFields = fields.ToArray();
+        }
+
+        private void ValidateFieldsOfMapAndReduceFunctions(Dictionary<string, Dictionary<string, List<JavaScriptMapOperation>>> collectionFunctions, long indexVersion)
+        {
+            if (ReduceOperation == null || indexVersion < IndexDefinitionBaseServerSide.IndexVersion.JavaScriptMapReduceFieldsValidation)
+                return;
+
+            JavaScriptMapOperation baseline = null;
+
+            foreach (var operation in collectionFunctions.SelectMany(x => x.Value).SelectMany(x => x.Value))
+            {
+                if (operation.HasDynamicReturns || operation.Fields.Count == 0)
+                    continue;
+
+                if (baseline == null)
+                {
+                    baseline = operation;
+                    continue;
+                }
+
+                if (baseline.Fields.SetEquals(operation.Fields) == false)
+                    ThrowFieldsMismatch(baseline.MapString, baseline.Fields, operation.MapString, operation.Fields);
+            }
+
+            if (baseline == null)
+                return;
+
+            foreach (var reduceFields in ReduceOperation.GetStaticallyKnownOutputFields())
+            {
+                if (baseline.Fields.SetEquals(reduceFields) == false)
+                    ThrowFieldsMismatch(baseline.MapString, baseline.Fields, ReduceOperation.ReduceString, reduceFields);
+            }
+
+            foreach (var groupByField in GroupByFields)
+            {
+                if (baseline.Fields.Contains(groupByField.Name) == false)
+                    ThrowIndexCreationException($"is grouping by field '{groupByField.Name}' which is not returned by its map functions. Map fields: {string.Join(", ", baseline.Fields)}");
+            }
+        }
+
+        [DoesNotReturn]
+        private void ThrowFieldsMismatch(string baselineFunction, HashSet<string> baselineFields, string nonMatchingFunction, ICollection<string> nonMatchingFields)
+        {
+            ThrowIndexCreationException($"""
+                                         must return identical fields in its Map and Reduce functions.
+                                         Baseline function: {baselineFunction}
+                                         Non matching function: {nonMatchingFunction}
+
+                                         Common fields: {string.Join(", ", baselineFields.Intersect(nonMatchingFields))}
+                                         Missing fields: {string.Join(", ", baselineFields.Except(nonMatchingFields))}
+                                         Additional fields: {string.Join(", ", nonMatchingFields.Except(baselineFields))}
+                                         """);
         }
 
         private void ProcessReduce(IndexDefinition definition, ObjectInstance definitions, JintPreventResolvingTasksReferenceResolver resolver, long indexVersion)

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptReduceOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptReduceOperation.cs
@@ -406,6 +406,44 @@ namespace Raven.Server.Documents.Indexes.Static
             }
         }
 
+        internal List<HashSet<string>> GetStaticallyKnownOutputFields()
+        {
+            var shapes = new List<HashSet<string>>();
+
+            foreach (var returnStatement in JavaScriptIndexUtils.GetReturnStatements(Reduce.FunctionDeclaration))
+            {
+                if (returnStatement.Argument is not ObjectExpression oe)
+                    continue;
+
+                var fields = new HashSet<string>();
+                var isStaticallyKnown = true;
+
+                foreach (var prop in oe.Properties)
+                {
+                    if (prop is Property { Computed: false } property)
+                    {
+                        var fieldName = property.GetKey(Engine).AsString();
+                        if (fieldName == "_")
+                        {
+                            isStaticallyKnown = false;
+                            break;
+                        }
+
+                        fields.Add(fieldName);
+                        continue;
+                    }
+
+                    isStaticallyKnown = false;
+                    break;
+                }
+
+                if (isStaticallyKnown && fields.Count > 0)
+                    shapes.Add(fields);
+            }
+
+            return shapes;
+        }
+
         public void SetBufferPoolForTestingPurposes(UnmanagedBuffersPoolWithLowMemoryHandling bufferPool)
         {
             _bufferPool = bufferPool;

--- a/test/SlowTests.Issues/Issues/RavenDB-14576.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-14576.cs
@@ -110,7 +110,7 @@ namespace SlowTests.Issues
         return {
             ParentId: g.key.ParentId,
             ParentName: g.key.ParentName,
-            ChildFolderOrDocument: arr
+            ChildDocument: arr
         };
     })"
                 };

--- a/test/SlowTests.Issues/Issues/RavenDB-14797.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-14797.cs
@@ -180,8 +180,10 @@ namespace SlowTests.Issues
                 {
                     @"map('FirstOutput', (row) => {
     return {
-        Value: row.Name,
         TypeName: 'CommunicationType',
+        Communication: {
+            Value: row.Name
+        }
     };
 })",
                 };
@@ -192,7 +194,7 @@ namespace SlowTests.Issues
     return {
         TypeName: g.key.TypeName,
         Communication: {
-            Value: g.values.reduce((x, val) => val.Value, '')
+            Value: g.values.reduce((x, val) => val.Communication.Value, '')
         }
     };
 })";

--- a/test/SlowTests.Issues/Issues/RavenDB_13497.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13497.cs
@@ -1,0 +1,225 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Documents.Indexes;
+using Raven.Server.Config;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Static;
+using Raven.Server.ServerWide;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_13497 : RavenTestBase
+    {
+        public RavenDB_13497(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
+        public void ThrowsWhenReduceReturnsDifferentFieldsThanMap()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var e = Assert.Throws<IndexCreationException>(() => store.ExecuteIndex(new UsersReducedWithAdditionalField()));
+
+                Assert.Contains("must return identical fields in its Map and Reduce functions", e.Message);
+                Assert.Contains("Missing fields: Count", e.Message);
+                Assert.Contains("Additional fields: Total", e.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
+        public void ThrowsWhenReduceReturnsSubsetOfMapFields()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var e = Assert.Throws<IndexCreationException>(() => store.ExecuteIndex(new UsersReducedWithMissingField()));
+
+                Assert.Contains("must return identical fields in its Map and Reduce functions", e.Message);
+                Assert.Contains("Missing fields: Count", e.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
+        public void ThrowsWhenMapsOfMultiMapIndexReturnDifferentFields()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var e = Assert.Throws<IndexCreationException>(() => store.ExecuteIndex(new UsersAndEmployeesReducedWithNonMatchingMaps()));
+
+                Assert.Contains("must return identical fields in its Map and Reduce functions", e.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
+        public void ThrowsWhenGroupByFieldIsMissingFromMap()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var e = Assert.Throws<IndexCreationException>(() => store.ExecuteIndex(new UsersReducedByFieldMissingFromMap()));
+
+                Assert.Contains("is grouping by field 'Age' which is not returned by its map functions", e.Message);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void CanCreateAndUseMapReduceIndexWithMatchingFields(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                store.ExecuteIndex(new UsersReducedByName());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Joe", Age = 33 });
+                    session.Store(new User { Name = "Joe", Age = 34 });
+
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var results = session.Query<ReduceResults>("UsersReducedByName").ToList();
+
+                    Assert.Equal(1, results.Count);
+                    Assert.Equal("Joe", results[0].Name);
+                    Assert.Equal(2, results[0].Count);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void SkipsValidationWhenMapHasDynamicReturns(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                store.ExecuteIndex(new UsersReducedByNameResultsPushedToJsArray());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Joe", Age = 33 });
+                    session.Store(new User { Name = "Joe", Age = 34 });
+
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var results = session.Query<ReduceResults>("UsersReducedByNameResultsPushedToJsArray").ToList();
+
+                    Assert.Equal(1, results.Count);
+                    Assert.Equal("Joe", results[0].Name);
+                    Assert.Equal(2, results[0].Count);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
+        public void SkipsValidationForOlderIndexVersions()
+        {
+            var definition = new IndexDefinition
+            {
+                Name = "UsersReducedWithAdditionalField",
+                Maps = new HashSet<string> { Maps.MatchingMap },
+                Reduce = Maps.ReduceWithAdditionalField
+            };
+
+            var configuration = RavenConfiguration.CreateForTesting("foo", ResourceType.Database);
+            configuration.Initialize();
+
+            var index = new JavaScriptIndex(definition, configuration, IndexDefinitionBaseServerSide.IndexVersion.LuceneExactDatesUseTimeTicks_72);
+            Assert.NotNull(index.ReduceOperation);
+
+            Assert.Throws<IndexCreationException>(() => new JavaScriptIndex(definition, configuration, IndexDefinitionBaseServerSide.IndexVersion.JavaScriptMapReduceFieldsValidation));
+        }
+
+        private class ReduceResults
+        {
+            public string Name { get; set; }
+
+            public int Count { get; set; }
+        }
+
+        private static class Maps
+        {
+            public const string MatchingMap = "map('Users', function (u) { return { Name: u.Name, Count: 1 }; })";
+
+            public const string MatchingReduce = @"groupBy(x => x.Name)
+                .aggregate(g => { return { Name: g.key, Count: g.values.reduce((total, val) => val.Count + total, 0) }; })";
+
+            public const string ReduceWithAdditionalField = @"groupBy(x => x.Name)
+                .aggregate(g => { return { Name: g.key, Total: g.values.reduce((total, val) => val.Count + total, 0) }; })";
+        }
+
+        private class UsersReducedWithAdditionalField : AbstractJavaScriptIndexCreationTask
+        {
+            public UsersReducedWithAdditionalField()
+            {
+                Maps = new HashSet<string> { RavenDB_13497.Maps.MatchingMap };
+                Reduce = RavenDB_13497.Maps.ReduceWithAdditionalField;
+            }
+        }
+
+        private class UsersReducedWithMissingField : AbstractJavaScriptIndexCreationTask
+        {
+            public UsersReducedWithMissingField()
+            {
+                Maps = new HashSet<string> { RavenDB_13497.Maps.MatchingMap };
+                Reduce = @"groupBy(x => x.Name)
+                    .aggregate(g => { return { Name: g.key }; })";
+            }
+        }
+
+        private class UsersAndEmployeesReducedWithNonMatchingMaps : AbstractJavaScriptIndexCreationTask
+        {
+            public UsersAndEmployeesReducedWithNonMatchingMaps()
+            {
+                Maps = new HashSet<string>
+                {
+                    RavenDB_13497.Maps.MatchingMap,
+                    "map('Employees', function (e) { return { Name: e.FirstName, Total: 1 }; })"
+                };
+                Reduce = RavenDB_13497.Maps.MatchingReduce;
+            }
+        }
+
+        private class UsersReducedByFieldMissingFromMap : AbstractJavaScriptIndexCreationTask
+        {
+            public UsersReducedByFieldMissingFromMap()
+            {
+                Maps = new HashSet<string> { RavenDB_13497.Maps.MatchingMap };
+                Reduce = @"groupBy(x => x.Age)
+                    .aggregate(g => { return { Name: g.key, Count: g.values.reduce((total, val) => val.Count + total, 0) }; })";
+            }
+        }
+
+        private class UsersReducedByName : AbstractJavaScriptIndexCreationTask
+        {
+            public UsersReducedByName()
+            {
+                Maps = new HashSet<string> { RavenDB_13497.Maps.MatchingMap };
+                Reduce = RavenDB_13497.Maps.MatchingReduce;
+            }
+        }
+
+        private class UsersReducedByNameResultsPushedToJsArray : AbstractJavaScriptIndexCreationTask
+        {
+            public UsersReducedByNameResultsPushedToJsArray()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"map('Users', function (u) {
+                        var res = [];
+                        res.push({ Name: u.Name, Count: 1 });
+                        return res;
+                    })"
+                };
+                Reduce = RavenDB_13497.Maps.MatchingReduce;
+            }
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_13497.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13497.cs
@@ -20,15 +20,14 @@ namespace SlowTests.Issues
         }
 
         [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
-        public void ThrowsWhenReduceReturnsDifferentFieldsThanMap()
+        public void ThrowsWhenReduceRenamesMapField()
         {
             using (var store = GetDocumentStore())
             {
-                var e = Assert.Throws<IndexCreationException>(() => store.ExecuteIndex(new UsersReducedWithAdditionalField()));
+                var e = Assert.Throws<IndexCreationException>(() => store.ExecuteIndex(new UsersReducedWithRenamedField()));
 
-                Assert.Contains("must return identical fields in its Map and Reduce functions", e.Message);
+                Assert.Contains("must return all fields of its Map functions in the Reduce function", e.Message);
                 Assert.Contains("Missing fields: Count", e.Message);
-                Assert.Contains("Additional fields: Total", e.Message);
             }
         }
 
@@ -39,7 +38,7 @@ namespace SlowTests.Issues
             {
                 var e = Assert.Throws<IndexCreationException>(() => store.ExecuteIndex(new UsersReducedWithMissingField()));
 
-                Assert.Contains("must return identical fields in its Map and Reduce functions", e.Message);
+                Assert.Contains("must return all fields of its Map functions in the Reduce function", e.Message);
                 Assert.Contains("Missing fields: Count", e.Message);
             }
         }
@@ -51,7 +50,34 @@ namespace SlowTests.Issues
             {
                 var e = Assert.Throws<IndexCreationException>(() => store.ExecuteIndex(new UsersAndEmployeesReducedWithNonMatchingMaps()));
 
-                Assert.Contains("must return identical fields in its Map and Reduce functions", e.Message);
+                Assert.Contains("must return identical fields in all its Map functions", e.Message);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void AllowsReduceWithAdditionalDerivedFields(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                store.ExecuteIndex(new UsersReducedWithDerivedField());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Joe", Age = 33 });
+                    session.Store(new User { Name = "Joe", Age = 34 });
+
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var results = session.Query<ReduceResults>("UsersReducedWithDerivedField").ToList();
+
+                    Assert.Equal(1, results.Count);
+                    Assert.Equal("Joe", results[0].Name);
+                    Assert.Equal(2, results[0].Count);
+                    Assert.Equal("Multiple", results[0].Status);
+                }
             }
         }
 
@@ -123,9 +149,9 @@ namespace SlowTests.Issues
         {
             var definition = new IndexDefinition
             {
-                Name = "UsersReducedWithAdditionalField",
+                Name = "UsersReducedWithRenamedField",
                 Maps = new HashSet<string> { Maps.MatchingMap },
-                Reduce = Maps.ReduceWithAdditionalField
+                Reduce = Maps.ReduceWithRenamedField
             };
 
             var configuration = RavenConfiguration.CreateForTesting("foo", ResourceType.Database);
@@ -142,6 +168,8 @@ namespace SlowTests.Issues
             public string Name { get; set; }
 
             public int Count { get; set; }
+
+            public string Status { get; set; }
         }
 
         private static class Maps
@@ -151,16 +179,29 @@ namespace SlowTests.Issues
             public const string MatchingReduce = @"groupBy(x => x.Name)
                 .aggregate(g => { return { Name: g.key, Count: g.values.reduce((total, val) => val.Count + total, 0) }; })";
 
-            public const string ReduceWithAdditionalField = @"groupBy(x => x.Name)
+            public const string ReduceWithRenamedField = @"groupBy(x => x.Name)
                 .aggregate(g => { return { Name: g.key, Total: g.values.reduce((total, val) => val.Count + total, 0) }; })";
         }
 
-        private class UsersReducedWithAdditionalField : AbstractJavaScriptIndexCreationTask
+        private class UsersReducedWithRenamedField : AbstractJavaScriptIndexCreationTask
         {
-            public UsersReducedWithAdditionalField()
+            public UsersReducedWithRenamedField()
             {
                 Maps = new HashSet<string> { RavenDB_13497.Maps.MatchingMap };
-                Reduce = RavenDB_13497.Maps.ReduceWithAdditionalField;
+                Reduce = RavenDB_13497.Maps.ReduceWithRenamedField;
+            }
+        }
+
+        private class UsersReducedWithDerivedField : AbstractJavaScriptIndexCreationTask
+        {
+            public UsersReducedWithDerivedField()
+            {
+                Maps = new HashSet<string> { RavenDB_13497.Maps.MatchingMap };
+                Reduce = @"groupBy(x => x.Name)
+                    .aggregate(g => {
+                        var count = g.values.reduce((total, val) => val.Count + total, 0);
+                        return { Name: g.key, Count: count, Status: count > 1 ? 'Multiple' : 'Single' };
+                    })";
             }
         }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_13497.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13497.cs
@@ -145,7 +145,7 @@ namespace SlowTests.Issues
         }
 
         [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Indexes)]
-        public void SkipsValidationForOlderIndexVersions()
+        public void CompilationSkipsValidationSoExistingIndexesKeepLoading()
         {
             var definition = new IndexDefinition
             {
@@ -157,10 +157,10 @@ namespace SlowTests.Issues
             var configuration = RavenConfiguration.CreateForTesting("foo", ResourceType.Database);
             configuration.Initialize();
 
-            var index = new JavaScriptIndex(definition, configuration, IndexDefinitionBaseServerSide.IndexVersion.LuceneExactDatesUseTimeTicks_72);
+            var index = new JavaScriptIndex(definition, configuration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
             Assert.NotNull(index.ReduceOperation);
 
-            Assert.Throws<IndexCreationException>(() => new JavaScriptIndex(definition, configuration, IndexDefinitionBaseServerSide.IndexVersion.JavaScriptMapReduceFieldsValidation));
+            Assert.Throws<IndexCreationException>(() => index.ValidateFieldsOfMapAndReduceFunctions());
         }
 
         private class ReduceResults

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalIndexingTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalIndexingTests.cs
@@ -1018,7 +1018,7 @@ public class DataArchivalIndexingTests : RavenTestBase
     {
         public CompaniesByNameJSMapReduce()
         {
-            Maps = new HashSet<string> {@"map('Companies', function (u){ return { Name: u.Name, Count: 1, Id: u.Id};})",};
+            Maps = new HashSet<string> {@"map('Companies', function (u){ return { Name: u.Name, Count: 1};})",};
 
             Reduce = @"groupBy(x => ({ Name: x.Name }))
 .aggregate(g => { 
@@ -1036,7 +1036,7 @@ public class DataArchivalIndexingTests : RavenTestBase
         {
             Maps = new HashSet<string>
             {
-                @"map('Companies', function (u){ return { Name: u.Name, Count: 1, Id: u.Id};})",
+                @"map('Companies', function (u){ return { Name: u.Name, Count: 1};})",
             };
             
             Reduce = @"groupBy(x => ({ Name: x.Name }))
@@ -1056,7 +1056,7 @@ public class DataArchivalIndexingTests : RavenTestBase
         {
             Maps = new HashSet<string>
             {
-                @"map('Companies', function (u){ return { Name: u.Name, Count: 1, Id: u.Id};})",
+                @"map('Companies', function (u){ return { Name: u.Name, Count: 1};})",
             };
 
             Reduce = @"groupBy(x => ({ Name: x.Name }))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13497/Map-Reduce-Javascript-Index-Report-a-relevant-error-when-Map-and-Reduce-functions-dont-have-the-same-structure

### Additional description

Note it's a static check, so not all cases are caught (e.g. dynamic fields).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. 
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
