### PR TITLE
RavenDB-25135 Guard VoronStream reads against out-of-chunk offsets

### DIFF
--- a/src/Raven.Server/Indexing/VoronBufferedInput.cs
+++ b/src/Raven.Server/Indexing/VoronBufferedInput.cs
@@ -207,7 +207,7 @@ public sealed class VoronBufferedInput : BufferedIndexInput
 
     public override void SeekInternal(long pos, IState s)
     {
-        if (pos > _stream.Length)
+        if (pos < 0 || pos > _stream.Length)
             ThrowInvalidSeekPosition(pos);
 
         if (s is not VoronState state)

--- a/src/Raven.Server/Indexing/VoronIndexInput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexInput.cs
@@ -124,7 +124,7 @@ namespace Raven.Server.Indexing
 
         public override void Seek(long pos, IState s)
         {
-            if (pos > _stream.Length)
+            if (pos < 0 || pos > _stream.Length)
                 ThrowInvalidSeekPosition(pos);
 
             var state = s as VoronState;

--- a/src/Voron/Data/VoronStream.cs
+++ b/src/Voron/Data/VoronStream.cs
@@ -113,6 +113,9 @@ namespace Voron.Data
             UpdateLastPageIfNeeded(chunk.PageNumber);
 
             var pos = _position - _chunksOffsets[_index];
+            if (pos < 0 || pos >= chunk.ChunkSize)
+                ThrowReadOutOfChunkBounds(pos, 1, chunk.ChunkSize);
+
             _position++; //move ptr
             return LastPage.DataPointer[pos];
         }
@@ -144,6 +147,10 @@ namespace Voron.Data
             UpdateLastPageIfNeeded(chunk.PageNumber);
 
             var pos = _position - _chunksOffsets[_index];
+            // fail here rather than let a bad offset turn into an out-of-bounds native read (AVE)
+            if (pos < 0 || pos + count > chunk.ChunkSize)
+                ThrowReadOutOfChunkBounds(pos, count, chunk.ChunkSize);
+
             fixed (byte* dst = buffer)
             {
                 Memory.Copy(dst + offset, LastPage.DataPointer + pos, count);
@@ -207,6 +214,13 @@ namespace Voron.Data
         public override void Write(byte[] buffer, int offset, int count)
         {
             throw new NotSupportedException("The method or operation is not supported by VoronStream.");
+        }
+
+        [DoesNotReturn]
+        private void ThrowReadOutOfChunkBounds(long pos, int count, int chunkSize)
+        {
+            throw new InvalidOperationException(
+                $"Attempted to read {count} byte(s) at offset {pos} of chunk {_index} of stream '{Name}', but that chunk holds {chunkSize} bytes. Stream position: {_position}, length: {Length}.");
         }
 
         [DoesNotReturn]


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25135

### Additional description

Precaution only, no known bug is fixed here.

`VoronStream.Read`/`ReadByte` hand `LastPage.DataPointer + pos` to `Memory.Copy` without checking that `pos` and `count` fall inside the chunk. Today they always do (the `Position` setter validates and `Read` clamps `count` to the chunk remainder), so this is a redundant check. It is there so that a future desync, or a `ChunkDetails` entry read back wrong, fails as a managed exception at the point of the bad offset instead of as an out-of-bounds native read.

Also makes `VoronBufferedInput.SeekInternal` and `VoronIndexInput.Seek` reject negative positions. They only checked `pos > Length`; a negative one fell through to the `Position` setter's `BinarySearch` and surfaced as an unrelated-looking `ArgumentException`.

This does not address the AVE reported in RavenDB-25135. That crash has a valid offset and a dangling `LastPage.DataPointer` (a decrypted `EncryptionBuffer` already returned to the pool), which no bounds check can detect.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature


### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
