### PR TITLE
RavenDB-27514 Do not cap the scanned terms when the sort field holds several per document

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -268,8 +268,9 @@ public static class CoraxQueryBuilder
                 var maxTermToScan = builderParameters.Take switch
                 {
                     < 0 => int.MaxValue, // meaning, take all
-                    // We cannot apply this optimization when we are returning statistics (RavenDB-21525).
-                    var take when builderParameters.Query.SkipStatistics => (long)take + 1, 
+                    // We cannot apply this optimization when we are returning statistics (RavenDB-21525),
+                    // nor when a document holds several terms in the sort field, because the cap counts terms, not documents.
+                    var take when builderParameters.Query.SkipStatistics && indexSearcher.HasMultipleTermsInField(sortBy.Field) == false => (long)take + 1, 
                     int.MaxValue => (long)int.MaxValue + 1, // avoid overflow
                     _ => int.MaxValue
                 };

--- a/test/SlowTests/Issues/RavenDB_27514.cs
+++ b/test/SlowTests/Issues/RavenDB_27514.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_27514 : RavenTestBase
+{
+    public RavenDB_27514(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void PagingAnOrderByOnAListFieldReturnsTheCorrectPage(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        Seed(store);
+
+        store.ExecuteIndex(new Movies_ByTitle());
+        Indexes.WaitForIndexing(store);
+
+        Assert.Equal(new[] { "movies/1", "movies/2" }, Page(store, "from index 'Movies/ByTitle' order by Title as long desc limit 2"));
+        Assert.Equal(new[] { "movies/2", "movies/1" }, Page(store, "from index 'Movies/ByTitle' order by Title as long asc limit 2"));
+
+        // the cap is computed from skip plus take, so the second page was cut short as well
+        Assert.Equal(new[] { "movies/2" }, Page(store, "from index 'Movies/ByTitle' order by Title as long desc limit 1, 1"));
+        Assert.Equal(new[] { "movies/1" }, Page(store, "from index 'Movies/ByTitle' order by Title as long asc limit 1, 1"));
+
+        // a page wide enough to cover every term was always correct
+        Assert.Equal(new[] { "movies/1", "movies/2" }, Page(store, "from index 'Movies/ByTitle' order by Title as long desc limit 6"));
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void PagingADynamicOrderByOnAListFieldReturnsTheCorrectPage(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        Seed(store);
+
+        Assert.Equal(new[] { "movies/1", "movies/2" }, Page(store, "from 'Movies' order by Title as long desc limit 2"));
+        Assert.Equal(new[] { "movies/2", "movies/1" }, Page(store, "from 'Movies' order by Title as long asc limit 2"));
+
+        // the same cap applies to a string sort field
+        Assert.Equal(new[] { "movies/1", "movies/2" }, Page(store, "from 'Movies' order by Tags desc limit 2"));
+        Assert.Equal(new[] { "movies/2", "movies/1" }, Page(store, "from 'Movies' order by Tags asc limit 2"));
+    }
+
+    private static void Seed(IDocumentStore store)
+    {
+        using var session = store.OpenSession();
+
+        session.Store(new Movie
+        {
+            Id = "movies/1",
+            Title = new object[] { 10L, 20L, 30L, 40L, 50L },
+            Tags = new[] { "a", "b", "c", "d", "e" }
+        });
+
+        session.Store(new Movie { Id = "movies/2", Title = new object[] { 5L }, Tags = new[] { "0" } });
+        session.SaveChanges();
+    }
+
+    private static string[] Page(IDocumentStore store, string query)
+    {
+        using var session = store.OpenSession();
+
+        return session.Advanced
+            .RawQuery<Movie>(query)
+            .WaitForNonStaleResults()
+            .ToList()
+            .Select(x => x.Id)
+            .ToArray();
+    }
+
+    private sealed class Movie
+    {
+        public string Id { get; set; }
+
+        public object Title { get; set; }
+
+        public string[] Tags { get; set; }
+    }
+
+    private sealed class Movies_ByTitle : AbstractIndexCreationTask<Movie>
+    {
+        public Movies_ByTitle()
+        {
+            Map = movies => from movie in movies
+                            select new { movie.Title };
+        }
+
+        public override string IndexName => "Movies/ByTitle";
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-27514

### Additional description

When an `order by` is served by scanning the sort field's value tree, the scan was capped at `take + 1` terms. That holds only while a document owns a single term. A document with a list of values owns several, so the cap is reached before the page has `take` distinct documents and deduplication then collapses what was scanned into fewer rows. The cap is derived from skip plus take, so later pages were cut short in the same way.

`StreamingOptimization` already asks `HasMultipleTermsInField` and gives up on such fields, but that guard only covers the branch that has a `where` clause. The branch without one enters the streaming scan on a sort-field type match alone and applied the cap unguarded.

The same check now guards the cap. On a multi-term sort field the cap is lifted while the scan stays streaming, so the consumer still stops as soon as the page is full. Disabling the branch outright, the way `OptimizationIsPossible` does, would fall back to a full `AllEntries` sort, which is slower for the same result.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

An `order by` on a field that holds several terms per document now scans the whole value tree instead of a capped prefix. Pages are correct; a query with more than one `order by` clause over such a field sorts the full set rather than a prefix.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed