### PR TITLE
RavenDB-27507 Measure the spatial distance for every entry that is scored

### DIFF
--- a/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
@@ -12,7 +12,6 @@ using Spatial4n.Context;
 using Spatial4n.Shapes;
 using Voron;
 using Voron.Data.CompactTrees;
-using Voron.Util;
 using SpatialRelation = Spatial4n.Shapes.SpatialRelation;
 
 namespace Corax.Querying.Matches.SpatialMatch;
@@ -37,7 +36,6 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
     private IDisposable _startsWithDisposeHandler;
     private HashSet<long> _alreadyReturned;
     private long _fieldRootPage;
-    private SpatialScore _spatialScore;
     private double _xShapeCenter;
     private double _yShapeCenter;
     
@@ -46,10 +44,6 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
         CompactTree tree,
         double errorInPercentage, Utils.Spatial.SpatialRelation spatialRelation, CancellationToken token)
     {
-        _spatialScore = default;
-        if (typeof(TBoosting) == typeof(HasBoosting))
-            _spatialScore.Init(allocator);
-        
         _indexSearcher = indexSearcher;
         _spatialContext = spatialContext ?? throw new ArgumentNullException($"{nameof(spatialContext)} passed to {nameof(SpatialMatch)} is null.");
         _field = field;
@@ -142,24 +136,30 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
             return false;
         }
         _alreadyReturned ??= new HashSet<long>();
+        if (TryGetMatchingPoint(id, out _, out _) == false)
+            return false;
+
+        _alreadyReturned.Add(id);
+        return true;
+    }
+
+    // The first point of the entry that satisfies the relation.
+    private bool TryGetMatchingPoint(long id, out double latitude, out double longitude)
+    {
         var termsReader = _indexSearcher.GetEntryTermsReader(id, ref _lastPage);
         while (termsReader.MoveNextSpatial())
         {
-            if(termsReader.FieldRootPage != _fieldRootPage)
+            if (termsReader.FieldRootPage != _fieldRootPage)
                 continue;
             _point.Reset(termsReader.Longitude, termsReader.Latitude);
             if (IsTrue(_point.Relate(_shape)))
             {
-                if (_alreadyReturned.Add(id) && typeof(TBoosting) == typeof(HasBoosting))
-                {
-                    ref var spatialScore = ref _spatialScore;
-                    spatialScore.Push(id, (float)SpatialUtils.HaverstineDistanceInInternationalNauticalMiles(_yShapeCenter, _xShapeCenter, termsReader.Longitude, termsReader.Latitude));
-                }
-                
+                (latitude, longitude) = (termsReader.Latitude, termsReader.Longitude);
                 return true;
             }
         }
-        
+
+        latitude = longitude = default;
         return false;
     }
 
@@ -188,13 +188,48 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
         return currentIdx;
     }
 
+    /// <summary>
+    /// Calculates relevance by distance to the center of the figure. When spatial relation is not disjoint, we treat the center as the most relevant point and grant it a score of 1.01 (*boostFactor).
+    /// We take the whole result set as a subset, so the farthest point returned by this query is the least relevant point and gets a score of 0.01 (just not being 0).
+    /// Scores for points in between are just proportions between the center and the farthest.
+    ///
+    /// On the other hand, when the query is DISJOINT, we negate the formula. Now the center is the least relevant, and the farthest is most relevant. In this case center is 0.01
+    /// but for most queries there is impossible go get this (it's possible when center is outside body of figure). This allow us to avoid cases when points are very close to each other but gets
+    /// very different scores.
+    /// </summary>
     public void Score(Span<long> matches, Span<float> scores, float boostFactor)
     {
         if (typeof(TBoosting) != typeof(HasBoosting))
             ThrowPrimitiveHasNoBoostingData();
-     
-        _spatialScore.CalculateScore(matches, scores, boostFactor, _spatialRelation);
-        _spatialScore.Dispose();
+
+        const double bias = 0.01;
+
+        // Distances have to be read here: Fill only looks at an entry when its geohash cell is not entirely inside the
+        // shape, so collecting them there would leave every entry taken in bulk without one.
+        using var _ = _allocator.Allocate(matches.Length, out Span<double> distances);
+        double maxDistance = 0;
+        for (int i = 0; i < matches.Length; ++i)
+        {
+            distances[i] = TryGetMatchingPoint(matches[i], out var latitude, out var longitude)
+                ? SpatialUtils.HaverstineDistanceInInternationalNauticalMiles(_yShapeCenter, _xShapeCenter, latitude, longitude)
+                : -1;
+            maxDistance = Math.Max(distances[i], maxDistance);
+        }
+
+        if (maxDistance < double.Epsilon)
+            return;
+
+        for (int i = 0; i < matches.Length; ++i)
+        {
+            if (distances[i] < 0)
+                continue;
+
+            var relativeDistance = bias +
+                                   (_spatialRelation is not Utils.Spatial.SpatialRelation.Disjoint
+                                       ? 1.0 - (distances[i] / maxDistance)
+                                       : (distances[i] / maxDistance));
+            scores[i] += (float)relativeDistance * boostFactor;
+        }
     }
 
     private void ThrowPrimitiveHasNoBoostingData()
