### PR TITLE
RavenDB-27506 Report a spatial match as boosting when it carries a score

### DIFF
--- a/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
@@ -91,7 +91,7 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
 
     public SkipSortingResult AttemptToSkipSorting() => SkipSortingResult.WillSkipSorting;
     public QueryCountConfidence Confidence => QueryCountConfidence.Low;
-    public bool IsBoosting => false;
+    public bool IsBoosting => typeof(TBoosting) == typeof(HasBoosting);
 
     public int Fill(Span<long> matches)
     {

--- a/test/SlowTests/Issues/RavenDB_27506.cs
+++ b/test/SlowTests/Issues/RavenDB_27506.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27506 : RavenTestBase
+{
+    public RavenDB_27506(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private const string Circle = "spatial.circle(120, 47.448, -122.309, 'miles')";
+
+    // SpatialMatch collects a distance for every entry it returns, but reported IsBoosting = false, and
+    // BinaryMatch.Score only asks a side for its score when that side says it has one - so the distance was
+    // discarded and every document came back with Bm25Relevance.InitialScoreValue.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void ASpatialLeafMustContributeItsDistanceToTheScore(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Place { Name = "near", Lat = 47.500, Lng = -122.300 }); // ~4 miles from the centre
+            session.Store(new Place { Name = "far", Lat = 48.500, Lng = -122.000 });  // ~74 miles, still inside
+            session.SaveChanges();
+        }
+
+        new Places_Score().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        var scores = Query(store, $"where boost(p.Name = 'nothing', 2) or spatial.within(p.Coordinates, {Circle})");
+
+        Assert.Equal(2, scores.Count);
+        Assert.NotEqual(scores.Single(x => x.Name == "near").Score, scores.Single(x => x.Name == "far").Score, 6);
+    }
+
+    private static List<Row> Query(IDocumentStore store, string where)
+    {
+        using var session = store.OpenSession();
+
+        return session.Advanced
+            .RawQuery<Row>($@"from index 'Places/Score' as p
+                              {where}
+                              order by score()
+                              select {{ Name: p.Name, Score: getMetadata(p)[""@index-score""] }}")
+            .ToList();
+    }
+
+    private class Row
+    {
+        public string Name { get; set; }
+
+        public double Score { get; set; }
+    }
+
+    private class Place
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public double Lat { get; set; }
+
+        public double Lng { get; set; }
+    }
+
+    private class Places_Score : AbstractIndexCreationTask<Place>
+    {
+        public Places_Score()
+        {
+            Map = places => from p in places
+                            select new { p.Name, Coordinates = CreateSpatialField(p.Lat, p.Lng) };
+
+            Index(x => x.Name, FieldIndexing.Exact);
+            Configuration[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = "true";
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27506

### Additional description

`SpatialMatch.IsBoosting` returned `false` regardless of `TBoosting`, while a `SpatialMatch<HasBoosting>` collects a distance for every entry it returns and implements `Score` to fold it in. `BinaryMatch.Score` only asks a side for its score when that side says it has one, so the distance was discarded and documents came back with `Bm25Relevance.InitialScoreValue`. The property now reflects its type parameter.

`NoBoosting` still reports `false`, so `BinaryMatch` never asks it for a score and the throw in `SpatialMatch.Score` stays unreachable. `AndNotMatch.Score` only scores its positive side, so a negated spatial clause is unaffected.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

A query with a spatial clause and `ORDER BY score()` now receives that clause's distance contribution, so the score values and the resulting order change where previously every document collapsed to the initial score.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed