### PR TITLE
RavenDB-22493 Make DatabaseState.IndexingStatus nullable so the client can parse a database with unknown indexing status

### DIFF
--- a/src/Raven.Client/ServerWide/Operations/DatabasesInfo.cs
+++ b/src/Raven.Client/ServerWide/Operations/DatabasesInfo.cs
@@ -92,7 +92,7 @@ namespace Raven.Client.ServerWide.Operations
         public long? PerformanceHints { get; set; }
         public string LoadError { get; set; }
         public long? IndexingErrors { get; set; }
-        public IndexRunningStatus IndexingStatus { get; set; }
+        public IndexRunningStatus? IndexingStatus { get; set; }
         public long? TasksErrors { get; set; }
 
         public virtual DynamicJsonValue ToJson()
@@ -119,7 +119,7 @@ namespace Raven.Client.ServerWide.Operations
                 [nameof(TasksErrors)] = TasksErrors,
 
                 [nameof(DocumentsCount)] = DocumentsCount,
-                [nameof(IndexingStatus)] = IndexingStatus.ToString()
+                [nameof(IndexingStatus)] = IndexingStatus?.ToString()
             };
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_15477.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15477.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Issues
                     Assert.True(item.TryGetMember(nameof(DatabaseInfo.IndexingStatus), out var indexingStatus));
                     Assert.Null(indexingStatus);
                     var dbInfo = JsonDeserializationServer.DatabaseInfo(item);
-                    Assert.Equal(IndexRunningStatus.Running, dbInfo.IndexingStatus);
+                    Assert.Null(dbInfo.IndexingStatus);
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB_22493.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22493.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Extensions;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
+using Sparrow.Server.Json.Sync;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22493 : RavenTestBase
+    {
+        public RavenDB_22493(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task CanDeserializeDatabasesInfoWhenIndexingStatusIsNull()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "egor" });
+                    await session.SaveChangesAsync();
+                }
+
+                store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, disable: true));
+
+                var client = store.GetRequestExecutor().HttpClient;
+                var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, $"{store.Urls.First()}/databases?name={store.Database}").WithConventions(store.Conventions));
+                var result = await response.Content.ReadAsStringAsync();
+
+                using (var ctx = JsonOperationContext.ShortTermSingleUse())
+                {
+                    using var bjro = ctx.Sync.ReadForMemory(result, "databases");
+                    var databasesInfo = store.Conventions.Serialization.DefaultConverter.FromBlittable<DatabasesInfo>(bjro, "databases");
+
+                    var databaseInfo = databasesInfo.Databases.Single(x => x.Name == store.Database);
+                    Assert.Null(databaseInfo.IndexingStatus);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22493

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