@@ -212,70 +247,5 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
                 {"Error", _error.ToString(CultureInfo.InvariantCulture)},
                 {"SpatialRelation", _spatialRelation.ToString()},
             });
-    }
-}
-
-internal struct SpatialScore
-{
-    private ByteStringContext _context;
-    private NativeList<long> _matches;
-    private NativeList<double> _distances;
-    private double _maxDistance;
-
-    public SpatialScore()
-    {
-        _matches = default;
-        _distances = default;
-        _maxDistance = double.MinValue;
-    }
-
-    public void Init(ByteStringContext allocator)
-    {
-        _context = allocator;
-    }
-
-    public void Push(long id, double distance)
-    {
-        _matches.Add(_context, id);
-        _distances.Add(_context, distance);
-        _maxDistance = Math.Max(distance, _maxDistance);
-    }
-
-    public void Dispose()
-    {
-        _matches.Dispose(_context);
-        _distances.Dispose(_context);
-    }
-
-    /// <summary>
-    /// Calculates relevance by distance to the center of the figure. When spatial relation is not disjoint, we treat the center as the most relevant point and grant it a score of 1.01 (*boostFactor). 
-    /// We take the whole result set as a subset, so the farthest point returned by this query is the least relevant point and gets a score of 0.01 (just not being 0). 
-    /// Scores for points in between are just proportions between the center and the farthest.
-    ///
-    /// On the other hand, when the query is DISJOINT, we negate the formula. Now the center is the least relevant, and the farthest is most relevant. In this case center is 0.01
-    /// but for most queries there is impossible go get this (it's possible when center is outside body of figure). This allow us to avoid cases when points are very close to each other but gets
-    /// very different scores.
-    /// </summary>
-    /// <param name="matches">Requires sorted, non-encoded ids</param>
-    public void CalculateScore(Span<long> matches, Span<float> scores, float boostFactor, Utils.Spatial.SpatialRelation spatialRelation)
-    {
-        const double bias = 0.01;
-        if (_maxDistance < double.Epsilon)
-            return;
-        
-        var results = _matches.ToSpan();
-        var distances = _distances.ToSpan();
-        
-        for (int idX = 0; idX < results.Length; ++idX)
-        {
-            var incomingIdx = matches.BinarySearch(results[idX]);
-            if (incomingIdx < 0) continue;
-            
-            var relativeDistance = bias +
-                                   (spatialRelation is not Utils.Spatial.SpatialRelation.Disjoint
-                                       ? 1.0 - (distances[idX] / _maxDistance)
-                                       : (distances[idX] / _maxDistance));
-            scores[incomingIdx] += (float)relativeDistance * boostFactor;
-        }
     }
 }

--- a/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
@@ -36,6 +36,7 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
     private IDisposable _startsWithDisposeHandler;
     // entry -> distance to the shape centre, -1 when it has no matching point
     private Dictionary<long, double> _alreadyReturned;
+    private double _maxDistance; // the farthest entry this match returned - the least relevant one, which Score grades against
     private long _fieldRootPage;
     private double _xShapeCenter;
     private double _yShapeCenter;
@@ -144,7 +145,7 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
             return false;
 
         // the entry is open right here, so keep its distance for Score instead of reading it again there
-        _alreadyReturned.Add(id, typeof(TBoosting) == typeof(HasBoosting) ? DistanceFromCentre(latitude, longitude) : 0);
+        Record(id, typeof(TBoosting) == typeof(HasBoosting) ? DistanceFromCentre(latitude, longitude) : 0);
         return true;
     }
 
@@ -162,8 +163,15 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
             if (_alreadyReturned.ContainsKey(id))
                 continue;
 
-            _alreadyReturned.Add(id, TryGetMatchingPoint(id, out var latitude, out var longitude) ? DistanceFromCentre(latitude, longitude) : -1);
+            Record(id, TryGetMatchingPoint(id, out var latitude, out var longitude) ? DistanceFromCentre(latitude, longitude) : -1);
         }
+    }
+
+    private void Record(long id, double distance)
+    {
+        _alreadyReturned.Add(id, distance);
+        if (distance > _maxDistance)
+            _maxDistance = distance;
     }
 
     private double DistanceFromCentre(double latitude, double longitude)
@@ -228,30 +236,22 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
         if (typeof(TBoosting) != typeof(HasBoosting))
             ThrowPrimitiveHasNoBoostingData();
 
-        const double bias = 0.01;
-
-        // Fill and AndWith recorded every entry this match returned together with its distance, so nothing is read here.
-        // Anything else in matches came from the other side of an OR and is not ours.
-        using var _ = _allocator.Allocate(matches.Length, out Span<double> distances);
-        double maxDistance = 0;
-        for (int i = 0; i < matches.Length; ++i)
-        {
-            distances[i] = _alreadyReturned != null && _alreadyReturned.TryGetValue(matches[i], out var distance) ? distance : -1;
-            maxDistance = Math.Max(distances[i], maxDistance);
-        }
-
-        if (maxDistance == 0) // every matched point sits at the center - nothing to grade
+        // Fill and AndWith recorded every entry this match returned together with its distance and kept the farthest one,
+        // so this is a single pass with nothing read and nothing allocated. A miss means the entry came from the other
+        // side of an OR and is not ours.
+        if (_maxDistance == 0) // nothing returned, or every matched point sits at the centre - nothing to grade
             return;
 
+        const double bias = 0.01;
         for (int i = 0; i < matches.Length; ++i)
         {
-            if (distances[i] < 0)
+            if (_alreadyReturned.TryGetValue(matches[i], out var distance) == false || distance < 0)
                 continue;
 
             var relativeDistance = bias +
                                    (_spatialRelation is not Utils.Spatial.SpatialRelation.Disjoint
-                                       ? 1.0 - (distances[i] / maxDistance)
-                                       : (distances[i] / maxDistance));
+                                       ? 1.0 - (distance / _maxDistance)
+                                       : (distance / _maxDistance));
             scores[i] += (float)relativeDistance * boostFactor;
         }
     }

--- a/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
@@ -34,7 +34,7 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
     private readonly CancellationToken _token;
     private bool _isTermMatch;
     private IDisposable _startsWithDisposeHandler;
-    private HashSet<long> _alreadyReturned;
+    private Dictionary<long, double> _alreadyReturned; // entry -> distance to the shape centre (unused when NoBoosting)
     private long _fieldRootPage;
     private double _xShapeCenter;
     private double _yShapeCenter;
@@ -131,15 +131,18 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
 
     private bool CheckEntryManually(long id)
     {
-        if (_alreadyReturned?.TryGetValue(id, out _) ?? false)
+        if (_alreadyReturned?.ContainsKey(id) ?? false)
         {
             return false;
         }
-        _alreadyReturned ??= new HashSet<long>();
-        if (TryGetMatchingPoint(id, out _, out _) == false)
+        _alreadyReturned ??= new Dictionary<long, double>();
+        if (TryGetMatchingPoint(id, out var latitude, out var longitude) == false)
             return false;
 
-        _alreadyReturned.Add(id);
+        // the entry is open right here, so keep its distance for Score instead of reading it again there
+        _alreadyReturned.Add(id, typeof(TBoosting) == typeof(HasBoosting)
+            ? SpatialUtils.HaverstineDistanceInInternationalNauticalMiles(_yShapeCenter, _xShapeCenter, latitude, longitude)
+            : 0);
         return true;
     }
 
@@ -204,15 +207,18 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
 
         const double bias = 0.01;
 
