### PR TITLE
RavenDB-27508 Match a point inside the shape for an intersects query

### DIFF
--- a/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
@@ -163,12 +163,12 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
         return false;
     }
 
+    // Corax indexes points only, so a point inside the shape satisfies within, contains and intersects alike.
     private bool IsTrue(SpatialRelation answer) => answer switch
     {
-        SpatialRelation.Within or SpatialRelation.Contains => _spatialRelation is Utils.Spatial.SpatialRelation.Within
-            or Utils.Spatial.SpatialRelation.Contains,
+        SpatialRelation.Within or SpatialRelation.Contains or SpatialRelation.Intersects
+            => _spatialRelation is not Utils.Spatial.SpatialRelation.Disjoint,
         SpatialRelation.Disjoint => _spatialRelation is Utils.Spatial.SpatialRelation.Disjoint,
-        SpatialRelation.Intersects => _spatialRelation is Utils.Spatial.SpatialRelation.Intersects,
         _ => throw new NotSupportedException()
     };
 

--- a/test/SlowTests/Issues/RavenDB_27508.cs
+++ b/test/SlowTests/Issues/RavenDB_27508.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27508 : RavenTestBase
+{
+    public RavenDB_27508(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    // Tight enough that the document's geohash cell is only partially covered, so the term generator hands the cell
+    // over for a per-entry check - the path that maps Spatial4n's answer onto the query relation. Spatial4n answers
+    // Within for a point inside a shape and never Intersects, so an intersects query used to reject the entry.
+    private const string Shape = "POLYGON((39.9 22.4, 40.1 22.4, 40.1 22.6, 39.9 22.6, 39.9 22.4))";
+
+    [RavenTheory(RavenTestCategory.Spatial | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void IntersectsMustMatchAPointInsideTheShape(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        Store(store, new Place { Name = "inside", Lat = 22.5, Lng = 40.0 });
+
+        // within is the control: the shape does contain the point, so the index and the query shape are sound
+        Assert.Equal(1, Query(store, "within").Count);
+        Assert.Equal(1, Query(store, "intersects").Count);
+    }
+
+    [RavenTheory(RavenTestCategory.Spatial | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void IntersectsMustNotMatchAPointOutsideTheShape(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        Store(store, new Place { Name = "outside", Lat = 60.0, Lng = 10.0 });
+
+        // no disjoint here - Lucene answers it with UnsupportedSpatialOperation, and that arm is untouched anyway
+        Assert.Equal(0, Query(store, "within").Count);
+        Assert.Equal(0, Query(store, "intersects").Count);
+    }
+
+    private void Store(IDocumentStore store, Place place)
+    {
+        using (var session = store.OpenSession())
+        {
+            session.Store(place);
+            session.SaveChanges();
+        }
+
+        new Places_ByCoordinates().Execute(store);
+        Indexes.WaitForIndexing(store);
+    }
+
+    private static List<Place> Query(IDocumentStore store, string relation)
+    {
+        using var session = store.OpenSession();
+
+        return session.Advanced
+            .RawQuery<Place>($"from index 'Places/ByCoordinates' as p where spatial.{relation}(p.Coordinates, spatial.wkt('{Shape}'))")
+            .ToList();
+    }
+
+    private class Place
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public double Lat { get; set; }
+
+        public double Lng { get; set; }
+    }
+
+    private class Places_ByCoordinates : AbstractIndexCreationTask<Place>
+    {
+        public Places_ByCoordinates()
+        {
+            Map = places => from p in places
+                            select new { p.Name, Coordinates = CreateSpatialField(p.Lat, p.Lng) };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27508

### Additional description

`spatial.intersects` dropped documents that `spatial.within` returned for the same shape.

`SpatialMatch.CheckEntryManually` maps Spatial4n's answer for the entry's point onto the relation the query asked for, and Spatial4n answers `Within` for a point that falls inside a shape - so the `Intersects` arm never fired for a point field and an intersects query rejected every entry that reached the per-entry check. Only those entries were lost: a geohash cell the shape covers whole is accepted in bulk without consulting the relation, so the result came back partially right, holding the interior cells and missing the boundary ones.

Corax indexes points, and a point inside a shape satisfies within, contains and intersects alike, so all three relations now accept the same non-disjoint answers. The disjoint arm is untouched. `IsTrue` is the single place where the mapping happens, and both filtering paths (`Fill`'s per-entry branch and `AndWith`) go through it.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Corax spatial queries with the `intersects` relation now return the points inside the shape that they used to drop. The degenerate case of a point-shaped query shape equal to the entry's point is now matched by `within` and `contains` as well. `disjoint` is unchanged, and Lucene is untouched.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
