### PR TITLE
RavenDB-27460 Do not score a leaf resolved from a negated clause

### DIFF
--- a/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Threading;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
@@ -262,16 +261,13 @@ public sealed class SpatialMatch<TBoosting> : IPostFilterMatch, ISpatialFilterQu
 
     public void Score(Span<long> matches, Span<float> scores, float boostFactor)
     {
+        // CompiledQueryMatch.Score calls every resolved leaf, negated ones included, and a negated leaf is resolved
+        // without boost - it has no score data to hand over. Same contract as TermMatch.Score.
         if (typeof(TBoosting) != typeof(HasBoosting))
-            ThrowPrimitiveHasNoBoostingData();
+            return;
 
         _spatialScore.CalculateScore(matches, scores, boostFactor, _spatialRelation);
         _spatialScore.Dispose();
-    }
-
-    private void ThrowPrimitiveHasNoBoostingData()
-    {
-        throw new InvalidDataException($"{nameof(SpatialMatch<TBoosting>)}");
     }
 
     public QueryInspectionNode Inspect()

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.ResolveClause.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryPlanBuilder/QueryPlanBuilder.Resolution.ResolveClause.cs
@@ -90,7 +90,7 @@ internal static partial class QueryPlanBuilder
                                ?? throw new InvalidOperationException("Spatial clause has no pre-resolved field name.");
 
             var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(allocator, fieldName, index, builderParams.IndexFieldsMapping,
-                builderParams.HasDynamics, builderParams.DynamicFields, hasBoost: builderParams.HasBoost);
+                builderParams.HasDynamics, builderParams.DynamicFields, hasBoost: builderParams.HasBoost && clause.IsNegated == false);
 
             var sp = cur.Spatial;
             var distanceErrorPct = sp.DistanceErrorPct >= 0

--- a/test/SlowTests.Issues/Issues/RavenDB_27460.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_27460.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27460 : RavenTestBase
+{
+    public RavenDB_27460(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void ANegatedTermMustNotContributeToTheScore(Options options)
+    {
+        const int documents = 200_000; // 'Planned' appears ~133k times - above the stored relevance threshold
+
+        using var store = GetDocumentStore(options);
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < documents; i++)
+            {
+                bulk.Store(new Movie
+                {
+                    Genre = i % 100 == 0 ? "Drama" : "Filler",
+                    Status = i % 3 == 0 ? "Released" : "Planned",
+                    Title = i % 50 == 0 ? "the matrix reloaded" : "some other movie title"
+                });
+            }
+        }
+
+        new Movies_Score().Execute(store);
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(15));
+
+        using var session = store.OpenSession();
+
+        // 'Planned' documents enter through the search() branch while holding the negated term,
+        // 'Released' ones satisfy the negated clause - both match the same two scoring terms.
+        var hits = session.Advanced
+            .RawQuery<Hit>(@"from index 'Movies/Score' as m
+                             where (m.Genre = 'Drama' and m.Status != 'Planned') or search(m.Title, 'matrix')
+                             order by score()
+                             select { Status: m.Status, Score: getMetadata(m)[""@index-score""] }
+                             limit 8192")
+            .ToList();
+
+        double satisfying = hits.Where(x => x.Status == "Released").Max(x => x.Score);
+        double holdingNegatedTerm = hits.Where(x => x.Status == "Planned").Max(x => x.Score);
+
+        Assert.True(satisfying >= holdingNegatedTerm,
+            $"a document holding the negated term scored {holdingNegatedTerm} against {satisfying} for one that satisfies the clause");
+    }
+
+    // A spatial leaf inside an OR stays in the pipeline instead of being lifted to a post-filter (see
+    // SpatialMatch.Inspect), so a negated one reaches CompiledQueryMatch.Score, which calls every resolved leaf
+    // without checking whether it carries score data. Both 'hit' documents sit inside the circle, so neither
+    // satisfies the negated clause and both match the boosted term exactly once - their scores must be equal.
+    // A negated leaf that still scores gives them its distance to the circle's centre instead.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void ANegatedSpatialClauseMustNotContributeToTheScore(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Place { Name = "hit", Lat = 47.500, Lng = -122.300 }); // ~4 miles from the centre
+            session.Store(new Place { Name = "hit", Lat = 48.500, Lng = -122.000 }); // ~74 miles, still inside
+            session.Store(new Place { Name = "miss", Lat = 10.000, Lng = 10.000 });  // outside, enters through the negated branch
+            session.SaveChanges();
+        }
+
+        new Places_Score().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using var read = store.OpenSession();
+
+        var hits = read.Advanced
+            .RawQuery<Hit>(@"from index 'Places/Score' as p
+                             where boost(p.Name = 'hit', 2)
+                                or not spatial.within(p.Coordinates, spatial.circle(120, 47.448, -122.309, 'miles'))
+                             order by score()
+                             select { Status: p.Name, Score: getMetadata(p)[""@index-score""] }")
+            .ToList()
+            .Where(x => x.Status == "hit")
+            .Select(x => x.Score)
+            .ToList();
+
+        Assert.Equal(2, hits.Count);
+        Assert.Equal(hits[0], hits[1], 6);
+    }
+
+    private class Place
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public double Lat { get; set; }
+
+        public double Lng { get; set; }
+    }
+
+    private class Places_Score : AbstractIndexCreationTask<Place>
+    {
+        public Places_Score()
+        {
+            Map = places => from p in places
+                            select new { p.Name, Coordinates = CreateSpatialField(p.Lat, p.Lng) };
+
+            Index(x => x.Name, FieldIndexing.Exact);
+            Configuration[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = "true";
+        }
+    }
+
+    private class Movie
+    {
+        public string Genre { get; set; }
+
+        public string Status { get; set; }
+
+        public string Title { get; set; }
+    }
+
+    private class Hit
+    {
+        public string Status { get; set; }
+
+        public double Score { get; set; }
+    }
+
+    private class Movies_Score : AbstractIndexCreationTask<Movie>
+    {
+        public Movies_Score()
+        {
+            Map = movies => from m in movies
+                            select new { m.Genre, m.Status, m.Title };
+
+            Index(x => x.Genre, FieldIndexing.Exact);
+            Index(x => x.Status, FieldIndexing.Exact);
+            Index(x => x.Title, FieldIndexing.Search);
+            Configuration[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = "true";
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27460

Remainder of https://issues.hibernatingrhinos.com/issue/RavenDB-26999, which covered the term and search paths.

### Additional description

Two changes, both needed:

- `ResolveClause.HandleSpatial` resolves the field metadata without boost when the clause is negated, the same way 26999 did for the other paths. A negated clause only subtracts, so its leaf has nothing to hand to the score pass.
- `SpatialMatch.Score` returns instead of throwing when the instance carries no score data. `CompiledQueryMatch.Score` calls every resolved leaf without an `IsBoosting` guard, and every other `Score` in Corax already tolerates that - `TermMatch` returns on a null score function, the vector matches state it in a comment. Without this the first change turns the wrong score into `InvalidDataException: SpatialMatch`.

A caller-side `IsBoosting` guard was the alternative and is wrong: `SpatialMatch.IsBoosting` is `false` even for `HasBoosting`, so it would skip legitimate distance scoring. `_spatialScore` is only initialised for `HasBoosting`, so the early return skips a `Dispose` on an untouched struct.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

A negated spatial clause no longer adds its distance to the score of documents that reach the result through another branch. Non-negated spatial scoring is unchanged.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed