### PR TITLE
RavenDB-27492 and RavenDB-27471 Run async-commit tests only on 64 bits

### DIFF
--- a/test/FastTests/Voron/CommitFinalizationGuard.cs
+++ b/test/FastTests/Voron/CommitFinalizationGuard.cs
@@ -32,7 +32,7 @@ namespace FastTests.Voron
             Assert.Contains("subscriber failed", FlattenMessages(e));
         }
 
-        [RavenFact(RavenTestCategory.Voron)]
+        [RavenMultiplatformFact(RavenTestCategory.Voron, RavenArchitecture.X64)]
         public void SubscriberFailureAfterAsyncJournalWriteTakesEnvironmentDown()
         {
             var tx = Env.WriteTransaction();

--- a/test/SlowTests/Server/Documents/DocumentsTransactionCacheTests.cs
+++ b/test/SlowTests/Server/Documents/DocumentsTransactionCacheTests.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Server.Documents
         {
         }
 
-        [RavenTheory(RavenTestCategory.Core | RavenTestCategory.Compression)]
+        [RavenMultiplatformTheory(RavenTestCategory.Core | RavenTestCategory.Compression, RavenArchitecture.X64)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task TransactionCacheShouldMatchStorageAfterEveryKindOfCollectionChange(bool compressed)

--- a/test/SlowTests/Voron/Storage/RavenDB-27178.cs
+++ b/test/SlowTests/Voron/Storage/RavenDB-27178.cs
@@ -10,7 +10,7 @@ namespace SlowTests.Voron.Storage
         {
         }
 
-        [RavenFact(RavenTestCategory.Voron)]
+        [RavenMultiplatformFact(RavenTestCategory.Voron, RavenArchitecture.X64)]
         public void AsyncCommitTransactionInheritsImmutableExternalStateFromCommittingTransaction()
         {
             // DocumentsStorage stores its per-commit cache in ImmutableExternalState during


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27492
https://issues.hibernatingrhinos.com/issue/RavenDB-27471

### Additional description

Three tests fail only on the Winx86 legs. All come from async-commit work and have nothing to assert on 32 bits, so they are gated with `RavenArchitecture.X64`.

- RavenDB-27492, RavenDB-27471: both call `BeginAsyncCommitAndStartNewTransaction` directly and trip the `Debug.Assert` in the `LowLevelTransaction` clone ctor. The other four `CommitFinalizationGuard` tests use the sync path and still run everywhere.
- `DocumentsTransactionCacheTests` hung the x86 host. Dump shows the 32-bit pool capped at 125 workers with 124 blocked in `commands.Put` -> `AsyncHelpers.RunSync`; the test queues 200 blocking work items, so it can never make progress. Not Voron: server side is idle. Gating is right anyway since `GetPendingOperationsStatus` returns `CompletedAll` on 32 bits, so the merger never async-commits there.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
