### PR TITLE
RavenDB-27022 Reject the reserved __all_fields name in a dynamic query

### DIFF
--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
@@ -241,22 +241,6 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 }
             }
 
-            if (query.Metadata.IsGroupBy)
-            {
-                result.IsGroupBy = true;
-                result.GroupByFieldNames = query.Metadata.GroupBy.Select(x => x.Name.Value).ToList();
-                result.GroupByFields = CreateGroupByFields(query, mapFields);
-
-                foreach (var field in mapFields)
-                {
-                    if (field.Value.AggregationOperation == AggregationOperation.None)
-                    {
-                        throw new InvalidQueryException($"Field '{field.Key}' is neither an aggregation operation nor part of the group by key", query.Metadata.QueryText,
-                            query.QueryParameters);
-                    }
-                }
-            }
-
             if (query.Metadata.HasHighlightings)
             {
                 foreach (var highlighting in query.Metadata.Highlightings)
@@ -278,6 +262,28 @@ namespace Raven.Server.Documents.Queries.Dynamic
                         value.HasSuggestions = true;
                     else
                         mapFields[fieldName] = DynamicQueryMappingItem.Create(fieldName, AggregationOperation.None, isFullTextSearch: false, isExactSearch: false, hasHighlighting: false, hasSuggestions: true, spatial: null);
+                }
+            }
+
+            // auto indexes have no field options to inherit, and the analyzer factories assert on this name
+            if (mapFields.ContainsKey(Constants.Documents.Indexing.Fields.AllFields) ||
+                (query.Metadata.IsGroupBy && query.Metadata.GroupByFieldNames.Contains(Constants.Documents.Indexing.Fields.AllFields)))
+                throw new InvalidQueryException($"Field '{Constants.Documents.Indexing.Fields.AllFields}' is reserved and cannot be used in a query.",
+                    query.Metadata.QueryText, query.QueryParameters);
+
+            if (query.Metadata.IsGroupBy)
+            {
+                result.IsGroupBy = true;
+                result.GroupByFieldNames = query.Metadata.GroupBy.Select(x => x.Name.Value).ToList();
+                result.GroupByFields = CreateGroupByFields(query, mapFields);
+
+                foreach (var field in mapFields)
+                {
+                    if (field.Value.AggregationOperation == AggregationOperation.None)
+                    {
+                        throw new InvalidQueryException($"Field '{field.Key}' is neither an aggregation operation nor part of the group by key", query.Metadata.QueryText,
+                            query.QueryParameters);
+                    }
                 }
             }
 

--- a/test/SlowTests/Issues/RavenDB_27022.cs
+++ b/test/SlowTests/Issues/RavenDB_27022.cs
@@ -1,0 +1,73 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27022 : RavenTestBase
+{
+    public RavenDB_27022(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void ReservedFieldNameCannotBeUsedInADynamicQuery(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        StoreOrder(store);
+
+        AssertRejected(store,
+            "from 'Orders' where search(__all_fields, '*')",
+            "from 'Orders' where __all_fields = 'companies/1'",
+            "from 'Orders' where exists(__all_fields)",
+            "from 'Orders' order by __all_fields",
+            "from 'Orders' group by __all_fields select count()",
+            "from 'Orders' select suggest(__all_fields, 'companies')");
+    }
+
+    // highlighting is not supported in a sharded database
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void ReservedFieldNameCannotBeHighlighted(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        StoreOrder(store);
+
+        AssertRejected(store, "from 'Orders' where search(Company, 'companies') include highlight(__all_fields, 18, 2)");
+    }
+
+    private static void StoreOrder(IDocumentStore store)
+    {
+        using var session = store.OpenSession();
+
+        session.Store(new Order { Company = "companies/1" });
+        session.SaveChanges();
+    }
+
+    private static void AssertRejected(IDocumentStore store, params string[] queries)
+    {
+        foreach (var query in queries)
+        {
+            using var session = store.OpenSession();
+
+            var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<Order>(query).ToList());
+            Assert.Contains("__all_fields", e.Message);
+        }
+
+        // the query must be rejected before an auto index is built from it, otherwise the index is left in an error state
+        Assert.Empty(store.Maintenance.Send(new GetIndexNamesOperation(0, 25)));
+    }
+
+    private sealed class Order
+    {
+        public string Company { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27022

### Additional description

`__all_fields` is the key that carries default field options in a static index definition. `MapIndexDefinition.GetFields` strips it before building the index fields, and the analyzer factories assert that it is gone.

A dynamic query never enforced that invariant. The name flowed from the query into the auto index fields, the first indexing batch hit the assertion, and since `AnalyzerErrorLimit` is 0 the index went to the error state immediately. The user got the internal "inheritance is done elsewhere" message and a broken auto index left behind.

`DynamicQueryMapping.Create` now rejects the name with an `InvalidQueryException` before the auto index is created. It is the single point every source of auto index fields goes through: where, exists, search, order by, group by, highlight and suggest. Queries against static indexes are unaffected.

The group by block moved below the highlighting and suggestion blocks. On a sharded database the orchestrator appends the group by key to the projection, and `CreateGroupByFields` threw `ArgumentNullException` before the check could run. Highlighting and suggestions cannot be combined with group by, so the reorder is behaviour preserving and keeps the validation to a single check.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed