### PR TITLE
RavenDB-27516 Use the right MAP_ANONYMOUS value on macOS

### DIFF
--- a/src/Sparrow.Server/Debugging/PosixElectricFencedMemory.cs
+++ b/src/Sparrow.Server/Debugging/PosixElectricFencedMemory.cs
@@ -17,7 +17,7 @@ namespace Sparrow.Server.Debugging
             var allocatedSize = (sizeInPages + 2) * 4096;
 
             var virtualAlloc = (byte*)Syscall.mmap64(IntPtr.Zero, (UIntPtr)allocatedSize, MmapProts.PROT_NONE,
-                MmapFlags.MAP_PRIVATE | MmapFlags.MAP_ANONYMOUS, -1, 0L);
+                MmapFlags.MAP_PRIVATE | PerPlatformValues.MmapFlags.MAP_ANONYMOUS, -1, 0L);
 
             if (virtualAlloc == (byte*)-1)
             {
@@ -33,7 +33,7 @@ namespace Sparrow.Server.Debugging
 
             virtualAlloc = (byte*)Syscall.mmap64((IntPtr)virtualAlloc, (UIntPtr)allocatedSize,
                 MmapProts.PROT_READ | MmapProts.PROT_WRITE,
-                MmapFlags.MAP_FIXED | MmapFlags.MAP_SHARED | MmapFlags.MAP_ANONYMOUS, -1, 0L);
+                MmapFlags.MAP_FIXED | MmapFlags.MAP_SHARED | PerPlatformValues.MmapFlags.MAP_ANONYMOUS, -1, 0L);
 
             if (virtualAlloc == (byte*)-1)
             {
@@ -91,7 +91,7 @@ namespace Sparrow.Server.Debugging
             var dwSize = *(int*)address;
 
             // var virtualAlloc = (byte*)Syscall.mmap((IntPtr)address, (UIntPtr)dwSize, MmapProts.PROT_NONE,
-            //     MmapFlags.MAP_FIXED | MmapFlags.MAP_PRIVATE | MmapFlags.MAP_ANONYMOUS, -1, IntPtr.Zero);
+            //     MmapFlags.MAP_FIXED | MmapFlags.MAP_PRIVATE | PerPlatformValues.MmapFlags.MAP_ANONYMOUS, -1, IntPtr.Zero);
 
             // if (virtualAlloc == null)
             // {

--- a/src/Sparrow.Server/Platform/PlatformSpecific.cs
+++ b/src/Sparrow.Server/Platform/PlatformSpecific.cs
@@ -48,7 +48,7 @@ namespace Sparrow.Server.Platform
                     // we pass NULL (IntPtr.Zero) as the first parameter (address / start) so the kernel chooses the(page-aligned) address at which to create the mapping
 
                     var pageAlignedMemory = Syscall.mmap64(IntPtr.Zero, (UIntPtr)size, MmapProts.PROT_READ | MmapProts.PROT_WRITE,
-                        MmapFlags.MAP_PRIVATE | MmapFlags.MAP_ANONYMOUS, -1, 0L);
+                        MmapFlags.MAP_PRIVATE | PerPlatformValues.MmapFlags.MAP_ANONYMOUS, -1, 0L);
 
                     if (pageAlignedMemory.ToInt64() == -1)
                     {

--- a/src/Sparrow.Server/Platform/Posix/MmapFlags.cs
+++ b/src/Sparrow.Server/Platform/Posix/MmapFlags.cs
@@ -10,8 +10,8 @@ namespace Sparrow.Server.Platform.Posix
         MAP_TYPE = 0x0f,     // Mask for type of mapping.
         MAP_FIXED = 0x10,     // Interpret addr exactly.
         MAP_FILE = 0,
-        MAP_ANONYMOUS = 0x20,     // Don't use a file.
-        MAP_ANON = MAP_ANONYMOUS,
+        // MAP_ANONYMOUS = 0x20,  // Don't use a file. Linux only value, on macOS it is 0x1000 - use PerPlatformValues.MmapFlags.MAP_ANONYMOUS
+        // MAP_ANON = MAP_ANONYMOUS,
 
         // These are Linux-specific.
         MAP_GROWSDOWN = 0x00100,  // Stack-like segment.

--- a/src/Sparrow.Server/Platform/Posix/PerPlatformValues.cs
+++ b/src/Sparrow.Server/Platform/Posix/PerPlatformValues.cs
@@ -58,6 +58,14 @@ namespace Sparrow.Server.Platform.Posix
                     : 4096);            
         }
 
+        public sealed class MmapFlags
+        {
+            public static Posix.MmapFlags MAP_ANONYMOUS = (Posix.MmapFlags)(
+                PlatformDetails.RunningOnMacOsx
+                    ? 0x1000 // MAP_ANON on macOS, 0x20 is MAP_RENAME there
+                    : 0x20);
+        }
+
         public sealed class SysconfNames
         {
             public static int _SC_PAGESIZE =

--- a/test/FastTests/Sparrow/EncryptionTests.cs
+++ b/test/FastTests/Sparrow/EncryptionTests.cs
@@ -21,7 +21,7 @@ namespace FastTests.Sparrow
 {
     public class EncryptionTests(ITestOutputHelper output) : StorageTest(output)
     {
-        [RavenMultiplatformFact(RavenTestCategory.Voron | RavenTestCategory.Encryption, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Encryption)]
         public unsafe void WriteAndReadPageUsingCryptoPager()
         {
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))
@@ -105,7 +105,7 @@ namespace FastTests.Sparrow
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Voron | RavenTestCategory.Encryption, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Encryption)]
         public unsafe void StreamsTempFile_With_Encryption_ShouldNotThrow_When_NotAllStreamsWereRead()
         {
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))
@@ -146,7 +146,7 @@ namespace FastTests.Sparrow
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Voron | RavenTestCategory.Encryption, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Encryption)]
         public unsafe void StreamsTempFile_With_Encryption_ShouldThrow_When_SeekAndWrite_AreMixed_Without_ExecutingReset()
         {
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))
@@ -184,7 +184,7 @@ namespace FastTests.Sparrow
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Voron | RavenTestCategory.Encryption, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Encryption)]
         public unsafe void RavenDB_15975()
         {
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))
@@ -226,7 +226,7 @@ namespace FastTests.Sparrow
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Encryption | RavenTestCategory.Voron, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenFact(RavenTestCategory.Encryption | RavenTestCategory.Voron)]
         public unsafe void RavenDB_159751()
         {
             using (var options = StorageEnvironmentOptions.ForPath(DataDir))

--- a/test/FastTests/Voron/EncryptionBufferPool.cs
+++ b/test/FastTests/Voron/EncryptionBufferPool.cs
@@ -18,7 +18,7 @@ namespace FastTests.Voron
         {
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Memory | RavenTestCategory.Encryption, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenFact(RavenTestCategory.Memory | RavenTestCategory.Encryption)]
         public void dont_pool_buffers_larger_than_8Mb()
         {
             var encryptionBuffersPool = new EncryptionBuffersPool();
@@ -57,7 +57,7 @@ namespace FastTests.Voron
             ClearMemory(encryptionBuffersPool);
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Memory | RavenTestCategory.Encryption, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenTheory(RavenTestCategory.Memory | RavenTestCategory.Encryption)]
         [InlineData(LowMemorySeverity.Low)]
         [InlineData(LowMemorySeverity.ExtremelyLow)]
         public void clear_all_buffers_from_current_generation_on_low_memory(LowMemorySeverity lowMemorySeverity)
@@ -106,7 +106,7 @@ namespace FastTests.Voron
             ClearMemory(encryptionBuffersPool);
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Memory | RavenTestCategory.Encryption, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenFact(RavenTestCategory.Memory | RavenTestCategory.Encryption)]
         public void clear_all_buffers_on_extremely_low_memory()
         {
             var encryptionBuffersPool = new EncryptionBuffersPool();
@@ -137,7 +137,7 @@ namespace FastTests.Voron
             ClearMemory(encryptionBuffersPool);
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Memory | RavenTestCategory.Encryption, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenFact(RavenTestCategory.Memory | RavenTestCategory.Encryption)]
         public void can_save_buffers_after_low_memory()
         {
             var encryptionBuffersPool = new EncryptionBuffersPool();
@@ -171,7 +171,7 @@ namespace FastTests.Voron
             ClearMemory(encryptionBuffersPool);
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Memory | RavenTestCategory.Encryption, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenFact(RavenTestCategory.Memory | RavenTestCategory.Encryption)]
         public void clear_buffers_only_when_in_extremely_low_memory()
         {
             var encryptionBuffersPool = new EncryptionBuffersPool();
@@ -191,7 +191,7 @@ namespace FastTests.Voron
             ClearMemory(encryptionBuffersPool);
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Memory | RavenTestCategory.Encryption, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenFact(RavenTestCategory.Memory | RavenTestCategory.Encryption)]
         public void properly_calculate_thread_total_allocations_when_we_cant_put_buffer_in_pool()
         {
             var encryptionBuffersPool = new EncryptionBuffersPool(registerLowMemory: false, registerCleanup: false);

--- a/test/SlowTests/Voron/Storage/MemoryMapWithoutBackingPagerTest.cs
+++ b/test/SlowTests/Voron/Storage/MemoryMapWithoutBackingPagerTest.cs
@@ -89,7 +89,7 @@ namespace SlowTests.Voron.Storage
             if (StorageEnvironmentOptions.RunningOnPosix)
             {
                 var p = Syscall.mmap64(new IntPtr(Env.Options.DataPager.PagerState.MapBase + totalAllocationSize), (UIntPtr)16,
-                    MmapProts.PROT_READ | MmapProts.PROT_WRITE, MmapFlags.MAP_ANONYMOUS, -1, 0L);
+                    MmapProts.PROT_READ | MmapProts.PROT_WRITE, PerPlatformValues.MmapFlags.MAP_ANONYMOUS, -1, 0L);
                 if (p.ToInt64() == -1)
                 {
                     return null;


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27516

### Additional description

MAP_ANONYMOUS is 0x20 on Linux but 0x1000 on Darwin (0x20 is MAP_RENAME there), so Allocate4KbAlignedMemory mmap'd with fd=-1 and no MAP_ANON and got EBADF. Encrypted Voron could not allocate a single crypto buffer on macOS. Moved the constant to PerPlatformValues and commented it out of the MmapFlags enum so the Linux-only value cannot be reached. Un-gated the 11 FastTests encryption tests that RavenDB-18128 skipped on macOS because of this.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
