### PR TITLE
RavenDB-27455 Truncate long Hub and Sink Cursor values in the Replication Sink panel

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationSinkPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationSinkPanel.tsx
@@ -1,4 +1,4 @@
-﻿import React from "react";
+import React from "react";
 import {
     BaseOngoingTaskPanelProps,
     ConnectionStringItem,
@@ -28,6 +28,7 @@ import { useAppSelector } from "components/store";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { ExternalReplicationTaskDistribution } from "components/pages/database/tasks/ongoingTasks/partials/ExternalReplicationTaskDistribution";
 import { Icon } from "components/common/Icon";
+import { ReplicationCursorDetailItem } from "components/pages/database/tasks/ongoingTasks/partials/ReplicationCursorDetailItem";
 
 type ReplicationSinkPanelProps = BaseOngoingTaskPanelProps<OngoingTaskReplicationSinkInfo>;
 
@@ -60,12 +61,8 @@ function Details(props: ReplicationSinkPanelProps & { canEdit: boolean }) {
                 </RichPanelDetailItem>
             ))}
 
-            {data.shared.hubCursor && (
-                <RichPanelDetailItem label="Hub Cursor">{data.shared.hubCursor}</RichPanelDetailItem>
-            )}
-            {data.shared.sinkCursor && (
-                <RichPanelDetailItem label="Sink Cursor">{data.shared.sinkCursor}</RichPanelDetailItem>
-            )}
+            <ReplicationCursorDetailItem label="Hub Cursor" cursor={data.shared.hubCursor} />
+            <ReplicationCursorDetailItem label="Sink Cursor" cursor={data.shared.sinkCursor} />
         </RichPanelDetails>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/ReplicationCursorDetailItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/ReplicationCursorDetailItem.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import Button from "react-bootstrap/Button";
+import copyToClipboard from "common/copyToClipboard";
+import { Icon } from "components/common/Icon";
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import { RichPanelDetailItem } from "components/common/RichPanel";
+
+const maxVisibleEntries = 10;
+
+interface ReplicationCursorDetailItemProps {
+    label: string;
+    cursor: string;
+}
+
+export function ReplicationCursorDetailItem({ label, cursor }: ReplicationCursorDetailItemProps) {
+    if (!cursor) {
+        return null;
+    }
+
+    const entries = cursor
+        .split(",")
+        .map((x) => x.trim())
+        .filter((x) => x);
+
+    const hiddenEntriesCount = entries.length - maxVisibleEntries;
+
+    if (hiddenEntriesCount <= 0) {
+        return <RichPanelDetailItem label={label}>{cursor}</RichPanelDetailItem>;
+    }
+
+    const handleCopyToClipboard = () => {
+        copyToClipboard.copy(cursor, `${label} has been copied to clipboard`);
+    };
+
+    return (
+        <RichPanelDetailItem label={label}>
+            <PopoverWithHoverWrapper
+                placement="top"
+                message={
+                    <>
+                        <div className="word-break overflow-auto" style={{ maxHeight: "300px" }}>
+                            {cursor}
+                        </div>
+                        <Button
+                            onClick={handleCopyToClipboard}
+                            size="sm"
+                            className="mt-2"
+                            title="Copy to clipboard"
+                            aria-label={`Copy ${label} to clipboard`}
+                        >
+                            <Icon icon="copy-to-clipboard" margin="m-0" />
+                        </Button>
+                    </>
+                }
+            >
+                {entries.slice(0, maxVisibleEntries).join(", ")}
+                <span className="text-muted">{` ... (+${hiddenEntriesCount} more)`}</span>
+            </PopoverWithHoverWrapper>
+        </RichPanelDetailItem>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/stories/ReplicationSink.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/stories/ReplicationSink.stories.tsx
@@ -71,6 +71,24 @@ export const Default: StoryObj<ReplicationSinkProps> = {
     },
 };
 
+function longChangeVector(etagBase: number): string {
+    return Array.from(
+        { length: 13 },
+        (_, i) => `${String.fromCharCode(65 + i)}:${etagBase + i}-${String.fromCharCode(97 + i).repeat(22)}`
+    ).join(", ");
+}
+
+export const LongCursors: StoryObj<ReplicationSinkProps> = {
+    ...Default,
+    args: {
+        ...Default.args,
+        customizeTask: (x) => {
+            x.HubCursor = longChangeVector(100);
+            x.SinkCursor = longChangeVector(200);
+        },
+    },
+};
+
 export const Disabled = {
     ...Default,
     args: {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/test/ReplicationSink.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/test/ReplicationSink.spec.tsx
@@ -34,4 +34,22 @@ describe("Replication Sink", function () {
         expect(await container.findByText(/Last DB Etag/)).toBeInTheDocument();
         expect(await container.findByText(/Last Sent Etag/)).toBeInTheDocument();
     });
+
+    it("truncates a long cursor and exposes the full value on hover", async () => {
+        const Story = composeStory(stories.LongCursors, stories.default);
+
+        const { screen, fireClick, user } = rtlRender(<Story />);
+        const container = within(await screen.findByTestId(containerTestId));
+
+        await fireClick(await container.findByTitle(/Click for details/));
+
+        const hubCursor = await container.findByText(/^A:100-/);
+        expect(within(hubCursor).getByText(/\(\+3 more\)/)).toBeInTheDocument();
+        expect(container.queryByText(new RegExp("M:112-mmmmmmmmmmmmmmmmmmmmmm"))).not.toBeInTheDocument();
+
+        await user.hover(hubCursor);
+
+        expect(await screen.findByText(new RegExp("M:112-mmmmmmmmmmmmmmmmmmmmmm"))).toBeInTheDocument();
+        expect(await screen.findByLabelText("Copy Hub Cursor to clipboard")).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27455

### Additional description

A cursor is a change vector with an entry per database id, so a large topology pushed a very long single line into the task panel. Show the first 10 entries plus a "+N more" hint and keep the full value available in a hover popover with a copy to clipboard button.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