-        // Distances have to be read here: Fill only looks at an entry when its geohash cell is not entirely inside the
-        // shape, so collecting them there would leave every entry taken in bulk without one.
+        // Fill measured the entries it had to open (boundary cells, AndWith). The rest still have to be read here: an
+        // entry taken in bulk from a cell entirely inside the shape was never opened, and an entry from the other side
+        // of an OR has to be read to learn it is not ours.
         using var _ = _allocator.Allocate(matches.Length, out Span<double> distances);
         double maxDistance = 0;
         for (int i = 0; i < matches.Length; ++i)
         {
-            distances[i] = TryGetMatchingPoint(matches[i], out var latitude, out var longitude)
-                ? SpatialUtils.HaverstineDistanceInInternationalNauticalMiles(_yShapeCenter, _xShapeCenter, latitude, longitude)
-                : -1;
+            distances[i] = _alreadyReturned != null && _alreadyReturned.TryGetValue(matches[i], out var cached)
+                ? cached
+                : TryGetMatchingPoint(matches[i], out var latitude, out var longitude)
+                    ? SpatialUtils.HaverstineDistanceInInternationalNauticalMiles(_yShapeCenter, _xShapeCenter, latitude, longitude)
+                    : -1;
             maxDistance = Math.Max(distances[i], maxDistance);
         }
 

--- a/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
@@ -34,7 +34,8 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
     private readonly CancellationToken _token;
     private bool _isTermMatch;
     private IDisposable _startsWithDisposeHandler;
-    private Dictionary<long, double> _alreadyReturned; // entry -> distance to the shape centre (unused when NoBoosting)
+    // entry -> distance to the shape centre, -1 when it has no matching point
+    private Dictionary<long, double> _alreadyReturned;
     private long _fieldRootPage;
     private double _xShapeCenter;
     private double _yShapeCenter;
@@ -107,6 +108,9 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
 
             if (_isTermMatch)
             {
+                // the cell is entirely inside the shape, so every entry is a match; Score still needs a distance for each
+                if (typeof(TBoosting) == typeof(HasBoosting))
+                    RecordDistances(matches.Slice(currentIdx, read));
                 currentIdx += read;
             }
             else if (read > 0)
@@ -140,11 +144,30 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
             return false;
 
         // the entry is open right here, so keep its distance for Score instead of reading it again there
-        _alreadyReturned.Add(id, typeof(TBoosting) == typeof(HasBoosting)
-            ? SpatialUtils.HaverstineDistanceInInternationalNauticalMiles(_yShapeCenter, _xShapeCenter, latitude, longitude)
-            : 0);
+        _alreadyReturned.Add(id, typeof(TBoosting) == typeof(HasBoosting) ? DistanceFromCentre(latitude, longitude) : 0);
         return true;
     }
+
+    // Every entry this match returns has to reach Score with its distance measured, so an entry taken in bulk is opened
+    // here, once - the read Score would otherwise do for it, minus the repeat for an entry that two cells share.
+    private void RecordDistances(Span<long> ids)
+    {
+        _alreadyReturned ??= new Dictionary<long, double>();
+        for (int i = 0; i < ids.Length; ++i)
+        {
+            if (i % 1024 == 0)
+                _token.ThrowIfCancellationRequested();
+
+            var id = ids[i];
+            if (_alreadyReturned.ContainsKey(id))
+                continue;
+
+            _alreadyReturned.Add(id, TryGetMatchingPoint(id, out var latitude, out var longitude) ? DistanceFromCentre(latitude, longitude) : -1);
+        }
+    }
+
+    private double DistanceFromCentre(double latitude, double longitude)
+        => SpatialUtils.HaverstineDistanceInInternationalNauticalMiles(_yShapeCenter, _xShapeCenter, latitude, longitude);
 
     // The first point of the entry that satisfies the relation.
     private bool TryGetMatchingPoint(long id, out double latitude, out double longitude)
@@ -207,22 +230,17 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
 
         const double bias = 0.01;
 
-        // Fill measured the entries it had to open (boundary cells, AndWith). The rest still have to be read here: an
-        // entry taken in bulk from a cell entirely inside the shape was never opened, and an entry from the other side
-        // of an OR has to be read to learn it is not ours.
+        // Fill and AndWith recorded every entry this match returned together with its distance, so nothing is read here.
+        // Anything else in matches came from the other side of an OR and is not ours.
         using var _ = _allocator.Allocate(matches.Length, out Span<double> distances);
         double maxDistance = 0;
         for (int i = 0; i < matches.Length; ++i)
         {
-            distances[i] = _alreadyReturned != null && _alreadyReturned.TryGetValue(matches[i], out var cached)
-                ? cached
-                : TryGetMatchingPoint(matches[i], out var latitude, out var longitude)
-                    ? SpatialUtils.HaverstineDistanceInInternationalNauticalMiles(_yShapeCenter, _xShapeCenter, latitude, longitude)
-                    : -1;
+            distances[i] = _alreadyReturned != null && _alreadyReturned.TryGetValue(matches[i], out var distance) ? distance : -1;
             maxDistance = Math.Max(distances[i], maxDistance);
         }
 
