### PR TITLE
RavenDB-27509 - Fix `VoronBufferedInput.ReadVLong` truncating values of 2 GB or more

### DIFF
--- a/src/Raven.Server/Indexing/VoronBufferedInput.cs
+++ b/src/Raven.Server/Indexing/VoronBufferedInput.cs
@@ -32,11 +32,11 @@ public sealed class VoronBufferedInput : BufferedIndexInput
         {
             // handle directly
             byte b = buffer[bufferPosition++];
-            int i = b & 0x7F;
+            long i = b & 0x7F;
             for (int shift = 7; (b & 0x80) != 0; shift += 7)
             {
                 b = buffer[bufferPosition++];
-                i |= (b & 0x7F) << shift;
+                i |= (b & 0x7FL) << shift;
             }
 
             return i;

--- a/test/SlowTests/Issues/RavenDB-27509.cs
+++ b/test/SlowTests/Issues/RavenDB-27509.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using FastTests.Voron;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Indexing;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_27509 : StorageTest
+    {
+        public RavenDB_27509(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private static readonly long[] Values =
+        {
+            0,
+            1,
+            127,
+            128,
+            16_383,
+            16_384,
+            (1L << 28) - 1,
+            1L << 28,
+            int.MaxValue,          // 5 bytes, still fits in an int
+            1L << 31,              // 5 bytes, does not fit in an int anymore
+            (1L << 31) + 12_345,
+            1L << 32,
+            (1L << 33) + 7,
+            1L << 35,              // 6 bytes -> shift 35 wraps to 3 with an int accumulator
+            1L << 40,
+            (1L << 42) + 99,
+            long.MaxValue >> 1,
+        };
+
+        [RavenTheory(RavenTestCategory.Lucene | RavenTestCategory.Querying)]
+        [InlineData(LuceneIndexInputType.Standard)]
+        [InlineData(LuceneIndexInputType.Buffered)]
+        public void ReadVLong_must_round_trip_values_larger_than_int32(LuceneIndexInputType inputType)
+        {
+            using (var tx = Env.WriteTransaction())
+            using (var cache = new TempFileCache(Env.Options))
+            {
+                var dir = new LuceneVoronDirectory(tx, Env, cache, inputType);
+                var state = new VoronState(tx);
+
+                using (var output = dir.CreateOutput("file", state))
+                {
+                    foreach (var value in Values)
+                        output.WriteVLong(value);
+
+                    // padding so that the buffered fast path (needs 10 more bytes in the buffer) is taken for all values
+                    for (var i = 0; i < 64; i++)
+                        output.WriteByte(0);
+                }
+
+                var failures = new List<string>();
+
+                using (var input = dir.OpenInput("file", state))
+                {
+                    foreach (var expected in Values)
+                    {
+                        var actual = input.ReadVLong(state);
+                        if (actual != expected)
+                            failures.Add($"expected {expected} (0x{expected:X}) but read {actual} (0x{actual:X})");
+                    }
+                }
+
+                Assert.True(failures.Count == 0, $"{inputType}: {failures.Count} VLong values were decoded wrongly:{Environment.NewLine}{string.Join(Environment.NewLine, failures)}");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Lucene | RavenTestCategory.Querying)]
+        public void Buffered_and_standard_inputs_must_decode_the_same_bytes_identically()
+        {
+            using (var tx = Env.WriteTransaction())
+            using (var cache = new TempFileCache(Env.Options))
+            {
+                var standardDir = new LuceneVoronDirectory(tx, Env, cache, "Standard", LuceneIndexInputType.Standard);
+                var bufferedDir = new LuceneVoronDirectory(tx, Env, cache, "Buffered", LuceneIndexInputType.Buffered);
+                var state = new VoronState(tx);
+
+                // the same term-dictionary-like sequence in both directories: a small VInt, a VLong delta, another VLong delta
+                var random = new Random(1234);
+                var deltas = new List<(int docFreq, long freqDelta, long proxDelta)>();
+                for (var i = 0; i < 2_000; i++)
+                {
+                    var freqDelta = i % 97 == 0 ? (1L << 31) + random.Next() : random.Next(1, 1 << 20);
+                    var proxDelta = i % 131 == 0 ? (1L << 33) + random.Next() : random.Next(1, 1 << 20);
+                    deltas.Add((random.Next(1, 1 << 15), freqDelta, proxDelta));
+                }
+
+                foreach (var dir in new[] { standardDir, bufferedDir })
+                {
+                    using (var output = dir.CreateOutput("_0.tis", state))
+                    {
+                        foreach (var (docFreq, freqDelta, proxDelta) in deltas)
+                        {
+                            output.WriteVInt(docFreq);
+                            output.WriteVLong(freqDelta);
+                            output.WriteVLong(proxDelta);
+                        }
+                    }
+                }
+
+                var mismatches = new StringBuilder();
+
+                using (var standard = standardDir.OpenInput("_0.tis", state))
+                using (var buffered = bufferedDir.OpenInput("_0.tis", state))
+                {
+                    long standardFreq = 0, bufferedFreq = 0, standardProx = 0, bufferedProx = 0;
+
+                    for (var i = 0; i < deltas.Count; i++)
+                    {
+                        var standardDocFreq = standard.ReadVInt(state);
+                        var bufferedDocFreq = buffered.ReadVInt(state);
+
+                        standardFreq += standard.ReadVLong(state);
+                        bufferedFreq += buffered.ReadVLong(state);
+
+                        standardProx += standard.ReadVLong(state);
+                        bufferedProx += buffered.ReadVLong(state);
+
+                        if (standardDocFreq != bufferedDocFreq || standardFreq != bufferedFreq || standardProx != bufferedProx)
+                        {
+                            mismatches.AppendLine($"entry {i}: docFreq {standardDocFreq}/{bufferedDocFreq}, freqPointer {standardFreq}/{bufferedFreq}, proxPointer {standardProx}/{bufferedProx}");
+                            if (mismatches.Length > 4_000)
+                                break;
+                        }
+                    }
+                }
+
+                Assert.True(mismatches.Length == 0, $"Buffered input diverged from Standard input (standard/buffered):{Environment.NewLine}{mismatches}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27509/Lucene-wildcard-search-fails-with-IndexOutOfRangeException-on-large-indexes

### Additional description

On a large Lucene index with a full text search field, `search(Query, 'random*')` fails with `IndexOutOfRangeException` thrown from `MultiTermQueryWrapperFilter.GetDocIdSet`, while `search(Query, 'random')` works.

`VoronBufferedInput.ReadVLong` (used with the default `Indexing.Lucene.IndexInputType = Buffered`) was a copy of `ReadVInt`. Its fast path decoded the value into an `int` accumulator with an `int` shift, so:

- any VLong of 2^31 or more had its upper bits dropped and came back sign-extended and negative
- values needing six or more bytes had their shift count wrapped modulo 32

The slow path (`IndexInput.ReadVLong`) and the `Standard` input type decode correctly, so the same bytes produced different values depending on where the VLong fell inside the 4 KB buffer.

Lucene stores the term dictionary freq and prox pointer deltas (`.tis`, and `.tii` between terms-index entries 128 terms apart) as VLongs and accumulates them into absolute pointers. One wrongly decoded delta corrupts the freq pointer of every term that follows it in the segment. `TermDocs` then reads postings from the wrong offset and yields garbage doc ids. A wildcard query feeds those ids into `OpenBitSet.Set`, which throws for a negative id. A plain `TermQuery` on such a term does not throw, it just returns wrong or no documents.

This needs a segment with 2 GB or more of `.frq` data inside one 128-term window, i.e. a very large segment, which is why it surfaced only after the index was rebuilt from scratch on new storage.

#### Fix

Use a `long` accumulator and a `long` mask (`0x7FL`) in the fast path of `VoronBufferedInput.ReadVLong`, matching `IndexInput.ReadVLong`.

#### Tests

`test/SlowTests/Issues/RavenDB-27509.cs`

- `ReadVLong_must_round_trip_values_larger_than_int32` writes VLongs through `LuceneVoronDirectory` and reads them back with both input types. Before the fix, `Buffered` decoded 8 of 17 values wrongly (for example `2^31` as `-2147483648`, `2^32` as `0`, `1 << 40` as `256`).
- `Buffered_and_standard_inputs_must_decode_the_same_bytes_identically` decodes the same term-dictionary-like stream with both readers and compares the accumulated freq and prox pointers. Before the fix every pointer after the first delta of `2^31` or more diverged and went negative.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
