### PR TITLE
Quill-369 Count CDC Sink processed messages per source operation instead of per document

### DIFF
--- a/src/Raven.Server/Documents/CdcSink/Commands/CdcSinkBatchCommand.cs
+++ b/src/Raven.Server/Documents/CdcSink/Commands/CdcSinkBatchCommand.cs
@@ -158,7 +158,7 @@ public sealed class CdcSinkBatchCommand : DocumentMergedTransactionCommand
                     ProcessDocumentGroup(context, documentId, ops);
                     ProcessedSuccessfully += ops.Count;
                     _statistics?.ConsumeSuccess(ops.Count);
-                    _statsScope?.RecordProcessedMessage();
+                    _statsScope?.RecordProcessedMessages(ops.Count);
                 }
                 catch (Exception e) when (IsTolerablePerDocumentError(e))
                 {

--- a/src/Raven.Server/Documents/CdcSink/Stats/CdcSinkStatsScope.cs
+++ b/src/Raven.Server/Documents/CdcSink/Stats/CdcSinkStatsScope.cs
@@ -41,9 +41,9 @@ public class CdcSinkStatsScope : StatsScope<CdcSinkRunStats, CdcSinkStatsScope>
         _stats.NumberOfReadMessages++;
     }
 
-    public void RecordProcessedMessage()
+    public void RecordProcessedMessages(int count)
     {
-        _stats.NumberOfProcessedMessages++;
+        _stats.NumberOfProcessedMessages += count;
     }
 
     public void RecordReadError()

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkBatchCommandTests.cs
@@ -15,6 +15,7 @@ using Raven.Client.Documents.Operations.CdcSink;
 using Raven.Server.Documents;
 using Raven.Server.Documents.CdcSink;
 using Raven.Server.Documents.CdcSink.Commands;
+using Raven.Server.Documents.CdcSink.Stats;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -812,6 +813,37 @@ namespace SlowTests.Server.Documents.CdcSink
                 Assert.Equal("Gadget", products[0]);
                 Assert.Equal("Widget", products[1]);
             }
+        }
+
+        [RavenFact(RavenTestCategory.Sinks)]
+        public async Task ProcessedMessagesCounter_CountsSourceOperationsNotDocuments()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            DynamicJsonValue Order(int version) => new DynamicJsonValue
+            {
+                ["Version"] = version,
+                [Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                {
+                    [Constants.Documents.Metadata.Collection] = "Orders"
+                }
+            };
+
+            var ops = new List<CdcSinkDocumentOp>
+            {
+                CreatePutOp("Orders/1", Order(1)),
+                CreatePutOp("Orders/1", Order(2)),
+                CreatePutOp("Orders/2", Order(1))
+            };
+
+            var runStats = new CdcSinkRunStats();
+            var statsScope = new CdcSinkStatsScope(runStats);
+            var cmd = new CdcSinkBatchCommand(database, ops, "test-config", null, null, null, statsScope, null, null);
+            await database.TxMerger.Enqueue(cmd);
+
+            Assert.Equal(3, cmd.ProcessedSuccessfully);
+            Assert.Equal(3, runStats.NumberOfProcessedMessages);
         }
 
         [RavenFact(RavenTestCategory.Sinks)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/Quill-369/CDC-Sink-processed-message-counter-counts-documents-instead-of-messages

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
