### PR TITLE
RavenDB-27511 - Fix NRE in idle operations and cluster maintenance report when an index is disabled via disable.marker

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -291,6 +291,8 @@ namespace Raven.Server.Documents.Indexes
             Definition = definition;
             Collections = new HashSet<string>(Definition.Collections, StringComparer.OrdinalIgnoreCase);
 
+            _lastQueriedTimeTracker = new LastQueriedTimeTracker(DateTime.UtcNow, elapsedSinceQueried: 0);
+
             if (Collections.Contains(Constants.Documents.Collections.AllDocumentsCollection))
             {
                 HandleAllDocs = true;
@@ -3288,6 +3290,9 @@ namespace Raven.Server.Documents.Indexes
 
         public bool NoQueryRecently()
         {
+            if (_initialized == false)
+                return false;
+
             var last = _lastQueriedTimeTracker.LastQueryDate;
             return DocumentDatabase.Time.GetUtcNow() - last > Configuration.TimeSinceLastQueryAfterWhichDeepCleanupCanBeExecuted.AsTimeSpan;
         }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -357,7 +357,7 @@ namespace Raven.Server.ServerWide.Maintenance
             report.LastCompletedClusterTransaction = dbInstance.LastCompletedClusterTransaction;
         }
 
-        private static void FillIndexInfo(Index index, QueryOperationContext context, DateTime now, DatabaseStatusReport report)
+        internal static void FillIndexInfo(Index index, QueryOperationContext context, DateTime now, DatabaseStatusReport report)
         {
             var stats = index.GetIndexingState(context);
             var lastQueried = GetLastQueryInfo(index);

--- a/test/SlowTests/Issues/RavenDB-19109.cs
+++ b/test/SlowTests/Issues/RavenDB-19109.cs
@@ -2,12 +2,17 @@
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Errors;
+using Raven.Server.ServerWide.Maintenance;
 using Raven.Server.Utils;
 using Tests.Infrastructure;
 using Xunit;
@@ -97,6 +102,98 @@ public class RavenDB_19109 : RavenTestBase
         {
             IOExtensions.DeleteFile(disableMarkerPath);
         }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task IdleOperationsShouldNotThrowWhenIndexIsDisabledByMarker()
+    {
+        DoNotReuseServer();
+
+        using var store = GetDocumentStore(out var databasePath);
+        var index = new IndexToDisable();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        DocumentDatabase database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        Assert.IsNotType<FaultyInMemoryIndex>(database.IndexStore.GetIndex(index.IndexName));
+
+        // sanity: a healthy index survives idle operations
+        database.IndexStore.RunIdleOperations(DatabaseCleanupMode.Regular);
+        database.IndexStore.RunIdleOperations(DatabaseCleanupMode.Deep);
+
+        var disableMarkerPath = Path.Combine(databasePath, "Indexes", index.IndexName, "disable.marker");
+        try
+        {
+            DoCommand(store, true, out _);
+            File.Create(disableMarkerPath).Dispose();
+            DoCommand(store, false, out _);
+
+            database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            Assert.IsType<FaultyInMemoryIndex>(database.IndexStore.GetIndex(index.IndexName));
+
+            // the faulty placeholder must not break the database-wide idle operations
+            database.IndexStore.RunIdleOperations(DatabaseCleanupMode.Regular);
+            database.IndexStore.RunIdleOperations(DatabaseCleanupMode.Deep);
+        }
+        finally
+        {
+            IOExtensions.DeleteFile(disableMarkerPath);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Cluster)]
+    public async Task ClusterMaintenanceReportShouldNotThrowWhenIndexIsDisabledByMarker()
+    {
+        DoNotReuseServer();
+
+        using var store = GetDocumentStore(out var databasePath);
+        var index = new IndexToDisable();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        DocumentDatabase database = await Databases.GetDocumentDatabaseInstanceFor(store);
+        Assert.IsNotType<FaultyInMemoryIndex>(database.IndexStore.GetIndex(index.IndexName));
+
+        // sanity: a healthy index can be reported
+        DatabaseStatusReport.ObservedIndexStatus status = FillIndexInfo(database, index.IndexName);
+        Assert.Equal(IndexState.Normal, status.State);
+        Assert.False(status.IsStale);
+
+        var disableMarkerPath = Path.Combine(databasePath, "Indexes", index.IndexName, "disable.marker");
+        try
+        {
+            DoCommand(store, true, out _);
+            File.Create(disableMarkerPath).Dispose();
+            DoCommand(store, false, out _);
+
+            database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            Assert.IsType<FaultyInMemoryIndex>(database.IndexStore.GetIndex(index.IndexName));
+
+            // the faulty placeholder must still produce a status entry for the cluster observer
+            status = FillIndexInfo(database, index.IndexName);
+            Assert.Equal(IndexState.Error, status.State);
+            Assert.True(status.IsStale);
+            Assert.Equal((long)Raven.Server.Documents.Indexes.Index.IndexProgressStatus.Faulty, status.LastIndexedEtag);
+        }
+        finally
+        {
+            IOExtensions.DeleteFile(disableMarkerPath);
+        }
+    }
+
+    private static DatabaseStatusReport.ObservedIndexStatus FillIndexInfo(DocumentDatabase database, string indexName)
+    {
+        var index = database.IndexStore.GetIndex(indexName);
+        Assert.NotNull(index);
+
+        var report = new DatabaseStatusReport();
+        using (var context = QueryOperationContext.Allocate(database, needsServerContext: true))
+        using (context.OpenReadTransaction())
+        {
+            ClusterMaintenanceWorker.FillIndexInfo(index, context, DateTime.UtcNow, report);
+        }
+
+        return report.LastIndexStats[indexName];
     }
 
     private IDocumentStore GetDocumentStore(out string databasePath, [CallerMemberName] string caller = null)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27511/NullReferenceException-in-idle-operations-and-cluster-maintenance-report-when-an-index-is-disabled-via-disable.marker

### Additional description

#### Problem

When an index directory contains a `disable.marker` file and the database is reloaded, the index fails to open and is registered as a `FaultyInMemoryIndex` placeholder (expected). From then on, two background paths throw `NullReferenceException` every time they reach that index:

* `IndexStore.RunIdleOperations` -> `Index.NoQueryRecently()`
* `ClusterMaintenanceWorker.FillIndexInfo` -> `Index.GetElapsedTimeFromLastQuery()`

Both methods abort on the exception, so healthy indexes positioned after the faulty one are not processed either, and the node's full `DatabaseStatusReport` for that database carries an error instead of per-index state.

#### Root cause

`FaultyInMemoryIndex` is constructed when opening the index storage fails, so `Index.Initialize` never runs for it. Two members are assigned only inside `Initialize`:

* `_lastQueriedTimeTracker` (assigned in `LoadValues`). Introduced by RavenDB-24649, which replaced the value-type fields `_lastQueryingTime` / `_timeElapsedFromLastQuery` with a reference type. This is what breaks `GetElapsedTimeFromLastQuery()` and the cluster maintenance report.
* `DocumentDatabase`. `NoQueryRecently()` reads `DocumentDatabase.Time` and has done so since RavenDB-17424, so the idle-operations failure predates the tracker change.

#### Fix

* `Index` constructor seeds `_lastQueriedTimeTracker` with zero elapsed time. `LoadValues` still replaces it with the persisted value once the storage is opened, so initialized indexes behave exactly as before. The tracker is never null for any index type.
* `Index.NoQueryRecently()` returns `false` when the index is not initialized. A faulty placeholder is never queried and has no readers to release; `Index.Cleanup` already returns early for it.
* `ClusterMaintenanceWorker.FillIndexInfo` is now `internal` so the test can call the exact frame from the reported stack trace.

#### Tests

Added to `SlowTests.Issues.RavenDB_19109` (non in-memory database, `Indexing.ThrowIfAnyIndexCannotBeOpened = false`). Each test calls the affected method directly against a healthy index, then disables the database, drops `disable.marker` into the index directory, re-enables the database, asserts the index came back as `FaultyInMemoryIndex`, and calls the method again:

* `IdleOperationsShouldNotThrowWhenIndexIsDisabledByMarker` - `IndexStore.RunIdleOperations` in `Regular` and `Deep` mode
* `ClusterMaintenanceReportShouldNotThrowWhenIndexIsDisabledByMarker` - `ClusterMaintenanceWorker.FillIndexInfo`, asserting the faulty index is reported with `IndexState.Error`, stale, and the `Faulty` progress etag

Both tests fail before the fix with the same two stack traces as the report and pass after it. Also verified green: existing `RavenDB_19109`, `RavenDB_24649` (tracker persistence and race tests), `RavenDB_10925`, and `FastTests.Server.Basic.IdleOperations`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