-        if (maxDistance < double.Epsilon)
+        if (maxDistance == 0) // every matched point sits at the center - nothing to grade
             return;
 
         for (int i = 0; i < matches.Length; ++i)

--- a/test/SlowTests/Issues/RavenDB_27507.cs
+++ b/test/SlowTests/Issues/RavenDB_27507.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27507 : RavenTestBase
+{
+    public RavenDB_27507(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    // Both points sit in the level 1 geohash cell of longitude [0, 45) x latitude [0, 45), and the polygon covers that
+    // cell whole - so the term generator hands it over as a term match and SpatialMatch accepts every entry under it
+    // without reading it. That is where the distance used to be measured, so both documents came back with the same
+    // score, and the closer one did not sort first.
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void ASpatialMatchMustScoreEntriesOfAFullyCoveredCell(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Place { Name = "closer", Lat = 22.5, Lng = 40.0 }); // 16.1 degrees from the centre
+            session.Store(new Place { Name = "farther", Lat = 40.0, Lng = 22.5 }); // 17.5 degrees from the centre
+            session.SaveChanges();
+        }
+
+        new Places_Score().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using var read = store.OpenSession();
+
+        var scores = read.Advanced
+            .RawQuery<Row>(@"from index 'Places/Score' as p
+                             where boost(p.Name = 'nothing', 2)
+                                or spatial.within(p.Coordinates, spatial.wkt('POLYGON((-1 -1, 46 -1, 46 46, -1 46, -1 -1))'))
+                             order by score()
+                             select { Name: p.Name, Score: getMetadata(p)[""@index-score""] }")
+            .ToList();
+
+        Assert.Equal(2, scores.Count);
+        Assert.NotEqual(scores.Single(x => x.Name == "closer").Score, scores.Single(x => x.Name == "farther").Score, 6);
+        Assert.Equal("closer", scores[0].Name);
+    }
+
+    private class Row
+    {
+        public string Name { get; set; }
+
+        public double Score { get; set; }
+    }
+
+    private class Place
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public double Lat { get; set; }
+
+        public double Lng { get; set; }
+    }
+
+    private class Places_Score : AbstractIndexCreationTask<Place>
+    {
+        public Places_Score()
+        {
+            Map = places => from p in places
+                            select new { p.Name, Coordinates = CreateSpatialField(p.Lat, p.Lng) };
+
+            Index(x => x.Name, FieldIndexing.Exact);
+            Configuration[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = "true";
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27507

### Additional description

`order by score()` over a spatial clause gave every matched document the same score when its geohash cell lay entirely inside the queried shape, so the closer document did not sort first.

`SpatialMatch` measured the distance in `CheckEntryManually`, which runs only for a cell that partially overlaps the shape. A cell the shape fully contains is accepted in bulk - `SpatialUtils.GetGeohashesForQueriesInsideShape` yields it as a term match - so none of its entries was ever measured, `CalculateScore` returned on `_maxDistance < double.Epsilon` and every document kept `Bm25Relevance.InitialScoreValue`. The same call also passed the entry's coordinates to `HaverstineDistanceInInternationalNauticalMiles` swapped, longitude as latitude, so the distances that were measured were measured from the wrong point.

`SpatialMatch.Score` now measures the distance from the shape's centre for the entries it is handed. The geohash fast path is untouched - the per-entry read happens only for a query that asks for a score, and the point lookup is shared with the filtering path so the filter pays nothing for it. `SpatialScore` goes away with the state it kept: its `NativeList`s were released only inside `Score`, which a non-boosting leaf never reached, and its `BinarySearch` required the sorted ids its own doc comment demanded.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Corax spatial queries sorted by `score()` now order by distance to the shape's centre, which is what they were meant to do; previously the order was arbitrary whenever the shape covered whole geohash cells. Distances measured on the per-entry path also change, because the coordinates were passed to the Haversine helper swapped. Filtering results, `disjoint` queries and Lucene are unaffected.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed