### PR TITLE
RavenDB-27342 Set the document expiration frequency with hours, minutes and seconds

### DIFF
--- a/src/Raven.Studio/typescript/components/common/DurationPicker.tsx
+++ b/src/Raven.Studio/typescript/components/common/DurationPicker.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { ChangeEvent, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useRef, useState } from "react";
 import Form from "react-bootstrap/Form";
 import FormGroup from "react-bootstrap/FormGroup";
 import InputGroup from "react-bootstrap/InputGroup";
@@ -36,14 +36,37 @@ export default function DurationPicker(props: DurationPickerProps) {
     const [minutes, setMinutes] = useState(initialValues?.minutes ?? null);
     const [seconds, setSeconds] = useState(initialValues?.seconds ?? null);
 
+    // the last value this picker and its consumer agreed on, so that emitting and syncing don't echo each other
+    const lastTotalSecondsRef = useRef(totalSeconds);
+
     useEffect(() => {
         if (days == null && hours == null && minutes == null && seconds == null) {
             return;
         }
 
         const calculatedTotalSeconds = seconds + minutes * 60 + hours * 60 * 60 + days * 24 * 60 * 60;
+
+        if (calculatedTotalSeconds === lastTotalSecondsRef.current) {
+            return;
+        }
+
+        lastTotalSecondsRef.current = calculatedTotalSeconds;
         onChange(calculatedTotalSeconds);
-    }, [onChange, days, hours, minutes, seconds, totalSeconds]);
+    }, [onChange, days, hours, minutes, seconds]);
+
+    useEffect(() => {
+        if (totalSeconds === lastTotalSecondsRef.current) {
+            return;
+        }
+
+        lastTotalSecondsRef.current = totalSeconds;
+
+        const values = getInitialValues(totalSeconds, showDays);
+        setDays(values?.days ?? null);
+        setHours(values?.hours ?? null);
+        setMinutes(values?.minutes ?? null);
+        setSeconds(values?.seconds ?? null);
+    }, [totalSeconds, showDays]);
 
     const getInputValue = (event: React.ChangeEvent<HTMLInputElement>) => {
         const value = event.currentTarget.value;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.spec.tsx
@@ -2,9 +2,22 @@ import React from "react";
 import { composeStories } from "@storybook/react-webpack5";
 import { rtlRender } from "test/rtlTestUtils";
 import * as stories from "./DocumentExpiration.stories";
-import { DatabasesStubs } from "test/stubs/DatabasesStubs";
+import { queryAllByClassName } from "test/byClassNameQueries";
 
 const { DefaultDocumentExpiration, LicenseRestricted, InitialDocumentExpiration } = composeStories(stories);
+
+// DatabasesStubs.expirationConfiguration().DeleteFrequencyInSec is 129599 seconds
+const expectedDeleteFrequency = [35, 59, 59];
+const licenseLimitWarning = "Your current license does not allow an expiration frequency below 36 hours.";
+// LicenseStubs limits the minimum period to 36 hours
+const expectedLicenseMinimumDeleteFrequency = [36, 0, 0];
+
+function getDeleteFrequencyInputs(durationPicker: HTMLElement) {
+    const inputs = queryAllByClassName(durationPicker, "form-control");
+    expect(inputs).toHaveLength(3);
+
+    return inputs;
+}
 
 describe("DocumentExpiration", () => {
     it("can render", async () => {
@@ -13,18 +26,24 @@ describe("DocumentExpiration", () => {
         expect(await screen.findByText("Enable Document Expiration")).toBeInTheDocument();
     });
 
-    it("can disable and set to null expiration frequency after disabling 'Enable Document Expiration'", async () => {
+    it("can disable expiration frequency after disabling 'Enable Document Expiration'", async () => {
         const { screen, fireClick } = rtlRender(<DefaultDocumentExpiration />);
 
-        const deleteFrequencyBefore = await screen.findByName("deleteFrequency");
-        expect(deleteFrequencyBefore).toBeEnabled();
-        expect(deleteFrequencyBefore).toHaveValue(DatabasesStubs.expirationConfiguration().DeleteFrequencyInSec);
+        const deleteFrequencyBefore = getDeleteFrequencyInputs(
+            await screen.findByTestId("deleteFrequencyDurationPicker")
+        );
+        deleteFrequencyBefore.forEach((input, index) => {
+            expect(input).toBeEnabled();
+            expect(input).toHaveValue(expectedDeleteFrequency[index]);
+        });
 
         await fireClick(screen.getByRole("checkbox", { name: "Enable Document Expiration" }));
 
-        const deleteFrequencyAfter = screen.getByName("deleteFrequency");
-        expect(deleteFrequencyAfter).toBeDisabled();
-        expect(deleteFrequencyAfter).toHaveValue(null);
+        const deleteFrequencyAfter = getDeleteFrequencyInputs(screen.getByTestId("deleteFrequencyDurationPicker"));
+        deleteFrequencyAfter.forEach((input) => {
+            expect(input).toBeDisabled();
+            expect(input).toHaveValue(null);
+        });
     });
 
     it("can set default batch size", async () => {
@@ -51,13 +70,43 @@ describe("DocumentExpiration", () => {
     it("is limit alert visible", async () => {
         const { screen } = rtlRender(<LicenseRestricted />);
 
-        const customExpirationFrequency = await screen.findByName("deleteFrequency");
-        expect(customExpirationFrequency).toBeEnabled();
-        expect(customExpirationFrequency).toHaveValue(DatabasesStubs.expirationConfiguration().DeleteFrequencyInSec);
-
-        const isAlertVisible = screen.getByText(
-            "Your current license does not allow a frequency higher than 36 hours (129600 seconds)"
+        const customExpirationFrequency = getDeleteFrequencyInputs(
+            await screen.findByTestId("deleteFrequencyDurationPicker")
         );
-        expect(isAlertVisible).toBeInTheDocument();
+        customExpirationFrequency.forEach((input, index) => {
+            expect(input).toBeEnabled();
+            expect(input).toHaveValue(expectedDeleteFrequency[index]);
+        });
+
+        expect(screen.getByText(licenseLimitWarning)).toBeInTheDocument();
+    });
+
+    it("turns custom expiration frequency on when the license enforces a minimum period", async () => {
+        const { screen, fireClick } = rtlRender(<LicenseRestricted />);
+
+        const documentExpirationSwitch = await screen.findByRole("checkbox", { name: "Enable Document Expiration" });
+
+        await fireClick(documentExpirationSwitch);
+        expect(screen.getByRole("checkbox", { name: "Set custom expiration frequency" })).not.toBeChecked();
+
+        await fireClick(documentExpirationSwitch);
+        expect(screen.getByRole("checkbox", { name: "Set custom expiration frequency" })).toBeChecked();
+
+        const deleteFrequency = getDeleteFrequencyInputs(screen.getByTestId("deleteFrequencyDurationPicker"));
+        deleteFrequency.forEach((input, index) => {
+            expect(input).toHaveValue(expectedLicenseMinimumDeleteFrequency[index]);
+        });
+
+        expect(screen.queryByText(licenseLimitWarning)).not.toBeInTheDocument();
+    });
+
+    it("blocks saving when the frequency falls back to the server default on a limited license", async () => {
+        const { screen, fireClick } = rtlRender(<LicenseRestricted />);
+
+        await fireClick(await screen.findByRole("checkbox", { name: "Set custom expiration frequency" }));
+
+        expect(screen.getByRole("checkbox", { name: "Set custom expiration frequency" })).not.toBeChecked();
+        expect(screen.getByText(licenseLimitWarning)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
     });
 });

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from "react";
 import Card from "react-bootstrap/Card";
+import Collapse from "react-bootstrap/Collapse";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import { AboutViewAnchored, AboutViewHeading, AccordionItemWrapper } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
-import { FormInput, FormSwitch } from "components/common/Form";
+import { FormDurationPicker, FormInput, FormSwitch } from "components/common/Form";
 import { SubmitHandler, useForm, useWatch } from "react-hook-form";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { useDirtyFlag } from "components/hooks/useDirtyFlag";
@@ -32,6 +33,7 @@ import activeDatabaseTracker = require("common/shell/activeDatabaseTracker");
 import RichAlert from "components/common/RichAlert";
 
 export const defaultItemsToProcess = 65536;
+const defaultDeleteFrequencyInSec = 60;
 
 export default function DocumentExpiration() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
@@ -65,12 +67,23 @@ export default function DocumentExpiration() {
         ],
     });
 
-    const deleteFrequencyInHours = moment.duration(formValues.deleteFrequency, "seconds").asHours();
+    const defaultDeleteFrequency =
+        minPeriodForExpirationInHours > 0
+            ? moment.duration(minPeriodForExpirationInHours, "hours").asSeconds()
+            : defaultDeleteFrequencyInSec;
+
+    const effectiveDeleteFrequencyInSec = formValues.isDeleteFrequencyEnabled
+        ? formValues.deleteFrequency
+        : defaultDeleteFrequencyInSec;
+
+    const deleteFrequencyInHours = moment.duration(effectiveDeleteFrequencyInSec, "seconds").asHours();
 
     const isLimitWarningVisible =
         minPeriodForExpirationInHours > 0 &&
-        formValues.isDeleteFrequencyEnabled &&
+        formValues.isDocumentExpirationEnabled &&
         deleteFrequencyInHours < minPeriodForExpirationInHours;
+
+    const deleteFrequencyPlaceholder = getDeleteFrequencyPlaceholder(defaultDeleteFrequency);
 
     useEffect(() => {
         const { unsubscribe } = watch((values, { name }) => {
@@ -78,6 +91,10 @@ export default function DocumentExpiration() {
                 case "isDocumentExpirationEnabled": {
                     if (values.isDocumentExpirationEnabled) {
                         setValue("isLimitMaxItemsToProcessEnabled", true, { shouldValidate: true });
+
+                        if (minPeriodForExpirationInHours > 0) {
+                            setValue("isDeleteFrequencyEnabled", true, { shouldValidate: true });
+                        }
                     } else {
                         setValue("isLimitMaxItemsToProcessEnabled", false, { shouldValidate: true });
                         setValue("isDeleteFrequencyEnabled", false, { shouldValidate: true });
@@ -93,7 +110,11 @@ export default function DocumentExpiration() {
                     break;
                 }
                 case "isDeleteFrequencyEnabled": {
-                    if (!values.isDeleteFrequencyEnabled) {
+                    if (values.isDeleteFrequencyEnabled) {
+                        if (values.deleteFrequency == null) {
+                            setValue("deleteFrequency", defaultDeleteFrequency, { shouldValidate: true });
+                        }
+                    } else {
                         setValue("deleteFrequency", null, { shouldValidate: true });
                     }
                     break;
@@ -101,7 +122,7 @@ export default function DocumentExpiration() {
             }
         });
         return () => unsubscribe();
-    }, [setValue, watch]);
+    }, [defaultDeleteFrequency, minPeriodForExpirationInHours, setValue, watch]);
 
     const onSave: SubmitHandler<DocumentExpirationFormData> = async (formData) => {
         return tryHandleSubmit(async () => {
@@ -161,7 +182,6 @@ export default function DocumentExpiration() {
                                                 <FormSwitch
                                                     name="isDeleteFrequencyEnabled"
                                                     control={control}
-                                                    className="mb-3"
                                                     disabled={
                                                         formState.isSubmitting ||
                                                         !formValues.isDocumentExpirationEnabled
@@ -169,30 +189,26 @@ export default function DocumentExpiration() {
                                                 >
                                                     Set custom expiration frequency
                                                 </FormSwitch>
-                                                <FormInput
-                                                    name="deleteFrequency"
-                                                    control={control}
-                                                    type="number"
-                                                    disabled={
-                                                        formState.isSubmitting || !formValues.isDeleteFrequencyEnabled
-                                                    }
-                                                    placeholder={
-                                                        minPeriodForExpirationInHours > 0
-                                                            ? `Default (${moment
-                                                                  .duration(minPeriodForExpirationInHours, "hours")
-                                                                  .asSeconds()})`
-                                                            : "Default (60)"
-                                                    }
-                                                    addon="seconds"
-                                                />
+                                                <Collapse appear in={formValues.isDeleteFrequencyEnabled}>
+                                                    <div className="pt-3">
+                                                        <div data-testid="deleteFrequencyDurationPicker">
+                                                            <FormDurationPicker
+                                                                name="deleteFrequency"
+                                                                control={control}
+                                                                disabled={
+                                                                    formState.isSubmitting ||
+                                                                    !formValues.isDeleteFrequencyEnabled
+                                                                }
+                                                                placeholder={deleteFrequencyPlaceholder}
+                                                                showSeconds
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                </Collapse>
                                                 {isLimitWarningVisible && (
                                                     <RichAlert variant="warning" className="mt-3">
-                                                        Your current license does not allow a frequency higher than{" "}
-                                                        {minPeriodForExpirationInHours} hours (
-                                                        {moment
-                                                            .duration(minPeriodForExpirationInHours, "hours")
-                                                            .asSeconds()}{" "}
-                                                        seconds)
+                                                        Your current license does not allow an expiration frequency
+                                                        below {minPeriodForExpirationInHours} hours.
                                                     </RichAlert>
                                                 )}
                                             </div>
@@ -261,6 +277,16 @@ export default function DocumentExpiration() {
             </Col>
         </div>
     );
+}
+
+function getDeleteFrequencyPlaceholder(totalSeconds: number) {
+    const duration = moment.duration(totalSeconds, "seconds");
+
+    return {
+        hours: `Default (${Math.floor(duration.asHours())})`,
+        minutes: `Default (${duration.minutes()})`,
+        seconds: `Default (${duration.seconds()})`,
+    };
 }
 
 function mapToFormData(dto: ServerExpirationConfiguration): DocumentExpirationFormData {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.spec.tsx
@@ -40,8 +40,8 @@ describe("RevisionsBinCleaner", () => {
         const durationPickerInputsAfter = queryAllByClassName(durationPickerAfter, "form-control");
         expect(durationPickerInputsAfter).toHaveLength(3);
 
-        durationPickerInputsAfter.forEach((input, index) => {
-            expect(input).toHaveValue(durationPickerValues[index]);
+        durationPickerInputsAfter.forEach((input) => {
+            expect(input).toHaveValue(null);
             expect(input).toBeDisabled();
         });
     });


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27342

### Additional description

Replace the seconds-only input with the duration picker already used by the revisions bin cleaner, and collapse it while the custom frequency switch is off.

A license that enforces a minimum period rejected every configuration saved without a custom frequency: the server falls back to its own 60 second default, which is always below the minimum. Enabling document expiration now turns the custom frequency on and prefills the licensed minimum, and the limit warning is evaluated against that same fallback so the Save button blocks what the server would refuse.

The duration picker only read its value when it mounted, so a programmatic setValue never reached the inputs. Sync it when the value changes from the outside, and stop the emitting effect from echoing a stale value back over it.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
