### PR TITLE
RavenDB-27513 Retry transient AI test failures, skip AI tests on x86

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -940,6 +940,10 @@ public class ChatCompletionClient : IDisposable
             catch (Exception)
             {
                 var rawBody = Encoding.UTF8.GetString(ms.GetBuffer(), 0, contentLength);
+
+                if (response.IsSuccessStatusCode == false)
+                    UnsuccessfulAiRequestException.Throw(rawBody, response.StatusCode, GetRequestId(response.Headers));
+
                 throw UnexpectedResponseException.Create(message: "Received an unrecognized response from the server", response, rawBody);
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB-23909.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23909.cs
@@ -13,7 +13,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task Auto(Options options)
     {
@@ -46,7 +46,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
     
-    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task AlreadyQuantizedVectorShouldThrow(Options options)
     {
@@ -93,7 +93,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task Static(Options options)
     {
@@ -130,7 +130,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task StaticJs(Options options)
     {

--- a/test/SlowTests.Issues/Issues/RavenDB-23960.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23960.cs
@@ -7,7 +7,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_23960(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task DisabledTaskDoesntImpactCreationOfOtherTasks(Options options)
     {

--- a/test/SlowTests.Issues/Issues/RavenDB-24816.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-24816.cs
@@ -17,7 +17,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
     {
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public void OverlapTokensSettingShouldWork()
     {
         const string plainTextToChunk = "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
@@ -45,7 +45,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
         Assert.Equal(expectedChunks, chunks);
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public void OverlapTokensSettingForMarkdownShouldWork()
     {
         const string markdownToChunk = """
@@ -80,7 +80,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
         Assert.Equal(expectedChunks, chunks);
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task OverlapTokensSettingInScriptShouldWork()
     {
         const string plainTextToChunk =
@@ -120,7 +120,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
         }
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task OverlapTokensSettingViaPathShouldWork()
     {
         const string plainTextToChunk =
@@ -202,7 +202,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
         }
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task UnsupportedChunkingSettingsInScriptThrowRelevantException()
     {
         const string plainTextToChunk =
@@ -231,7 +231,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
         }
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task OverlapTokensShouldBeBackwardCompatible()
     {
         const string plainTextToChunk =

--- a/test/SlowTests.Issues/Issues/RavenDB-25306.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25306.cs
@@ -12,7 +12,7 @@ public class RavenDB_25306 : EmbeddingsGenerationTestBase
     {
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task EmbeddingsGenerationTaskShouldHandleReset()
     {
         using (var store = GetDocumentStore())

--- a/test/SlowTests.Issues/Issues/RavenDB-25698.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25698.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_25698(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task EmbeddingGenerationCreatesValueInEmbeddingCacheDocument()
     {
 

--- a/test/SlowTests.Issues/Issues/RavenDB-26603.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26603.cs
@@ -11,7 +11,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_26603(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public void ChunkPlainTextWithContextPrefixShouldPrependPrefixToEachChunk()
     {
         const string plainTextToChunk =
@@ -40,7 +40,7 @@ public class RavenDB_26603(ITestOutputHelper output) : EmbeddingsGenerationTestB
         Assert.All(withPrefix, c => Assert.StartsWith(prefix, c));
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public void ContextPrefixLargerThanMaxTokensShouldThrow()
     {
         const string prefix = "this prefix has a number of tokens that should not fit within the budget";
@@ -57,7 +57,7 @@ public class RavenDB_26603(ITestOutputHelper output) : EmbeddingsGenerationTestB
         Assert.Contains("ContextPrefix is too long", ex.Message);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public void OverlapLargerThanEffectiveMaxTokensShouldThrow()
     {
         // MaxTokensPerChunk=10, OverlapTokens=8 is valid by itself (8 <= 10).
@@ -96,7 +96,7 @@ public class RavenDB_26603(ITestOutputHelper output) : EmbeddingsGenerationTestB
         Assert.Contains("ContextPrefix cannot be empty or whitespace-only", exception.Message);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task TextSplitWithContextPrefixInScript()
     {
         const string plainTextToChunk =
@@ -141,7 +141,7 @@ public class RavenDB_26603(ITestOutputHelper output) : EmbeddingsGenerationTestB
             "ChunkedName", expectedChunks, dto.Id);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task TextWithContextInScript()
     {
         const string title = "Document title";
@@ -170,7 +170,7 @@ public class RavenDB_26603(ITestOutputHelper output) : EmbeddingsGenerationTestB
             "Field", [prefix + title], dto.Id);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task TextSplitParagraphsWithOverlapAndContextPrefixInScript()
     {
         const string body =
@@ -217,7 +217,7 @@ public class RavenDB_26603(ITestOutputHelper output) : EmbeddingsGenerationTestB
             "Paragraphs", expectedChunks, dto.Id);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task ObjectWideContextPrefixOnEmbeddingsGenerate()
     {
         const string body =
@@ -260,7 +260,7 @@ public class RavenDB_26603(ITestOutputHelper output) : EmbeddingsGenerationTestB
             "ChunkedName", expectedChunks, dto.Id);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task ObjectWideContextPrefixDoesNotOverridePerPropertyPrefix()
     {
         const string body =

--- a/test/SlowTests.Issues/Issues/RavenDB-27365.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-27365.cs
@@ -120,7 +120,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Licensing | RavenTestCategory.Cluster | RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenFact(RavenTestCategory.Licensing | RavenTestCategory.Cluster | RavenTestCategory.Ai)]
         public async Task SystemCollections_AreReported_FromCollectionsTheProductCreates()
         {
             var (nodes, leader) = await CreateRaftCluster(1, watcherCluster: true);

--- a/test/SlowTests.Issues/Issues/RavenDB_24613.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_24613.cs
@@ -8,7 +8,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_24613_MultipleEmbeddingsGenerateCalls(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task MultipleEmbeddingsGenerateCallsShouldCreateAllEmbeddings()
     {
         using var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -185,7 +185,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             Assert.NotNull(chat.Id);
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenRetryTheory(RavenTestCategory.Ai, maxRetries: 3, delayBetweenRetriesMs: 10_000)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanRunTest(Options options, GenAiConfiguration config)
         {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -43,7 +43,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         {
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenTheory(RavenTestCategory.Ai)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanCreateAiAgent(Options options, GenAiConfiguration config)
         {
@@ -92,7 +92,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             Assert.NotNull(chat1);
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenTheory(RavenTestCategory.Ai)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanGetAiAgent(Options options, GenAiConfiguration config)
         {
@@ -135,7 +135,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             }
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenTheory(RavenTestCategory.Ai)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Google | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanResumeConversation(Options options, GenAiConfiguration config)
         {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
@@ -41,7 +41,7 @@ public class AiAgentClientApiBasics : RavenTestBase
         public int Quantity;
     }
 
-    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true })]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
     public async Task AiAgentClientApiBasicTest(Options options, GenAiConfiguration config, bool sendSchema)
@@ -174,7 +174,7 @@ public class AiAgentClientApiBasics : RavenTestBase
         var r = await chat.RunAsync<AnswerSchema>();
     }
 
-    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task AiAgentClientApi(Options options, GenAiConfiguration config)
     {
@@ -246,7 +246,7 @@ public class AiAgentClientApiBasics : RavenTestBase
         Assert.Equal(AiConversationResult.Done, r.Status);
     }
 
-    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ThrowConcurrencyException(Options options, GenAiConfiguration config)
     {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -287,9 +287,15 @@ public class RavenDB_24407 : RavenTestBase
                 Assert.True(chatDoc.LinkedConversations.Count > 0);
 
                 var historyChat = await GetChat(store, chatDoc.LinkedConversations.First());
-                var lastMsg = historyChat.Messages.Last();
 
-                await AssertWithDumpAsync(lastMsg.Role, async () => await DumpAllAsync(store, chatDoc, chatDoc.LinkedConversations));
+                AssertNoOrphanToolMessages(historyChat);
+
+                var lastMsg = historyChat.Messages.Last();
+                if (lastMsg.Role == "user")
+                {
+                    var dump = await DumpAllAsync(store, chatDoc, chatDoc.LinkedConversations);
+                    Assert.Fail($"History conversation ends on an unanswered 'user' message.\n{dump}");
+                }
             }
             else
             {
@@ -444,17 +450,6 @@ public class RavenDB_24407 : RavenTestBase
         using (var session = store.OpenAsyncSession())
         {
             return await session.LoadAsync<Chat>(chatId);
-        }
-    }
-
-    private static async Task AssertWithDumpAsync(
-        string lastMsgRole,
-        Func<Task<string>> dumpFactory)
-    {
-        if (lastMsgRole != "tool")
-        {
-            var msg = await dumpFactory(); // build dump only on failure
-            Assert.Fail($"Expected last history message role 'tool' but was '{lastMsgRole}'.\n{msg}");
         }
     }
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -73,7 +73,7 @@ public class RavenDB_24407 : RavenTestBase
         public string[] Tags { get; set; }
     }
 
-    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenRetryTheory(RavenTestCategory.Ai, maxRetries: 3, delayBetweenRetriesMs: 10_000)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, false])]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true], Skip = "RavenDB-24806")]

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
@@ -105,7 +105,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             Assert.Contains("'orders/1-A' doesn't exists", ex.InnerException?.Message);
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenTheory(RavenTestCategory.Ai)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task Concurrency_When_Resuming_Same_Conversation(Options options, GenAiConfiguration config)
         {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25142.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25142.cs
@@ -29,7 +29,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             public string[] RelatedProducts { get; set; } = [""];
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenRetryTheory(RavenTestCategory.Ai, maxRetries: 3, delayBetweenRetriesMs: 10_000)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task Can_recreate_negative_total_tokens_with_truncation(Options options, GenAiConfiguration config)
         {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25255.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25255.cs
@@ -24,7 +24,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         {
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenTheory(RavenTestCategory.Ai)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanUseQueryToolWithSecuredServer(Options options, GenAiConfiguration config)
         {

--- a/test/SlowTests/Server/Documents/AI/AiConnectionStringsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiConnectionStringsTests.cs
@@ -196,7 +196,7 @@ public class AiConnectionStringsTests : RavenTestBase
 
     private readonly List<string> _testValuesList = ["First test value", "Second test value", "Third test value"];
 
-    [RavenMultiplatformTheory(RavenTestCategory.Etl | RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenTheory(RavenTestCategory.Etl | RavenTestCategory.Ai)]
     [RavenAiEmbeddingsData(IntegrationType = RavenAiIntegration.All)]
     public void SemanticKernel_WithValidConfiguration_ShouldWork(Options options, EmbeddingsGenerationConfiguration embeddingsGenerationConfiguration)
     {

--- a/test/SlowTests/Server/Documents/AI/AiConnectionTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiConnectionTests.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Server.Documents.AI
             }
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenTheory(RavenTestCategory.Ai)]
         [ClassData(typeof(IntegrationDataType<Embeddings>))]
         public void CanConnectEmbeddings(RavenAiIntegration integration)
         {
@@ -61,7 +61,7 @@ namespace SlowTests.Server.Documents.AI
             }
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenTheory(RavenTestCategory.Ai)]
         [RavenAiEmbeddingsData(IntegrationType = RavenAiIntegration.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanTestAiEmbeddingsConnectionString(Options options, EmbeddingsGenerationConfiguration configuration)
         {

--- a/test/SlowTests/Server/Documents/AI/Embeddings/Cache/QueryEmbeddingsCacherTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/Cache/QueryEmbeddingsCacherTests.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings.Cache;
 
 public class QueryEmbeddingsCacherTests(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task ShouldCacheEmbeddings()
     {
         var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
@@ -24,7 +24,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task CanSingleDocumentHaveTwoEmbeddings()
     {
         using var store = GetDocumentStore();
@@ -76,7 +76,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         AssertMissingEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Names", ["Name3"], id);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task DocumentsWithSingleValue()
     {
         using (var store = GetDocumentStore())
@@ -99,7 +99,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task DocumentsWithListOfValues()
     {
         using (var store = GetDocumentStore())
@@ -123,7 +123,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task DocumentsWithNestedPropertyPath()
     {
         using (var store = GetDocumentStore())
@@ -149,7 +149,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task DocumentsWithNestedArrayPropertyPath()
     {
         using (var store = GetDocumentStore())
@@ -175,7 +175,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task EmbeddingsMustBeGeneratedOnlyOnceInDifferentBatches()
     {
         using (var store = GetDocumentStore())
@@ -229,7 +229,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task UpdateOfDocumentsWithSingleValue()
     {
         using (var store = GetDocumentStore())
@@ -268,7 +268,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task HandlingOfNonStringValues()
     {
         using (var store = GetDocumentStore())
@@ -292,7 +292,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task FieldsToIncludeMustBeRespected()
     {
         using (var store = GetDocumentStore())
@@ -322,7 +322,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task ModificationOfNonProcessedFieldsWillTriggerTaskButWontGenerateEmbeddings()
     {
         using (var store = GetDocumentStore())
@@ -386,7 +386,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task DefaultBatchSizeMustBeRespected()
     {
         using (var store = GetDocumentStore())
@@ -416,7 +416,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task CustomBatchSizeMustBeRespected()
     {
         const int batchSize = 4;
@@ -454,7 +454,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task HandlingOfDocumentDeletions()
     {
         var dto1 = new Dto { Name = "Name1" };
@@ -497,7 +497,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task WillSetExpirationOnCacheDocuments()
     {
         var dto = new Dto { Name = "Name1" };
@@ -532,7 +532,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task WillUpdateExpirationOnCacheDocuments()
     {
         var dto = new Dto { Id = "dtos/1", Name = "Name1" };
@@ -599,7 +599,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task SimpleJsTransformation()
     {
         const string aiIntegrationName = "local-Onnx-AI";
@@ -633,7 +633,7 @@ embeddings.generate(
         }
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task NestedJsTransformation()
     {
         const string aiIntegrationName = "local-Onnx-AI";
@@ -665,7 +665,7 @@ embeddings.generate(
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task HashingOfTextShouldBeCaseInsensitiveAndTrimWhitespaces()
     {
         var dto = new Dto() { Name = "\n UPPERCASEVALUE\n\r " };
@@ -693,7 +693,7 @@ embeddings.generate(
 
     private record Test(string Id, DateTime? Expires);
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task TextChunkingInScript()
     {
         const string plainTextToChunk =
@@ -724,7 +724,7 @@ embeddings.generate(
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public void ChunkPlainTextShouldWork()
     {
         const string plainTextToChunk = "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
@@ -735,7 +735,7 @@ embeddings.generate(
         Assert.Equal(expectedChunks, chunks);
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public void PlainTextSplitLinesShouldWork()
     {
         const string plainTextToChunk = "This is a relatively - long text\n that should produce multiple chunks\n\r because of the chunking configuration; (max tokens per chunk). It also contains, separators in random places.";
@@ -746,7 +746,7 @@ embeddings.generate(
         Assert.Equal(expectedChunks, chunks);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task MarkdownChunkingInScript()
     {
         const string markdownTextToChunk =
@@ -801,7 +801,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task CanUseHtmlChunkingInScript()
     {
         const string htmlTextToChunk =
@@ -849,7 +849,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task CanUseHtmlChunkingInPaths()
     {
         const string htmlTextToChunk =
@@ -903,7 +903,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task TransformationWithArrayFieldOutput()
     {
         var dto = new Dto { Name = "CoolName" };
@@ -929,7 +929,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai | RavenTestCategory.Vector | RavenTestCategory.Etl, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai | RavenTestCategory.Vector | RavenTestCategory.Etl)]
     public async Task QuantizationOfEmbeddingsInTwoTasks()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
@@ -962,7 +962,7 @@ Console.WriteLine(""Hello, World!"");";
         AssertEmbeddingsForPath(store, configuration2, connectionString2, "Names", ["CoolName"], id);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task QuantizationOfEmbeddingsInTask()
     {
         var dto = new Dto { Name = "CoolName" };
@@ -1009,7 +1009,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
 
-    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenTheory(RavenTestCategory.Ai)]
     [InlineData(VectorEmbeddingType.Int8)]
     [InlineData(VectorEmbeddingType.Binary)]
     [InlineData(VectorEmbeddingType.Single)]
@@ -1107,7 +1107,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task CollisionOfTwoEmbeddingsInSingleTask()
     {
         using var store = GetDocumentStore();
@@ -1145,7 +1145,7 @@ Console.WriteLine(""Hello, World!"");";
         AssertEmbeddingsForPath(store, config, connection, "Names", ["Name1"], id);
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task CollisionOfTwoEmbeddingsInTwoTasks()
     {
         using var store = GetDocumentStore();
@@ -1193,7 +1193,7 @@ Console.WriteLine(""Hello, World!"");";
         AssertEmbeddingsForPath(store, config2, connection2, "Names", ["Name1"], id);
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public async Task CanUseProjectedFieldNameForQuery()
     {
         const string plainTextToChunk = "some text that should produce a single chunk";

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_24311.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_24311.cs
@@ -7,7 +7,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 #if DEBUG
 public class RavenDB_24311(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenMultiplatformFact(RavenTestCategory.Ai | RavenTestCategory.Core, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai | RavenTestCategory.Core)]
     public async Task CanAssertEmbeddingsGenerationChangeInSchema()
     {
         using var store = GetDocumentStore(new Options() { RunInMemory = false });

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RemovalTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RemovalTests.cs
@@ -8,7 +8,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class RemovalTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenMultiplatformFact(RavenTestCategory.Ai | RavenTestCategory.Etl, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai | RavenTestCategory.Etl)]
     public async Task TaskRemoveEmbeddingsDocumentOfRemovedDocument()
     {
         using var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
@@ -17,7 +17,7 @@ public class TasksManagementTests : RavenTestBase
     {
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public void CanDeleteTask()
     {
         using var store = GetDocumentStore();
@@ -47,7 +47,7 @@ public class TasksManagementTests : RavenTestBase
         Assert.Null(ongoingTask);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+    [RavenFact(RavenTestCategory.Ai)]
     public void CanUpdateTask()
     {
         using var store = GetDocumentStore();

--- a/test/Tests.Infrastructure/RavenDataAttributeBase.cs
+++ b/test/Tests.Infrastructure/RavenDataAttributeBase.cs
@@ -9,6 +9,7 @@ public abstract class RavenDataAttributeBase : DataAttribute
 
     internal static readonly bool Is32Bit = RuntimeInformation.ProcessArchitecture == Architecture.X86;
     internal const string ShardingSkipMessage = "RavenDB-19879: Skip Sharded database tests on x86 architecture.";
+    internal const string AiSkipMessage = "RavenDB-27513: Skip AI tests on x86 architecture.";
 
     protected string GetSkipReason(RavenDatabaseMode databaseMode) => GetSkipReason(databaseMode, Skip);
 

--- a/test/Tests.Infrastructure/RavenFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenFactAttribute.cs
@@ -187,6 +187,9 @@ public class RavenFactAttribute : FactAttribute, ITraitAttribute, Xunit.v3.IFact
         {
             if (category.HasFlag(RavenTestCategory.Sharding))
                 return RavenDataAttributeBase.ShardingSkipMessage;
+
+            if (category.HasFlag(RavenTestCategory.Ai))
+                return RavenDataAttributeBase.AiSkipMessage;
         }
 
         if (licenseRequired && ShouldSkipLicense(out skip))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27513
https://issues.hibernatingrhinos.com/issue/RavenDB-25201
https://issues.hibernatingrhinos.com/issue/RavenDB-27494
https://issues.hibernatingrhinos.com/issue/RavenDB-26392
https://issues.hibernatingrhinos.com/issue/RavenDB-26786

### Additional description

- Retry on 3 AI tests that fail on provider HTTP errors.
- Skip AI tests on x86.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No.

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
